### PR TITLE
fix(ci): restore macOS Pod files before release identity gate

### DIFF
--- a/scripts/release/hermetic_build.sh
+++ b/scripts/release/hermetic_build.sh
@@ -3,7 +3,7 @@
 #
 # Flutter `pub get` / `flutter build` re-resolves SDK-pinned transitive files
 # (apps/flutter_client/pubspec.lock, analysis_options.yaml, .metadata and, on
-# macOS, Runner.xcodeproj/project.pbxproj), stamping the source checkout dirty
+# macOS, the CocoaPods/Xcode project files), stamping the source checkout dirty
 # AFTER each release build.  The release workflow historically compensated
 # with repeated `git checkout --` blocks (9 sites).  This helper centralizes
 # that compensation and — more usefully — lets a job assert the invariant the
@@ -54,10 +54,19 @@ do_restore() {
     fi
   done
   if [ "$macos" -eq 1 ]; then
-    local pbx="apps/flutter_client/macos/Runner.xcodeproj/project.pbxproj"
-    if [ -e "$pbx" ]; then
-      files+=("$pbx")
-    fi
+    # `flutter build macos` may run pod install and update both the Podfile
+    # inputs and the generated lockfile in addition to the Xcode project.
+    # Restore every tracked macOS integration file that Flutter/CocoaPods can
+    # migrate so the release identity gate sees the original checkout.
+    local macos_file
+    for macos_file in \
+      "apps/flutter_client/macos/Podfile" \
+      "apps/flutter_client/macos/Podfile.lock" \
+      "apps/flutter_client/macos/Runner.xcodeproj/project.pbxproj"; do
+      if [ -e "$macos_file" ]; then
+        files+=("$macos_file")
+      fi
+    done
   fi
   if [ "${#files[@]}" -gt 0 ]; then
     git checkout -- "${files[@]}"

--- a/scripts/release/test_hermetic_build.sh
+++ b/scripts/release/test_hermetic_build.sh
@@ -6,10 +6,13 @@ trap 'rm -rf "$TMP"' EXIT
 cd "$TMP"
 git init -q
 git config user.email t@t; git config user.name t
-mkdir -p apps/flutter_client
+mkdir -p apps/flutter_client/macos/Runner.xcodeproj
 echo v1 > apps/flutter_client/pubspec.lock
 echo analysis > apps/flutter_client/analysis_options.yaml
 echo meta > apps/flutter_client/.metadata
+echo podfile-v1 > apps/flutter_client/macos/Podfile
+echo podlock-v1 > apps/flutter_client/macos/Podfile.lock
+echo pbx-v1 > apps/flutter_client/macos/Runner.xcodeproj/project.pbxproj
 git add -A && git commit -qm init
 
 "$HELPER" check >/dev/null && echo "check-clean-PASS"
@@ -21,6 +24,15 @@ echo "check-dirty-FAILS-PASS"
 "$HELPER" restore >/dev/null
 [ "$(cat apps/flutter_client/pubspec.lock)" = "v1" ] || { echo "ERROR: restore failed"; exit 1; }
 "$HELPER" check >/dev/null && echo "restore-AND-check-clean-PASS"
+
+printf 'podfile-v2\n' > apps/flutter_client/macos/Podfile
+printf 'podlock-v2\n' > apps/flutter_client/macos/Podfile.lock
+printf 'pbx-v2\n' > apps/flutter_client/macos/Runner.xcodeproj/project.pbxproj
+"$HELPER" restore --macos >/dev/null
+[ "$(cat apps/flutter_client/macos/Podfile)" = "podfile-v1" ] || { echo "ERROR: macOS Podfile restore failed"; exit 1; }
+[ "$(cat apps/flutter_client/macos/Podfile.lock)" = "podlock-v1" ] || { echo "ERROR: macOS Podfile.lock restore failed"; exit 1; }
+[ "$(cat apps/flutter_client/macos/Runner.xcodeproj/project.pbxproj)" = "pbx-v1" ] || { echo "ERROR: macOS project restore failed"; exit 1; }
+"$HELPER" check >/dev/null && echo "macos-restore-AND-check-clean-PASS"
 
 touch scratch.json
 "$HELPER" check >/dev/null


### PR DESCRIPTION
The macOS release jobs run CocoaPods during `flutter build macos`, which mutates tracked `macos/Podfile` and `macos/Podfile.lock`. Restore them with the existing Xcode project before the release identity gate.

- extend hermetic restore for macOS Podfile/Podfile.lock
- add regression coverage
- local shell and release identity tests pass