### PR TITLE
fix(daemon): prevent refresh storms and profile dataplane latency

### DIFF
--- a/client/daemon/src/candidate_refresh.rs
+++ b/client/daemon/src/candidate_refresh.rs
@@ -53,6 +53,107 @@ mod tests {
     }
 
     #[test]
+    fn refresh_c1_periodic_wake_starts_one_full_gather() {
+        let wake = refresh_wake_reason(true, false).expect("periodic wake");
+        assert_eq!(wake, RefreshWakeReason::Periodic);
+        assert!(wake.permits_full_gather());
+    }
+
+    #[test]
+    fn refresh_c2_volatile_deadline_publishes_without_full_gather() {
+        let wake = refresh_wake_reason(false, true).expect("volatile wake");
+        assert_eq!(wake, RefreshWakeReason::VolatileDeadline);
+        assert!(!wake.permits_full_gather());
+
+        let now = Instant::now();
+        let mut coalescer = VolatilePublishCoalescer::default();
+        assert_eq!(
+            coalescer.on_churn(1, now),
+            VolatileChurnAction::SchedulePublish
+        );
+        assert_eq!(
+            coalescer.take_due(now + Duration::from_millis(500)),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn refresh_c3_continuous_volatile_changes_coalesce_to_one_publish() {
+        let now = Instant::now();
+        let mut coalescer = VolatilePublishCoalescer::default();
+        let mut scheduled = 0;
+        let mut coalesced = 0;
+        for (offset_ms, hash) in [10u64, 20, 30, 40, 50].into_iter().enumerate() {
+            let action = coalescer.on_churn(hash, now + Duration::from_millis(offset_ms as u64));
+            match action {
+                VolatileChurnAction::SchedulePublish => scheduled += 1,
+                VolatileChurnAction::CoalescedNewest => coalesced += 1,
+                VolatileChurnAction::SuppressIdentical => {}
+            }
+        }
+        assert_eq!(scheduled, 1);
+        assert_eq!(coalesced, 4);
+        assert_eq!(
+            coalescer.take_due(now + Duration::from_millis(510)),
+            Some(50)
+        );
+        assert_eq!(coalescer.take_due(now + Duration::from_secs(1)), None);
+    }
+
+    #[test]
+    fn refresh_c4_simultaneous_periodic_and_volatile_wake_keeps_periodic_gather() {
+        let wake = refresh_wake_reason(true, true).expect("simultaneous wake");
+        assert_eq!(wake, RefreshWakeReason::Periodic);
+        assert!(wake.permits_full_gather());
+    }
+
+    #[test]
+    fn refresh_c5_sixty_seconds_has_only_periodic_full_gathers() {
+        let start = Instant::now();
+        let volatile_changes = [1u64, 5, 16, 30, 45, 59];
+        let mut coalescer = VolatilePublishCoalescer::default();
+        let mut full_gathers = 0;
+        let mut volatile_publishes = 0;
+
+        // The production worker consumes the immediate interval tick during
+        // startup. This fake-clock run therefore models periodic gathers at
+        // 15, 30, 45, and 60 seconds, while volatile deadlines are serviced
+        // independently between them.
+        for second in 0..=60u64 {
+            let now = start + Duration::from_secs(second);
+            if volatile_changes.contains(&second) {
+                coalescer.on_churn(second, now);
+            }
+            let periodic_ready = second > 0 && second % 15 == 0;
+            let volatile_ready = coalescer.pending_due(now);
+            let Some(wake) = refresh_wake_reason(periodic_ready, volatile_ready) else {
+                continue;
+            };
+
+            if volatile_ready {
+                assert!(
+                    coalescer.take_due(now).is_some(),
+                    "a ready volatile deadline must be consumed"
+                );
+                volatile_publishes += 1;
+            }
+            if wake.permits_full_gather() {
+                full_gathers += 1;
+            }
+        }
+
+        assert_eq!(
+            full_gathers, 4,
+            "only the 15-second periodic cadence gathers"
+        );
+        assert_eq!(volatile_publishes, volatile_changes.len());
+        assert!(
+            full_gathers <= 5,
+            "60-second run must not become a gather storm"
+        );
+    }
+
+    #[test]
     fn canonical_candidate_set_hash_is_order_insensitive_but_sensitive_to_content() {
         let mut sources = HashMap::new();
         sources.insert("1.2.3.4:1000".to_string(), "stun_observed".to_string());

--- a/client/daemon/src/candidate_refresh/runtime.rs
+++ b/client/daemon/src/candidate_refresh/runtime.rs
@@ -21,6 +21,41 @@ pub(super) struct UdpCandidateRefreshContext {
     pub(super) boot_epoch_ms: u64,
 }
 
+/// The reason that woke the candidate-refresh scheduler.
+///
+/// These reasons are intentionally kept separate: a volatile publication is
+/// a control-plane flush of an already gathered snapshot, while a periodic
+/// wake is the only event allowed to start a full STUN/gateway gather.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RefreshWakeReason {
+    Periodic,
+    VolatileDeadline,
+}
+
+impl RefreshWakeReason {
+    fn permits_full_gather(self) -> bool {
+        matches!(self, Self::Periodic)
+    }
+}
+
+/// Mirror the ordering used by the biased Tokio `select!` below.  Keeping the
+/// decision pure makes the simultaneous-ready behavior deterministic in unit
+/// tests: a periodic tick is never lost when it is ready at the same time as a
+/// volatile deadline.
+#[cfg(test)]
+fn refresh_wake_reason(
+    periodic_ready: bool,
+    volatile_deadline_ready: bool,
+) -> Option<RefreshWakeReason> {
+    if periodic_ready {
+        Some(RefreshWakeReason::Periodic)
+    } else if volatile_deadline_ready {
+        Some(RefreshWakeReason::VolatileDeadline)
+    } else {
+        None
+    }
+}
+
 /// Volatile candidate churn (source-only or short-lived port changes on the
 /// same public IP) is coalesced newest-wins and published at most once per
 /// short, fixed debounce window.  This is deliberately sub-second: a NAT
@@ -153,6 +188,7 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
     } else {
         CANDIDATE_REFRESH_INTERVAL
     });
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     if initial_refresh_needs_fast_retry {
         // The startup gather intentionally has a short budget.  If it only
         // produced a host candidate (or only an observer-specific mapping on
@@ -179,14 +215,20 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
         // gather tick or the fixed debounce deadline, whichever comes first.
         // The latter is what prevents a changed NAT mapping from sitting in
         // the committed snapshot while the peer keeps using an old endpoint.
-        if let Some(deadline) = volatile_coalescer.pending_deadline() {
+        let wake_reason = if let Some(deadline) = volatile_coalescer.pending_deadline() {
             tokio::select! {
-                _ = ticker.tick() => {}
-                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {}
+                // Prefer a periodic refresh when both futures are ready. The
+                // volatile publication is flushed below before the periodic
+                // gather, so neither event is lost and only the periodic
+                // branch may start STUN/gateway discovery.
+                biased;
+                _ = ticker.tick() => RefreshWakeReason::Periodic,
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => RefreshWakeReason::VolatileDeadline,
             }
         } else {
             ticker.tick().await;
-        }
+            RefreshWakeReason::Periodic
+        };
 
         // Flush a coalesced volatile publication whose debounce window
         // elapsed.  The pending set is the newest committed candidate set;
@@ -217,9 +259,12 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
                 )
                 .await;
                 volatile_coalescer.record_published(hash);
-                info!(
-                    "Published coalesced volatile UDP candidate refresh (hash={hash}, candidates={})",
-                    pending.candidates.len()
+                debug!(
+                    target: "p2wlan_daemon::candidate_refresh",
+                    event = "candidate_volatile_publish_completed",
+                    hash,
+                    candidate_count = pending.candidates.len(),
+                    "Published coalesced volatile UDP candidate refresh"
                 );
             } else {
                 debug!(
@@ -228,9 +273,30 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
             }
         }
 
+        // A volatile deadline only flushes the already committed newest
+        // candidate set. It must return to the scheduler here: falling
+        // through into the gather below turns every debounce expiry into a
+        // full STUN refresh and recreates the observed refresh storm. If a
+        // periodic tick was simultaneously ready, `biased` selected it above
+        // and this branch deliberately falls through to the legitimate gather.
+        if !wake_reason.permits_full_gather() {
+            debug!(
+                target: "p2wlan_daemon::candidate_refresh",
+                event = "candidate_volatile_publish_completed",
+                wake_reason = ?wake_reason,
+                "volatile candidate publication completed without a full gather"
+            );
+            continue;
+        }
+
         let gather_started = Instant::now();
         debug!(
             target: "p2wlan_daemon::candidate_refresh",
+            event = "candidate_gather_started",
+            wake_reason = ?wake_reason,
+            network_generation = peers.current_network_generation_sync(),
+            stun_query_count = stun_servers.len(),
+            pool_socket_count = udp.socket_count(),
             "UDP candidate refresh started"
         );
 
@@ -265,10 +331,13 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
             );
             (discovered, discovered_sources)
         };
+        let profiler = crate::dataplane::global_dataplane_profiler();
+        profiler.set_candidate_gather_active(true);
         let (report_result, (mapped_candidates, mapped_sources)) = tokio::join!(
             udp.gather_candidate_report_live_parallel_full(stun_servers.clone(), stun_timeout),
             mapping_future,
         );
+        profiler.set_candidate_gather_active(false);
         let gather_elapsed_ms = gather_started.elapsed().as_millis() as u64;
         let refresh_lock_wait_started = Instant::now();
         let refresh_guard = candidate_refresh_lock.lock().await;
@@ -279,8 +348,13 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
             Err(err) => {
                 warn!(
                     target: "p2wlan_daemon::candidate_refresh",
+                    event = "candidate_gather_completed",
+                    wake_reason = ?wake_reason,
                     refresh_lock_wait_ms,
                     gather_elapsed_ms,
+                    stun_query_count = stun_servers.len(),
+                    pool_socket_count = udp.socket_count(),
+                    candidate_count = 0,
                     "Periodic UDP candidate refresh failed: {err}"
                 );
                 continue;
@@ -289,8 +363,12 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
         let (mut candidates, mut candidate_sources) = candidate_endpoints_from_report(&report);
         debug!(
             target: "p2wlan_daemon::candidate_refresh",
+            event = "candidate_gather_completed",
+            wake_reason = ?wake_reason,
             refresh_lock_wait_ms,
             gather_elapsed_ms,
+            stun_query_count = report.nat_profile.observations.len(),
+            pool_socket_count = udp.socket_count(),
             candidate_count = candidates.len(),
             "UDP candidate refresh gather completed"
         );
@@ -374,6 +452,7 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
                 CANDIDATE_REFRESH_INTERVAL
             };
             ticker = interval(interval_ms);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             // Consume the new interval's immediate tick; the next periodic
             // refresh happens one full cadence later.
             ticker.tick().await;

--- a/client/daemon/src/dataplane.rs
+++ b/client/daemon/src/dataplane.rs
@@ -21,6 +21,7 @@ use crate::peer::PeerManager;
 include!("dataplane/core.rs");
 include!("dataplane/normalization.rs");
 include!("dataplane/logging.rs");
+include!("dataplane/profiling.rs");
 
 #[cfg(test)]
 mod tests {

--- a/client/daemon/src/dataplane/core.rs
+++ b/client/daemon/src/dataplane/core.rs
@@ -7,6 +7,9 @@ pub struct OutboundPacket {
     pub dst_ip: String,
     /// Raw IP packet bytes read from TUN.
     pub packet: Vec<u8>,
+    /// Low-frequency userspace latency context. It is never used for routing
+    /// or path selection and is absent for synthetic/control packets.
+    pub(crate) trace: Option<DataplaneTxTrace>,
 }
 
 /// A raw IP packet decrypted from a peer and ready to write into TUN.
@@ -26,6 +29,9 @@ pub struct InboundPacket {
     /// the bounded WireGuard overlap window, but they are never path or
     /// first-usable evidence for the current session.
     pub from_previous_session: bool,
+    /// Low-frequency userspace latency context, attached only by the live
+    /// decrypt worker before the packet is written to TUN.
+    pub(crate) trace: Option<DataplaneRxTrace>,
 }
 
 /// Reads packets from a virtual interface and routes them by destination IP.
@@ -118,12 +124,17 @@ where
             loop {
                 tokio::select! {
                     result = self.read_packet(&mut buf) => {
-                        let packet = result?;
+                        let (packet, tun_read_started, tun_read_completed) = result?;
                         if !packet.is_empty() {
                             // The TUN read has completed.  Route outside the
                             // select future so a competing inbound packet
                             // cannot cancel after bytes were consumed.
-                            self.route_outbound_packet(&packet).await?;
+                            self.route_outbound_packet(
+                                &packet,
+                                tun_read_started,
+                                tun_read_completed,
+                            )
+                            .await?;
                         }
                     }
                     inbound = inbound_rx.recv() => {
@@ -143,30 +154,47 @@ where
     }
 
     async fn read_and_route_once(&mut self, buf: &mut [u8]) -> Result<()> {
-        let packet = self.read_packet(buf).await?;
+        let (packet, tun_read_started, tun_read_completed) = self.read_packet(buf).await?;
         if packet.is_empty() {
             return Ok(());
         }
-        self.route_outbound_packet(&packet).await
+        self.route_outbound_packet(&packet, tun_read_started, tun_read_completed)
+            .await
     }
 
     /// Read exactly one TUN packet without doing any further asynchronous
     /// work.  `run` deliberately completes this future before entering the
     /// peer-resolution/routing phase: cancelling a future after it has
     /// consumed a packet from a TUN implementation is a silent packet loss.
-    async fn read_packet(&mut self, buf: &mut [u8]) -> Result<Vec<u8>> {
+    async fn read_packet(
+        &mut self,
+        buf: &mut [u8],
+    ) -> Result<(Vec<u8>, std::time::Instant, std::time::Instant)> {
+        let started = std::time::Instant::now();
         let n = self
             .tun
             .read(buf)
             .await
             .map_err(|e| DaemonError::Network(format!("TUN read failed: {e}")))?;
-        Ok(buf[..n].to_vec())
+        Ok((buf[..n].to_vec(), started, std::time::Instant::now()))
     }
 
     /// Route a packet that has already been removed from the TUN read queue.
     /// This method may await peer state and ACL locks, but it is never placed
     /// directly in the `select!` that owns the TUN read operation.
-    async fn route_outbound_packet(&mut self, packet: &[u8]) -> Result<()> {
+    async fn route_outbound_packet(
+        &mut self,
+        packet: &[u8],
+        tun_read_started: std::time::Instant,
+        tun_read_completed: std::time::Instant,
+    ) -> Result<()> {
+        let profiler = global_dataplane_profiler();
+        let sampled = profiler.sample_next_packet();
+        profiler.record(
+            sampled,
+            "tun_read_us",
+            tun_read_completed.duration_since(tun_read_started),
+        );
         let parsed = match IpPacket::new(packet) {
             Ok(parsed) => parsed,
             Err(err) => {
@@ -218,12 +246,41 @@ where
             peer_id: peer_id.clone(),
             dst_ip: dst_ip.clone(),
             packet: routed_packet,
+            trace: Some(DataplaneTxTrace {
+                sampled,
+                tun_read_started,
+                tun_read_completed,
+                route_ready: Some(std::time::Instant::now()),
+            }),
         };
 
+        let queue_started = std::time::Instant::now();
         self.outbound_tx
             .send(routed)
             .await
             .map_err(|_| DaemonError::Network("outbound packet channel closed".to_string()))?;
+        let queue_wait = queue_started.elapsed();
+        profiler.record(sampled, "udp_send_queue_us", queue_wait);
+        profiler.record(
+            sampled,
+            "tun_read_to_route_us",
+            queue_started.duration_since(tun_read_completed),
+        );
+        if queue_wait >= DATAPLANE_STALL_THRESHOLD {
+            tracing::debug!(
+                event = "dataplane_stall",
+                peer_id = %peer_id,
+                active_path = if self.peers.is_direct_sync(&peer_id) { "direct" } else { "relay_or_unknown" },
+                tun_to_send_us = queue_started
+                    .duration_since(tun_read_started)
+                    .as_micros() as u64,
+                receive_to_tun_us = 0u64,
+                candidate_gather_active = profiler.candidate_gather_active(),
+                network_generation = self.peers.current_network_generation_sync(),
+                queue_wait_us = queue_wait.as_micros() as u64,
+                "outbound dataplane packet waited beyond the diagnostic stall threshold"
+            );
+        }
         self.peers.record_sent(&peer_id, total_len as u64).await;
 
         debug!("Routed {total_len} byte {protocol} packet to {peer_id} ({dst_ip})");
@@ -231,6 +288,7 @@ where
     }
 
     async fn write_inbound(&mut self, packet: InboundPacket) -> Result<()> {
+        let trace = packet.trace.clone();
         let parsed = match IpPacket::new(&packet.packet) {
             Ok(parsed) => parsed,
             Err(err) => {
@@ -318,6 +376,29 @@ where
                 written,
                 inbound_packet.len()
             )));
+        }
+
+        if let Some(trace) = trace {
+            let profiler = global_dataplane_profiler();
+            let receive_to_tun = trace.transport_dequeued.elapsed();
+            profiler.record(
+                trace.sampled,
+                "decrypt_to_tun_write_us",
+                trace.decrypt_completed.elapsed(),
+            );
+            profiler.record(trace.sampled, "total_userspace_rx_us", receive_to_tun);
+            if receive_to_tun >= DATAPLANE_STALL_THRESHOLD {
+                tracing::debug!(
+                    event = "dataplane_stall",
+                    peer_id = %packet.peer_id,
+                    active_path = if self.peers.is_direct_sync(&packet.peer_id) { "direct" } else { "relay_or_unknown" },
+                    tun_to_send_us = 0u64,
+                    receive_to_tun_us = receive_to_tun.as_micros() as u64,
+                    candidate_gather_active = profiler.candidate_gather_active(),
+                    network_generation = self.peers.current_network_generation_sync(),
+                    "inbound dataplane packet exceeded the diagnostic stall threshold"
+                );
+            }
         }
 
         self.peers

--- a/client/daemon/src/dataplane/profiling.rs
+++ b/client/daemon/src/dataplane/profiling.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// One packet out of every fixed-size sample window carries this context
+/// through the raw outbound queue. The sample rate is deliberately low so
+/// diagnostics cannot become a source of dataplane work themselves.
+const PROFILE_SAMPLE_EVERY: u64 = 64;
+const MAX_PROFILE_SAMPLES: usize = 512;
+const PROFILE_REPORT_EVERY: u64 = 64;
+/// A diagnostic threshold for the field-observed 30ms+ tail, intentionally
+/// far above normal sub-millisecond stage work. It emits an event only when a
+/// real packet crosses the threshold; it is not a correctness timeout.
+pub(crate) const DATAPLANE_STALL_THRESHOLD: Duration = Duration::from_millis(25);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataplaneTxTrace {
+    pub(crate) sampled: bool,
+    pub(crate) tun_read_started: Instant,
+    pub(crate) tun_read_completed: Instant,
+    pub(crate) route_ready: Option<Instant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataplaneRxTrace {
+    pub(crate) sampled: bool,
+    pub(crate) transport_dequeued: Instant,
+    pub(crate) decrypt_completed: Instant,
+}
+
+#[derive(Default)]
+struct StageSamples {
+    values: Vec<u64>,
+    total: u64,
+}
+
+#[derive(Default)]
+struct DataplaneProfilerState {
+    stages: HashMap<&'static str, StageSamples>,
+}
+
+/// Process-local, low-frequency dataplane profiler. It is intentionally a
+/// diagnostic histogram rather than a routing input: no path or candidate
+/// decision reads these values.
+pub(crate) struct DataplaneProfiler {
+    packet_counter: AtomicU64,
+    candidate_gather_active: std::sync::atomic::AtomicBool,
+    state: Mutex<DataplaneProfilerState>,
+}
+
+impl DataplaneProfiler {
+    fn new() -> Self {
+        Self {
+            packet_counter: AtomicU64::new(0),
+            candidate_gather_active: std::sync::atomic::AtomicBool::new(false),
+            state: Mutex::new(DataplaneProfilerState::default()),
+        }
+    }
+
+    pub(crate) fn sample_next_packet(&self) -> bool {
+        self.packet_counter
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(PROFILE_SAMPLE_EVERY)
+    }
+
+    pub(crate) fn set_candidate_gather_active(&self, active: bool) {
+        self.candidate_gather_active.store(active, Ordering::Release);
+    }
+
+    pub(crate) fn candidate_gather_active(&self) -> bool {
+        self.candidate_gather_active.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn record(&self, sampled: bool, stage: &'static str, duration: Duration) {
+        if !sampled {
+            return;
+        }
+        let micros = duration.as_micros().min(u128::from(u64::MAX)) as u64;
+        let mut state = self.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let samples = state.stages.entry(stage).or_default();
+        samples.total = samples.total.saturating_add(1);
+        if samples.values.len() >= MAX_PROFILE_SAMPLES {
+            samples.values.remove(0);
+        }
+        samples.values.push(micros);
+
+        if !samples.total.is_multiple_of(PROFILE_REPORT_EVERY) {
+            return;
+        }
+        let mut sorted = samples.values.clone();
+        sorted.sort_unstable();
+        let p50_us = percentile(&sorted, 50, 100);
+        let p95_us = percentile(&sorted, 95, 100);
+        let p99_us = percentile(&sorted, 99, 100);
+        let max_us = sorted.last().copied().unwrap_or(0);
+        tracing::debug!(
+            target: "p2wlan_daemon::dataplane",
+            event = "dataplane_profile",
+            stage,
+            sample_count = samples.total,
+            p50_us,
+            p95_us,
+            p99_us,
+            max_us,
+            "sampled userspace dataplane stage histogram"
+        );
+    }
+}
+
+fn percentile(sorted: &[u64], numerator: usize, denominator: usize) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = ((sorted.len() - 1) * numerator).div_ceil(denominator);
+    sorted[index.min(sorted.len() - 1)]
+}
+
+pub(crate) fn global_dataplane_profiler() -> &'static DataplaneProfiler {
+    static PROFILER: OnceLock<DataplaneProfiler> = OnceLock::new();
+    PROFILER.get_or_init(DataplaneProfiler::new)
+}

--- a/client/daemon/src/dataplane/tests.rs
+++ b/client/daemon/src/dataplane/tests.rs
@@ -98,6 +98,7 @@ use std::net::Ipv4Addr;
                         packet,
                         session_instance: None,
                         from_previous_session: false,
+                        trace: None,
                     })
                     .await
                     .expect("inbound channel closed");
@@ -184,6 +185,7 @@ use std::net::Ipv4Addr;
                 packet: packet.clone(),
                 session_instance: None,
                 from_previous_session: false,
+                trace: None,
             })
             .await
             .unwrap();
@@ -225,6 +227,7 @@ use std::net::Ipv4Addr;
                 packet,
                 session_instance: None,
                 from_previous_session: false,
+                trace: None,
             })
             .await
             .unwrap();
@@ -266,6 +269,7 @@ use std::net::Ipv4Addr;
                 packet,
                 session_instance: None,
                 from_previous_session: false,
+                trace: None,
             })
             .await
             .unwrap();
@@ -312,6 +316,7 @@ use std::net::Ipv4Addr;
                 packet,
                 session_instance: None,
                 from_previous_session: false,
+                trace: None,
             })
             .await
             .unwrap();
@@ -427,6 +432,7 @@ use std::net::Ipv4Addr;
                 packet,
                 session_instance: None,
                 from_previous_session: false,
+                trace: None,
             })
             .await
             .unwrap();

--- a/client/daemon/src/lib/daemon/handshake/answer.rs
+++ b/client/daemon/src/lib/daemon/handshake/answer.rs
@@ -347,6 +347,7 @@ impl Daemon {
                         sequence as u16,
                         REKEY_CONFIRMATION_PAYLOAD,
                     ),
+                    trace: None,
                 };
 
                 if let (Some(udp), Some(endpoint)) = (udp, direct_endpoint) {

--- a/client/daemon/src/lib/direct_runtime/encrypted_validation.rs
+++ b/client/daemon/src/lib/direct_runtime/encrypted_validation.rs
@@ -1026,6 +1026,7 @@ async fn run_direct_encrypted_validation_session(
                     peer_id: peer_id.clone(),
                     dst_ip: connection.virtual_ip.clone(),
                     packet,
+                    trace: None,
                 },
                 crate::transport::DIRECT_VALIDATION_EMIT_LOCK_TIMEOUT,
                 move |encrypted| async move {

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -926,6 +926,7 @@ async fn incomplete_modern_answer_preserves_pending_handshake_and_old_session() 
     let encrypted = daemon
         .transport
         .encrypt_outbound(OutboundPacket {
+                trace: None,
             peer_id: peer_id.to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -2379,6 +2380,7 @@ async fn test_network_outbound_uses_relay_when_udp_unavailable() {
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -2486,6 +2488,7 @@ async fn test_network_outbound_uses_relay_until_direct_is_verified() {
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -2612,6 +2615,7 @@ async fn test_network_outbound_waits_for_relay_even_when_direct_is_confirmed_bef
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -2995,6 +2999,7 @@ async fn test_network_outbound_relay_wait_timeout_emits_reason_and_never_deliver
     let payload = vec![1, 2, 3];
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -3101,6 +3106,7 @@ async fn test_network_outbound_direct_only_degrades_immediately_with_stable_reas
 
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -3206,6 +3212,7 @@ async fn test_network_outbound_waiting_peer_never_blocks_confirmed_peer() {
     // node-b's first packet parks (bounded wait, not a blocking loop).
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -3232,6 +3239,7 @@ async fn test_network_outbound_waiting_peer_never_blocks_confirmed_peer() {
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-c".to_string(),
             dst_ip: "10.20.0.3".to_string(),
             packet: packet.clone(),
@@ -3312,6 +3320,7 @@ async fn test_network_outbound_multi_packet_burst_shares_one_startup_deadline() 
     for seq in 0..3u8 {
         dataplane_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -3432,6 +3441,7 @@ async fn test_network_outbound_direct_commit_is_bounded_fallback_when_relay_neve
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -3537,6 +3547,7 @@ async fn test_network_outbound_relay_confirm_after_deadline_flushes_not_drops() 
     );
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),
@@ -3858,6 +3869,7 @@ async fn test_network_outbound_first_packet_wait_never_blocks_relay_probe() {
     // The first business packet parks PLAINTEXT (peer not usable yet).
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -3891,6 +3903,7 @@ async fn test_network_outbound_first_packet_wait_never_blocks_relay_probe() {
     let probe_sent = transport
         .encrypt_and_emit_outbound(
             OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: probe_packet,
@@ -4038,6 +4051,7 @@ async fn run_burst_confirmation_replay_test(count: usize) {
     for seq in 0..count as u16 {
         dataplane_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -4072,6 +4086,7 @@ async fn run_burst_confirmation_replay_test(count: usize) {
     let probe_sent = transport
         .encrypt_and_emit_outbound(
             OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: probe_packet.clone(),
@@ -4231,6 +4246,7 @@ async fn test_network_outbound_control_packet_between_bursts_keeps_monotonic_cou
             transport
                 .encrypt_and_emit_outbound(
                     OutboundPacket {
+                trace: None,
                         peer_id: "node-b".to_string(),
                         dst_ip: "10.20.0.2".to_string(),
                         packet: Ipv4Packet::build_icmp_echo_request(
@@ -4259,6 +4275,7 @@ async fn test_network_outbound_control_packet_between_bursts_keeps_monotonic_cou
     for seq in 0..20u16 {
         dataplane_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -4280,6 +4297,7 @@ async fn test_network_outbound_control_packet_between_bursts_keeps_monotonic_cou
     for seq in 0..20u16 {
         dataplane_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -4385,6 +4403,7 @@ async fn test_network_outbound_queue_overflow_counts_packets_and_bytes_exactly()
     for seq in 0..total as u16 {
         dataplane_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "node-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -4546,6 +4565,7 @@ async fn test_network_outbound_worker_shutdown_counts_parked_packets() {
 
     dataplane_tx
         .send(OutboundPacket {
+                trace: None,
             peer_id: "node-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(

--- a/client/daemon/src/network_outbound.rs
+++ b/client/daemon/src/network_outbound.rs
@@ -44,7 +44,7 @@ use tokio::time::{interval, timeout, MissedTickBehavior};
 use tracing::{debug, warn};
 
 use crate::connection_timeline::ConnectionTimeline;
-use crate::dataplane::OutboundPacket;
+use crate::dataplane::{global_dataplane_profiler, OutboundPacket};
 use crate::peer::{
     NetworkPath, PathSelection, PeerManager, REASON_DIRECT_SEND_FAILED, REASON_PATH_UNAVAILABLE,
 };
@@ -746,6 +746,8 @@ async fn encrypt_then_send(
     relay_expected: bool,
 ) -> EncryptSendOutcome {
     let retry_packet = packet.clone();
+    let profiler = global_dataplane_profiler();
+    let encrypt_started = Instant::now();
     // Acquire the per-peer counter-ordering guard BEFORE the global epoch
     // gate.  Inbound relay ACK/business evidence uses the same order
     // (`emit -> epoch`); taking these in the opposite order here would let an
@@ -822,6 +824,27 @@ async fn encrypt_then_send(
         }
     };
     let encrypted = encrypted_and_guard;
+    let encrypt_completed = Instant::now();
+    if let Some(trace) = retry_packet.trace.as_ref() {
+        profiler.record(
+            trace.sampled,
+            "tun_read_to_encrypt_us",
+            encrypt_started.duration_since(trace.tun_read_completed),
+        );
+        if let Some(route_ready) = trace.route_ready {
+            profiler.record(
+                trace.sampled,
+                "route_to_encrypt_us",
+                encrypt_started.duration_since(route_ready),
+            );
+        }
+        profiler.record(
+            trace.sampled,
+            "encrypt_us",
+            encrypt_completed.duration_since(encrypt_started),
+        );
+    }
+    let transport_handoff_started = Instant::now();
     let outcome = send_encrypted_packet_bounded(
         &encrypted,
         peers,
@@ -831,6 +854,29 @@ async fn encrypt_then_send(
         relay_expected,
     )
     .await;
+    let transport_handoff_completed = Instant::now();
+    if let Some(trace) = retry_packet.trace.as_ref() {
+        let total_userspace_tx =
+            transport_handoff_completed.duration_since(trace.tun_read_completed);
+        profiler.record(
+            trace.sampled,
+            "encrypt_to_send_us",
+            transport_handoff_started.duration_since(encrypt_completed),
+        );
+        profiler.record(trace.sampled, "total_userspace_tx_us", total_userspace_tx);
+        if total_userspace_tx >= crate::dataplane::DATAPLANE_STALL_THRESHOLD {
+            debug!(
+                event = "dataplane_stall",
+                peer_id = %retry_packet.peer_id,
+                active_path = if peers.is_direct_sync(&retry_packet.peer_id) { "direct" } else { "relay_or_unknown" },
+                tun_to_send_us = total_userspace_tx.as_micros() as u64,
+                receive_to_tun_us = 0u64,
+                candidate_gather_active = profiler.candidate_gather_active(),
+                network_generation = expected_generation,
+                "outbound encrypted dataplane packet exceeded the diagnostic stall threshold"
+            );
+        }
+    }
     if let Some((nonce, sequence, direction)) = overlay_packet_identity(&retry_packet.packet) {
         let outcome_label = match &outcome {
             SendOutcome::Sent => "sent",
@@ -2072,6 +2118,7 @@ mod tests {
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: vec![0x45, 0x00, 0x00, 0x14],
+                trace: None,
             },
             &transport,
             &manager,
@@ -2106,6 +2153,7 @@ mod tests {
             peer_id: "peer-a".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: vec![0x45, 0, 0, 20],
+            trace: None,
         }));
 
         let (_peer_id, remaining) = flush_one_peer(
@@ -2139,6 +2187,7 @@ mod tests {
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: vec![sequence],
+                trace: None,
             }
         }
 

--- a/client/daemon/src/relay_runtime.rs
+++ b/client/daemon/src/relay_runtime.rs
@@ -1250,6 +1250,7 @@ pub(super) async fn run_relay_peer_validation_loop(
                             peer_id: send_peer_id.clone(),
                             dst_ip: send_peer_virtual_ip,
                             packet,
+                            trace: None,
                         },
                         move |encrypted| async move {
                             let Some(peer_session_generation) = send_peers
@@ -1562,6 +1563,7 @@ pub(super) async fn run_relay_peer_probe_loop(
                             peer_id: send_peer_id.clone(),
                             dst_ip: send_peer_virtual_ip,
                             packet,
+                            trace: None,
                         },
                         move |encrypted| async move {
                             send_relay
@@ -1812,6 +1814,7 @@ pub(super) async fn run_relay_peer_probe_loop(
                                 peer_id: send_peer_id.clone(),
                                 dst_ip: send_peer_virtual_ip,
                                 packet,
+                                trace: None,
                             },
                             move |encrypted| async move {
                                 send_relay
@@ -1937,6 +1940,7 @@ pub(super) async fn send_relay_validation_packet(
                 peer_id: validation.peer_id.to_string(),
                 dst_ip: validation.peer_virtual_ip.to_string(),
                 packet,
+                trace: None,
             },
             |encrypted| async move { relay.send_packet(&encrypted).await },
         )

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -17,7 +17,9 @@ use p2pnet_wireguard::{MessageTransport, TransportSession};
 use tokio::sync::{mpsc, watch, Mutex, OwnedMutexGuard, RwLock};
 use tracing::{debug, info, warn};
 
-use crate::dataplane::{InboundPacket, OutboundPacket};
+use crate::dataplane::{
+    global_dataplane_profiler, DataplaneRxTrace, InboundPacket, OutboundPacket,
+};
 use crate::error::{DaemonError, Result};
 use crate::peer::{PeerManager, PeerSessionGeneration};
 use crate::relay::RelayTransport;
@@ -2184,6 +2186,7 @@ impl WireGuardTransport {
                 packet,
                 session_instance: Some(session_instance),
                 from_previous_session: false,
+                trace: None,
             }));
         }
 
@@ -2276,6 +2279,7 @@ impl WireGuardTransport {
                 packet,
                 session_instance: Some(session_instance),
                 from_previous_session: false,
+                trace: None,
             }));
         }
 
@@ -2293,6 +2297,7 @@ impl WireGuardTransport {
                         packet,
                         session_instance: Some(previous.slot.session_instance),
                         from_previous_session: true,
+                        trace: None,
                     }));
                 }
                 Err(error) => {
@@ -2487,6 +2492,9 @@ impl WireGuardTransport {
         evidence: Option<InboundEvidenceFeed>,
     ) -> Result<()> {
         while let Some(packet) = encrypted_rx.recv().await {
+            let profiler = global_dataplane_profiler();
+            let sampled = profiler.sample_next_packet();
+            let transport_dequeued = Instant::now();
             let source = packet.source;
             let local_endpoint = packet.local_endpoint;
             let relay_endpoint = packet.relay_endpoint;
@@ -2510,8 +2518,25 @@ impl WireGuardTransport {
                 network_generation = ?packet_network_generation,
                 "encrypted datagram reached the daemon transport decrypt boundary"
             );
+            let decrypt_started = Instant::now();
             match self.decrypt_inbound(&packet.wire_bytes).await {
-                Ok(Some(inbound)) => {
+                Ok(Some(mut inbound)) => {
+                    let decrypt_completed = Instant::now();
+                    profiler.record(
+                        sampled,
+                        "transport_queue_to_decrypt_us",
+                        decrypt_started.duration_since(transport_dequeued),
+                    );
+                    profiler.record(
+                        sampled,
+                        "decrypt_us",
+                        decrypt_completed.duration_since(decrypt_started),
+                    );
+                    inbound.trace = Some(DataplaneRxTrace {
+                        sampled,
+                        transport_dequeued,
+                        decrypt_completed,
+                    });
                     debug!(
                         event = "wireguard_inbound_decrypt_succeeded",
                         peer_id = %inbound.peer_id,
@@ -3538,6 +3563,7 @@ impl WireGuardTransport {
                             peer_id: peer_id_owned.clone(),
                             dst_ip: ip.src_addr().to_string(),
                             packet: ack_packet,
+                            trace: None,
                         },
                         DIRECT_VALIDATION_EMIT_LOCK_TIMEOUT,
                         move |encrypted| async move {
@@ -4200,6 +4226,7 @@ impl WireGuardTransport {
                             peer_id: peer_id.to_string(),
                             dst_ip: ip.src_addr().to_string(),
                             packet: ack_packet,
+                            trace: None,
                         },
                         move |encrypted| async move {
                             relay_send.send_packet(&encrypted).await.map(|_| ())
@@ -4338,6 +4365,7 @@ impl WireGuardTransport {
                             peer_id: peer_id.to_string(),
                             dst_ip: ip.src_addr().to_string(),
                             packet: ack_packet,
+                            trace: None,
                         },
                         move |encrypted| async move {
                             relay_send.send_packet(&encrypted).await.map(|_| ())

--- a/client/daemon/src/transport/tests.rs
+++ b/client/daemon/src/transport/tests.rs
@@ -154,6 +154,7 @@ mod tests {
 
         outbound_tx
             .send(OutboundPacket {
+                trace: None,
                 peer_id: "peer-b".to_string(),
                 dst_ip: "10.20.0.2".to_string(),
                 packet: packet.clone(),
@@ -187,6 +188,7 @@ mod tests {
         let ingress_lock = transport.outbound_ingress_lock("peer-missing").await;
         let _ingress_guard = ingress_lock.lock().await;
         let packet = OutboundPacket {
+                trace: None,
             peer_id: "peer-missing".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -227,6 +229,7 @@ mod tests {
         let generation = peers.advance_network_generation("session_queue_test").await;
 
         let packet = OutboundPacket {
+                trace: None,
             peer_id: "peer-a".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: vec![1, 2, 3, 4],
@@ -255,6 +258,7 @@ mod tests {
 
         let dropped = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "missing-peer".to_string(),
                 dst_ip: "10.20.0.9".to_string(),
                 packet: vec![0x45, 0x00, 0x00, 0x14],
@@ -285,6 +289,7 @@ mod tests {
             async move {
                 transport
                     .encrypt_or_queue_outbound(OutboundPacket {
+                trace: None,
                         peer_id: "peer-a".to_string(),
                         dst_ip: "10.20.0.1".to_string(),
                         packet,
@@ -326,6 +331,7 @@ mod tests {
         for sequence in 0..96u16 {
             assert!(transport
                 .encrypt_or_queue_outbound(OutboundPacket {
+                trace: None,
                     peer_id: "peer-a".to_string(),
                     dst_ip: "10.20.0.1".to_string(),
                     packet: Ipv4Packet::build_icmp_echo_request(
@@ -347,6 +353,7 @@ mod tests {
             async move { transport.run_outbound(dataplane_rx).await }
         });
         let live_packet = OutboundPacket {
+                trace: None,
             peer_id: "peer-a".to_string(),
             dst_ip: "10.20.0.1".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -385,6 +392,7 @@ mod tests {
         let mut counters = Vec::new();
         for raw in received {
             let packet = OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -424,6 +432,7 @@ mod tests {
         for sequence in 0..96u16 {
             assert!(transport
                 .encrypt_or_queue_outbound(OutboundPacket {
+                trace: None,
                     peer_id: "peer-a".to_string(),
                     dst_ip: "10.20.0.1".to_string(),
                     packet: Ipv4Packet::build_icmp_echo_request(
@@ -440,6 +449,7 @@ mod tests {
         }
 
         let filler = OutboundPacket {
+                trace: None,
             peer_id: "filler".to_string(),
             dst_ip: "10.20.0.254".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -487,6 +497,7 @@ mod tests {
         }
 
         let live_packet = OutboundPacket {
+                trace: None,
             peer_id: "peer-a".to_string(),
             dst_ip: "10.20.0.1".to_string(),
             packet: Ipv4Packet::build_icmp_echo_request(
@@ -534,6 +545,7 @@ mod tests {
 
         let dropped = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: vec![0x45, 0x00, 0x00, 0x14],
@@ -586,6 +598,7 @@ mod tests {
 
         let (encrypted, emit_guard) = transport
             .encrypt_outbound_with_guard(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -869,6 +882,7 @@ mod tests {
         );
         let encrypted = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: old_outbound.clone(),
@@ -920,6 +934,7 @@ mod tests {
         );
         let encrypted = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: new_outbound.clone(),
@@ -962,6 +977,7 @@ mod tests {
         assert!(status.has_pending_responder);
         assert!(transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: vec![0x45, 0x00, 0x00, 0x14],
@@ -1304,6 +1320,7 @@ mod tests {
         );
         let encrypted = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: packet.clone(),
@@ -1376,6 +1393,7 @@ mod tests {
         );
         let encrypted = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: outbound.clone(),
@@ -1406,6 +1424,7 @@ mod tests {
         );
         let (encrypted_first, guard) = transport
             .encrypt_outbound_with_guard(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: first.clone(),
@@ -1433,6 +1452,7 @@ mod tests {
                 transport
                     .encrypt_and_emit_outbound(
                         OutboundPacket {
+                trace: None,
                             peer_id: "peer-a".to_string(),
                             dst_ip: "10.20.0.1".to_string(),
                             packet: second,
@@ -1488,6 +1508,7 @@ mod tests {
         let emitted = transport
             .encrypt_and_emit_outbound_with_lock_timeout(
                 OutboundPacket {
+                trace: None,
                     peer_id: "peer-a".to_string(),
                     dst_ip: "10.20.0.1".to_string(),
                     packet: vec![0],
@@ -1516,6 +1537,7 @@ mod tests {
         transport.add_session("peer-a", local).await;
         let (encrypted, guard) = transport
             .encrypt_outbound_with_guard(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -1581,6 +1603,7 @@ mod tests {
                 transport
                     .encrypt_and_emit_outbound(
                         OutboundPacket {
+                trace: None,
                             peer_id: "peer-a".to_string(),
                             dst_ip: "10.20.0.1".to_string(),
                             packet: Ipv4Packet::build_icmp_echo_request(
@@ -1613,6 +1636,7 @@ mod tests {
                     transport
                         .encrypt_and_emit_outbound(
                             OutboundPacket {
+                trace: None,
                                 peer_id: "peer-a".to_string(),
                                 dst_ip: "10.20.0.1".to_string(),
                                 packet: Ipv4Packet::build_icmp_echo_request(
@@ -1779,6 +1803,7 @@ mod tests {
         );
         let encrypted = transport
             .encrypt_outbound(OutboundPacket {
+                trace: None,
                 peer_id: "peer-a".to_string(),
                 dst_ip: "10.20.0.1".to_string(),
                 packet: packet.clone(),

--- a/client/daemon/src/udp/tests/part03.rs
+++ b/client/daemon/src/udp/tests/part03.rs
@@ -771,6 +771,7 @@ async fn authenticated_pending_probe_promotes_matching_wireguard_and_probe_trans
     );
     let encrypted = wireguard
         .encrypt_outbound(crate::dataplane::OutboundPacket {
+                trace: None,
             peer_id: "peer-b".to_string(),
             dst_ip: "10.20.0.2".to_string(),
             packet: packet.clone(),


### PR DESCRIPTION
合并 Phase 3 LAN Direct 稳定性与用户态数据面 profiling 修复。\n\n- 修复 volatile candidate refresh 落入完整 STUN gather 的刷新风暴\n- 新增 C1-C5 确定性回归测试\n- 新增低频 TUN/加密/发送/接收/解密/TUN profiling 与 stall diagnostics\n- 本地 Rust 全部门禁通过，Android clean-identity debug APK 通过\n- GitHub Flutter workflow 的唯一失败是 Flutter 3.47.1 对未修改 Dart 测试文件的格式 baseline 差异；其他平台及 Android job 通过\n