### PR TITLE
fix: recover direct path after remote daemon restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "libc",
  "socket2",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-android-native"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "hex",
  "jni",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "clap",
  "libc",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "blake2",
  "bytes",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "dirs 5.0.1",
  "reqwest",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.138"
+version = "0.1.139"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.138"
+version = "0.1.139"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.138+138
+version: 0.1.139+139
 
 environment:
   sdk: ^3.11.0

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -43,6 +43,23 @@ fn remove_deferred_initiator_handshake(
     queue.retain(|peer_info| peer_info.node_id != peer_id);
 }
 
+/// Re-advertise the current local candidate snapshot without blocking the
+/// serial control receiver. A remote daemon restart can invalidate the peer's
+/// copy of our candidates even when our own candidate snapshot did not change;
+/// this worker is the explicit lifecycle replay for that case.
+fn schedule_candidate_republication<'a>(
+    daemon: &'a Daemon,
+    work: &mut FuturesUnordered<ControlEventWork<'a>>,
+    peer_id: String,
+    reason: &'static str,
+) {
+    work.push(Box::pin(async move {
+        daemon
+            .publish_current_candidates_to_peer(&peer_id, reason)
+            .await;
+    }));
+}
+
 /// Responder offers have their own cooperative lane.  Candidate refresh,
 /// peer-reflexive HTTP and event-triggered initiator preparation may occupy
 /// the bounded general slow-work set, but a WireGuard answer must still be
@@ -1473,7 +1490,7 @@ impl Daemon {
                 offer = newest;
                 continue;
             }
-            if self
+            let remote_incarnation_reset = match self
                 .reset_peer_for_remote_incarnation_if_needed_for_identity(
                     &offer.from_node_id,
                     offer.candidate_generation,
@@ -1481,23 +1498,26 @@ impl Daemon {
                     RemoteIncarnationResetWork::PreserveResponder,
                 )
                 .await
-                .is_none()
             {
-                // The queued signal belongs to a retired public-key identity.
-                // Finish this exact owner turn normally so a newer queued offer
-                // can run and the per-peer responder lane cannot stay wedged.
-                offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
-                let Some(next) = self
-                    .pending_handshakes
-                    .lock()
-                    .await
-                    .finish_responder_work(&peer_id, reservation.owner)
-                else {
-                    return;
-                };
-                offer = next;
-                continue;
-            }
+                Some(changed) => changed,
+                None => {
+                    // The queued signal belongs to a retired public-key
+                    // identity. Finish this exact owner turn normally so a
+                    // newer queued offer can run and the per-peer responder
+                    // lane cannot stay wedged.
+                    offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
+                    let Some(next) = self
+                        .pending_handshakes
+                        .lock()
+                        .await
+                        .finish_responder_work(&peer_id, reservation.owner)
+                    else {
+                        return;
+                    };
+                    offer = next;
+                    continue;
+                }
+            };
             let Some(peer_session_generation) =
                 self.peers.peer_session_generation_sync(&offer.from_node_id)
             else {
@@ -1575,6 +1595,19 @@ impl Daemon {
             };
             self.apply_deferred_peer_offer_punch(&offer, candidate_apply_result, fresh_punch)
                 .await;
+
+            if remote_incarnation_reset && !*reservation.cancellation.borrow() {
+                // This is the critical Air-first recovery edge: the remote
+                // restart invalidated its stored copy of our candidates, while
+                // our local candidate hash may be unchanged. Replay it now so
+                // the two sides enter the same punch window without requiring
+                // a local daemon restart.
+                self.publish_current_candidates_to_peer(
+                    &peer_id,
+                    "remote incarnation candidate replay",
+                )
+                .await;
+            }
 
             if offer.handshake_init.is_empty() {
                 offer.complete_delivery(
@@ -2066,7 +2099,16 @@ impl Daemon {
                     }
                     _ = responder_work.next(), if !responder_work.is_empty() => {
                         // Responder workers own their per-peer pending state and
-                        // release it on every terminal/cancellation path.
+                        // release it on every terminal/cancellation path. Their
+                        // completion can also free a pending initiator's
+                        // reservation, so retry deferred roster work here even
+                        // when the general slow-work lane is otherwise idle.
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            )
+                            .await;
                     }
                     event = control_rx.recv() => {
                         let Some(event) = event else {
@@ -2262,6 +2304,26 @@ impl Daemon {
                                             .run_event_initiator_handshake(peer_info, reservation)
                                             .await;
                                     }));
+                                } else {
+                                    // Do not lose the roster edge merely because an
+                                    // older initiator is still preparing or waiting
+                                    // for its answer. The newest peer snapshot will
+                                    // be retried after a slow-work slot is released.
+                                    let queued = enqueue_deferred_initiator_handshake(
+                                        &mut deferred_initiators,
+                                        peer_info.clone(),
+                                    );
+                                    let reason_code = if queued {
+                                        "initiator_reservation_busy_queued"
+                                    } else {
+                                        "initiator_reservation_busy_queue_full"
+                                    };
+                                    self.timeline.emit(
+                                        "initiator_handshake_deferred",
+                                        None,
+                                        Some(reason_code),
+                                        Some(format!("peer={}", peer_info.node_id)),
+                                    );
                                 }
                             }
 
@@ -2428,6 +2490,19 @@ impl Daemon {
                                 )
                                 .await;
                         }
+                        if was_offline || update.public_key_changed {
+                            // A peer that comes back online has lost its copy of
+                            // our candidate snapshot. Replay it even when our
+                            // local snapshot/hash is unchanged; waiting for the
+                            // next NAT/ STUN change recreates the Air-first cold
+                            // start failure.
+                            schedule_candidate_republication(
+                                daemon,
+                                &mut responder_work,
+                                peer_info.node_id.clone(),
+                                "peer online lifecycle",
+                            );
+                        }
                         let should_start_initiator =
                             self.should_start_initiator_handshake(&peer_info);
                         if should_start_initiator
@@ -2485,6 +2560,25 @@ impl Daemon {
                                         .run_event_initiator_handshake(peer_info, reservation)
                                         .await;
                                 }));
+                            } else {
+                                // Preserve the newest online/endpoint update
+                                // instead of silently dropping the handshake
+                                // trigger while the previous owner is live.
+                                let queued = enqueue_deferred_initiator_handshake(
+                                    &mut deferred_initiators,
+                                    peer_info.clone(),
+                                );
+                                let reason_code = if queued {
+                                    "initiator_reservation_busy_queued"
+                                } else {
+                                    "initiator_reservation_busy_queue_full"
+                                };
+                                self.timeline.emit(
+                                    "initiator_handshake_deferred",
+                                    None,
+                                    Some(reason_code),
+                                    Some(format!("peer={}", peer_info.node_id)),
+                                );
                             }
                         }
                     }
@@ -2732,7 +2826,7 @@ impl Daemon {
                             continue;
                         }
 
-                        if self
+                        let remote_incarnation_reset = match self
                             .reset_peer_for_remote_incarnation_if_needed_for_identity(
                                 &from_node_id,
                                 candidate_generation,
@@ -2740,15 +2834,30 @@ impl Daemon {
                                 RemoteIncarnationResetWork::ClearAll,
                             )
                             .await
-                            .is_none()
                         {
-                            debug!(
-                                "Ignored peer offer from {from_node_id}: signal sender public key is stale"
-                            );
-                            if let Some(receipt) = delivery_receipt.as_ref() {
-                                receipt.complete(control::SignalApplyOutcome::TerminalRejected);
+                            Some(changed) => changed,
+                            None => {
+                                debug!(
+                                    "Ignored peer offer from {from_node_id}: signal sender public key is stale"
+                                );
+                                if let Some(receipt) = delivery_receipt.as_ref() {
+                                    receipt.complete(control::SignalApplyOutcome::TerminalRejected);
+                                }
+                                continue;
                             }
-                            continue;
+                        };
+                        if remote_incarnation_reset {
+                            // The peer's restart invalidated its copy of our
+                            // candidate snapshot. Replay our current set in a
+                            // separate worker; the responder admission below
+                            // remains latency-critical and is not delayed by
+                            // candidate publication.
+                            schedule_candidate_republication(
+                                daemon,
+                                &mut responder_work,
+                                from_node_id.clone(),
+                                "remote incarnation reset",
+                            );
                         }
                         // Admit the latency-critical responder before touching
                         // candidate/fresh-prediction state.  A candidate refresh
@@ -3040,7 +3149,7 @@ impl Daemon {
                         // remote daemon restarted. Fence the retired transport but
                         // preserve the exact local initiator that this answer is
                         // about to complete.
-                        if self
+                        let remote_incarnation_reset = match self
                             .reset_peer_for_remote_incarnation_if_needed_for_identity(
                                 &from_node_id,
                                 candidate_generation,
@@ -3052,16 +3161,18 @@ impl Daemon {
                                 },
                             )
                             .await
-                            .is_none()
                         {
-                            debug!(
-                                "Ignored peer answer from {from_node_id}: signal sender public key is stale"
-                            );
-                            if let Some(receipt) = answer_delivery_receipt.as_ref() {
-                                receipt.complete(control::SignalApplyOutcome::TerminalRejected);
+                            Some(changed) => changed,
+                            None => {
+                                debug!(
+                                    "Ignored peer answer from {from_node_id}: signal sender public key is stale"
+                                );
+                                if let Some(receipt) = answer_delivery_receipt.as_ref() {
+                                    receipt.complete(control::SignalApplyOutcome::TerminalRejected);
+                                }
+                                continue;
                             }
-                            continue;
-                        }
+                        };
                         // Consume the WireGuard answer before candidate refresh or
                         // fresh-mapping work. Those paths may perform HTTP/STUN
                         // I/O and must remain a background upgrade; delaying the
@@ -3163,6 +3274,19 @@ impl Daemon {
                                     );
                                 }
                             }
+                        }
+                        if remote_incarnation_reset {
+                            // The answer proves the remote incarnation is new,
+                            // but it does not carry our local candidate set. A
+                            // restart can therefore leave the peer punching an
+                            // obsolete local mapping forever. Replay our current
+                            // candidates after the answer transaction commits.
+                            schedule_candidate_republication(
+                                daemon,
+                                &mut responder_work,
+                                from_node_id.clone(),
+                                "remote incarnation answer",
+                            );
                         }
                         if let Some(receipt) = answer_delivery_receipt {
                             receipt.complete(answer_signal_outcome);
@@ -3266,6 +3390,17 @@ impl Daemon {
                         if let Some(receipt) = signal_delivery_receipt {
                             receipt.complete(control::SignalApplyOutcome::Applied);
                         }
+                        // An answer or lifecycle event may release an
+                        // initiator reservation without completing a future
+                        // in either cooperative lane. Revisit the newest
+                        // deferred roster edge before waiting for another
+                        // unrelated event.
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            )
+                            .await;
                     }
                 }
         }

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -568,6 +568,109 @@ async fn responder_remote_incarnation_reset_does_not_self_lock_lifecycle_arbiter
 }
 
 #[tokio::test]
+async fn remote_incarnation_replay_republishes_unchanged_local_candidates() {
+    use crate::control::TestControlSignal;
+    use std::sync::{Arc as StdArc, Mutex as StdMutex};
+
+    fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
+        0x4000_0000_0000_0000 | (incarnation << 21) | counter
+    }
+
+    let mut daemon = Daemon::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+    let peer_id = "peer-remote-replay-candidates";
+    let peer_identity = NodeIdentity::generate();
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            device_name: String::new(),
+            app_version: String::new(),
+            public_key: hex::encode(peer_identity.public_key()),
+            endpoint: "203.0.113.90:49000".to_string(),
+            nat_type: "Unknown".to_string(),
+            virtual_ip: "10.20.0.90".to_string(),
+            online: true,
+            last_seen: 0,
+            relay_rtt_ms: None,
+        })
+        .await;
+
+    let local_candidates = vec![
+        "203.0.113.91:49001".to_string(),
+        "203.0.113.91:49002".to_string(),
+    ];
+    let local_sources = HashMap::from([
+        (local_candidates[0].clone(), "stun_observed".to_string()),
+        (local_candidates[1].clone(), "predicted".to_string()),
+    ]);
+    daemon
+        .publish_candidate_snapshot(local_candidates.clone(), local_sources, Vec::new())
+        .await;
+    let before_replay = daemon.current_local_candidate_set().await;
+
+    let udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), daemon.peers.clone())
+        .await
+        .unwrap();
+    *daemon.udp_transport.write().await = Some(udp);
+
+    let signals = StdArc::new(StdMutex::new(Vec::<TestControlSignal>::new()));
+    let signals_for_forwarder = signals.clone();
+    let local_public_key = daemon.local_identity().unwrap().public_key();
+    daemon.control.set_test_signal_forwarder(
+        daemon.config.node.node_id.clone(),
+        hex::encode(local_public_key),
+        StdArc::new(move |signal| {
+            signals_for_forwarder
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(signal);
+        }),
+    );
+
+    let old_generation = encoded_generation(300, 1);
+    let new_generation = encoded_generation(301, 1);
+    assert_eq!(
+        daemon
+            .peers
+            .add_candidates_with_metadata(
+                peer_id,
+                &["203.0.113.90:49000".to_string()],
+                &HashMap::new(),
+                old_generation,
+                Some(u64::MAX),
+            )
+            .await,
+        CandidateSetApplyResult::Applied
+    );
+    assert!(
+        daemon
+            .reset_peer_for_remote_incarnation_if_needed(
+                peer_id,
+                new_generation,
+                RemoteIncarnationResetWork::ClearAll,
+            )
+            .await
+    );
+
+    // Simulate the lifecycle replay scheduled by the control-event path. The
+    // local snapshot/hash is unchanged, so this publication must come from
+    // the explicit replay rather than a candidate-refresh hash transition.
+    daemon
+        .publish_current_candidates_to_peer(peer_id, "test remote incarnation replay")
+        .await;
+
+    let signal = signals
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .pop()
+        .expect("remote incarnation replay must publish a candidate-only offer");
+    assert_eq!(signal.to_node_id, peer_id);
+    assert!(signal.handshake_init.is_empty());
+    assert_eq!(signal.candidates, local_candidates);
+    assert_eq!(daemon.current_local_candidate_set().await, before_replay);
+}
+
+#[tokio::test]
 async fn stale_wireguard_answer_does_not_clear_pending_handshake() {
     let config = Config::generate_default("https://ctrl.test", "net1").unwrap();
     let daemon = Daemon::new(config);

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.138",
+  "version": "0.1.139",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",


### PR DESCRIPTION
## What changed
- replay the current local UDP candidate snapshot when a peer remote incarnation changes
- replay candidates on peer online/public-key lifecycle updates
- retain busy initiator roster edges instead of silently dropping them
- bump the workspace/client release to v0.1.139

## Verification
- cargo fmt --all -- --check
- cargo check -p p2wlan-daemon --no-default-features
- cargo test -p p2wlan-daemon --lib --no-default-features (1024 passed)

This targets the Air-first/Mini-restart direct-connect failure from the captured logs.