### PR TITLE
fix(windows): stabilize startup ACL and tray events

### DIFF
--- a/.github/workflows/flutter-client.yml
+++ b/.github/workflows/flutter-client.yml
@@ -329,11 +329,14 @@ jobs:
         working-directory: apps/flutter_client
         run: .\scripts\bundle_msvc_runtime.ps1 -DestinationDirectory "build\windows\x64\runner\Release"
 
-      - name: Run Windows daemon binary probe integration
+      - name: Run Windows startup integration tests
         working-directory: apps/flutter_client
         env:
           P2WLAN_DAEMON_BIN: ${{ github.workspace }}/apps/flutter_client/build/windows/x64/runner/Release/p2wlan-daemon.exe
-        run: flutter test test/windows_binary_probe_integration_test.dart
+        run: >
+          flutter test
+          test/windows_binary_probe_integration_test.dart
+          test/windows_tray_event_contract_test.dart
 
       - name: Pack Windows bundle
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,11 +455,14 @@ jobs:
           --release
           --split-debug-info build/symbols/windows-${{ matrix.arch }}
 
-      - name: Run Windows daemon binary probe integration
+      - name: Run Windows startup integration tests
         working-directory: apps/flutter_client
         env:
           P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
-        run: flutter test test/windows_binary_probe_integration_test.dart
+        run: >
+          flutter test
+          test/windows_binary_probe_integration_test.dart
+          test/windows_tray_event_contract_test.dart
 
       - name: Install Inno Setup
         shell: pwsh

--- a/apps/flutter_client/lib/app/desktop_tray_controller.dart
+++ b/apps/flutter_client/lib/app/desktop_tray_controller.dart
@@ -15,6 +15,11 @@ import 'app_constants.dart';
 import 'app_strings.dart';
 import 'desktop_window_operations.dart';
 
+/// The native Windows tray plug-in dispatches its click notifications through
+/// the `MouseDown` listener callbacks. Other desktop implementations retain
+/// the established `MouseUp` menu behavior.
+enum DesktopTrayPointerAction { showWindow, contextMenu }
+
 class DesktopTrayController with TrayListener, WindowListener {
   DesktopTrayController({
     required this.settingsStore,
@@ -114,13 +119,64 @@ class DesktopTrayController with TrayListener, WindowListener {
   }
 
   @override
+  void onTrayIconMouseDown() {
+    _handleTrayPointer(mouseDown: true, rightButton: false);
+  }
+
+  @override
+  void onTrayIconRightMouseDown() {
+    _handleTrayPointer(mouseDown: true, rightButton: true);
+  }
+
+  @override
   void onTrayIconMouseUp() {
-    unawaited(trayManager.popUpContextMenu());
+    _handleTrayPointer(mouseDown: false, rightButton: false);
   }
 
   @override
   void onTrayIconRightMouseUp() {
-    unawaited(trayManager.popUpContextMenu());
+    _handleTrayPointer(mouseDown: false, rightButton: true);
+  }
+
+  void _handleTrayPointer({
+    required bool mouseDown,
+    required bool rightButton,
+  }) {
+    switch (trayPointerActionForTesting(
+      isWindows: Platform.isWindows,
+      mouseDown: mouseDown,
+      rightButton: rightButton,
+    )) {
+      case DesktopTrayPointerAction.showWindow:
+        unawaited(_showWindow());
+        break;
+      case DesktopTrayPointerAction.contextMenu:
+        unawaited(trayManager.popUpContextMenu());
+        break;
+      case null:
+        break;
+    }
+  }
+
+  /// Maps a native tray notification to one application action.
+  ///
+  /// On Windows, tray_manager 0.5.x sends the callbacks named `MouseDown`
+  /// from the Windows native handler even though the underlying message is a
+  /// button-up notification. Handling only that side avoids a second menu
+  /// after upgrading or changing the native plug-in implementation.
+  @visibleForTesting
+  static DesktopTrayPointerAction? trayPointerActionForTesting({
+    required bool isWindows,
+    required bool mouseDown,
+    required bool rightButton,
+  }) {
+    if (isWindows) {
+      if (!mouseDown) return null;
+      return rightButton
+          ? DesktopTrayPointerAction.contextMenu
+          : DesktopTrayPointerAction.showWindow;
+    }
+    return mouseDown ? null : DesktopTrayPointerAction.contextMenu;
   }
 
   void _scheduleMenuUpdate() {

--- a/apps/flutter_client/lib/core/daemon/daemon_controller.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller.dart
@@ -211,6 +211,11 @@ class DaemonController {
       if (Platform.isWindows) await protectRuntimeDirectory(logDir);
       await startupTrace?.stageOk(5, 'runtime_acl');
     } catch (error) {
+      await _recordWindowsStartupError(
+        startupTrace,
+        '05 runtime_acl ERROR',
+        error,
+      );
       return _startupFailure(
         startupTrace,
         stage: 5,
@@ -221,33 +226,62 @@ class DaemonController {
 
     await startupTrace?.stageStart(6, 'launch_token');
     if (!useManualMode && (requiresElevation || Platform.isWindows)) {
-      try {
-        tokenFile = await createEphemeralLaunchTokenFile(logDir, authToken);
+      if (Platform.isWindows) {
+        // Stage 05 is the sole owner of the runtime-directory DACL. Rewriting
+        // it here can fail independently and used to be misreported as a
+        // token-access failure before UAC was even requested.
+        await startupTrace?.detail('06a stale_cleanup START');
+        try {
+          await cleanupStaleLaunchTokenFiles(logDir);
+          await startupTrace?.detail('06a stale_cleanup OK');
+        } catch (error) {
+          return _launchTokenStartupFailure(
+            startupTrace,
+            substage: 'stale_cleanup',
+            error: error,
+          );
+        }
+
+        await startupTrace?.detail('06b token_write START');
+        late final File writtenToken;
+        try {
+          writtenToken = await writeEphemeralLaunchTokenFile(logDir, authToken);
+          tokenFile = writtenToken;
+          await startupTrace?.detail('06b token_write OK');
+        } catch (error) {
+          return _launchTokenStartupFailure(
+            startupTrace,
+            substage: 'token_write',
+            error: error,
+          );
+        }
+
+        await startupTrace?.detail('06c token_acl START');
+        try {
+          await protectEphemeralLaunchTokenFile(writtenToken);
+          await startupTrace?.detail('06c token_acl OK');
+        } catch (error) {
+          try {
+            await deleteEphemeralLaunchTokenFile(writtenToken);
+          } catch (_) {}
+          return _launchTokenStartupFailure(
+            startupTrace,
+            substage: 'token_acl',
+            error: error,
+          );
+        }
         await startupTrace?.stageOk(6, 'launch_token');
-      } catch (error) {
-        return _startupFailure(
-          startupTrace,
-          stage: 6,
-          code: Platform.isWindows
-              ? DaemonStartupFailureCode.tokenAccessFailed
-              : _failureCodeForError(error),
-          message: _startFailureMessage(error),
-        );
-      }
-    } else if (Platform.isWindows) {
-      try {
-        // Manual/offline mode has no launch token, but an elevated daemon
-        // still needs the same user/admin ACL on the runtime directory for
-        // its log, PID marker, and diagnostics session file.
-        await protectRuntimeDirectory(logDir);
-        await startupTrace?.stageOk(6, 'launch_token');
-      } catch (error) {
-        return _startupFailure(
-          startupTrace,
-          stage: 6,
-          code: _failureCodeForError(error),
-          message: _startFailureMessage(error),
-        );
+      } else {
+        try {
+          tokenFile = await createEphemeralLaunchTokenFile(logDir, authToken);
+          await startupTrace?.stageOk(6, 'launch_token');
+        } catch (error) {
+          return _launchTokenStartupFailure(
+            startupTrace,
+            substage: 'token_prepare',
+            error: error,
+          );
+        }
       }
     } else {
       await startupTrace?.stageSkipped(6, 'launch_token');
@@ -307,10 +341,9 @@ class DaemonController {
       await logDir.create(recursive: true);
       if (Platform.isWindows) {
         // The daemon may run under the alternate administrator selected in
-        // the UAC prompt. Grant only the interactive SID and local
-        // Administrators (never Everyone) access to both runtime roots.
+        // the UAC prompt. The log directory DACL was completed once in stage
+        // 05; only the config root needs protection here.
         await protectRuntimeDirectory(configPath.parent);
-        await protectRuntimeDirectory(logDir);
         if (await configPath.exists()) {
           await _restrictLaunchPath(configPath.path);
         }
@@ -335,6 +368,11 @@ class DaemonController {
       try {
         await deleteEphemeralLaunchTokenFile(tokenFile);
       } catch (_) {}
+      await _recordWindowsStartupError(
+        startupTrace,
+        '07 log_prepare ERROR',
+        error,
+      );
       return _startupFailure(
         startupTrace,
         stage: 7,
@@ -595,6 +633,37 @@ class DaemonController {
       manualCommand: manualCommand,
       failureCode: code,
     );
+  }
+
+  Future<DaemonCommandResult> _launchTokenStartupFailure(
+    WindowsStartupTrace? trace, {
+    required String substage,
+    required Object error,
+  }) async {
+    final code = Platform.isWindows
+        ? windowsLaunchTokenFailureCodeForError(error)
+        : _failureCodeForError(error);
+    await _recordWindowsStartupError(trace, '06 $substage ERROR', error);
+    final message = Platform.isWindows
+        ? switch (code) {
+            DaemonStartupFailureCode.aclFailure =>
+              '[ACL_FAILURE] 无法为启动凭据设置安全 Windows ACL。',
+            _ => '[TOKEN_ACCESS_FAILED] 无法准备安全的一次性 Windows 启动凭据。',
+          }
+        : _startFailureMessage(error);
+    return _startupFailure(trace, stage: 6, code: code, message: message);
+  }
+
+  Future<void> _recordWindowsStartupError(
+    WindowsStartupTrace? trace,
+    String prefix,
+    Object error,
+  ) async {
+    if (!Platform.isWindows) return;
+    final detail = error is WindowsAclProtectionException
+        ? error.diagnostic
+        : 'error=${_sanitizeProbeOutput(error.toString())}';
+    await trace?.detail('$prefix $detail');
   }
 
   DaemonStartupFailureCode _failureCodeForError(Object error) {

--- a/apps/flutter_client/lib/core/daemon/daemon_controller/launch_token.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller/launch_token.dart
@@ -1,5 +1,43 @@
 part of '../daemon_controller.dart';
 
+/// A failed Windows DACL write with redacted child-process diagnostics.
+///
+/// The launcher must distinguish ACL failures from token file failures: both
+/// happen before UAC, but only the former means the runtime root itself is
+/// unsafe. The raw helper output never leaves this object unredacted.
+class WindowsAclProtectionException implements Exception {
+  WindowsAclProtectionException({
+    required this.directory,
+    required this.exitCode,
+    required String stdout,
+    required String stderr,
+  }) : stdout = _sanitizeProbeOutput(stdout),
+       stderr = _sanitizeProbeOutput(stderr);
+
+  final bool directory;
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  String get diagnostic =>
+      'windows_acl target=${directory ? 'directory' : 'file'} '
+      'exitCode=$exitCode '
+      'stdout=$stdout '
+      'stderr=$stderr';
+
+  @override
+  String toString() => 'Windows ACL protection failed: $diagnostic';
+}
+
+/// Windows launch-token failures are deliberately more specific than the
+/// broad pre-UAC failure classifier. A token write remains a token failure;
+/// only a DACL write is an ACL failure.
+DaemonStartupFailureCode windowsLaunchTokenFailureCodeForError(Object error) {
+  return error is WindowsAclProtectionException
+      ? DaemonStartupFailureCode.aclFailure
+      : DaemonStartupFailureCode.tokenAccessFailed;
+}
+
 extension DaemonControllerLaunchToken on DaemonController {
   static final _launchTokenName = RegExp(r'^p2wlan-launch-[0-9a-f]+\.token$');
 
@@ -11,6 +49,26 @@ extension DaemonControllerLaunchToken on DaemonController {
     await protectRuntimeDirectory(runtimeDir);
     await cleanupStaleLaunchTokenFiles(runtimeDir);
 
+    final file = await writeEphemeralLaunchTokenFile(runtimeDir, token);
+    try {
+      await protectEphemeralLaunchTokenFile(file);
+      return file;
+    } catch (_) {
+      try {
+        if (await file.exists()) await file.delete();
+      } catch (_) {}
+      rethrow;
+    }
+  }
+
+  /// Write a token only after its containing runtime directory is protected.
+  ///
+  /// Windows startup uses this directly after stage 5 so it cannot rewrite the
+  /// runtime directory ACL a second time.
+  Future<File> writeEphemeralLaunchTokenFile(
+    Directory runtimeDir,
+    String token,
+  ) async {
     final random = math.Random.secure();
     final suffix = List.generate(
       16,
@@ -21,7 +79,6 @@ extension DaemonControllerLaunchToken on DaemonController {
     );
     try {
       await file.writeAsString(token, flush: true);
-      await _restrictLaunchPath(file.path);
       return file;
     } catch (_) {
       try {
@@ -29,6 +86,11 @@ extension DaemonControllerLaunchToken on DaemonController {
       } catch (_) {}
       rethrow;
     }
+  }
+
+  /// Protect a token file after it has been written.
+  Future<void> protectEphemeralLaunchTokenFile(File file) {
+    return _restrictLaunchPath(file.path);
   }
 
   Future<void> protectRuntimeDirectory(Directory runtimeDir) async {
@@ -84,6 +146,7 @@ extension DaemonControllerLaunchToken on DaemonController {
         '[void]\$acl.RemoveAccessRuleSpecific(\$rule) }; '
         '\$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User; '
         '\$adminSid = [System.Security.Principal.SecurityIdentifier]::new(\'S-1-5-32-544\'); '
+        '\$systemSid = [System.Security.Principal.SecurityIdentifier]::new(\'S-1-5-18\'); '
         '\$rights = [System.Security.AccessControl.FileSystemRights]::FullControl; '
         '\$inheritance = [System.Security.AccessControl.InheritanceFlags]::None; '
         'if (\'$directory\' -eq \'True\') { '
@@ -93,11 +156,15 @@ extension DaemonControllerLaunchToken on DaemonController {
         '\$allow = [System.Security.AccessControl.AccessControlType]::Allow; '
         '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$currentSid, \$rights, \$inheritance, \$propagation, \$allow)); '
         '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$adminSid, \$rights, \$inheritance, \$propagation, \$allow)); '
+        '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$systemSid, \$rights, \$inheritance, \$propagation, \$allow)); '
         'Set-Acl -LiteralPath $quotedPath -AclObject \$acl',
       );
       if (result.exitCode != 0) {
-        throw StateError(
-          'Windows ACL protection failed for the launch ${directory ? 'directory' : 'file'}',
+        throw WindowsAclProtectionException(
+          directory: directory,
+          exitCode: result.exitCode,
+          stdout: result.stdout.toString(),
+          stderr: result.stderr.toString(),
         );
       }
       return;

--- a/apps/flutter_client/lib/core/daemon/daemon_controller/launch_token.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller/launch_token.dart
@@ -136,7 +136,14 @@ extension DaemonControllerLaunchToken on DaemonController {
       // immediately after startup and is never a credential store.
       final quotedPath = _powershellSingleQuoted(path);
       final result = await _runWindowsPowerShell(
-        '\$acl = Get-Acl -LiteralPath $quotedPath; '
+        // Do not depend on Get-Acl/Set-Acl from Microsoft.PowerShell.Security:
+        // some non-interactive Windows children cannot load that module even
+        // though the underlying .NET access-control APIs are available.
+        '\$path = $quotedPath; '
+        'if (\'$directory\' -eq \'True\') { '
+        '\$acl = [System.IO.Directory]::GetAccessControl(\$path) '
+        '} else { '
+        '\$acl = [System.IO.File]::GetAccessControl(\$path) }; '
         // Remove inherited and pre-existing explicit ACEs first.  `/grant:r`
         // alone only replaces grants for the two named SIDs and can leave a
         // stale explicit Everyone/Users entry behind on a directory created
@@ -157,7 +164,10 @@ extension DaemonControllerLaunchToken on DaemonController {
         '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$currentSid, \$rights, \$inheritance, \$propagation, \$allow)); '
         '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$adminSid, \$rights, \$inheritance, \$propagation, \$allow)); '
         '\$acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(\$systemSid, \$rights, \$inheritance, \$propagation, \$allow)); '
-        'Set-Acl -LiteralPath $quotedPath -AclObject \$acl',
+        'if (\'$directory\' -eq \'True\') { '
+        '[System.IO.Directory]::SetAccessControl(\$path, \$acl) '
+        '} else { '
+        '[System.IO.File]::SetAccessControl(\$path, \$acl) }',
       );
       if (result.exitCode != 0) {
         throw WindowsAclProtectionException(

--- a/apps/flutter_client/test/daemon_controller_log_test.dart
+++ b/apps/flutter_client/test/daemon_controller_log_test.dart
@@ -148,6 +148,34 @@ void main() {
     },
   );
 
+  test(
+    'Windows token failures distinguish ACL errors and redact diagnostics',
+    () {
+      final aclError = WindowsAclProtectionException(
+        directory: false,
+        exitCode: 5,
+        stdout: 'token=should-not-leak',
+        stderr: 'secret=also-should-not-leak',
+      );
+
+      expect(
+        windowsLaunchTokenFailureCodeForError(aclError),
+        DaemonStartupFailureCode.aclFailure,
+      );
+      expect(
+        windowsLaunchTokenFailureCodeForError(
+          StateError('token file write failed'),
+        ),
+        DaemonStartupFailureCode.tokenAccessFailed,
+      );
+      expect(aclError.diagnostic, contains('exitCode=5'));
+      expect(aclError.diagnostic, contains('token=<redacted>'));
+      expect(aclError.diagnostic, contains('secret=<redacted>'));
+      expect(aclError.diagnostic, isNot(contains('should-not-leak')));
+      expect(aclError.diagnostic, isNot(contains('also-should-not-leak')));
+    },
+  );
+
   test('an unrelated relay 404 log is not an auth failure', () async {
     final log = await writeLog(
       'WARN p2pnet_daemon::relay: Received relay runtime error: code=404, '

--- a/apps/flutter_client/test/windows_binary_probe_integration_test.dart
+++ b/apps/flutter_client/test/windows_binary_probe_integration_test.dart
@@ -169,7 +169,7 @@ void main() {
       await controller.protectRuntimeDirectory(runtime);
       final currentSid = await _windowsCurrentUserSid(controller);
       _expectRestrictedWindowsAcl(
-        await _readWindowsAcl(controller, runtime.path),
+        await _readWindowsAcl(controller, runtime.path, directory: true),
         currentSid,
       );
 
@@ -183,7 +183,7 @@ void main() {
       await controller.protectEphemeralLaunchTokenFile(token);
       expect(await token.readAsString(), 'integration-launch-token');
       _expectRestrictedWindowsAcl(
-        await _readWindowsAcl(controller, token.path),
+        await _readWindowsAcl(controller, token.path, directory: false),
         currentSid,
       );
 
@@ -321,11 +321,16 @@ Future<String> _windowsCurrentUserSid(DaemonController controller) async {
 
 Future<_WindowsAclSnapshot> _readWindowsAcl(
   DaemonController controller,
-  String path,
-) async {
+  String path, {
+  required bool directory,
+}) async {
   final quotedPath = path.replaceAll("'", "''");
   final result = await controller.runWindowsPowerShellForTesting(
-    '\$acl = Get-Acl -LiteralPath \'$quotedPath\'; '
+    '\$path = \'$quotedPath\'; '
+    'if (\'$directory\' -eq \'true\') { '
+    '\$acl = [System.IO.Directory]::GetAccessControl(\$path) '
+    '} else { '
+    '\$acl = [System.IO.File]::GetAccessControl(\$path) }; '
     '\$sids = @(\$acl.Access | ForEach-Object { '
     'try { \$_.IdentityReference.Translate('
     '[System.Security.Principal.SecurityIdentifier]).Value } '

--- a/apps/flutter_client/test/windows_binary_probe_integration_test.dart
+++ b/apps/flutter_client/test/windows_binary_probe_integration_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -142,6 +143,55 @@ void main() {
     await Future<void>.delayed(const Duration(seconds: 1));
     expect(marker.existsSync(), isFalse);
   }, skip: !Platform.isWindows);
+
+  test(
+    'Windows ACL token preparation keeps only the required runtime access',
+    () async {
+      final root = await _createTempRoot();
+      addTearDown(() => _deleteTempRoot(root));
+      final api = DiagnosticsApi(authTokenReader: () async => null);
+      addTearDown(api.close);
+      final controller = DaemonController(diagnosticsApi: api);
+      final runtime = Directory('${root.path}${Platform.pathSeparator}runtime');
+      await runtime.create(recursive: true);
+      final stale = File(
+        '${runtime.path}${Platform.pathSeparator}'
+        'p2wlan-launch-abcdef0123456789.token',
+      );
+      await stale.writeAsString('expired');
+      await stale.setLastModified(
+        DateTime.now().subtract(const Duration(minutes: 11)),
+      );
+
+      // This is the production stage-05/06 sequence: protect the directory
+      // once, then clean stale files, write the new token, and protect only
+      // that token file.
+      await controller.protectRuntimeDirectory(runtime);
+      final currentSid = await _windowsCurrentUserSid(controller);
+      _expectRestrictedWindowsAcl(
+        await _readWindowsAcl(controller, runtime.path),
+        currentSid,
+      );
+
+      await controller.cleanupStaleLaunchTokenFiles(runtime);
+      expect(await stale.exists(), isFalse);
+
+      final token = await controller.writeEphemeralLaunchTokenFile(
+        runtime,
+        'integration-launch-token',
+      );
+      await controller.protectEphemeralLaunchTokenFile(token);
+      expect(await token.readAsString(), 'integration-launch-token');
+      _expectRestrictedWindowsAcl(
+        await _readWindowsAcl(controller, token.path),
+        currentSid,
+      );
+
+      await controller.deleteEphemeralLaunchTokenFile(token);
+      expect(await token.exists(), isFalse);
+    },
+    skip: !Platform.isWindows,
+  );
 }
 
 Future<Directory> _createTempRoot() {
@@ -253,4 +303,66 @@ String? _resolveWindowsDaemonBinary() {
     if (File(candidate).existsSync()) return File(candidate).absolute.path;
   }
   return null;
+}
+
+Future<String> _windowsCurrentUserSid(DaemonController controller) async {
+  final result = await controller.runWindowsPowerShellForTesting(
+    '[Security.Principal.WindowsIdentity]::GetCurrent().User.Value',
+  );
+  expect(result.exitCode, 0, reason: result.stderr.toString());
+  final sid = result.stdout.toString().trim();
+  expect(
+    RegExp(r'^S-\d-\d+(?:-\d+)+$').hasMatch(sid),
+    isTrue,
+    reason: result.stdout.toString(),
+  );
+  return sid;
+}
+
+Future<_WindowsAclSnapshot> _readWindowsAcl(
+  DaemonController controller,
+  String path,
+) async {
+  final quotedPath = path.replaceAll("'", "''");
+  final result = await controller.runWindowsPowerShellForTesting(
+    '\$acl = Get-Acl -LiteralPath \'$quotedPath\'; '
+    '\$sids = @(\$acl.Access | ForEach-Object { '
+    'try { \$_.IdentityReference.Translate('
+    '[System.Security.Principal.SecurityIdentifier]).Value } '
+    'catch { \$_.IdentityReference.Value } } | Sort-Object -Unique); '
+    '[pscustomobject]@{ '
+    'protected = [bool]\$acl.AreAccessRulesProtected; '
+    'sids = @(\$sids) '
+    '} | ConvertTo-Json -Compress',
+  );
+  expect(result.exitCode, 0, reason: result.stderr.toString());
+  final decoded = jsonDecode(result.stdout.toString().trim());
+  expect(
+    decoded,
+    isA<Map<String, dynamic>>(),
+    reason: result.stdout.toString(),
+  );
+  final json = decoded! as Map<String, dynamic>;
+  final rawSids = json['sids'];
+  final values = rawSids is List<Object?> ? rawSids : <Object?>[rawSids];
+  return _WindowsAclSnapshot(
+    isProtected: json['protected'] == true,
+    sids: values.whereType<String>().toSet(),
+  );
+}
+
+void _expectRestrictedWindowsAcl(_WindowsAclSnapshot acl, String currentSid) {
+  expect(acl.isProtected, isTrue);
+  expect(acl.sids, contains(currentSid));
+  expect(acl.sids, contains('S-1-5-32-544'));
+  expect(acl.sids, contains('S-1-5-18'));
+  expect(acl.sids, isNot(contains('S-1-1-0')));
+  expect(acl.sids, isNot(contains('S-1-5-32-545')));
+}
+
+class _WindowsAclSnapshot {
+  const _WindowsAclSnapshot({required this.isProtected, required this.sids});
+
+  final bool isProtected;
+  final Set<String> sids;
 }

--- a/apps/flutter_client/test/windows_tray_event_contract_test.dart
+++ b/apps/flutter_client/test/windows_tray_event_contract_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2wlan_flutter_client/app/desktop_tray_controller.dart';
+
+void main() {
+  test(
+    'Windows tray down-event contract restores the window or opens menu',
+    () {
+      expect(
+        DesktopTrayController.trayPointerActionForTesting(
+          isWindows: true,
+          mouseDown: true,
+          rightButton: false,
+        ),
+        DesktopTrayPointerAction.showWindow,
+      );
+      expect(
+        DesktopTrayController.trayPointerActionForTesting(
+          isWindows: true,
+          mouseDown: true,
+          rightButton: true,
+        ),
+        DesktopTrayPointerAction.contextMenu,
+      );
+
+      // Do not handle both callback names on Windows: that would make one
+      // native click restore/show a second menu after the down callback fired.
+      expect(
+        DesktopTrayController.trayPointerActionForTesting(
+          isWindows: true,
+          mouseDown: false,
+          rightButton: false,
+        ),
+        isNull,
+      );
+      expect(
+        DesktopTrayController.trayPointerActionForTesting(
+          isWindows: true,
+          mouseDown: false,
+          rightButton: true,
+        ),
+        isNull,
+      );
+    },
+  );
+
+  test('non-Windows tray behavior remains mouse-up context menus', () {
+    expect(
+      DesktopTrayController.trayPointerActionForTesting(
+        isWindows: false,
+        mouseDown: true,
+        rightButton: false,
+      ),
+      isNull,
+    );
+    expect(
+      DesktopTrayController.trayPointerActionForTesting(
+        isWindows: false,
+        mouseDown: false,
+        rightButton: false,
+      ),
+      DesktopTrayPointerAction.contextMenu,
+    );
+  });
+}

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.134",
+  "version": "0.1.137",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",


### PR DESCRIPTION
## Summary
- keep the Windows runtime-directory DACL write at startup stage 05 only
- split stage 06 into stale cleanup, token write, and token-file ACL with redacted child diagnostics
- preserve SYSTEM alongside the user SID and Administrators
- handle tray_manager Windows MouseDown callbacks without duplicate MouseUp behavior
- add real Windows daemon probe, ACL/token, and tray callback regression coverage

## Validation
- `dart format`
- `git diff --check`
- GitHub Actions Windows startup integration tests pending (no local build/test by request)

No Wintun, netsh, or route code changes.