### PR TITLE
fix(windows): pass MTU as a netsh assignment

### DIFF
--- a/client/tun/src/platform/windows/helpers.rs
+++ b/client/tun/src/platform/windows/helpers.rs
@@ -115,17 +115,9 @@ fn set_interface_address(name: &str, addr: Ipv4Addr, netmask: Ipv4Addr) -> Resul
 fn set_interface_mtu(name: &str, mtu: u32) -> Result<()> {
     info!("[tun] configuring MTU: interface={name} mtu={mtu}");
 
+    let args = crate::windows_command::netsh_set_mtu_args(name, mtu);
     let output = hidden_command("netsh")
-        .args([
-            "interface",
-            "ipv4",
-            "set",
-            "subinterface",
-            name,
-            "mtu",
-            &mtu.to_string(),
-            "store=persistent",
-        ])
+        .args(args)
         .output()
         .map_err(|e| Error::Platform(format!("failed to run netsh: {e}")))?;
 

--- a/client/tun/src/windows_command.rs
+++ b/client/tun/src/windows_command.rs
@@ -2,6 +2,21 @@ use crate::error::{Error, Result};
 
 const MAX_COMMAND_OUTPUT_CHARS: usize = 2048;
 
+/// Build the argv expected by `netsh interface ipv4 set subinterface`.
+/// `netsh` requires the MTU option to be passed as one `mtu=<value>`
+/// argument; splitting the name and value makes it parse `mtu` as the value.
+pub(crate) fn netsh_set_mtu_args(interface: &str, mtu: u32) -> [String; 7] {
+    [
+        "interface".to_string(),
+        "ipv4".to_string(),
+        "set".to_string(),
+        "subinterface".to_string(),
+        interface.to_string(),
+        format!("mtu={mtu}"),
+        "store=persistent".to_string(),
+    ]
+}
+
 /// Convert a Windows command result into a hard failure when the command did
 /// not complete successfully. Keeping this boundary independent of
 /// `std::process::Output` makes the failure semantics testable without
@@ -49,7 +64,23 @@ fn matches_sensitive_word(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::require_success;
+    use super::{netsh_set_mtu_args, require_success};
+
+    #[test]
+    fn mtu_argument_uses_netsh_assignment_syntax() {
+        assert_eq!(
+            netsh_set_mtu_args("P2WLAN Adapter", 1420),
+            [
+                "interface",
+                "ipv4",
+                "set",
+                "subinterface",
+                "P2WLAN Adapter",
+                "mtu=1420",
+                "store=persistent",
+            ]
+        );
+    }
 
     #[test]
     fn zero_exit_status_is_ok() {


### PR DESCRIPTION
## Summary
- pass the Windows netsh MTU option as one mtu=value argument
- centralize MTU argv construction so production and tests share the exact command shape
- add a regression test covering MTU 1420 and an interface name containing spaces

## Root cause
The daemon invoked netsh with separate mtu and 1420 arguments. netsh parsed the literal word mtu as the MTU value and exited with 无效 mtu 参数 (mtu), causing stage 11 MTU_CONFIG_FAILED.

## Validation
GitHub Actions only, per project request. No local build or test was run.