### PR TITLE
release: v0.1.138

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "libc",
  "socket2",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-android-native"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "hex",
  "jni",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "clap",
  "libc",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "blake2",
  "bytes",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "dirs 5.0.1",
  "reqwest",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.137"
+version = "0.1.138"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.137"
+version = "0.1.138"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.137+137
+version: 0.1.138+138
 
 environment:
   sdk: ^3.11.0

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.137",
+  "version": "0.1.138",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",


### PR DESCRIPTION
## Release
- bump Cargo workspace version to `0.1.138`
- bump Flutter version/build number to `0.1.138+138`
- synchronize the shared status contract fixture

This release contains the merged Windows ACL/token and tray callback fixes from #6.

Validation: GitHub Actions pending; no local build/test by request.