### PR TITLE
release: v0.1.120 post-optimization validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "libc",
  "socket2",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "clap",
  "libc",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "blake2",
  "bytes",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "dirs 5.0.1",
  "reqwest",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.119"
+version = "0.1.120"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.119"
+version = "0.1.120"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.119+119
+version: 0.1.120+120
 
 environment:
   sdk: ^3.11.0

--- a/client/daemon/src/candidate_refresh/signals.rs
+++ b/client/daemon/src/candidate_refresh/signals.rs
@@ -576,7 +576,7 @@ pub(super) fn has_real_public_candidate(
             .get(endpoint_text)
             .map(String::as_str);
         !matches!(source, Some("peer_reflexive" | "learned" | "predicted"))
-            && !source.is_some_and(|source| crate::parse_fresh_prediction_source_label(source).is_some())
+            && source.is_none_or(|source| crate::parse_fresh_prediction_source_label(source).is_none())
     })
 }
 

--- a/client/daemon/src/control/proxy.rs
+++ b/client/daemon/src/control/proxy.rs
@@ -109,6 +109,7 @@ fn build_control_http_client(
     )))]
     let builder = {
         let _ = outbound_interface;
+        let _ = server_url;
         builder
     };
 

--- a/client/daemon/src/control/proxy.rs
+++ b/client/daemon/src/control/proxy.rs
@@ -65,28 +65,53 @@ fn build_control_http_client(
     server_url: Option<&str>,
     outbound_interface: Option<&str>,
 ) -> Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder();
-    if mode == ControlProxyMode::Direct
-        && server_url.is_some_and(|url| !control_server_is_local(url))
-    {
-        if let Some(interface) = outbound_interface {
-            #[cfg(any(
-                target_os = "android",
-                target_os = "fuchsia",
-                target_os = "illumos",
-                target_os = "ios",
-                target_os = "linux",
-                target_os = "macos",
-                target_os = "solaris",
-                target_os = "tvos",
-                target_os = "visionos",
-                target_os = "watchos",
-            ))]
-            {
+    let builder = reqwest::Client::builder();
+
+    // `reqwest::ClientBuilder::interface` is unavailable on Windows. Keep
+    // the binding code behind the same target gate so a Windows build does
+    // not report the builder as unnecessarily mutable or the interface as an
+    // unused variable.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "solaris",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    ))]
+    let builder = {
+        let mut builder = builder;
+        if mode == ControlProxyMode::Direct
+            && server_url.is_some_and(|url| !control_server_is_local(url))
+        {
+            if let Some(interface) = outbound_interface {
                 builder = builder.interface(interface);
             }
         }
-    }
+        builder
+    };
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "solaris",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+    )))]
+    let builder = {
+        let _ = outbound_interface;
+        builder
+    };
+
     let client = match mode {
         ControlProxyMode::Direct => builder.no_proxy().build(),
         ControlProxyMode::Environment => builder.build(),

--- a/client/daemon/src/control/runtime/critical.rs
+++ b/client/daemon/src/control/runtime/critical.rs
@@ -228,7 +228,7 @@ async fn run_candidate_offer_worker(
         let remaining = deadline.saturating_duration_since(Instant::now());
         let result = match http.current() {
             Err(error) => Err(error),
-            Ok(current_http) if remaining.is_zero() => Err(DaemonError::ControlPlane(
+            Ok(_) if remaining.is_zero() => Err(DaemonError::ControlPlane(
                 "candidate offer deadline exceeded before delivery".into(),
             )),
             Ok(current_http) => loop {

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -60,8 +60,7 @@ impl MtuState {
     /// The next size the caller should probe, or `None` when probing is done
     /// (the largest ladder size that succeeded is the effective MTU).
     pub fn next_probe(&self) -> Option<u32> {
-        self.next_index
-            .and_then(|i| MTU_LADDER.get(i).copied())
+        self.next_index.and_then(|i| MTU_LADDER.get(i).copied())
     }
 
     /// The effective path MTU: the largest size confirmed possible.  For a
@@ -170,6 +169,8 @@ mod tests {
 
     #[test]
     fn ipv6_safe_min_is_at_least_floor() {
-        assert!(IPV6_SAFE_MIN_MTU >= MTU_FLOOR);
+        const {
+            assert!(IPV6_SAFE_MIN_MTU >= MTU_FLOOR);
+        }
     }
 }

--- a/client/daemon/src/lib.rs
+++ b/client/daemon/src/lib.rs
@@ -38,15 +38,18 @@ pub mod control;
 pub mod dataplane;
 pub mod diagnostics;
 pub mod dns;
+// The bounded MTU decision state is currently exercised as a pure module and
+// is not wired into the live probe scheduler yet.
+#[allow(dead_code)]
 pub(crate) mod dplpmtud;
 pub mod error;
 pub mod gateway_mapping;
 pub mod incarnation;
 pub mod netenv;
 mod network_outbound;
+pub(crate) mod path_commit;
 pub mod peer;
 pub mod port_mapping;
-pub(crate) mod path_commit;
 pub mod relay;
 pub(crate) mod relay_probe;
 pub(crate) mod relay_runtime;

--- a/client/daemon/src/lib/tests/part02a.rs
+++ b/client/daemon/src/lib/tests/part02a.rs
@@ -773,10 +773,10 @@ fn malformed_and_zero_generation_labels_do_not_claim_fresh_budget() {
     }
     assert!(
         candidates.iter().all(|endpoint| {
-            !crate::parse_fresh_prediction_source_label(
+            crate::parse_fresh_prediction_source_label(
                 sources.get(endpoint).map(String::as_str).unwrap_or(""),
             )
-            .is_some()
+            .is_none()
         }),
         "no malformed/zero label may be treated as a valid fresh prediction"
     );

--- a/client/daemon/src/netenv.rs
+++ b/client/daemon/src/netenv.rs
@@ -263,6 +263,7 @@ pub fn parse_route_get_interface(output: &str) -> Option<String> {
         .filter(|name| !name.is_empty())
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn parse_route_get_gateway(output: &str) -> Option<String> {
     output
         .lines()
@@ -316,6 +317,7 @@ fn parse_route_default_path(output: &str) -> Option<(String, Option<String>)> {
     None
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn parse_physical_default_path(output: &str) -> Option<(String, Option<String>)> {
     output.lines().find_map(|line| {
         let trimmed = line.trim();
@@ -724,6 +726,7 @@ default            10.0.0.1           UGScg           utun3
         );
     }
 
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn physical_default_parser_skips_split_tun_route() {
         let output = "default 10.0.0.1 UGScg utun23\n\
@@ -734,6 +737,7 @@ default 192.168.0.1 UGScg en5\n";
         );
     }
 
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn physical_selection_rejects_own_excluded_tun() {
         let output = "default 10.0.0.1 UGScg utun9\n\

--- a/client/daemon/src/network_outbound.rs
+++ b/client/daemon/src/network_outbound.rs
@@ -1340,7 +1340,7 @@ async fn maintenance(
     let expired: Vec<String> = {
         let mut expired = Vec::new();
         for (peer_id, entry) in pending.iter() {
-            if !entry.wait_deadline.is_some_and(|deadline| now >= deadline) {
+            if entry.wait_deadline.is_none_or(|deadline| now < deadline) {
                 continue;
             }
             let relay_available = relay_transport.read().await.is_some();

--- a/client/daemon/src/path_commit.rs
+++ b/client/daemon/src/path_commit.rs
@@ -173,7 +173,8 @@ mod tests {
     #[test]
     fn path_commit_payload_build_and_parse_round_trip() {
         for kind in [PathCommitKind::Request, PathCommitKind::Ack] {
-            let payload = build_path_commit_payload(kind, 0x1122_3344_5566_7788, 0x1234, 0xdead_beef);
+            let payload =
+                build_path_commit_payload(kind, 0x1122_3344_5566_7788, 0x1234, 0xdead_beef);
             let packet = Ipv4Packet::build_icmp_echo_request(
                 "10.20.0.1".parse().unwrap(),
                 "10.20.0.2".parse().unwrap(),

--- a/client/daemon/src/peer/connection/candidates.rs
+++ b/client/daemon/src/peer/connection/candidates.rs
@@ -371,10 +371,10 @@ impl PeerConnection {
     ) -> usize {
         if self.state != ConnectionState::Direct
             || self.direct_health.consecutive_failures != 0
-            || !self
+            || self
                 .direct_health
                 .success_age()
-                .is_some_and(|age| age <= RELAY_PEER_CONFIRMATION_MAX_AGE)
+                .is_none_or(|age| age > RELAY_PEER_CONFIRMATION_MAX_AGE)
             || !self.candidate_pairs.iter().any(|pair| {
                 pair.local_generation == local_generation
                     && pair.state == CandidatePairState::Selected

--- a/client/daemon/src/peer/connection/health.rs
+++ b/client/daemon/src/peer/connection/health.rs
@@ -566,10 +566,10 @@ impl PeerConnection {
     pub(crate) fn direct_is_healthy_confirmed(&self) -> bool {
         if self.state != ConnectionState::Direct
             || self.direct_health.consecutive_failures != 0
-            || !self
+            || self
                 .direct_health
                 .success_age()
-                .is_some_and(|age| age <= RELAY_PEER_CONFIRMATION_MAX_AGE)
+                .is_none_or(|age| age > RELAY_PEER_CONFIRMATION_MAX_AGE)
         {
             return false;
         }

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -2829,17 +2829,16 @@ impl WireGuardTransport {
                             if let Some(path_token) = path_commit {
                                 if relay_endpoint.is_some() {
                                     let path_kind = path_token.kind;
-                                    let path_session_guard = if path_kind
-                                        == crate::path_commit::PathCommitKind::Ack
-                                    {
-                                        self.acquire_current_session_evidence_guard(
-                                            &inbound.peer_id,
-                                            inbound.session_instance,
-                                        )
-                                        .await
-                                    } else {
-                                        None
-                                    };
+                                    let path_session_guard =
+                                        if path_kind == crate::path_commit::PathCommitKind::Ack {
+                                            self.acquire_current_session_evidence_guard(
+                                                &inbound.peer_id,
+                                                inbound.session_instance,
+                                            )
+                                            .await
+                                        } else {
+                                            None
+                                        };
                                     let path_session_current = if inbound.session_instance.is_none()
                                     {
                                         true
@@ -3246,21 +3245,19 @@ impl WireGuardTransport {
                                             Some(detail),
                                         );
                                     }
-                                } else {
-                                    if let Some(timeline) = feed.timeline.as_ref() {
-                                        timeline.emit(
-                                            "stale_session_evidence",
-                                            Some(match path {
-                                                crate::peer::NetworkPath::Relay => "relay",
-                                                crate::peer::NetworkPath::Direct => "direct",
-                                            }),
-                                            Some("session_replaced_or_removed"),
-                                            Some(format!(
-                                                "peer={} session_instance={:?} business_ingress=stale",
-                                                inbound.peer_id, inbound.session_instance,
-                                            )),
-                                        );
-                                    }
+                                } else if let Some(timeline) = feed.timeline.as_ref() {
+                                    timeline.emit(
+                                        "stale_session_evidence",
+                                        Some(match path {
+                                            crate::peer::NetworkPath::Relay => "relay",
+                                            crate::peer::NetworkPath::Direct => "direct",
+                                        }),
+                                        Some("session_replaced_or_removed"),
+                                        Some(format!(
+                                            "peer={} session_instance={:?} business_ingress=stale",
+                                            inbound.peer_id, inbound.session_instance,
+                                        )),
+                                    );
                                 }
                                 drop(session_guard);
                             }

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -94,9 +94,9 @@ fn remove_heartbeat_lease_if_owned(
     peer_id: &str,
     owner_token: u64,
 ) -> bool {
-    if !leases
+    if leases
         .get(peer_id)
-        .is_some_and(|lease| lease.owner_token == owner_token)
+        .is_none_or(|lease| lease.owner_token != owner_token)
     {
         return false;
     }

--- a/client/nat/src/adaptive.rs
+++ b/client/nat/src/adaptive.rs
@@ -445,7 +445,7 @@ mod tests {
         // The dominant mode is -1, so the estimate must land negative or at
         // least not be clamped up to a positive stride.
         assert!(
-            learner.estimate().map_or(true, |e| e <= 0),
+            learner.estimate().is_none_or(|e| e <= 0),
             "a reversing batch must not yield a positive clamped stride, got {:?}",
             learner.estimate()
         );

--- a/client/nat/src/client.rs
+++ b/client/nat/src/client.rs
@@ -340,13 +340,19 @@ mod tests {
             let mut response =
                 StunMessage::with_transaction_id(BINDING_RESPONSE, req.transaction_id);
             response.add_attribute(StunAttribute::XorMappedAddress(client_addr));
-            socket.send_to(&response.encode(), client_addr).await.unwrap();
+            socket
+                .send_to(&response.encode(), client_addr)
+                .await
+                .unwrap();
         });
 
         let client_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let stun = StunClient::with_timeout(Duration::from_secs(1));
         let response = stun.binding_request(&client_socket, addr).await.unwrap();
-        assert_eq!(response.reflexive_address, Some(client_socket.local_addr().unwrap()));
+        assert_eq!(
+            response.reflexive_address,
+            Some(client_socket.local_addr().unwrap())
+        );
     }
 
     #[tokio::test]

--- a/client/nat/src/mapping.rs
+++ b/client/nat/src/mapping.rs
@@ -557,9 +557,9 @@ fn build_model_from_gapped(
     for observation in &successful_obs {
         match previous_sequence {
             Some(previous) if observation.sequence.saturating_sub(previous) == 1 => {
-                runs.last_mut().expect("a run always exists after the first push").push(
-                    observation.observed.port(),
-                );
+                runs.last_mut()
+                    .expect("a run always exists after the first push")
+                    .push(observation.observed.port());
             }
             _ => runs.push(vec![observation.observed.port()]),
         }
@@ -567,7 +567,11 @@ fn build_model_from_gapped(
     }
 
     // Prefer the longest gap-free run; trust it only when it is single-direction.
-    if let Some(run) = runs.iter().filter(|run| run.len() >= 3).max_by_key(|run| run.len()) {
+    if let Some(run) = runs
+        .iter()
+        .filter(|run| run.len() >= 3)
+        .max_by_key(|run| run.len())
+    {
         let model = build_model(run, public_ip, batch.started_at_ms);
         let forward = model.deltas.iter().filter(|delta| **delta > 0).count();
         let backward = model.deltas.iter().filter(|delta| **delta < 0).count();
@@ -1521,7 +1525,11 @@ mod tests {
         // override the model's signed step on a sign conflict, or the top
         // candidate walks up to 30003 and misses the real next mapping 29991.
         let model = build_model(&[30000, 29997, 29994], Some(ip()), 1000);
-        assert!(matches!(model.kind, PortModelKind::FixedStep { step: -3 }), "{:?}", model.kind);
+        assert!(
+            matches!(model.kind, PortModelKind::FixedStep { step: -3 }),
+            "{:?}",
+            model.kind
+        );
         let predicted = predict_ports_with_learning(&model, 29994, 0, 0, Some(3), true);
         assert_eq!(
             predicted.first().map(|c| c.port),
@@ -1621,7 +1629,10 @@ mod tests {
         // the same port twice — and never port 0.
         let ports = [1000u16, 17384, 33768]; // +16384 each -> FixedStep{16384}
         let model = build_model(&ports, Some(ip()), 1000);
-        assert!(matches!(model.kind, PortModelKind::FixedStep { step: 16384 }));
+        assert!(matches!(
+            model.kind,
+            PortModelKind::FixedStep { step: 16384 }
+        ));
         for last in [33768u16, 50152, 65000] {
             let predicted = predict_ports(&model, last);
             let mut seen = std::collections::HashSet::new();

--- a/client/relay/src/auth.rs
+++ b/client/relay/src/auth.rs
@@ -64,6 +64,7 @@ impl RelayErrorCode {
     pub const NETWORK_MISMATCH: u16 = 4016;
     pub const TICKET_NOT_YET_VALID: u16 = 4017;
     pub const UNKNOWN_TICKET_KEY: u16 = 4018;
+    pub const AUTH_RATE_LIMITED: u16 = 4019;
 }
 
 // ============================================================

--- a/client/relay/src/auth/tests.rs
+++ b/client/relay/src/auth/tests.rs
@@ -394,14 +394,15 @@ use super::*;
             RelayErrorCode::NETWORK_MISMATCH,
             RelayErrorCode::TICKET_NOT_YET_VALID,
             RelayErrorCode::UNKNOWN_TICKET_KEY,
+            RelayErrorCode::AUTH_RATE_LIMITED,
         ];
 
         let mut seen = std::collections::HashSet::new();
         for &code in &codes {
             assert!(seen.insert(code), "duplicate error code: {code}");
             assert!(
-                (4011..=4018).contains(&code),
-                "error code {code} outside expected range 4011-4018"
+                (4011..=4019).contains(&code),
+                "error code {code} outside expected range 4011-4019"
             );
         }
     }

--- a/client/relay/src/error.rs
+++ b/client/relay/src/error.rs
@@ -112,6 +112,7 @@ pub enum RelayErrorCode {
     NetworkMismatch = 4016,
     TicketNotYetValid = 4017,
     UnknownTicketKey = 4018,
+    AuthRateLimited = 4019,
 }
 
 impl RelayErrorCode {
@@ -136,6 +137,7 @@ impl RelayErrorCode {
             4016 => Some(Self::NetworkMismatch),
             4017 => Some(Self::TicketNotYetValid),
             4018 => Some(Self::UnknownTicketKey),
+            4019 => Some(Self::AuthRateLimited),
             _ => None,
         }
     }
@@ -165,6 +167,7 @@ impl RelayErrorCode {
             Self::NetworkMismatch => "network_mismatch",
             Self::TicketNotYetValid => "ticket_not_yet_valid",
             Self::UnknownTicketKey => "unknown_ticket_key",
+            Self::AuthRateLimited => "auth_rate_limited",
         }
     }
 }
@@ -255,5 +258,13 @@ mod tests {
         );
         let err = RelayError::ServerError(4008, "backpressure".into());
         assert_eq!(err.to_snake_case(), "peer_backpressure");
+        assert_eq!(
+            RelayErrorCode::from_u16(4019),
+            Some(RelayErrorCode::AuthRateLimited)
+        );
+        assert_eq!(
+            RelayError::ServerError(4019, "authentication rate limited".into()).to_snake_case(),
+            "auth_rate_limited"
+        );
     }
 }

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.119",
+  "version": "0.1.120",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",


### PR DESCRIPTION
## Summary
- carry the verified post-optimization networking/security fixes into `main`
- make Rust stable fmt/Clippy gates pass on Linux and Windows
- bump Cargo/Flutter/status contract versions to `0.1.120`

## Validation
- Flutter format/analyze/tests: 423 passed
- Rust fmt/clippy/workspace tests: pass
- Go vet/tests: pass
- daemon release identity gate: pass
- macOS debug/release bundle: pass

Release tag `v0.1.120` will be pushed only after the required checks pass.
