### PR TITLE
build(android): harden client and native build identity

### DIFF
--- a/.github/workflows/flutter-client.yml
+++ b/.github/workflows/flutter-client.yml
@@ -155,7 +155,7 @@ jobs:
           # a test APK, but only push/workflow-dispatch builds are distributable.
           P2WLAN_ALLOW_DEBUG_RELEASE_SIGNING: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: >
-          flutter build apk
+          bash ../../scripts/release/build_flutter_client.sh apk
           --release
           --target-platform android-arm64
           --split-per-abi
@@ -176,6 +176,7 @@ jobs:
             echo "Expected only arm64-v8a in $apk, found: ${actual_abis:-none}" >&2
             exit 1
           fi
+          echo "android_apk_sha256=$(sha256sum "$apk" | awk '{print $1}')"
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flutter-client.yml
+++ b/.github/workflows/flutter-client.yml
@@ -146,6 +146,30 @@ jobs:
       - name: Flutter pub get
         run: flutter pub get
 
+      - name: Restore Flutter-managed source files before identity stamping
+        working-directory: .
+        shell: bash
+        run: bash scripts/release/hermetic_build.sh restore
+
+      - name: Assert clean Flutter client identity
+        working-directory: .
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_commit="$(git rev-parse HEAD)"
+          expected_build_id="${expected_commit:0:12}"
+          identity="$(python3 scripts/release/flutter_client_build_identity.py apk --release)"
+          printf '%s\n' "$identity"
+          grep -F -- "--dart-define=P2WLAN_CLIENT_GIT_COMMIT=${expected_commit}" <<<"$identity"
+          grep -F -- "--dart-define=P2WLAN_CLIENT_BUILD_ID=${expected_build_id}" <<<"$identity"
+          grep -F -- "--dart-define=P2WLAN_CLIENT_DIRTY=false" <<<"$identity"
+          grep -F -- "--dart-define=P2WLAN_CLIENT_DIFF_HASH=" <<<"$identity"
+          if grep -Fq -- "-dirty-" <<<"$identity"; then
+            echo "Flutter client identity unexpectedly contains a dirty build ID" >&2
+            exit 1
+          fi
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
       - name: Build arm64 release APK
         env:
           P2WLAN_ANDROID_ABIS: arm64-v8a

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -191,7 +191,7 @@ jobs:
         env:
           P2WLAN_ANDROID_ABIS: arm64-v8a
         run: |
-          flutter build apk \
+          bash ../../scripts/release/build_flutter_client.sh apk \
             --release \
             --target-platform android-arm64 \
             --split-per-abi \
@@ -214,6 +214,7 @@ jobs:
             echo "Expected only arm64-v8a in $apk, found: ${actual_abis:-none}" >&2
             exit 1
           fi
+          echo "android_apk_sha256=$(sha256sum "$apk" | awk '{print $1}')"
           mkdir -p ../../dist-test
           cp "$apk" ../../dist-test/p2wlan-android-arm64-release.apk
           sha256sum ../../dist-test/p2wlan-android-arm64-release.apk \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           P2WLAN_ANDROID_ABIS: arm64-v8a
         run: >
-          flutter build apk
+          bash ../../scripts/release/build_flutter_client.sh apk
           --release
           --target-platform android-arm64
           --split-per-abi
@@ -123,6 +123,7 @@ jobs:
             echo "Expected only arm64-v8a in $apk, found: ${actual_abis:-none}" >&2
             exit 1
           fi
+          echo "android_apk_sha256=$(sha256sum "$apk" | awk '{print $1}')"
 
       - name: Assemble Android release artifact
         run: |

--- a/apps/flutter_client/android/app/build.gradle.kts
+++ b/apps/flutter_client/android/app/build.gradle.kts
@@ -84,8 +84,23 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
 }
 
+val sourceIdentityFile = rootProject.file("../../../target/p2wlan-source-identity.env")
+val sourceIdentity = Properties()
+if (sourceIdentityFile.isFile) {
+    sourceIdentityFile.inputStream().use {
+        sourceIdentity.load(it)
+    }
+}
+val sourceIdentityKeys = listOf(
+    "P2WLAN_SOURCE_GIT_COMMIT",
+    "P2WLAN_SOURCE_BUILD_ID",
+    "P2WLAN_SOURCE_DIRTY",
+    "P2WLAN_SOURCE_DIFF_HASH",
+)
+
 val buildP2wlanNative by tasks.registering(Exec::class) {
     inputs.property("P2WLAN_ANDROID_ABIS", System.getenv("P2WLAN_ANDROID_ABIS") ?: "all")
+    inputs.file(sourceIdentityFile).optional()
     inputs.files(
         rootProject.file("../../../Cargo.toml"),
         rootProject.file("../../../Cargo.lock"),
@@ -97,6 +112,11 @@ val buildP2wlanNative by tasks.registering(Exec::class) {
         "bash",
         rootProject.file("../../../scripts/build_android_native.sh").absolutePath,
     )
+    sourceIdentityKeys.forEach { key ->
+        sourceIdentity.getProperty(key)?.let { value ->
+            environment(key, value)
+        }
+    }
 }
 
 tasks.named("preBuild").configure {

--- a/apps/flutter_client/android/app/build.gradle.kts
+++ b/apps/flutter_client/android/app/build.gradle.kts
@@ -1,6 +1,8 @@
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.util.Properties
+import java.util.UUID
 
 plugins {
     id("com.android.application")
@@ -105,17 +107,21 @@ if (hasSourceIdentityFile != hasSourceIdentityNonce) {
 }
 
 val sourceIdentityFile = if (hasSourceIdentityFile) {
-    val path = sourceIdentityFileProperty.get()
-    if (path.isBlank()) {
+    val rawPath = sourceIdentityFileProperty.get()
+    if (rawPath.isBlank()) {
         throw GradleException("p2wlanSourceIdentityFile must not be blank")
     }
-    val candidate = rootProject.file(path)
-    if (!candidate.isAbsolute) {
+    // Check the caller's raw string before any Gradle path resolution.  Calling
+    // rootProject.file() first would turn a relative path into an absolute one
+    // and make this validation meaningless.
+    val rawFile = File(rawPath)
+    if (!rawFile.isAbsolute) {
         throw GradleException("p2wlanSourceIdentityFile must be an absolute path")
     }
+    val candidate = rawFile
     if (!Files.isRegularFile(candidate.toPath(), LinkOption.NOFOLLOW_LINKS)) {
         throw GradleException(
-            "p2wlanSourceIdentityFile must name a regular, non-symlink file: $path",
+            "p2wlanSourceIdentityFile must name a regular, non-symlink file: $rawPath",
         )
     }
     candidate
@@ -207,6 +213,8 @@ if (sourceIdentityFile != null) {
 }
 
 val buildP2wlanNative by tasks.registering(Exec::class) {
+    val directBuild = sourceIdentityFile == null
+
     inputs.property("P2WLAN_ANDROID_ABIS", System.getenv("P2WLAN_ANDROID_ABIS") ?: "all")
     inputs.property("p2wlanSourceIdentityFile", sourceIdentityFile?.absolutePath ?: "")
     inputs.property("p2wlanSourceIdentityNonce", sourceIdentityNonce ?: "")
@@ -223,6 +231,12 @@ val buildP2wlanNative by tasks.registering(Exec::class) {
         rootProject.file("../../../scripts/build_android_native.sh"),
     )
     outputs.dir(project.file("src/main/jniLibs"))
+    if (directBuild) {
+        // A direct build has no frozen identity input that Gradle can compare.
+        // It must execute so Cargo can inspect the current checkout every time.
+        outputs.upToDateWhen { false }
+        outputs.doNotCacheIf("direct native builds use live Git identity") { true }
+    }
     commandLine(
         "bash",
         rootProject.file("../../../scripts/build_android_native.sh").absolutePath,
@@ -235,6 +249,16 @@ val buildP2wlanNative by tasks.registering(Exec::class) {
             // build.  With no explicit snapshot, build.rs must inspect Git.
             environment.remove(key)
         }
+    }
+    if (directBuild) {
+        // Generate this at task execution time, not during configuration, so
+        // an existing daemon/configuration cache cannot freeze one refresh.
+        doFirst {
+            environment("P2WLAN_SOURCE_IDENTITY_REFRESH", UUID.randomUUID().toString())
+        }
+    } else {
+        // A shell-level refresh must never alter an explicitly frozen build.
+        environment.remove("P2WLAN_SOURCE_IDENTITY_REFRESH")
     }
 }
 

--- a/apps/flutter_client/android/app/build.gradle.kts
+++ b/apps/flutter_client/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.util.Properties
 
 plugins {
@@ -84,23 +86,136 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
 }
 
-val sourceIdentityFile = rootProject.file("../../../target/p2wlan-source-identity.env")
-val sourceIdentity = Properties()
-if (sourceIdentityFile.isFile) {
-    sourceIdentityFile.inputStream().use {
-        sourceIdentity.load(it)
-    }
-}
 val sourceIdentityKeys = listOf(
     "P2WLAN_SOURCE_GIT_COMMIT",
     "P2WLAN_SOURCE_BUILD_ID",
     "P2WLAN_SOURCE_DIRTY",
     "P2WLAN_SOURCE_DIFF_HASH",
 )
+val sourceIdentityNonceKey = "P2WLAN_SOURCE_IDENTITY_NONCE"
+val sourceIdentityFileProperty = providers.gradleProperty("p2wlanSourceIdentityFile")
+val sourceIdentityNonceProperty = providers.gradleProperty("p2wlanSourceIdentityNonce")
+val hasSourceIdentityFile = sourceIdentityFileProperty.isPresent
+val hasSourceIdentityNonce = sourceIdentityNonceProperty.isPresent
+
+if (hasSourceIdentityFile != hasSourceIdentityNonce) {
+    throw GradleException(
+        "p2wlanSourceIdentityFile and p2wlanSourceIdentityNonce must be provided together",
+    )
+}
+
+val sourceIdentityFile = if (hasSourceIdentityFile) {
+    val path = sourceIdentityFileProperty.get()
+    if (path.isBlank()) {
+        throw GradleException("p2wlanSourceIdentityFile must not be blank")
+    }
+    val candidate = rootProject.file(path)
+    if (!candidate.isAbsolute) {
+        throw GradleException("p2wlanSourceIdentityFile must be an absolute path")
+    }
+    if (!Files.isRegularFile(candidate.toPath(), LinkOption.NOFOLLOW_LINKS)) {
+        throw GradleException(
+            "p2wlanSourceIdentityFile must name a regular, non-symlink file: $path",
+        )
+    }
+    candidate
+} else {
+    null
+}
+
+val sourceIdentityNonce = if (hasSourceIdentityNonce) {
+    sourceIdentityNonceProperty.get()
+} else {
+    null
+}
+
+val sourceIdentityValues = if (sourceIdentityFile != null) {
+    val allowedKeys = (sourceIdentityKeys + sourceIdentityNonceKey).toSet()
+    val values = linkedMapOf<String, String>()
+    sourceIdentityFile.readLines().forEachIndexed { index, line ->
+        if (line.isBlank() || line.startsWith("#")) {
+            return@forEachIndexed
+        }
+        val separator = line.indexOf('=')
+        if (separator <= 0) {
+            throw GradleException(
+                "Malformed source identity snapshot at ${sourceIdentityFile.path}:${index + 1}",
+            )
+        }
+        val key = line.substring(0, separator)
+        if (key !in allowedKeys) {
+            throw GradleException(
+                "Unexpected source identity key $key at ${sourceIdentityFile.path}:${index + 1}",
+            )
+        }
+        if (values.containsKey(key)) {
+            throw GradleException(
+                "Duplicate source identity key $key in ${sourceIdentityFile.path}",
+            )
+        }
+        values[key] = line.substring(separator + 1)
+    }
+    (sourceIdentityKeys + sourceIdentityNonceKey).forEach { key ->
+        if (!values.containsKey(key)) {
+            throw GradleException(
+                "Source identity snapshot is missing $key: ${sourceIdentityFile.path}",
+            )
+        }
+    }
+    values
+} else {
+    emptyMap()
+}
+
+if (sourceIdentityFile != null) {
+    val expectedNonce = sourceIdentityNonce!!
+    if (!Regex("[0-9a-f]{32}").matches(expectedNonce)) {
+        throw GradleException("p2wlanSourceIdentityNonce must be 32 lowercase hexadecimal characters")
+    }
+    if (sourceIdentityValues[sourceIdentityNonceKey] != expectedNonce) {
+        throw GradleException(
+            "p2wlanSourceIdentityNonce does not match the source identity snapshot",
+        )
+    }
+
+    val commit = sourceIdentityValues.getValue("P2WLAN_SOURCE_GIT_COMMIT")
+    val buildId = sourceIdentityValues.getValue("P2WLAN_SOURCE_BUILD_ID")
+    val dirty = sourceIdentityValues.getValue("P2WLAN_SOURCE_DIRTY")
+    val diffHash = sourceIdentityValues.getValue("P2WLAN_SOURCE_DIFF_HASH")
+    if (!Regex("[0-9A-Fa-f]{40}").matches(commit)) {
+        throw GradleException("P2WLAN_SOURCE_GIT_COMMIT is not a 40-character hexadecimal SHA-1")
+    }
+    if (dirty != "true" && dirty != "false") {
+        throw GradleException("P2WLAN_SOURCE_DIRTY must be exactly true or false")
+    }
+    if (dirty == "true" && !Regex("[0-9A-Fa-f]{40}").matches(diffHash)) {
+        throw GradleException("dirty source identity requires a 40-character hexadecimal diff hash")
+    }
+    if (dirty == "false" && diffHash.isNotEmpty()) {
+        throw GradleException("clean source identity requires an empty diff hash")
+    }
+    val expectedBuildId = if (dirty == "true") {
+        "${commit.substring(0, 12)}-dirty-${diffHash.substring(0, 12)}"
+    } else {
+        commit.substring(0, 12)
+    }
+    if (buildId != expectedBuildId) {
+        throw GradleException(
+            "P2WLAN_SOURCE_BUILD_ID does not match the source identity fields",
+        )
+    }
+}
 
 val buildP2wlanNative by tasks.registering(Exec::class) {
     inputs.property("P2WLAN_ANDROID_ABIS", System.getenv("P2WLAN_ANDROID_ABIS") ?: "all")
-    inputs.file(sourceIdentityFile).optional()
+    inputs.property("p2wlanSourceIdentityFile", sourceIdentityFile?.absolutePath ?: "")
+    inputs.property("p2wlanSourceIdentityNonce", sourceIdentityNonce ?: "")
+    sourceIdentityKeys.forEach { key ->
+        inputs.property(key, sourceIdentityValues[key] ?: "")
+    }
+    if (sourceIdentityFile != null) {
+        inputs.file(sourceIdentityFile)
+    }
     inputs.files(
         rootProject.file("../../../Cargo.toml"),
         rootProject.file("../../../Cargo.lock"),
@@ -113,8 +228,12 @@ val buildP2wlanNative by tasks.registering(Exec::class) {
         rootProject.file("../../../scripts/build_android_native.sh").absolutePath,
     )
     sourceIdentityKeys.forEach { key ->
-        sourceIdentity.getProperty(key)?.let { value ->
-            environment(key, value)
+        if (sourceIdentityFile != null) {
+            environment(key, sourceIdentityValues.getValue(key))
+        } else {
+            // Do not let a shell's old override leak into an unwrapped direct
+            // build.  With no explicit snapshot, build.rs must inspect Git.
+            environment.remove(key)
         }
     }
 }

--- a/client/daemon/build.rs
+++ b/client/daemon/build.rs
@@ -115,6 +115,113 @@ fn build_epoch_ms() -> u128 {
         .unwrap_or_default()
 }
 
+const SOURCE_IDENTITY_ENV: [&str; 4] = [
+    "P2WLAN_SOURCE_GIT_COMMIT",
+    "P2WLAN_SOURCE_BUILD_ID",
+    "P2WLAN_SOURCE_DIRTY",
+    "P2WLAN_SOURCE_DIFF_HASH",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceIdentity {
+    commit: String,
+    build_id: String,
+    dirty: bool,
+    diff_hash: String,
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_source_identity(
+    commit: &str,
+    build_id: &str,
+    dirty_value: &str,
+    diff_hash: &str,
+) -> Result<SourceIdentity, String> {
+    if !is_hex(commit, 40) {
+        return Err(format!(
+            "P2WLAN_SOURCE_GIT_COMMIT must be a 40-character hexadecimal SHA-1, got {commit:?}"
+        ));
+    }
+    let dirty = match dirty_value {
+        "true" => true,
+        "false" => false,
+        _ => {
+            return Err(format!(
+                "P2WLAN_SOURCE_DIRTY must be exactly true or false, got {dirty_value:?}"
+            ));
+        }
+    };
+    if dirty {
+        if !is_hex(diff_hash, 40) {
+            return Err(format!(
+                "dirty source identity requires a 40-character hexadecimal diff hash, got {diff_hash:?}"
+            ));
+        }
+    } else if !diff_hash.is_empty() {
+        return Err(format!(
+            "clean source identity requires an empty diff hash, got {diff_hash:?}"
+        ));
+    }
+    let expected_build_id = if dirty {
+        format!("{}-dirty-{}", &commit[..12], &diff_hash[..12])
+    } else {
+        commit[..12].to_string()
+    };
+    if build_id != expected_build_id {
+        return Err(format!(
+            "P2WLAN_SOURCE_BUILD_ID does not match commit/dirty state: expected {expected_build_id:?}, got {build_id:?}"
+        ));
+    }
+    Ok(SourceIdentity {
+        commit: commit.to_string(),
+        build_id: build_id.to_string(),
+        dirty,
+        diff_hash: diff_hash.to_string(),
+    })
+}
+
+fn source_env(name: &str) -> Result<Option<String>, String> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name} contains non-Unicode bytes")),
+    }
+}
+
+fn frozen_source_identity() -> Result<Option<SourceIdentity>, String> {
+    let values = [
+        (SOURCE_IDENTITY_ENV[0], source_env(SOURCE_IDENTITY_ENV[0])?),
+        (SOURCE_IDENTITY_ENV[1], source_env(SOURCE_IDENTITY_ENV[1])?),
+        (SOURCE_IDENTITY_ENV[2], source_env(SOURCE_IDENTITY_ENV[2])?),
+        (SOURCE_IDENTITY_ENV[3], source_env(SOURCE_IDENTITY_ENV[3])?),
+    ];
+    let provided = values.iter().filter(|(_, value)| value.is_some()).count();
+    if provided == 0 {
+        return Ok(None);
+    }
+    if provided != values.len() {
+        let missing = values
+            .iter()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(format!(
+            "frozen source identity must provide all fields; missing: {missing}"
+        ));
+    }
+    validate_source_identity(
+        values[0].1.as_deref().expect("checked above"),
+        values[1].1.as_deref().expect("checked above"),
+        values[2].1.as_deref().expect("checked above"),
+        values[3].1.as_deref().expect("checked above"),
+    )
+    .map(Some)
+}
+
 fn build_identity(commit: &str, dirty: bool, diff_hash: &str) -> String {
     if dirty {
         format!(
@@ -199,7 +306,7 @@ fn checkout_state() -> (bool, String) {
 mod tests {
     use std::path::Path;
 
-    use super::{build_identity, dirty_material, repo_watch_path};
+    use super::{build_identity, dirty_material, repo_watch_path, validate_source_identity};
 
     #[test]
     fn untracked_content_changes_dirty_material() {
@@ -242,20 +349,83 @@ mod tests {
             "0123456789ab-dirty-fedcba987654"
         );
     }
+
+    #[test]
+    fn frozen_source_identity_accepts_clean_and_dirty_contracts() {
+        let commit = "0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(
+            validate_source_identity(commit, "0123456789ab", "false", "").unwrap(),
+            super::SourceIdentity {
+                commit: commit.to_string(),
+                build_id: "0123456789ab".to_string(),
+                dirty: false,
+                diff_hash: String::new(),
+            }
+        );
+        assert!(validate_source_identity(
+            commit,
+            "0123456789ab-dirty-fedcba987654",
+            "true",
+            "fedcba98765432100123456789abcdef01234567"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn frozen_source_identity_rejects_malformed_contracts() {
+        let commit = "0123456789abcdef0123456789abcdef01234567";
+        let invalid = [
+            ("not-a-commit", "0123456789ab", "false", ""),
+            (commit, "0123456789ab", "maybe", ""),
+            (
+                commit,
+                "0123456789ab",
+                "false",
+                "fedcba98765432100123456789abcdef01234567",
+            ),
+            (commit, "0123456789ab-dirty-fedcba987654", "true", ""),
+            (commit, "wrong-build-id", "false", ""),
+        ];
+        for (commit, build_id, dirty, diff_hash) in invalid {
+            assert!(
+                validate_source_identity(commit, build_id, dirty, diff_hash).is_err(),
+                "invalid frozen identity unexpectedly accepted: {} {} {} {}",
+                commit,
+                build_id,
+                dirty,
+                diff_hash,
+            );
+        }
+    }
 }
 
 fn main() {
     println!("cargo:rerun-if-env-changed=P2WLAN_BUILD_EPOCH_MS");
-    let commit = git_root()
-        .as_deref()
-        .and_then(git_head)
-        .unwrap_or_else(|| "unknown".to_string());
+    for name in SOURCE_IDENTITY_ENV {
+        println!("cargo:rerun-if-env-changed={name}");
+    }
+    let frozen = frozen_source_identity()
+        .unwrap_or_else(|error| panic!("invalid frozen source identity override: {}", error));
+    let (commit, dirty, diff_hash, build_id) = if let Some(identity) = frozen {
+        (
+            identity.commit,
+            identity.dirty,
+            identity.diff_hash,
+            identity.build_id,
+        )
+    } else {
+        let commit = git_root()
+            .as_deref()
+            .and_then(git_head)
+            .unwrap_or_else(|| "unknown".to_string());
+        let (dirty, diff_hash) = checkout_state();
+        let build_id = build_identity(&commit, dirty, &diff_hash);
+        (commit, dirty, diff_hash, build_id)
+    };
     println!("cargo:rustc-env=P2WLAN_GIT_COMMIT={commit}");
-    let (dirty, diff_hash) = checkout_state();
     println!("cargo:rustc-env=P2WLAN_DIRTY={dirty}");
     println!("cargo:rustc-env=P2WLAN_DIFF_HASH={diff_hash}");
     let build_ms = build_epoch_ms();
-    let build_id = build_identity(&commit, dirty, &diff_hash);
     println!("cargo:rustc-env=P2WLAN_BUILD_ID={build_id}");
     println!("cargo:rustc-env=P2WLAN_BUILD_TIME_MS={build_ms}");
     // Re-run when the checked-out commit moves so stale builds never claim a

--- a/client/daemon/build.rs
+++ b/client/daemon/build.rs
@@ -401,6 +401,7 @@ mod tests {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=P2WLAN_BUILD_EPOCH_MS");
+    println!("cargo:rerun-if-env-changed=P2WLAN_SOURCE_IDENTITY_REFRESH");
     for name in SOURCE_IDENTITY_ENV {
         println!("cargo:rerun-if-env-changed={name}");
     }

--- a/client/daemon/src/peer/connection/health.rs
+++ b/client/daemon/src/peer/connection/health.rs
@@ -538,6 +538,7 @@ impl PeerConnection {
         retired_pair_count: usize,
     ) {
         debug_assert_eq!(self.state, ConnectionState::Direct);
+        debug_assert_eq!(self.direct_generation, local_generation);
         debug_assert!(self
             .selected_direct_endpoint_for_consent(local_generation)
             .is_some_and(|endpoint| endpoint == retained_endpoint));

--- a/client/daemon/src/peer/manager/candidates/signaled.rs
+++ b/client/daemon/src/peer/manager/candidates/signaled.rs
@@ -219,7 +219,8 @@ impl PeerManager {
         // strict epoch/cancellation fence.
         let retained_direct_endpoint = remote_candidate_set_changed
             .then(|| {
-                (conn.state == ConnectionState::Direct)
+                (conn.state == ConnectionState::Direct
+                    && conn.direct_generation == generation)
                     .then(|| conn.selected_direct_endpoint_for_consent(generation))
                     .flatten()
             })

--- a/client/daemon/src/peer/manager/candidates/signaled.rs
+++ b/client/daemon/src/peer/manager/candidates/signaled.rs
@@ -217,6 +217,9 @@ impl PeerManager {
         // failure remains the hard liveness fence that can demote it.  Without
         // Direct proof, a changed set is still a real handover and retains the
         // strict epoch/cancellation fence.
+        // The generation comparison is defense-in-depth: public lifecycle
+        // transitions update both values under the shared epoch gate, while
+        // this guard also rejects a synthetic invariant violation.
         let retained_direct_endpoint = remote_candidate_set_changed
             .then(|| {
                 (conn.state == ConnectionState::Direct

--- a/client/daemon/src/peer/tests/part03a.rs
+++ b/client/daemon/src/peer/tests/part03a.rs
@@ -411,6 +411,67 @@ async fn remote_candidate_refresh_retains_confirmed_direct_when_endpoint_is_omit
 }
 
 #[tokio::test]
+async fn remote_candidate_refresh_does_not_retain_direct_from_stale_local_generation() {
+    let manager = PeerManager::new(test_config());
+    let old_endpoint: SocketAddr = "203.0.113.10:41010".parse().unwrap();
+    let fresh_endpoint: SocketAddr = "203.0.113.10:42010".parse().unwrap();
+    manager.add_peer(&test_peer("peer1", old_endpoint)).await;
+
+    assert_eq!(
+        manager
+            .add_candidates_with_metadata(
+                "peer1",
+                &[old_endpoint.to_string()],
+                &HashMap::new(),
+                20,
+                Some(u64::MAX),
+            )
+            .await,
+        CandidateSetApplyResult::Applied
+    );
+    manager
+        .record_direct_probe_success_with_latency(
+            "peer1",
+            old_endpoint,
+            Some(Duration::from_millis(6)),
+        )
+        .await;
+    manager.record_direct_success("peer1", Some(old_endpoint)).await;
+
+    let generation = manager.current_network_generation().await;
+    {
+        let mut connections = manager.connections.write().await;
+        let connection = connections.get_mut("peer1").expect("peer must remain present");
+        assert_eq!(connection.state, ConnectionState::Direct);
+        // A Direct state from a different local generation is not valid
+        // evidence for retaining a changed remote transport context.
+        connection.direct_generation = generation.saturating_add(1);
+    }
+    let before = manager.get_connection("peer1").await.unwrap();
+    let previous_remote_epoch = before.remote_candidate_epoch();
+
+    assert_eq!(
+        manager
+            .add_candidates_with_metadata(
+                "peer1",
+                &[fresh_endpoint.to_string()],
+                &HashMap::new(),
+                21,
+                Some(u64::MAX),
+            )
+            .await,
+        CandidateSetApplyResult::Applied
+    );
+
+    let after = manager.get_connection("peer1").await.unwrap();
+    assert!(after.remote_candidate_epoch() > previous_remote_epoch);
+    assert_eq!(after.state, ConnectionState::FallbackToRelay);
+    assert_eq!(after.endpoint, Some(fresh_endpoint));
+    assert!(!after.candidates.contains(&old_endpoint.to_string()));
+    assert!(after.candidates.contains(&fresh_endpoint.to_string()));
+}
+
+#[tokio::test]
 async fn identical_versioned_candidate_refresh_advances_only_freshness_revision() {
     let manager = PeerManager::new(test_config());
     let endpoint: SocketAddr = "203.0.113.10:41030".parse().unwrap();

--- a/client/daemon/src/peer/tests/part03a.rs
+++ b/client/daemon/src/peer/tests/part03a.rs
@@ -411,7 +411,7 @@ async fn remote_candidate_refresh_retains_confirmed_direct_when_endpoint_is_omit
 }
 
 #[tokio::test]
-async fn remote_candidate_refresh_does_not_retain_direct_from_stale_local_generation() {
+async fn remote_candidate_refresh_defense_in_depth_rejects_mismatched_direct_generation() {
     let manager = PeerManager::new(test_config());
     let old_endpoint: SocketAddr = "203.0.113.10:41010".parse().unwrap();
     let fresh_endpoint: SocketAddr = "203.0.113.10:42010".parse().unwrap();
@@ -443,8 +443,10 @@ async fn remote_candidate_refresh_does_not_retain_direct_from_stale_local_genera
         let mut connections = manager.connections.write().await;
         let connection = connections.get_mut("peer1").expect("peer must remain present");
         assert_eq!(connection.state, ConnectionState::Direct);
-        // A Direct state from a different local generation is not valid
-        // evidence for retaining a changed remote transport context.
+        // Synthetic invariant violation: public lifecycle APIs update Direct
+        // state and direct_generation together under the shared epoch gate.
+        // This white-box case verifies the defense-in-depth fence if an
+        // impossible mismatch ever reaches candidate application.
         connection.direct_generation = generation.saturating_add(1);
     }
     let before = manager.get_connection("peer1").await.unwrap();

--- a/scripts/build_android_native.sh
+++ b/scripts/build_android_native.sh
@@ -70,6 +70,10 @@ build_native() {
   export "CC_${target_key}=$llvm_bin/$clang"
   export "CXX_${target_key}=$llvm_bin/${clang/clang/clang++}"
   export "AR_${target_key}=$llvm_bin/llvm-ar"
+  # Flutter may migrate tracked Android Gradle files during `flutter build`.
+  # Restore the managed checkout immediately before Cargo stamps the native
+  # daemon, so the embedded daemon identity describes the clean source HEAD.
+  P2WLAN_ROOT_DIR="$repo_root" bash "$repo_root/scripts/release/hermetic_build.sh" restore
   cargo build --manifest-path "$repo_root/Cargo.toml" \
     -p p2wlan-android-native --release --target "$target"
 

--- a/scripts/build_android_native.sh
+++ b/scripts/build_android_native.sh
@@ -70,10 +70,6 @@ build_native() {
   export "CC_${target_key}=$llvm_bin/$clang"
   export "CXX_${target_key}=$llvm_bin/${clang/clang/clang++}"
   export "AR_${target_key}=$llvm_bin/llvm-ar"
-  # Flutter may migrate tracked Android Gradle files during `flutter build`.
-  # Restore the managed checkout immediately before Cargo stamps the native
-  # daemon, so the embedded daemon identity describes the clean source HEAD.
-  P2WLAN_ROOT_DIR="$repo_root" bash "$repo_root/scripts/release/hermetic_build.sh" restore
   cargo build --manifest-path "$repo_root/Cargo.toml" \
     -p p2wlan-android-native --release --target "$target"
 

--- a/scripts/release/build_flutter_client.sh
+++ b/scripts/release/build_flutter_client.sh
@@ -4,6 +4,52 @@ set -euo pipefail
 # Build Flutter through the identity stamper so the client and daemon can be
 # compared at Windows startup.  Usage: build_flutter_client.sh windows --release
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-mapfile -t DEFINES < <(python3 "$ROOT_DIR/scripts/release/flutter_client_build_identity.py" "$@")
+DEFINES=()
+while IFS= read -r define; do
+  DEFINES+=("$define")
+done < <(python3 "$ROOT_DIR/scripts/release/flutter_client_build_identity.py" "$@")
+
+# Freeze the identity before Flutter can migrate SDK-managed files.  The
+# snapshot lives under Cargo's ignored target directory so Gradle can read it
+# even when it reuses a daemon whose environment predates this invocation.
+source_commit=""
+source_build_id=""
+source_dirty=""
+source_diff_hash=""
+source_diff_hash_seen=0
+for define in "${DEFINES[@]}"; do
+  key_value="${define#--dart-define=}"
+  key="${key_value%%=*}"
+  value="${key_value#*=}"
+  case "$key" in
+    P2WLAN_CLIENT_GIT_COMMIT) source_commit="$value" ;;
+    P2WLAN_CLIENT_BUILD_ID) source_build_id="$value" ;;
+    P2WLAN_CLIENT_DIRTY) source_dirty="$value" ;;
+    P2WLAN_CLIENT_DIFF_HASH)
+      source_diff_hash="$value"
+      source_diff_hash_seen=1
+      ;;
+  esac
+done
+if [[ -z "$source_commit" || -z "$source_build_id" || -z "$source_dirty" || "$source_diff_hash_seen" -ne 1 ]]; then
+  echo "identity helper did not emit the complete source identity" >&2
+  exit 1
+fi
+
+source_identity_file="$ROOT_DIR/target/p2wlan-source-identity.env"
+mkdir -p "$(dirname "$source_identity_file")"
+rm -f -- "$source_identity_file"
+umask 077
+{
+  printf 'P2WLAN_SOURCE_GIT_COMMIT=%s\n' "$source_commit"
+  printf 'P2WLAN_SOURCE_BUILD_ID=%s\n' "$source_build_id"
+  printf 'P2WLAN_SOURCE_DIRTY=%s\n' "$source_dirty"
+  printf 'P2WLAN_SOURCE_DIFF_HASH=%s\n' "$source_diff_hash"
+} > "$source_identity_file"
+cleanup() {
+  rm -f -- "$source_identity_file"
+}
+trap cleanup EXIT
+
 cd "$ROOT_DIR/apps/flutter_client"
-exec flutter build "$@" "${DEFINES[@]}"
+flutter build "$@" "${DEFINES[@]}"

--- a/scripts/release/build_flutter_client.sh
+++ b/scripts/release/build_flutter_client.sh
@@ -4,10 +4,19 @@ set -euo pipefail
 # Build Flutter through the identity stamper so the client and daemon can be
 # compared at Windows startup.  Usage: build_flutter_client.sh windows --release
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Do not use process substitution here.  Bash reports the status of the
+# while-loop, not the process substitution, so a helper that prints partial
+# output and then fails could otherwise be mistaken for a successful stamp.
+if ! identity_output="$(python3 "$ROOT_DIR/scripts/release/flutter_client_build_identity.py" "$@")"; then
+  echo "Flutter client identity helper failed" >&2
+  exit 1
+fi
+
 DEFINES=()
 while IFS= read -r define; do
   DEFINES+=("$define")
-done < <(python3 "$ROOT_DIR/scripts/release/flutter_client_build_identity.py" "$@")
+done <<< "$identity_output"
 
 # Freeze the identity before Flutter can migrate SDK-managed files.  The
 # snapshot lives under Cargo's ignored target directory so Gradle can read it
@@ -16,40 +25,126 @@ source_commit=""
 source_build_id=""
 source_dirty=""
 source_diff_hash=""
+source_commit_seen=0
+source_build_id_seen=0
+source_dirty_seen=0
 source_diff_hash_seen=0
 for define in "${DEFINES[@]}"; do
+  if [[ "$define" != --dart-define=* ]]; then
+    echo "identity helper emitted malformed output: $define" >&2
+    exit 1
+  fi
   key_value="${define#--dart-define=}"
+  if [[ "$key_value" != *=* ]]; then
+    echo "identity helper emitted malformed define: $define" >&2
+    exit 1
+  fi
   key="${key_value%%=*}"
   value="${key_value#*=}"
   case "$key" in
-    P2WLAN_CLIENT_GIT_COMMIT) source_commit="$value" ;;
-    P2WLAN_CLIENT_BUILD_ID) source_build_id="$value" ;;
-    P2WLAN_CLIENT_DIRTY) source_dirty="$value" ;;
+    P2WLAN_CLIENT_APP_VERSION|P2WLAN_CLIENT_PROFILE) ;;
+    P2WLAN_CLIENT_GIT_COMMIT)
+      if [[ "$source_commit_seen" -ne 0 ]]; then
+        echo "identity helper emitted duplicate P2WLAN_CLIENT_GIT_COMMIT" >&2
+        exit 1
+      fi
+      source_commit="$value"
+      source_commit_seen=1
+      ;;
+    P2WLAN_CLIENT_BUILD_ID)
+      if [[ "$source_build_id_seen" -ne 0 ]]; then
+        echo "identity helper emitted duplicate P2WLAN_CLIENT_BUILD_ID" >&2
+        exit 1
+      fi
+      source_build_id="$value"
+      source_build_id_seen=1
+      ;;
+    P2WLAN_CLIENT_DIRTY)
+      if [[ "$source_dirty_seen" -ne 0 ]]; then
+        echo "identity helper emitted duplicate P2WLAN_CLIENT_DIRTY" >&2
+        exit 1
+      fi
+      source_dirty="$value"
+      source_dirty_seen=1
+      ;;
     P2WLAN_CLIENT_DIFF_HASH)
+      if [[ "$source_diff_hash_seen" -ne 0 ]]; then
+        echo "identity helper emitted duplicate P2WLAN_CLIENT_DIFF_HASH" >&2
+        exit 1
+      fi
       source_diff_hash="$value"
       source_diff_hash_seen=1
       ;;
+    *)
+      echo "identity helper emitted unexpected define: $define" >&2
+      exit 1
+      ;;
   esac
 done
-if [[ -z "$source_commit" || -z "$source_build_id" || -z "$source_dirty" || "$source_diff_hash_seen" -ne 1 ]]; then
+if [[ "$source_commit_seen" -ne 1 || "$source_build_id_seen" -ne 1 || \
+  "$source_dirty_seen" -ne 1 || "$source_diff_hash_seen" -ne 1 ]]; then
   echo "identity helper did not emit the complete source identity" >&2
   exit 1
 fi
+if [[ ! "$source_commit" =~ ^[0-9a-fA-F]{40}$ || "$source_dirty" != true && "$source_dirty" != false ]]; then
+  echo "identity helper emitted invalid source identity fields" >&2
+  exit 1
+fi
+if [[ "$source_dirty" == true && ! "$source_diff_hash" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "identity helper emitted an invalid dirty diff hash" >&2
+  exit 1
+fi
+if [[ "$source_dirty" == false && -n "$source_diff_hash" ]]; then
+  echo "identity helper emitted a clean identity with a diff hash" >&2
+  exit 1
+fi
+expected_build_id="${source_commit:0:12}"
+if [[ "$source_dirty" == true ]]; then
+  expected_build_id="${source_commit:0:12}-dirty-${source_diff_hash:0:12}"
+fi
+if [[ "$source_build_id" != "$expected_build_id" ]]; then
+  echo "identity helper emitted an inconsistent build ID" >&2
+  exit 1
+fi
 
-source_identity_file="$ROOT_DIR/target/p2wlan-source-identity.env"
-mkdir -p "$(dirname "$source_identity_file")"
-rm -f -- "$source_identity_file"
 umask 077
+source_identity_dir=""
+source_identity_file=""
+cleanup() {
+  if [[ -n "$source_identity_file" ]]; then
+    rm -f -- "$source_identity_file"
+  fi
+  if [[ -n "$source_identity_dir" ]]; then
+    rmdir "$source_identity_dir" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+mkdir -p "$ROOT_DIR/target"
+source_identity_dir="$(mktemp -d "$ROOT_DIR/target/p2wlan-source-identity.XXXXXXXX")"
+source_identity_file="$source_identity_dir/source.env"
+identity_nonce="$(od -An -N16 -tx1 /dev/urandom | tr -d '[:space:]')"
+if [[ ! "$identity_nonce" =~ ^[0-9a-f]{32}$ ]]; then
+  echo "failed to generate a valid source identity nonce" >&2
+  exit 1
+fi
 {
   printf 'P2WLAN_SOURCE_GIT_COMMIT=%s\n' "$source_commit"
   printf 'P2WLAN_SOURCE_BUILD_ID=%s\n' "$source_build_id"
   printf 'P2WLAN_SOURCE_DIRTY=%s\n' "$source_dirty"
   printf 'P2WLAN_SOURCE_DIFF_HASH=%s\n' "$source_diff_hash"
+  printf 'P2WLAN_SOURCE_IDENTITY_NONCE=%s\n' "$identity_nonce"
 } > "$source_identity_file"
-cleanup() {
-  rm -f -- "$source_identity_file"
-}
-trap cleanup EXIT
+chmod 600 "$source_identity_file"
+
+# Gradle project properties are carried with each build request, including
+# requests handled by an already-running daemon.  The wrapper never exposes a
+# default path: a direct Gradle/Flutter build has no identity snapshot.
+export ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile="$source_identity_file"
+export ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce="$identity_nonce"
 
 cd "$ROOT_DIR/apps/flutter_client"
 flutter build "$@" "${DEFINES[@]}"

--- a/scripts/release/build_flutter_client.sh
+++ b/scripts/release/build_flutter_client.sh
@@ -15,6 +15,9 @@ fi
 
 DEFINES=()
 while IFS= read -r define; do
+  # Python on Windows may write CRLF to stdout; normalize the record before
+  # validating fields so the same wrapper works under Git Bash and POSIX bash.
+  define="${define%$'\r'}"
   DEFINES+=("$define")
 done <<< "$identity_output"
 

--- a/scripts/release/hermetic_build.sh
+++ b/scripts/release/hermetic_build.sh
@@ -35,6 +35,7 @@ FLUTTER_MANAGED=(
   "apps/flutter_client/pubspec.lock"
   "apps/flutter_client/analysis_options.yaml"
   "apps/flutter_client/.metadata"
+  "apps/flutter_client/android/app/build.gradle.kts"
   "apps/flutter_client/linux/flutter/generated_plugin_registrant.cc"
   "apps/flutter_client/linux/flutter/generated_plugin_registrant.h"
   "apps/flutter_client/linux/flutter/generated_plugins.cmake"

--- a/scripts/release/test_flutter_client_build_identity.py
+++ b/scripts/release/test_flutter_client_build_identity.py
@@ -5,7 +5,9 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -15,10 +17,22 @@ BUILD_WRAPPER = ROOT / "scripts/release/build_flutter_client.sh"
 ANDROID_NATIVE_BUILD = ROOT / "scripts/build_android_native.sh"
 HERMETIC_BUILD = ROOT / "scripts/release/hermetic_build.sh"
 DAEMON_BUILD = ROOT / "client/daemon/build.rs"
+ANDROID_GRADLE_DIR = ROOT / "apps/flutter_client/android"
+GENERATED_NATIVE_LIBRARY = (
+    ROOT
+    / "apps/flutter_client/android/app/src/main/jniLibs/arm64-v8a/libp2wlan_android.so"
+)
+FIXED_SOURCE_IDENTITY_FILE = ROOT / "target/p2wlan-source-identity.env"
 ANDROID_WORKFLOWS = (
     ".github/workflows/flutter-client.yml",
     ".github/workflows/package-test.yml",
     ".github/workflows/release.yml",
+)
+SOURCE_ENV_KEYS = (
+    "P2WLAN_SOURCE_GIT_COMMIT",
+    "P2WLAN_SOURCE_BUILD_ID",
+    "P2WLAN_SOURCE_DIRTY",
+    "P2WLAN_SOURCE_DIFF_HASH",
 )
 
 
@@ -74,7 +88,7 @@ def make_identity_repo() -> tuple[tempfile.TemporaryDirectory, Path, Path]:
 def make_native_safety_repo() -> tuple[tempfile.TemporaryDirectory, Path, Path, Path]:
     temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-native-safety-")
     repo = Path(temp_dir.name)
-    for source in (ANDROID_NATIVE_BUILD, HERMETIC_BUILD, SCRIPT):
+    for source in (ANDROID_NATIVE_BUILD, HERMETIC_BUILD, SCRIPT, DAEMON_BUILD):
         destination = repo / source.relative_to(ROOT)
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination)
@@ -102,10 +116,171 @@ def write_executable(path: Path, contents: str) -> None:
     path.chmod(0o755)
 
 
-def run_build_script(binary: Path, env: dict[str, str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [str(binary)], cwd=cwd, env=env, text=True, capture_output=True
+@contextmanager
+def preserve_file(path: Path):
+    existed = path.exists()
+    original = path.read_bytes() if existed else None
+    original_mode = path.stat().st_mode & 0o777 if existed else None
+    try:
+        yield
+    finally:
+        if existed:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(original)
+            path.chmod(original_mode)
+        elif path.exists():
+            path.unlink()
+
+
+def write_source_snapshot(
+    path: Path,
+    *,
+    commit: str,
+    nonce: str,
+    dirty: str = "false",
+    diff_hash: str = "",
+) -> None:
+    build_id = (
+        f"{commit[:12]}-dirty-{diff_hash[:12]}"
+        if dirty == "true"
+        else commit[:12]
     )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            (
+                f"P2WLAN_SOURCE_GIT_COMMIT={commit}",
+                f"P2WLAN_SOURCE_BUILD_ID={build_id}",
+                f"P2WLAN_SOURCE_DIRTY={dirty}",
+                f"P2WLAN_SOURCE_DIFF_HASH={diff_hash}",
+                f"P2WLAN_SOURCE_IDENTITY_NONCE={nonce}",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def make_fake_android_toolchain(temp_dir: str) -> tuple[Path, Path]:
+    root = Path(temp_dir)
+    fake_bin = root / "fake-bin"
+    fake_bin.mkdir()
+    host_tag = "darwin-arm64" if os.uname().sysname == "Darwin" else "linux-x86_64"
+    ndk_bin = root / f"ndk/toolchains/llvm/prebuilt/{host_tag}/bin"
+    ndk_bin.mkdir(parents=True)
+    write_executable(
+        fake_bin / "rustup",
+        """#!/bin/sh
+set -eu
+if [ "$#" -ge 3 ] && [ "$1" = target ] && [ "$2" = list ] && [ "$3" = --installed ]; then
+  printf '%s\n' aarch64-linux-android
+fi
+""",
+    )
+    write_executable(
+        fake_bin / "cargo",
+        """#!/bin/sh
+set -eu
+target=
+previous=
+for arg in "$@"; do
+  if [ "$previous" = target ]; then target="$arg"; previous=; continue; fi
+  if [ "$arg" = --target ]; then previous=target; fi
+done
+test -n "$target"
+source_commit="$(printenv P2WLAN_SOURCE_GIT_COMMIT 2>/dev/null || true)"
+source_build_id="$(printenv P2WLAN_SOURCE_BUILD_ID 2>/dev/null || true)"
+source_dirty="$(printenv P2WLAN_SOURCE_DIRTY 2>/dev/null || true)"
+source_diff_hash="$(printenv P2WLAN_SOURCE_DIFF_HASH 2>/dev/null || true)"
+if [ -z "$source_commit" ]; then source_commit=UNSET; fi
+if [ -z "$source_build_id" ]; then source_build_id=UNSET; fi
+if [ -z "$source_dirty" ]; then source_dirty=UNSET; fi
+if [ -z "$source_diff_hash" ]; then source_diff_hash=UNSET; fi
+printf '%s\t%s\t%s\t%s\n' "$source_commit" "$source_build_id" "$source_dirty" "$source_diff_hash" >> "$FAKE_CARGO_LOG"
+build_script="$(printenv FAKE_BUILD_SCRIPT 2>/dev/null || true)"
+if [ -n "$build_script" ]; then
+  mkdir -p "$FAKE_BUILD_OUT"
+  CARGO_MANIFEST_DIR="$FAKE_REPO/client/daemon" OUT_DIR="$FAKE_BUILD_OUT" \
+    "$build_script" > "$FAKE_BUILD_SCRIPT_OUTPUT"
+fi
+mkdir -p "$FAKE_REPO/target/$target/release"
+printf '%s\n' fake-native > "$FAKE_REPO/target/$target/release/libp2wlan_android.so"
+""",
+    )
+    write_executable(ndk_bin / "llvm-ar", "#!/bin/sh\nexit 0\n")
+    write_executable(
+        ndk_bin / "aarch64-linux-android23-clang", "#!/bin/sh\nexit 0\n"
+    )
+    return fake_bin, root / "ndk"
+
+
+def make_fake_android_env(
+    temp_dir: str, repo: Path, cargo_log: Path
+) -> dict[str, str]:
+    fake_bin, ndk_root = make_fake_android_toolchain(temp_dir)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["ANDROID_NDK_HOME"] = str(ndk_root)
+    env["P2WLAN_ANDROID_ABIS"] = "arm64-v8a"
+    env["FAKE_REPO"] = str(repo)
+    env["FAKE_CARGO_LOG"] = str(cargo_log)
+    for name in SOURCE_ENV_KEYS + (
+        "ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile",
+        "ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce",
+    ):
+        env.pop(name, None)
+    return env
+
+
+def run_gradle_native(
+    env: dict[str, str], *, no_daemon: bool, task: str = ":app:buildP2wlanNative"
+) -> subprocess.CompletedProcess[str]:
+    command = ["bash", "gradlew", task, "--console=plain"]
+    command.append("--no-daemon" if no_daemon else "--daemon")
+    return subprocess.run(
+        command,
+        cwd=ANDROID_GRADLE_DIR,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def read_fake_cargo_records(path: Path) -> list[tuple[str, str, str, str]]:
+    if not path.exists():
+        return []
+    records = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        values = line.split("\t")
+        if len(values) != 4:
+            raise AssertionError(f"malformed fake Cargo record: {line!r}")
+        records.append(tuple(values))
+    return records
+
+
+def remove_generated_native_library() -> None:
+    if GENERATED_NATIVE_LIBRARY.exists():
+        GENERATED_NATIVE_LIBRARY.unlink()
+    try:
+        GENERATED_NATIVE_LIBRARY.parent.rmdir()
+    except OSError:
+        pass
+
+
+def wait_for_file(
+    path: Path, process: subprocess.Popen[str], timeout: float = 15.0
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"process exited before {path}: rc={process.returncode}\n"
+                f"stdout={stdout}\nstderr={stderr}"
+            )
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for {path}")
+        time.sleep(0.02)
 
 
 class FlutterClientBuildIdentityTest(unittest.TestCase):
@@ -174,15 +349,27 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
         self.addCleanup(temp_dir.cleanup)
         fake_bin = Path(temp_dir.name) / "fake-bin"
         fake_bin.mkdir()
-        ndk_bin = Path(temp_dir.name) / "ndk/toolchains/llvm/prebuilt/darwin-arm64/bin"
+        host_tag = "darwin-arm64" if os.uname().sysname == "Darwin" else "linux-x86_64"
+        ndk_bin = Path(temp_dir.name) / f"ndk/toolchains/llvm/prebuilt/{host_tag}/bin"
         ndk_bin.mkdir(parents=True)
         write_executable(
             fake_bin / "rustup",
-            "#!/bin/sh\nif [ \"$1\" = target ] && [ \"$2\" = list ] && [ \"$3\" = --installed ]; then\n  printf '%s\\n' aarch64-linux-android\nfi\n",
+            "#!/bin/sh\n"
+            "if [ \"$1\" = target ] && [ \"$2\" = list ] && [ \"$3\" = --installed ]; then\n"
+            "  printf '%s\\n' aarch64-linux-android\n"
+            "fi\n",
         )
         write_executable(
             fake_bin / "cargo",
-            "#!/bin/sh\nset -eu\ntarget=\nprevious=\nfor arg in \"$@\"; do\n  if [ \"$previous\" = target ]; then target=\"$arg\"; previous=; continue; fi\n  if [ \"$arg\" = --target ]; then previous=target; fi\ndone\ntest -n \"$target\"\nmkdir -p \"$FAKE_REPO/target/$target/release\"\nprintf '%s\\n' fake-native > \"$FAKE_REPO/target/$target/release/libp2wlan_android.so\"\n",
+            "#!/bin/sh\nset -eu\n"
+            "target=\nprevious=\n"
+            "for arg in \"$@\"; do\n"
+            "  if [ \"$previous\" = target ]; then target=\"$arg\"; previous=; continue; fi\n"
+            "  if [ \"$arg\" = --target ]; then previous=target; fi\n"
+            "done\n"
+            "test -n \"$target\"\n"
+            "mkdir -p \"$FAKE_REPO/target/$target/release\"\n"
+            "printf '%s\\n' fake-native > \"$FAKE_REPO/target/$target/release/libp2wlan_android.so\"\n",
         )
         write_executable(ndk_bin / "llvm-ar", "#!/bin/sh\nexit 0\n")
         write_executable(ndk_bin / "aarch64-linux-android23-clang", "#!/bin/sh\nexit 0\n")
@@ -212,18 +399,73 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
 
         values = parse_defines(
             subprocess.check_output(
-                ["python3", str(repo / "scripts/release/flutter_client_build_identity.py"), "apk", "--release"],
+                [
+                    "python3",
+                    str(repo / "scripts/release/flutter_client_build_identity.py"),
+                    "apk",
+                    "--release",
+                ],
                 cwd=repo,
                 text=True,
             )
         )
         self.assertEqual(values["P2WLAN_CLIENT_DIRTY"], "true")
         self.assertRegex(values["P2WLAN_CLIENT_DIFF_HASH"], r"^[0-9a-f]{40}$")
-        self.assertTrue(values["P2WLAN_CLIENT_BUILD_ID"].endswith(
-            f"-dirty-{values['P2WLAN_CLIENT_DIFF_HASH'][:12]}"
-        ))
+        self.assertTrue(
+            values["P2WLAN_CLIENT_BUILD_ID"].endswith(
+                f"-dirty-{values['P2WLAN_CLIENT_DIFF_HASH'][:12]}"
+            )
+        )
 
-    def test_build_wrapper_freezes_snapshot_for_flutter_and_cleans_it(self):
+    def test_direct_native_build_uses_current_dirty_git_not_historical_snapshot(self):
+        temp_dir, repo, gradle, untracked = make_native_safety_repo()
+        self.addCleanup(temp_dir.cleanup)
+        build_script_binary = Path(temp_dir.name) / "daemon-build-script"
+        subprocess.run(
+            ["rustc", str(repo / "client/daemon/build.rs"), "-o", str(build_script_binary)],
+            check=True,
+        )
+        cargo_log = Path(temp_dir.name) / "cargo.log"
+        build_script_output = Path(temp_dir.name) / "build-script-output.log"
+        fake_env = make_fake_android_env(temp_dir.name, repo, cargo_log)
+        fake_env["FAKE_BUILD_SCRIPT"] = str(build_script_binary)
+        fake_env["FAKE_BUILD_OUT"] = str(Path(temp_dir.name) / "build-out")
+        fake_env["FAKE_BUILD_SCRIPT_OUTPUT"] = str(build_script_output)
+
+        stale = repo / "target/p2wlan-source-identity.env"
+        with preserve_file(stale):
+            write_source_snapshot(
+                stale,
+                commit="1" * 40,
+                nonce="1" * 32,
+                dirty="false",
+            )
+            result = subprocess.run(
+                ["bash", str(repo / "scripts/build_android_native.sh")],
+                cwd=repo,
+                env=fake_env,
+                text=True,
+                capture_output=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(gradle.read_bytes(), b"developer local tracked edit\n")
+        self.assertTrue(untracked.exists())
+        values = {}
+        for line in build_script_output.read_text(encoding="utf-8").splitlines():
+            if line.startswith("cargo:rustc-env="):
+                key, value = line[len("cargo:rustc-env=") :].split("=", 1)
+                values[key] = value
+        expected_commit = run_git(repo, "rev-parse", "HEAD")
+        self.assertEqual(values["P2WLAN_GIT_COMMIT"], expected_commit)
+        self.assertNotEqual(values["P2WLAN_GIT_COMMIT"], "1" * 40)
+        self.assertEqual(values["P2WLAN_DIRTY"], "true")
+        self.assertRegex(values["P2WLAN_DIFF_HASH"], r"^[0-9a-f]{40}$")
+        self.assertRegex(
+            values["P2WLAN_BUILD_ID"],
+            rf"^{expected_commit[:12]}-dirty-[0-9a-f]{{12}}$",
+        )
+
+    def test_build_wrapper_freezes_unique_snapshot_for_flutter_and_cleans_it(self):
         expected = parse_defines(
             subprocess.check_output(
                 ["python3", str(SCRIPT), "apk", "--release"], cwd=ROOT, text=True
@@ -233,18 +475,199 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
         self.addCleanup(temp_dir.cleanup)
         fake_bin = Path(temp_dir.name) / "bin"
         fake_bin.mkdir()
-        snapshot = ROOT / "target/p2wlan-source-identity.env"
+        record = Path(temp_dir.name) / "snapshot.path"
         write_executable(
             fake_bin / "flutter",
-            "#!/bin/sh\nset -eu\ntest \"$1\" = build\ntest -f \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_GIT_COMMIT=$P2WLAN_TEST_COMMIT\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_BUILD_ID=$P2WLAN_TEST_BUILD_ID\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_DIRTY=$P2WLAN_TEST_DIRTY\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_DIFF_HASH=$P2WLAN_TEST_DIFF_HASH\" \"$P2WLAN_TEST_SNAPSHOT\"\n",
+            """#!/bin/sh
+set -eu
+test "$1" = build
+snapshot="$(printenv ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile 2>/dev/null || true)"
+nonce="$(printenv ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce 2>/dev/null || true)"
+test -n "$snapshot"
+test -n "$nonce"
+test -f "$snapshot"
+test "$(sed -n 's/^P2WLAN_SOURCE_IDENTITY_NONCE=//p' "$snapshot")" = "$nonce"
+grep -Fx "P2WLAN_SOURCE_GIT_COMMIT=$P2WLAN_TEST_COMMIT" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_BUILD_ID=$P2WLAN_TEST_BUILD_ID" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_DIRTY=$P2WLAN_TEST_DIRTY" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_DIFF_HASH=$P2WLAN_TEST_DIFF_HASH" "$snapshot"
+printf '%s\n' "$snapshot" > "$P2WLAN_TEST_SNAPSHOT_RECORD"
+""",
         )
         env = os.environ.copy()
         env["PATH"] = f"{fake_bin}:{env['PATH']}"
-        env["P2WLAN_TEST_SNAPSHOT"] = str(snapshot)
+        env["P2WLAN_TEST_SNAPSHOT_RECORD"] = str(record)
         env["P2WLAN_TEST_COMMIT"] = expected["P2WLAN_CLIENT_GIT_COMMIT"]
         env["P2WLAN_TEST_BUILD_ID"] = expected["P2WLAN_CLIENT_BUILD_ID"]
         env["P2WLAN_TEST_DIRTY"] = expected["P2WLAN_CLIENT_DIRTY"]
         env["P2WLAN_TEST_DIFF_HASH"] = expected["P2WLAN_CLIENT_DIFF_HASH"]
+        fixed_existed = FIXED_SOURCE_IDENTITY_FILE.exists()
+        with preserve_file(FIXED_SOURCE_IDENTITY_FILE):
+            result = subprocess.run(
+                ["bash", str(BUILD_WRAPPER), "apk", "--release"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            if not fixed_existed:
+                self.assertFalse(FIXED_SOURCE_IDENTITY_FILE.exists())
+        snapshot = Path(record.read_text(encoding="utf-8").strip())
+        self.assertFalse(snapshot.exists())
+        self.assertFalse(snapshot.parent.exists())
+
+    def test_wrapper_failure_cleans_only_its_snapshot(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-wrapper-failure-")
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "bin"
+        fake_bin.mkdir()
+        record = Path(temp_dir.name) / "snapshot.path"
+        write_executable(
+            fake_bin / "flutter",
+            """#!/bin/sh
+set -eu
+snapshot="$(printenv ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile 2>/dev/null || true)"
+test -f "$snapshot"
+printf '%s\n' "$snapshot" > "$P2WLAN_TEST_SNAPSHOT_RECORD"
+exit 23
+""",
+        )
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["P2WLAN_TEST_SNAPSHOT_RECORD"] = str(record)
+        fixed_existed = FIXED_SOURCE_IDENTITY_FILE.exists()
+        with preserve_file(FIXED_SOURCE_IDENTITY_FILE):
+            result = subprocess.run(
+                ["bash", str(BUILD_WRAPPER), "apk", "--release"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            if not fixed_existed:
+                self.assertFalse(FIXED_SOURCE_IDENTITY_FILE.exists())
+        snapshot = Path(record.read_text(encoding="utf-8").strip())
+        self.assertFalse(snapshot.exists())
+        self.assertFalse(snapshot.parent.exists())
+
+    def test_concurrent_wrappers_have_isolated_snapshots_and_cleanup(self):
+        expected = parse_defines(
+            subprocess.check_output(
+                ["python3", str(SCRIPT), "apk", "--release"], cwd=ROOT, text=True
+            )
+        )
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-wrapper-concurrent-")
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "bin"
+        fake_bin.mkdir()
+        capture_dir = Path(temp_dir.name) / "captures"
+        capture_dir.mkdir()
+        write_executable(
+            fake_bin / "flutter",
+            """#!/bin/sh
+set -eu
+test "$1" = build
+snapshot="$(printenv ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile 2>/dev/null || true)"
+nonce="$(printenv ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce 2>/dev/null || true)"
+role="$(printenv P2WLAN_TEST_ROLE)"
+test -f "$snapshot"
+test -n "$nonce"
+test "$(sed -n 's/^P2WLAN_SOURCE_IDENTITY_NONCE=//p' "$snapshot")" = "$nonce"
+grep -Fx "P2WLAN_SOURCE_GIT_COMMIT=$P2WLAN_TEST_COMMIT" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_BUILD_ID=$P2WLAN_TEST_BUILD_ID" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_DIRTY=$P2WLAN_TEST_DIRTY" "$snapshot"
+grep -Fx "P2WLAN_SOURCE_DIFF_HASH=$P2WLAN_TEST_DIFF_HASH" "$snapshot"
+printf '%s\n' "$snapshot" > "$P2WLAN_TEST_CAPTURE_DIR/$role.path"
+printf '%s\n' "$nonce" > "$P2WLAN_TEST_CAPTURE_DIR/$role.nonce"
+touch "$P2WLAN_TEST_CAPTURE_DIR/$role.ready"
+while [ ! -f "$P2WLAN_TEST_CAPTURE_DIR/$role.release" ]; do
+  sleep 0.02
+done
+""",
+        )
+        base_env = os.environ.copy()
+        base_env["PATH"] = f"{fake_bin}:{base_env['PATH']}"
+        base_env["P2WLAN_TEST_CAPTURE_DIR"] = str(capture_dir)
+        base_env["P2WLAN_TEST_COMMIT"] = expected["P2WLAN_CLIENT_GIT_COMMIT"]
+        base_env["P2WLAN_TEST_BUILD_ID"] = expected["P2WLAN_CLIENT_BUILD_ID"]
+        base_env["P2WLAN_TEST_DIRTY"] = expected["P2WLAN_CLIENT_DIRTY"]
+        base_env["P2WLAN_TEST_DIFF_HASH"] = expected["P2WLAN_CLIENT_DIFF_HASH"]
+        processes: dict[str, subprocess.Popen[str]] = {}
+        fixed_existed = FIXED_SOURCE_IDENTITY_FILE.exists()
+        try:
+            for role in ("A", "B"):
+                role_env = base_env.copy()
+                role_env["P2WLAN_TEST_ROLE"] = role
+                processes[role] = subprocess.Popen(
+                    ["bash", str(BUILD_WRAPPER), "apk", "--release"],
+                    cwd=ROOT,
+                    env=role_env,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            for role in ("A", "B"):
+                wait_for_file(capture_dir / f"{role}.ready", processes[role])
+            path_a = Path((capture_dir / "A.path").read_text(encoding="utf-8").strip())
+            path_b = Path((capture_dir / "B.path").read_text(encoding="utf-8").strip())
+            nonce_a = (capture_dir / "A.nonce").read_text(encoding="utf-8").strip()
+            nonce_b = (capture_dir / "B.nonce").read_text(encoding="utf-8").strip()
+            self.assertNotEqual(path_a, path_b)
+            self.assertNotEqual(nonce_a, nonce_b)
+            self.assertTrue(path_a.is_file())
+            self.assertTrue(path_b.is_file())
+            self.assertTrue(str(path_a).startswith(str(ROOT / "target")))
+            self.assertTrue(str(path_b).startswith(str(ROOT / "target")))
+            (capture_dir / "A.release").touch()
+            self.assertEqual(processes["A"].wait(timeout=10), 0)
+            self.assertFalse(path_a.exists())
+            self.assertTrue(path_b.is_file())
+            (capture_dir / "B.release").touch()
+            self.assertEqual(processes["B"].wait(timeout=10), 0)
+            self.assertFalse(path_b.exists())
+            if not fixed_existed:
+                self.assertFalse(FIXED_SOURCE_IDENTITY_FILE.exists())
+        finally:
+            for role in ("A", "B"):
+                (capture_dir / f"{role}.release").touch()
+            for process in processes.values():
+                if process.poll() is None:
+                    process.terminate()
+                try:
+                    process.communicate(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.communicate()
+
+    def test_identity_helper_failure_with_partial_output_stops_flutter(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-wrapper-helper-failure-")
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "bin"
+        fake_bin.mkdir()
+        marker = Path(temp_dir.name) / "flutter-called"
+        write_executable(
+            fake_bin / "python3",
+            """#!/bin/sh
+printf '%s\n' '--dart-define=P2WLAN_CLIENT_GIT_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf '%s\n' '--dart-define=P2WLAN_CLIENT_BUILD_ID=aaaaaaaaaaaa'
+printf '%s\n' '--dart-define=P2WLAN_CLIENT_DIRTY=false'
+printf '%s\n' '--dart-define=P2WLAN_CLIENT_DIFF_HASH='
+exit 17
+""",
+        )
+        write_executable(
+            fake_bin / "flutter",
+            """#!/bin/sh
+touch "$P2WLAN_TEST_FLUTTER_MARKER"
+exit 0
+""",
+        )
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["P2WLAN_TEST_FLUTTER_MARKER"] = str(marker)
+        before = set((ROOT / "target").glob("p2wlan-source-identity.*"))
         result = subprocess.run(
             ["bash", str(BUILD_WRAPPER), "apk", "--release"],
             cwd=ROOT,
@@ -252,8 +675,124 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
             text=True,
             capture_output=True,
         )
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertFalse(snapshot.exists())
+        after = set((ROOT / "target").glob("p2wlan-source-identity.*"))
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("identity helper failed", result.stderr)
+        self.assertFalse(marker.exists())
+        self.assertEqual(before, after)
+
+    def test_direct_gradle_ignores_stale_fixed_snapshot(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-gradle-stale-")
+        self.addCleanup(temp_dir.cleanup)
+        cargo_log = Path(temp_dir.name) / "cargo.log"
+        env = make_fake_android_env(temp_dir.name, ROOT, cargo_log)
+        stale = ROOT / "target/p2wlan-source-identity.env"
+        with preserve_file(stale), preserve_file(GENERATED_NATIVE_LIBRARY):
+            remove_generated_native_library()
+            write_source_snapshot(
+                stale,
+                commit="1" * 40,
+                nonce="1" * 32,
+                dirty="false",
+            )
+            result = run_gradle_native(env, no_daemon=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                read_fake_cargo_records(cargo_log),
+                [("UNSET", "UNSET", "UNSET", "UNSET")],
+            )
+
+    def test_gradle_requires_explicit_matching_snapshot_path_and_nonce(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-gradle-properties-")
+        self.addCleanup(temp_dir.cleanup)
+        cargo_log = Path(temp_dir.name) / "cargo.log"
+        env = make_fake_android_env(temp_dir.name, ROOT, cargo_log)
+        snapshot = Path(temp_dir.name) / "identity-a.env"
+        nonce = "a" * 32
+        write_source_snapshot(snapshot, commit="a" * 40, nonce=nonce)
+        with preserve_file(GENERATED_NATIVE_LIBRARY):
+            remove_generated_native_library()
+            valid_env = env.copy()
+            valid_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(snapshot)
+            valid_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+            result = run_gradle_native(valid_env, no_daemon=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                read_fake_cargo_records(cargo_log),
+                [("a" * 40, "a" * 12, "false", "UNSET")],
+            )
+
+            missing_nonce = env.copy()
+            missing_nonce["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(snapshot)
+            missing_path = env.copy()
+            missing_path["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+            mismatch = env.copy()
+            mismatch["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(snapshot)
+            mismatch["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = "b" * 32
+            nonexistent = env.copy()
+            nonexistent["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(
+                Path(temp_dir.name) / "does-not-exist.env"
+            )
+            nonexistent["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+            for case_name, case_env in (
+                ("missing nonce", missing_nonce),
+                ("missing path", missing_path),
+                ("nonce mismatch", mismatch),
+                ("missing file", nonexistent),
+            ):
+                invalid = run_gradle_native(
+                    case_env, no_daemon=True, task=":app:tasks"
+                )
+                self.assertNotEqual(
+                    invalid.returncode,
+                    0,
+                    f"{case_name} unexpectedly succeeded:\n"
+                    f"{invalid.stdout}\n{invalid.stderr}",
+                )
+
+    def test_gradle_daemon_refreshes_identity_and_native_task_inputs(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-gradle-daemon-")
+        self.addCleanup(temp_dir.cleanup)
+        cargo_log = Path(temp_dir.name) / "cargo.log"
+        env = make_fake_android_env(temp_dir.name, ROOT, cargo_log)
+        snapshot_a = Path(temp_dir.name) / "identity-a.env"
+        snapshot_b = Path(temp_dir.name) / "identity-b.env"
+        write_source_snapshot(snapshot_a, commit="a" * 40, nonce="a" * 32)
+        write_source_snapshot(snapshot_b, commit="b" * 40, nonce="b" * 32)
+        stale = ROOT / "target/p2wlan-source-identity.env"
+        with preserve_file(stale), preserve_file(GENERATED_NATIVE_LIBRARY):
+            remove_generated_native_library()
+            for snapshot, nonce in (
+                (snapshot_a, "a" * 32),
+                (snapshot_b, "b" * 32),
+            ):
+                invocation_env = env.copy()
+                invocation_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(
+                    snapshot
+                )
+                invocation_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+                result = run_gradle_native(invocation_env, no_daemon=False)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            write_source_snapshot(
+                stale,
+                commit="1" * 40,
+                nonce="1" * 32,
+                dirty="false",
+            )
+            direct_result = run_gradle_native(env, no_daemon=False)
+            self.assertEqual(
+                direct_result.returncode,
+                0,
+                direct_result.stdout + direct_result.stderr,
+            )
+        self.assertEqual(
+            read_fake_cargo_records(cargo_log),
+            [
+                ("a" * 40, "a" * 12, "false", "UNSET"),
+                ("b" * 40, "b" * 12, "false", "UNSET"),
+                ("UNSET", "UNSET", "UNSET", "UNSET"),
+            ],
+        )
 
     def test_daemon_source_identity_override_is_complete_and_fail_closed(self):
         temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-build-script-")
@@ -262,14 +801,11 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
         subprocess.run(["rustc", str(DAEMON_BUILD), "-o", str(binary)], check=True)
 
         base_env = os.environ.copy()
-        for name in (
-            "P2WLAN_SOURCE_GIT_COMMIT",
-            "P2WLAN_SOURCE_BUILD_ID",
-            "P2WLAN_SOURCE_DIRTY",
-            "P2WLAN_SOURCE_DIFF_HASH",
-        ):
+        for name in SOURCE_ENV_KEYS:
             base_env.pop(name, None)
-        no_override = run_build_script(binary, base_env, ROOT)
+        no_override = subprocess.run(
+            [str(binary)], cwd=ROOT, env=base_env, text=True, capture_output=True
+        )
         self.assertEqual(no_override.returncode, 0, no_override.stderr)
 
         temp_identity, identity_repo, identity_script = make_identity_repo()
@@ -287,7 +823,13 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
             "P2WLAN_SOURCE_DIRTY": client_values["P2WLAN_CLIENT_DIRTY"],
             "P2WLAN_SOURCE_DIFF_HASH": client_values["P2WLAN_CLIENT_DIFF_HASH"],
         }
-        valid = run_build_script(binary, source_env, identity_repo)
+        valid = subprocess.run(
+            [str(binary)],
+            cwd=identity_repo,
+            env=source_env,
+            text=True,
+            capture_output=True,
+        )
         self.assertEqual(valid.returncode, 0, valid.stderr)
         self.assertIn(
             f"cargo:rustc-env=P2WLAN_GIT_COMMIT={client_values['P2WLAN_CLIENT_GIT_COMMIT']}",
@@ -300,20 +842,57 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
 
         partial = dict(base_env)
         partial["P2WLAN_SOURCE_GIT_COMMIT"] = client_values["P2WLAN_CLIENT_GIT_COMMIT"]
-        result = run_build_script(binary, partial, identity_repo)
+        result = subprocess.run(
+            [str(binary)],
+            cwd=identity_repo,
+            env=partial,
+            text=True,
+            capture_output=True,
+        )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must provide all fields", result.stderr)
 
         commit = "0123456789abcdef0123456789abcdef01234567"
         malformed = [
-            {"P2WLAN_SOURCE_GIT_COMMIT": "not-a-commit", "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": ""},
-            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "maybe", "P2WLAN_SOURCE_DIFF_HASH": ""},
-            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": "fedcba98765432100123456789abcdef01234567"},
-            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab-dirty-fedcba987654", "P2WLAN_SOURCE_DIRTY": "true", "P2WLAN_SOURCE_DIFF_HASH": ""},
-            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "wrong-build-id", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": ""},
+            {
+                "P2WLAN_SOURCE_GIT_COMMIT": "not-a-commit",
+                "P2WLAN_SOURCE_BUILD_ID": "0123456789ab",
+                "P2WLAN_SOURCE_DIRTY": "false",
+                "P2WLAN_SOURCE_DIFF_HASH": "",
+            },
+            {
+                "P2WLAN_SOURCE_GIT_COMMIT": commit,
+                "P2WLAN_SOURCE_BUILD_ID": "0123456789ab",
+                "P2WLAN_SOURCE_DIRTY": "maybe",
+                "P2WLAN_SOURCE_DIFF_HASH": "",
+            },
+            {
+                "P2WLAN_SOURCE_GIT_COMMIT": commit,
+                "P2WLAN_SOURCE_BUILD_ID": "0123456789ab",
+                "P2WLAN_SOURCE_DIRTY": "false",
+                "P2WLAN_SOURCE_DIFF_HASH": "fedcba98765432100123456789abcdef01234567",
+            },
+            {
+                "P2WLAN_SOURCE_GIT_COMMIT": commit,
+                "P2WLAN_SOURCE_BUILD_ID": "0123456789ab-dirty-fedcba987654",
+                "P2WLAN_SOURCE_DIRTY": "true",
+                "P2WLAN_SOURCE_DIFF_HASH": "",
+            },
+            {
+                "P2WLAN_SOURCE_GIT_COMMIT": commit,
+                "P2WLAN_SOURCE_BUILD_ID": "wrong-build-id",
+                "P2WLAN_SOURCE_DIRTY": "false",
+                "P2WLAN_SOURCE_DIFF_HASH": "",
+            },
         ]
         for override in malformed:
-            result = run_build_script(binary, base_env | override, identity_repo)
+            result = subprocess.run(
+                [str(binary)],
+                cwd=identity_repo,
+                env=base_env | override,
+                text=True,
+                capture_output=True,
+            )
             self.assertNotEqual(result.returncode, 0, override)
             self.assertIn("invalid frozen source identity override", result.stderr)
 
@@ -337,8 +916,11 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
         gradle = (ROOT / "apps/flutter_client/android/app/build.gradle.kts").read_text(
             encoding="utf-8"
         )
-        self.assertIn("p2wlan-source-identity.env", gradle)
-        self.assertIn("environment(key, value)", gradle)
+        self.assertIn('providers.gradleProperty("p2wlanSourceIdentityFile")', gradle)
+        self.assertIn('providers.gradleProperty("p2wlanSourceIdentityNonce")', gradle)
+        self.assertIn('inputs.property("p2wlanSourceIdentityNonce"', gradle)
+        self.assertNotIn("target/p2wlan-source-identity.env", gradle)
+        self.assertIn("environment(key, sourceIdentityValues.getValue(key))", gradle)
         native = ANDROID_NATIVE_BUILD.read_text(encoding="utf-8")
         self.assertNotIn("hermetic_build.sh restore", native)
         self.assertNotRegex(native, r"git (checkout|restore|reset|clean)")

--- a/scripts/release/test_flutter_client_build_identity.py
+++ b/scripts/release/test_flutter_client_build_identity.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -10,6 +11,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/release/flutter_client_build_identity.py"
+BUILD_WRAPPER = ROOT / "scripts/release/build_flutter_client.sh"
+ANDROID_NATIVE_BUILD = ROOT / "scripts/build_android_native.sh"
+HERMETIC_BUILD = ROOT / "scripts/release/hermetic_build.sh"
+DAEMON_BUILD = ROOT / "client/daemon/build.rs"
 ANDROID_WORKFLOWS = (
     ".github/workflows/flutter-client.yml",
     ".github/workflows/package-test.yml",
@@ -19,6 +24,24 @@ ANDROID_WORKFLOWS = (
 
 def run_git(repo: Path, *args: str) -> str:
     return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def init_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "identity-test@example.invalid"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Identity Test"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "identity fixture"],
+        cwd=repo,
+        check=True,
+    )
 
 
 def parse_defines(output: str) -> dict[str, str]:
@@ -44,18 +67,45 @@ def make_identity_repo() -> tuple[tempfile.TemporaryDirectory, Path, Path]:
         "name: identity_test\nversion: 9.8.7+1\n",
         encoding="utf-8",
     )
-    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "identity-test@example.invalid"],
-        cwd=repo,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Identity Test"], cwd=repo, check=True
-    )
-    subprocess.run(["git", "add", "."], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "--quiet", "-m", "identity fixture"], cwd=repo, check=True)
+    init_git_repo(repo)
     return temp_dir, repo, script
+
+
+def make_native_safety_repo() -> tuple[tempfile.TemporaryDirectory, Path, Path, Path]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-native-safety-")
+    repo = Path(temp_dir.name)
+    for source in (ANDROID_NATIVE_BUILD, HERMETIC_BUILD, SCRIPT):
+        destination = repo / source.relative_to(ROOT)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    app = repo / "apps/flutter_client"
+    gradle = app / "android/app/build.gradle.kts"
+    gradle.parent.mkdir(parents=True)
+    (app / "pubspec.yaml").write_text(
+        "name: native_safety_test\nversion: 9.8.7+1\n", encoding="utf-8"
+    )
+    gradle.write_bytes(b"original managed Gradle input\n")
+    (repo / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+    (repo / ".gitignore").write_text(
+        "target/\napps/flutter_client/android/app/src/main/jniLibs/\n",
+        encoding="utf-8",
+    )
+    init_git_repo(repo)
+    untracked = app / "android/app/local-developer-source.gradle.kts"
+    untracked.write_bytes(b"developer-only source\n")
+    gradle.write_bytes(b"developer local tracked edit\n")
+    return temp_dir, repo, gradle, untracked
+
+
+def write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def run_build_script(binary: Path, env: dict[str, str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(binary)], cwd=cwd, env=env, text=True, capture_output=True
+    )
 
 
 class FlutterClientBuildIdentityTest(unittest.TestCase):
@@ -119,6 +169,154 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
             f"{expected_commit[:12]}-dirty-{first['P2WLAN_CLIENT_DIFF_HASH'][:12]}",
         )
 
+    def test_android_native_build_preserves_tracked_and_untracked_local_changes(self):
+        temp_dir, repo, gradle, untracked = make_native_safety_repo()
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "fake-bin"
+        fake_bin.mkdir()
+        ndk_bin = Path(temp_dir.name) / "ndk/toolchains/llvm/prebuilt/darwin-arm64/bin"
+        ndk_bin.mkdir(parents=True)
+        write_executable(
+            fake_bin / "rustup",
+            "#!/bin/sh\nif [ \"$1\" = target ] && [ \"$2\" = list ] && [ \"$3\" = --installed ]; then\n  printf '%s\\n' aarch64-linux-android\nfi\n",
+        )
+        write_executable(
+            fake_bin / "cargo",
+            "#!/bin/sh\nset -eu\ntarget=\nprevious=\nfor arg in \"$@\"; do\n  if [ \"$previous\" = target ]; then target=\"$arg\"; previous=; continue; fi\n  if [ \"$arg\" = --target ]; then previous=target; fi\ndone\ntest -n \"$target\"\nmkdir -p \"$FAKE_REPO/target/$target/release\"\nprintf '%s\\n' fake-native > \"$FAKE_REPO/target/$target/release/libp2wlan_android.so\"\n",
+        )
+        write_executable(ndk_bin / "llvm-ar", "#!/bin/sh\nexit 0\n")
+        write_executable(ndk_bin / "aarch64-linux-android23-clang", "#!/bin/sh\nexit 0\n")
+
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["ANDROID_NDK_HOME"] = str(Path(temp_dir.name) / "ndk")
+        env["P2WLAN_ANDROID_ABIS"] = "arm64-v8a"
+        env["FAKE_REPO"] = str(repo)
+        result = subprocess.run(
+            ["bash", str(repo / "scripts/build_android_native.sh")],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(gradle.read_bytes(), b"developer local tracked edit\n")
+        self.assertTrue(untracked.exists())
+        status = subprocess.check_output(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=repo,
+            text=True,
+        )
+        self.assertIn(" M apps/flutter_client/android/app/build.gradle.kts", status)
+        self.assertIn("?? apps/flutter_client/android/app/local-developer-source.gradle.kts", status)
+
+        values = parse_defines(
+            subprocess.check_output(
+                ["python3", str(repo / "scripts/release/flutter_client_build_identity.py"), "apk", "--release"],
+                cwd=repo,
+                text=True,
+            )
+        )
+        self.assertEqual(values["P2WLAN_CLIENT_DIRTY"], "true")
+        self.assertRegex(values["P2WLAN_CLIENT_DIFF_HASH"], r"^[0-9a-f]{40}$")
+        self.assertTrue(values["P2WLAN_CLIENT_BUILD_ID"].endswith(
+            f"-dirty-{values['P2WLAN_CLIENT_DIFF_HASH'][:12]}"
+        ))
+
+    def test_build_wrapper_freezes_snapshot_for_flutter_and_cleans_it(self):
+        expected = parse_defines(
+            subprocess.check_output(
+                ["python3", str(SCRIPT), "apk", "--release"], cwd=ROOT, text=True
+            )
+        )
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-wrapper-fake-flutter-")
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "bin"
+        fake_bin.mkdir()
+        snapshot = ROOT / "target/p2wlan-source-identity.env"
+        write_executable(
+            fake_bin / "flutter",
+            "#!/bin/sh\nset -eu\ntest \"$1\" = build\ntest -f \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_GIT_COMMIT=$P2WLAN_TEST_COMMIT\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_BUILD_ID=$P2WLAN_TEST_BUILD_ID\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_DIRTY=$P2WLAN_TEST_DIRTY\" \"$P2WLAN_TEST_SNAPSHOT\"\ngrep -Fx \"P2WLAN_SOURCE_DIFF_HASH=$P2WLAN_TEST_DIFF_HASH\" \"$P2WLAN_TEST_SNAPSHOT\"\n",
+        )
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["P2WLAN_TEST_SNAPSHOT"] = str(snapshot)
+        env["P2WLAN_TEST_COMMIT"] = expected["P2WLAN_CLIENT_GIT_COMMIT"]
+        env["P2WLAN_TEST_BUILD_ID"] = expected["P2WLAN_CLIENT_BUILD_ID"]
+        env["P2WLAN_TEST_DIRTY"] = expected["P2WLAN_CLIENT_DIRTY"]
+        env["P2WLAN_TEST_DIFF_HASH"] = expected["P2WLAN_CLIENT_DIFF_HASH"]
+        result = subprocess.run(
+            ["bash", str(BUILD_WRAPPER), "apk", "--release"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(snapshot.exists())
+
+    def test_daemon_source_identity_override_is_complete_and_fail_closed(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-build-script-")
+        self.addCleanup(temp_dir.cleanup)
+        binary = Path(temp_dir.name) / "daemon-build-script"
+        subprocess.run(["rustc", str(DAEMON_BUILD), "-o", str(binary)], check=True)
+
+        base_env = os.environ.copy()
+        for name in (
+            "P2WLAN_SOURCE_GIT_COMMIT",
+            "P2WLAN_SOURCE_BUILD_ID",
+            "P2WLAN_SOURCE_DIRTY",
+            "P2WLAN_SOURCE_DIFF_HASH",
+        ):
+            base_env.pop(name, None)
+        no_override = run_build_script(binary, base_env, ROOT)
+        self.assertEqual(no_override.returncode, 0, no_override.stderr)
+
+        temp_identity, identity_repo, identity_script = make_identity_repo()
+        self.addCleanup(temp_identity.cleanup)
+        client_values = parse_defines(
+            subprocess.check_output(
+                ["python3", str(identity_script), "apk", "--release"],
+                cwd=identity_repo,
+                text=True,
+            )
+        )
+        source_env = base_env | {
+            "P2WLAN_SOURCE_GIT_COMMIT": client_values["P2WLAN_CLIENT_GIT_COMMIT"],
+            "P2WLAN_SOURCE_BUILD_ID": client_values["P2WLAN_CLIENT_BUILD_ID"],
+            "P2WLAN_SOURCE_DIRTY": client_values["P2WLAN_CLIENT_DIRTY"],
+            "P2WLAN_SOURCE_DIFF_HASH": client_values["P2WLAN_CLIENT_DIFF_HASH"],
+        }
+        valid = run_build_script(binary, source_env, identity_repo)
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+        self.assertIn(
+            f"cargo:rustc-env=P2WLAN_GIT_COMMIT={client_values['P2WLAN_CLIENT_GIT_COMMIT']}",
+            valid.stdout,
+        )
+        self.assertIn(
+            f"cargo:rustc-env=P2WLAN_BUILD_ID={client_values['P2WLAN_CLIENT_BUILD_ID']}",
+            valid.stdout,
+        )
+
+        partial = dict(base_env)
+        partial["P2WLAN_SOURCE_GIT_COMMIT"] = client_values["P2WLAN_CLIENT_GIT_COMMIT"]
+        result = run_build_script(binary, partial, identity_repo)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must provide all fields", result.stderr)
+
+        commit = "0123456789abcdef0123456789abcdef01234567"
+        malformed = [
+            {"P2WLAN_SOURCE_GIT_COMMIT": "not-a-commit", "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": ""},
+            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "maybe", "P2WLAN_SOURCE_DIFF_HASH": ""},
+            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": "fedcba98765432100123456789abcdef01234567"},
+            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "0123456789ab-dirty-fedcba987654", "P2WLAN_SOURCE_DIRTY": "true", "P2WLAN_SOURCE_DIFF_HASH": ""},
+            {"P2WLAN_SOURCE_GIT_COMMIT": commit, "P2WLAN_SOURCE_BUILD_ID": "wrong-build-id", "P2WLAN_SOURCE_DIRTY": "false", "P2WLAN_SOURCE_DIFF_HASH": ""},
+        ]
+        for override in malformed:
+            result = run_build_script(binary, base_env | override, identity_repo)
+            self.assertNotEqual(result.returncode, 0, override)
+            self.assertIn("invalid frozen source identity override", result.stderr)
+
     def test_flutter_android_workflow_orders_restore_identity_and_wrapper(self):
         workflow = (ROOT / ANDROID_WORKFLOWS[0]).read_text(encoding="utf-8")
         android_job = workflow[workflow.index("  android:\n") :]
@@ -136,6 +334,14 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
             "python3 scripts/release/flutter_client_build_identity.py apk --release",
             android_job,
         )
+        gradle = (ROOT / "apps/flutter_client/android/app/build.gradle.kts").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("p2wlan-source-identity.env", gradle)
+        self.assertIn("environment(key, value)", gradle)
+        native = ANDROID_NATIVE_BUILD.read_text(encoding="utf-8")
+        self.assertNotIn("hermetic_build.sh restore", native)
+        self.assertNotRegex(native, r"git (checkout|restore|reset|clean)")
 
     def test_android_workflows_use_wrapper_without_bare_flutter_apk_build(self):
         for workflow_path in ANDROID_WORKFLOWS:

--- a/scripts/release/test_flutter_client_build_identity.py
+++ b/scripts/release/test_flutter_client_build_identity.py
@@ -58,6 +58,47 @@ def init_git_repo(repo: Path) -> None:
     )
 
 
+def commit_git_changes(repo: Path, message: str) -> None:
+    subprocess.run(["git", "add", "--all"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", message], cwd=repo, check=True
+    )
+
+
+def make_direct_identity_repo() -> tuple[tempfile.TemporaryDirectory, Path]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-direct-identity-")
+    repo = Path(temp_dir.name)
+    (repo / "client/daemon").mkdir(parents=True)
+    (repo / ".gitignore").write_text(
+        "target/\n.test-artifacts/\nfake-bin/\nndk/\n", encoding="utf-8"
+    )
+    (repo / "README.md").write_text("identity A\n", encoding="utf-8")
+    init_git_repo(repo)
+    return temp_dir, repo
+
+
+def make_cargo_refresh_repo() -> tuple[tempfile.TemporaryDirectory, Path]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-cargo-refresh-")
+    repo = Path(temp_dir.name)
+    (repo / "client/daemon").mkdir(parents=True)
+    shutil.copy2(DAEMON_BUILD, repo / "client/daemon/build.rs")
+    (repo / "Cargo.toml").write_text(
+        "[package]\n"
+        "name = \"identity-refresh-fixture\"\n"
+        "version = \"0.1.0\"\n"
+        "edition = \"2021\"\n"
+        "build = \"client/daemon/build.rs\"\n"
+        "\n"
+        "[lib]\n"
+        "path = \"lib.rs\"\n",
+        encoding="utf-8",
+    )
+    (repo / "lib.rs").write_text("pub fn identity_fixture() {}\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("target/\n", encoding="utf-8")
+    init_git_repo(repo)
+    return temp_dir, repo
+
+
 def parse_defines(output: str) -> dict[str, str]:
     prefix = "--dart-define="
     values = {}
@@ -197,14 +238,22 @@ if [ -z "$source_build_id" ]; then source_build_id=UNSET; fi
 if [ -z "$source_dirty" ]; then source_dirty=UNSET; fi
 if [ -z "$source_diff_hash" ]; then source_diff_hash=UNSET; fi
 printf '%s\t%s\t%s\t%s\n' "$source_commit" "$source_build_id" "$source_dirty" "$source_diff_hash" >> "$FAKE_CARGO_LOG"
+refresh="$(printenv P2WLAN_SOURCE_IDENTITY_REFRESH 2>/dev/null || true)"
+if [ -z "$refresh" ]; then refresh=UNSET; fi
+refresh_log="$(printenv FAKE_REFRESH_LOG 2>/dev/null || true)"
+if [ -n "$refresh_log" ]; then printf '%s\n' "$refresh" >> "$refresh_log"; fi
 build_script="$(printenv FAKE_BUILD_SCRIPT 2>/dev/null || true)"
+native_identity="$source_commit"
 if [ -n "$build_script" ]; then
   mkdir -p "$FAKE_BUILD_OUT"
-  CARGO_MANIFEST_DIR="$FAKE_REPO/client/daemon" OUT_DIR="$FAKE_BUILD_OUT" \
+  build_manifest_repo="$(printenv FAKE_BUILD_MANIFEST_REPO 2>/dev/null || true)"
+  if [ -z "$build_manifest_repo" ]; then build_manifest_repo="$FAKE_REPO"; fi
+  CARGO_MANIFEST_DIR="$build_manifest_repo/client/daemon" OUT_DIR="$FAKE_BUILD_OUT" \
     "$build_script" > "$FAKE_BUILD_SCRIPT_OUTPUT"
+  native_identity="$(sed -n 's/^cargo:rustc-env=P2WLAN_GIT_COMMIT=//p' "$FAKE_BUILD_SCRIPT_OUTPUT" | tail -n 1)"
 fi
 mkdir -p "$FAKE_REPO/target/$target/release"
-printf '%s\n' fake-native > "$FAKE_REPO/target/$target/release/libp2wlan_android.so"
+printf 'fake-native identity=%s\n' "$native_identity" > "$FAKE_REPO/target/$target/release/libp2wlan_android.so"
 """,
     )
     write_executable(ndk_bin / "llvm-ar", "#!/bin/sh\nexit 0\n")
@@ -225,6 +274,7 @@ def make_fake_android_env(
     env["FAKE_REPO"] = str(repo)
     env["FAKE_CARGO_LOG"] = str(cargo_log)
     for name in SOURCE_ENV_KEYS + (
+        "P2WLAN_SOURCE_IDENTITY_REFRESH",
         "ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile",
         "ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce",
     ):
@@ -233,9 +283,21 @@ def make_fake_android_env(
 
 
 def run_gradle_native(
-    env: dict[str, str], *, no_daemon: bool, task: str = ":app:buildP2wlanNative"
+    env: dict[str, str],
+    *,
+    no_daemon: bool,
+    task: str = ":app:buildP2wlanNative",
+    project_cache_dir: Path | None = None,
+    build_cache: bool = False,
+    configuration_cache: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     command = ["bash", "gradlew", task, "--console=plain"]
+    if project_cache_dir is not None:
+        command.extend(["--project-cache-dir", str(project_cache_dir)])
+    if build_cache:
+        command.append("--build-cache")
+    if configuration_cache:
+        command.append("--configuration-cache")
     command.append("--no-daemon" if no_daemon else "--daemon")
     return subprocess.run(
         command,
@@ -256,6 +318,45 @@ def read_fake_cargo_records(path: Path) -> list[tuple[str, str, str, str]]:
             raise AssertionError(f"malformed fake Cargo record: {line!r}")
         records.append(tuple(values))
     return records
+
+
+def parse_build_script_identity(output: str) -> dict[str, str]:
+    values = {}
+    for line in output.splitlines():
+        if line.startswith("cargo:rustc-env="):
+            key, value = line[len("cargo:rustc-env=") :].split("=", 1)
+            values[key] = value
+    return values
+
+
+def read_build_script_identity(path: Path) -> dict[str, str]:
+    return parse_build_script_identity(path.read_text(encoding="utf-8"))
+
+
+def gradle_task_line(output: str, task: str = ":app:buildP2wlanNative") -> str:
+    lines = [line for line in output.splitlines() if line.startswith(f"> Task {task}")]
+    if not lines:
+        raise AssertionError(f"Gradle did not report {task}:\n{output}")
+    return lines[-1]
+
+
+def make_direct_gradle_context(
+    temp_dir: tempfile.TemporaryDirectory, repo: Path, build_script_binary: Path
+) -> tuple[dict[str, str], Path, Path, Path, Path]:
+    artifact_dir = repo / ".test-artifacts"
+    artifact_dir.mkdir()
+    cargo_log = artifact_dir / "cargo.log"
+    refresh_log = artifact_dir / "refresh.log"
+    build_script_output = artifact_dir / "build-script-output.log"
+    build_out = artifact_dir / "build-out"
+    project_cache_dir = artifact_dir / "gradle-project-cache"
+    env = make_fake_android_env(temp_dir.name, ROOT, cargo_log)
+    env["FAKE_BUILD_MANIFEST_REPO"] = str(repo)
+    env["FAKE_BUILD_SCRIPT"] = str(build_script_binary)
+    env["FAKE_BUILD_OUT"] = str(build_out)
+    env["FAKE_BUILD_SCRIPT_OUTPUT"] = str(build_script_output)
+    env["FAKE_REFRESH_LOG"] = str(refresh_log)
+    return env, cargo_log, refresh_log, build_script_output, project_cache_dir
 
 
 def remove_generated_native_library() -> None:
@@ -284,6 +385,32 @@ def wait_for_file(
 
 
 class FlutterClientBuildIdentityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.build_script_tempdir = tempfile.TemporaryDirectory(
+            prefix="p2wlan-build-script-test-"
+        )
+        cls.build_script_binary = (
+            Path(cls.build_script_tempdir.name) / "daemon-build-script"
+        )
+        result = subprocess.run(
+            ["rustc", str(DAEMON_BUILD), "-o", str(cls.build_script_binary)],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            cls.build_script_tempdir.cleanup()
+            raise RuntimeError(
+                "failed to compile build.rs for behavior tests:\n"
+                f"stdout={result.stdout}\nstderr={result.stderr}"
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.build_script_tempdir.cleanup()
+        super().tearDownClass()
+
     def test_clean_temporary_checkout_has_exact_commit_identity(self):
         temp_dir, repo, script = make_identity_repo()
         self.addCleanup(temp_dir.cleanup)
@@ -420,11 +547,7 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
     def test_direct_native_build_uses_current_dirty_git_not_historical_snapshot(self):
         temp_dir, repo, gradle, untracked = make_native_safety_repo()
         self.addCleanup(temp_dir.cleanup)
-        build_script_binary = Path(temp_dir.name) / "daemon-build-script"
-        subprocess.run(
-            ["rustc", str(repo / "client/daemon/build.rs"), "-o", str(build_script_binary)],
-            check=True,
-        )
+        build_script_binary = self.build_script_binary
         cargo_log = Path(temp_dir.name) / "cargo.log"
         build_script_output = Path(temp_dir.name) / "build-script-output.log"
         fake_env = make_fake_android_env(temp_dir.name, repo, cargo_log)
@@ -464,6 +587,245 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
             values["P2WLAN_BUILD_ID"],
             rf"^{expected_commit[:12]}-dirty-[0-9a-f]{{12}}$",
         )
+
+    def test_direct_build_rebuilds_for_clean_and_dirty_identity_changes(self):
+        temp_dir, repo = make_direct_identity_repo()
+        self.addCleanup(temp_dir.cleanup)
+        env, cargo_log, refresh_log, build_script_output, project_cache_dir = (
+            make_direct_gradle_context(temp_dir, repo, self.build_script_binary)
+        )
+        identities = []
+        refreshes = []
+
+        def run_direct_build() -> dict[str, str]:
+            if identities:
+                self.assertTrue(
+                    GENERATED_NATIVE_LIBRARY.exists(),
+                    "direct rebuild must not delete the previous native output",
+                )
+                self.assertTrue(project_cache_dir.exists())
+            result = run_gradle_native(
+                env,
+                no_daemon=False,
+                project_cache_dir=project_cache_dir,
+                build_cache=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            task_line = gradle_task_line(result.stdout)
+            self.assertNotIn("UP-TO-DATE", task_line)
+            self.assertNotIn("FROM-CACHE", task_line)
+            self.assertTrue(
+                GENERATED_NATIVE_LIBRARY.exists(),
+                "the next invocation must start with the previous native output",
+            )
+            identity = read_build_script_identity(build_script_output)
+            self.assertIn(
+                f"identity={identity['P2WLAN_GIT_COMMIT']}",
+                GENERATED_NATIVE_LIBRARY.read_text(encoding="utf-8"),
+            )
+            identities.append(identity)
+            refreshes.append(refresh_log.read_text(encoding="utf-8").splitlines()[-1])
+            return identity
+
+        with preserve_file(GENERATED_NATIVE_LIBRARY):
+            remove_generated_native_library()
+
+            identity_a = run_direct_build()
+            commit_a = run_git(repo, "rev-parse", "HEAD")
+            self.assertEqual(identity_a["P2WLAN_GIT_COMMIT"], commit_a)
+            self.assertEqual(
+                identity_a["P2WLAN_DIRTY"],
+                "false",
+                run_git(repo, "status", "--porcelain=v1", "--untracked-files=all"),
+            )
+            self.assertEqual(identity_a["P2WLAN_DIFF_HASH"], "")
+
+            (repo / "README.md").write_text("identity B\n", encoding="utf-8")
+            commit_git_changes(repo, "identity B")
+            identity_b = run_direct_build()
+            commit_b = run_git(repo, "rev-parse", "HEAD")
+            self.assertNotEqual(commit_a, commit_b)
+            self.assertEqual(identity_b["P2WLAN_GIT_COMMIT"], commit_b)
+            self.assertEqual(identity_b["P2WLAN_DIRTY"], "false")
+            self.assertEqual(identity_b["P2WLAN_BUILD_ID"], commit_b[:12])
+
+            (repo / "README.md").write_text("tracked dirty\n", encoding="utf-8")
+            identity_tracked_dirty = run_direct_build()
+            self.assertEqual(identity_tracked_dirty["P2WLAN_GIT_COMMIT"], commit_b)
+            self.assertEqual(identity_tracked_dirty["P2WLAN_DIRTY"], "true")
+            tracked_diff_hash = identity_tracked_dirty["P2WLAN_DIFF_HASH"]
+            self.assertRegex(tracked_diff_hash, r"^[0-9a-f]{40}$")
+            self.assertEqual(
+                identity_tracked_dirty["P2WLAN_BUILD_ID"],
+                f"{commit_b[:12]}-dirty-{tracked_diff_hash[:12]}",
+            )
+
+            untracked = repo / "staging-input.txt"
+            untracked.write_text("untracked A\n", encoding="utf-8")
+            identity_untracked = run_direct_build()
+            self.assertEqual(identity_untracked["P2WLAN_DIRTY"], "true")
+            untracked_diff_hash = identity_untracked["P2WLAN_DIFF_HASH"]
+            self.assertRegex(untracked_diff_hash, r"^[0-9a-f]{40}$")
+            self.assertNotEqual(tracked_diff_hash, untracked_diff_hash)
+
+            untracked.write_text("untracked B\n", encoding="utf-8")
+            identity_untracked_changed = run_direct_build()
+            changed_diff_hash = identity_untracked_changed["P2WLAN_DIFF_HASH"]
+            self.assertRegex(changed_diff_hash, r"^[0-9a-f]{40}$")
+            self.assertNotEqual(untracked_diff_hash, changed_diff_hash)
+
+            commit_git_changes(repo, "identity clean again")
+            identity_clean_again = run_direct_build()
+            commit_c = run_git(repo, "rev-parse", "HEAD")
+            self.assertEqual(identity_clean_again["P2WLAN_GIT_COMMIT"], commit_c)
+            self.assertEqual(identity_clean_again["P2WLAN_DIRTY"], "false")
+            self.assertEqual(identity_clean_again["P2WLAN_DIFF_HASH"], "")
+            self.assertEqual(identity_clean_again["P2WLAN_BUILD_ID"], commit_c[:12])
+
+        self.assertEqual(len(read_fake_cargo_records(cargo_log)), 6)
+        self.assertEqual(len(identities), 6)
+        self.assertEqual(len(refreshes), 6)
+        self.assertTrue(all(value != "UNSET" for value in refreshes))
+        self.assertEqual(len(set(refreshes)), len(refreshes))
+
+    def test_same_direct_identity_still_refreshes_without_cache_reuse(self):
+        temp_dir, repo = make_direct_identity_repo()
+        self.addCleanup(temp_dir.cleanup)
+        env, cargo_log, refresh_log, build_script_output, project_cache_dir = (
+            make_direct_gradle_context(temp_dir, repo, self.build_script_binary)
+        )
+        with preserve_file(GENERATED_NATIVE_LIBRARY):
+            remove_generated_native_library()
+            first = run_gradle_native(
+                env,
+                no_daemon=False,
+                project_cache_dir=project_cache_dir,
+                build_cache=True,
+                configuration_cache=True,
+            )
+            self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+            self.assertNotIn("UP-TO-DATE", gradle_task_line(first.stdout))
+            self.assertNotIn("FROM-CACHE", gradle_task_line(first.stdout))
+            self.assertTrue(GENERATED_NATIVE_LIBRARY.exists())
+            first_identity = read_build_script_identity(build_script_output)
+            self.assertIn(
+                f"identity={first_identity['P2WLAN_GIT_COMMIT']}",
+                GENERATED_NATIVE_LIBRARY.read_text(encoding="utf-8"),
+            )
+
+            self.assertTrue(
+                GENERATED_NATIVE_LIBRARY.exists(),
+                "the second direct invocation must retain the first native output",
+            )
+            second = run_gradle_native(
+                env,
+                no_daemon=False,
+                project_cache_dir=project_cache_dir,
+                build_cache=True,
+                configuration_cache=True,
+            )
+            self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+            task_line = gradle_task_line(second.stdout)
+            self.assertNotIn("UP-TO-DATE", task_line)
+            self.assertNotIn("FROM-CACHE", task_line)
+            second_identity = read_build_script_identity(build_script_output)
+            self.assertIn(
+                f"identity={second_identity['P2WLAN_GIT_COMMIT']}",
+                GENERATED_NATIVE_LIBRARY.read_text(encoding="utf-8"),
+            )
+
+        self.assertEqual(first_identity, second_identity)
+        self.assertEqual(len(read_fake_cargo_records(cargo_log)), 2)
+        refreshes = refresh_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(refreshes), 2)
+        self.assertNotEqual(refreshes[0], refreshes[1])
+        self.assertNotIn("UNSET", refreshes)
+
+    def test_cargo_refresh_env_forces_build_script_rerun(self):
+        temp_dir, repo = make_cargo_refresh_repo()
+        self.addCleanup(temp_dir.cleanup)
+        target_dir = repo / "target"
+        env = os.environ.copy()
+        env["CARGO_TERM_COLOR"] = "never"
+        env["P2WLAN_BUILD_EPOCH_MS"] = "0"
+        for name in SOURCE_ENV_KEYS:
+            env.pop(name, None)
+
+        def run_build_script(refresh: str | None) -> tuple[dict[str, str], str]:
+            invocation_env = env.copy()
+            invocation_env["CARGO_MANIFEST_DIR"] = str(repo / "client/daemon")
+            if refresh is None:
+                invocation_env.pop("P2WLAN_SOURCE_IDENTITY_REFRESH", None)
+            else:
+                invocation_env["P2WLAN_SOURCE_IDENTITY_REFRESH"] = refresh
+            result = subprocess.run(
+                [str(self.build_script_binary)],
+                cwd=repo,
+                env=invocation_env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            return parse_build_script_identity(result.stdout), result.stdout
+
+        identity_without_refresh, output_without_refresh = run_build_script(None)
+        identity_with_empty_refresh, output_with_empty_refresh = run_build_script("")
+        identity_with_refresh_a, output_with_refresh_a = run_build_script("refresh-A")
+        identity_with_refresh_b, output_with_refresh_b = run_build_script("refresh-B")
+        for identity in (
+            identity_with_empty_refresh,
+            identity_with_refresh_a,
+            identity_with_refresh_b,
+        ):
+            self.assertEqual(identity, identity_without_refresh)
+        for output in (
+            output_without_refresh,
+            output_with_empty_refresh,
+            output_with_refresh_a,
+            output_with_refresh_b,
+        ):
+            self.assertNotIn("refresh-A", output)
+            self.assertNotIn("refresh-B", output)
+
+        def cargo_build(refresh: str) -> subprocess.CompletedProcess[str]:
+            invocation_env = env.copy()
+            invocation_env["P2WLAN_SOURCE_IDENTITY_REFRESH"] = refresh
+            return subprocess.run(
+                [
+                    "cargo",
+                    "build",
+                    "-vv",
+                    "--target-dir",
+                    str(target_dir),
+                ],
+                cwd=repo,
+                env=invocation_env,
+                text=True,
+                capture_output=True,
+            )
+
+        first = cargo_build("refresh-A")
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        output_files = list((target_dir / "debug/build").glob("*/output"))
+        self.assertEqual(len(output_files), 1)
+        output_file = output_files[0]
+        first_output = output_file.read_text(encoding="utf-8")
+        first_mtime = output_file.stat().st_mtime_ns
+        time.sleep(0.05)
+
+        second = cargo_build("refresh-B")
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        second_log = second.stdout + second.stderr
+        second_output = output_file.read_text(encoding="utf-8")
+        self.assertIn("P2WLAN_SOURCE_IDENTITY_REFRESH", second_log)
+        self.assertIn("build-script-build", second_log)
+        self.assertGreater(output_file.stat().st_mtime_ns, first_mtime)
+        self.assertEqual(
+            [line for line in first_output.splitlines() if "P2WLAN_BUILD_ID" in line],
+            [line for line in second_output.splitlines() if "P2WLAN_BUILD_ID" in line],
+        )
+        self.assertNotIn("refresh-A", second_output)
+        self.assertNotIn("refresh-B", second_output)
 
     def test_build_wrapper_freezes_unique_snapshot_for_flutter_and_cleans_it(self):
         expected = parse_defines(
@@ -788,11 +1150,24 @@ test "$(sed -n 's/^P2WLAN_SOURCE_GIT_COMMIT=//p' "$snapshot")" = "$P2WLAN_TEST_C
                 Path(temp_dir.name) / "does-not-exist.env"
             )
             nonexistent["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+            relative_cases = []
+            for relative_path in (
+                "relative/source.env",
+                "./relative/source.env",
+                "target/source.env",
+            ):
+                relative_env = env.copy()
+                relative_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = (
+                    relative_path
+                )
+                relative_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
+                relative_cases.append((f"relative path {relative_path}", relative_env))
             for case_name, case_env in (
                 ("missing nonce", missing_nonce),
                 ("missing path", missing_path),
                 ("nonce mismatch", mismatch),
                 ("missing file", nonexistent),
+                *relative_cases,
             ):
                 invalid = run_gradle_native(
                     case_env, no_daemon=True, task=":app:tasks"
@@ -803,50 +1178,84 @@ test "$(sed -n 's/^P2WLAN_SOURCE_GIT_COMMIT=//p' "$snapshot")" = "$P2WLAN_TEST_C
                     f"{case_name} unexpectedly succeeded:\n"
                     f"{invalid.stdout}\n{invalid.stderr}",
                 )
+                if case_name.startswith("relative path"):
+                    self.assertIn("must be an absolute path", invalid.stderr)
 
     def test_gradle_daemon_refreshes_identity_and_native_task_inputs(self):
         temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-gradle-daemon-")
         self.addCleanup(temp_dir.cleanup)
         cargo_log = Path(temp_dir.name) / "cargo.log"
+        refresh_log = Path(temp_dir.name) / "refresh.log"
         env = make_fake_android_env(temp_dir.name, ROOT, cargo_log)
+        env["FAKE_REFRESH_LOG"] = str(refresh_log)
         snapshot_a = Path(temp_dir.name) / "identity-a.env"
         snapshot_b = Path(temp_dir.name) / "identity-b.env"
         write_source_snapshot(snapshot_a, commit="a" * 40, nonce="a" * 32)
         write_source_snapshot(snapshot_b, commit="b" * 40, nonce="b" * 32)
         stale = ROOT / "target/p2wlan-source-identity.env"
+        project_cache_dir = Path(temp_dir.name) / "gradle-project-cache"
         with preserve_file(stale), preserve_file(GENERATED_NATIVE_LIBRARY):
             remove_generated_native_library()
-            for snapshot, nonce in (
-                (snapshot_a, "a" * 32),
-                (snapshot_b, "b" * 32),
-            ):
-                invocation_env = env.copy()
-                invocation_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(
-                    snapshot
-                )
-                invocation_env["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = nonce
-                result = run_gradle_native(invocation_env, no_daemon=False)
-                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            invocation_a = env.copy()
+            invocation_a["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(
+                snapshot_a
+            )
+            invocation_a["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = "a" * 32
+            result_a = run_gradle_native(
+                invocation_a, no_daemon=False, project_cache_dir=project_cache_dir
+            )
+            self.assertEqual(result_a.returncode, 0, result_a.stdout + result_a.stderr)
+            self.assertTrue(GENERATED_NATIVE_LIBRARY.exists())
+            result_a_again = run_gradle_native(
+                invocation_a, no_daemon=False, project_cache_dir=project_cache_dir
+            )
+            self.assertEqual(
+                result_a_again.returncode,
+                0,
+                result_a_again.stdout + result_a_again.stderr,
+            )
+            self.assertIn("UP-TO-DATE", result_a_again.stdout)
+
+            invocation_b = env.copy()
+            invocation_b["ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"] = str(
+                snapshot_b
+            )
+            invocation_b["ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce"] = "b" * 32
+            result_b = run_gradle_native(
+                invocation_b, no_daemon=False, project_cache_dir=project_cache_dir
+            )
+            self.assertEqual(result_b.returncode, 0, result_b.stdout + result_b.stderr)
             write_source_snapshot(
                 stale,
                 commit="1" * 40,
                 nonce="1" * 32,
                 dirty="false",
             )
-            direct_result = run_gradle_native(env, no_daemon=False)
-            self.assertEqual(
-                direct_result.returncode,
-                0,
-                direct_result.stdout + direct_result.stderr,
+            direct_result = run_gradle_native(
+                env, no_daemon=False, project_cache_dir=project_cache_dir
             )
+            self.assertEqual(direct_result.returncode, 0, direct_result.stdout + direct_result.stderr)
+            self.assertNotIn("UP-TO-DATE", gradle_task_line(direct_result.stdout))
+            direct_again = run_gradle_native(
+                env, no_daemon=False, project_cache_dir=project_cache_dir
+            )
+            self.assertEqual(direct_again.returncode, 0, direct_again.stdout + direct_again.stderr)
+            self.assertNotIn("UP-TO-DATE", gradle_task_line(direct_again.stdout))
         self.assertEqual(
             read_fake_cargo_records(cargo_log),
             [
                 ("a" * 40, "a" * 12, "false", "UNSET"),
                 ("b" * 40, "b" * 12, "false", "UNSET"),
                 ("UNSET", "UNSET", "UNSET", "UNSET"),
+                ("UNSET", "UNSET", "UNSET", "UNSET"),
             ],
         )
+        refreshes = refresh_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(refreshes), 4)
+        self.assertEqual(refreshes[:2], ["UNSET", "UNSET"])
+        self.assertNotEqual(refreshes[2], "UNSET")
+        self.assertNotEqual(refreshes[3], "UNSET")
+        self.assertNotEqual(refreshes[2], refreshes[3])
 
     def test_daemon_source_identity_override_is_complete_and_fail_closed(self):
         temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-build-script-")
@@ -970,14 +1379,24 @@ test "$(sed -n 's/^P2WLAN_SOURCE_GIT_COMMIT=//p' "$snapshot")" = "$P2WLAN_TEST_C
         gradle = (ROOT / "apps/flutter_client/android/app/build.gradle.kts").read_text(
             encoding="utf-8"
         )
+        self.assertIn("val rawFile = File(rawPath)", gradle)
+        self.assertIn("outputs.upToDateWhen { false }", gradle)
+        self.assertIn("outputs.doNotCacheIf", gradle)
+        self.assertIn("P2WLAN_SOURCE_IDENTITY_REFRESH", gradle)
+        self.assertIn("UUID.randomUUID()", gradle)
         self.assertIn('providers.gradleProperty("p2wlanSourceIdentityFile")', gradle)
         self.assertIn('providers.gradleProperty("p2wlanSourceIdentityNonce")', gradle)
         self.assertIn('inputs.property("p2wlanSourceIdentityNonce"', gradle)
         self.assertNotIn("target/p2wlan-source-identity.env", gradle)
+        self.assertNotIn("val candidate = rootProject.file(path)", gradle)
         self.assertIn("environment(key, sourceIdentityValues.getValue(key))", gradle)
         native = ANDROID_NATIVE_BUILD.read_text(encoding="utf-8")
         self.assertNotIn("hermetic_build.sh restore", native)
         self.assertNotRegex(native, r"git (checkout|restore|reset|clean)")
+        build_rs = DAEMON_BUILD.read_text(encoding="utf-8")
+        self.assertIn(
+            'cargo:rerun-if-env-changed=P2WLAN_SOURCE_IDENTITY_REFRESH', build_rs
+        )
 
     def test_android_workflows_use_wrapper_without_bare_flutter_apk_build(self):
         for workflow_path in ANDROID_WORKFLOWS:

--- a/scripts/release/test_flutter_client_build_identity.py
+++ b/scripts/release/test_flutter_client_build_identity.py
@@ -681,6 +681,60 @@ exit 0
         self.assertFalse(marker.exists())
         self.assertEqual(before, after)
 
+    def test_wrapper_normalizes_windows_crlf_helper_output(self):
+        temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-wrapper-crlf-")
+        self.addCleanup(temp_dir.cleanup)
+        fake_bin = Path(temp_dir.name) / "bin"
+        fake_bin.mkdir()
+        marker = Path(temp_dir.name) / "flutter-called"
+        expected = parse_defines(
+            subprocess.check_output(
+                ["python3", str(SCRIPT), "apk", "--release"], cwd=ROOT, text=True
+            )
+        )
+        write_executable(
+            fake_bin / "python3",
+            """#!/bin/sh
+set -eu
+printf '%s\\r\\n' "--dart-define=P2WLAN_CLIENT_APP_VERSION=0.1.0"
+printf '%s\\r\\n' "--dart-define=P2WLAN_CLIENT_GIT_COMMIT=$P2WLAN_TEST_COMMIT"
+printf '%s\\r\\n' "--dart-define=P2WLAN_CLIENT_BUILD_ID=$P2WLAN_TEST_BUILD_ID"
+printf '%s\\r\\n' "--dart-define=P2WLAN_CLIENT_DIRTY=$P2WLAN_TEST_DIRTY"
+printf '%s\\r\\n' "--dart-define=P2WLAN_CLIENT_DIFF_HASH=$P2WLAN_TEST_DIFF_HASH"
+printf '%s\\r\\n' '--dart-define=P2WLAN_CLIENT_PROFILE=release'
+""",
+        )
+        write_executable(
+            fake_bin / "flutter",
+            """#!/bin/sh
+set -eu
+touch "$P2WLAN_TEST_FLUTTER_MARKER"
+snapshot="$ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile"
+test -f "$snapshot"
+test "$(sed -n 's/^P2WLAN_SOURCE_GIT_COMMIT=//p' "$snapshot")" = "$P2WLAN_TEST_COMMIT"
+""",
+        )
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        env["P2WLAN_TEST_FLUTTER_MARKER"] = str(marker)
+        env["P2WLAN_TEST_COMMIT"] = expected["P2WLAN_CLIENT_GIT_COMMIT"]
+        env["P2WLAN_TEST_BUILD_ID"] = expected["P2WLAN_CLIENT_BUILD_ID"]
+        env["P2WLAN_TEST_DIRTY"] = expected["P2WLAN_CLIENT_DIRTY"]
+        env["P2WLAN_TEST_DIFF_HASH"] = expected["P2WLAN_CLIENT_DIFF_HASH"]
+        fixed_existed = FIXED_SOURCE_IDENTITY_FILE.exists()
+        with preserve_file(FIXED_SOURCE_IDENTITY_FILE):
+            result = subprocess.run(
+                ["bash", str(BUILD_WRAPPER), "apk", "--release"],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertTrue(marker.exists())
+            if not fixed_existed:
+                self.assertFalse(FIXED_SOURCE_IDENTITY_FILE.exists())
+
     def test_direct_gradle_ignores_stale_fixed_snapshot(self):
         temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-gradle-stale-")
         self.addCleanup(temp_dir.cleanup)

--- a/scripts/release/test_flutter_client_build_identity.py
+++ b/scripts/release/test_flutter_client_build_identity.py
@@ -1,41 +1,78 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/release/flutter_client_build_identity.py"
+ANDROID_WORKFLOWS = (
+    ".github/workflows/flutter-client.yml",
+    ".github/workflows/package-test.yml",
+    ".github/workflows/release.yml",
+)
+
+
+def run_git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def parse_defines(output: str) -> dict[str, str]:
+    prefix = "--dart-define="
+    values = {}
+    for line in output.splitlines():
+        if not line.startswith(prefix):
+            raise AssertionError(f"unexpected identity output line: {line!r}")
+        key, value = line[len(prefix) :].split("=", 1)
+        values[key] = value
+    return values
+
+
+def make_identity_repo() -> tuple[tempfile.TemporaryDirectory, Path, Path]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="p2wlan-client-identity-")
+    repo = Path(temp_dir.name)
+    script = repo / "scripts/release/flutter_client_build_identity.py"
+    script.parent.mkdir(parents=True)
+    shutil.copy2(SCRIPT, script)
+    app = repo / "apps/flutter_client"
+    app.mkdir(parents=True)
+    (app / "pubspec.yaml").write_text(
+        "name: identity_test\nversion: 9.8.7+1\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "identity-test@example.invalid"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Identity Test"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "--quiet", "-m", "identity fixture"], cwd=repo, check=True)
+    return temp_dir, repo, script
 
 
 class FlutterClientBuildIdentityTest(unittest.TestCase):
-    def test_emits_all_required_defines_for_current_checkout(self):
+    def test_clean_temporary_checkout_has_exact_commit_identity(self):
+        temp_dir, repo, script = make_identity_repo()
+        self.addCleanup(temp_dir.cleanup)
         output = subprocess.check_output(
-            ["python3", str(SCRIPT), "windows", "--release"],
-            cwd=ROOT,
+            ["python3", str(script), "windows", "--release"],
+            cwd=repo,
             text=True,
         )
-        values = {
-            line.split("=", 2)[1]: line.split("=", 2)[2]
-            for line in output.splitlines()
-        }
-        expected_commit = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
-        ).strip()
+        values = parse_defines(output)
+        expected_commit = run_git(repo, "rev-parse", "HEAD")
         self.assertEqual(values["P2WLAN_CLIENT_GIT_COMMIT"], expected_commit)
-        self.assertIn(values["P2WLAN_CLIENT_DIRTY"], {"true", "false"})
-        if values["P2WLAN_CLIENT_DIRTY"] == "true":
-            self.assertTrue(values["P2WLAN_CLIENT_DIFF_HASH"])
-            self.assertTrue(
-                values["P2WLAN_CLIENT_BUILD_ID"].endswith(
-                    f"-dirty-{values['P2WLAN_CLIENT_DIFF_HASH'][:12]}"
-                )
-            )
-        else:
-            self.assertEqual(values["P2WLAN_CLIENT_DIFF_HASH"], "")
-            self.assertEqual(
-                values["P2WLAN_CLIENT_BUILD_ID"], expected_commit[:12]
-            )
+        self.assertEqual(values["P2WLAN_CLIENT_DIRTY"], "false")
+        self.assertEqual(values["P2WLAN_CLIENT_DIFF_HASH"], "")
+        self.assertEqual(values["P2WLAN_CLIENT_BUILD_ID"], expected_commit[:12])
         self.assertEqual(values["P2WLAN_CLIENT_PROFILE"], "release")
         self.assertEqual(
             set(values),
@@ -48,6 +85,67 @@ class FlutterClientBuildIdentityTest(unittest.TestCase):
                 "P2WLAN_CLIENT_PROFILE",
             },
         )
+
+    def test_real_dirty_temporary_checkout_has_stable_diff_identity(self):
+        temp_dir, repo, script = make_identity_repo()
+        self.addCleanup(temp_dir.cleanup)
+        pubspec = repo / "apps/flutter_client/pubspec.yaml"
+        pubspec.write_text(
+            "name: identity_test\nversion: 9.8.8+1\n",
+            encoding="utf-8",
+        )
+        (repo / "apps/flutter_client/untracked.txt").write_text(
+            "untracked dirty fixture\n", encoding="utf-8"
+        )
+        expected_commit = run_git(repo, "rev-parse", "HEAD")
+
+        first = parse_defines(
+            subprocess.check_output(
+                ["python3", str(script), "apk", "--release"], cwd=repo, text=True
+            )
+        )
+        second = parse_defines(
+            subprocess.check_output(
+                ["python3", str(script), "apk", "--release"], cwd=repo, text=True
+            )
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["P2WLAN_CLIENT_GIT_COMMIT"], expected_commit)
+        self.assertEqual(first["P2WLAN_CLIENT_DIRTY"], "true")
+        self.assertRegex(first["P2WLAN_CLIENT_DIFF_HASH"], r"^[0-9a-f]{40}$")
+        self.assertEqual(
+            first["P2WLAN_CLIENT_BUILD_ID"],
+            f"{expected_commit[:12]}-dirty-{first['P2WLAN_CLIENT_DIFF_HASH'][:12]}",
+        )
+
+    def test_flutter_android_workflow_orders_restore_identity_and_wrapper(self):
+        workflow = (ROOT / ANDROID_WORKFLOWS[0]).read_text(encoding="utf-8")
+        android_job = workflow[workflow.index("  android:\n") :]
+        pub_get = android_job.index("run: flutter pub get")
+        restore = android_job.index(
+            "Restore Flutter-managed source files before identity stamping"
+        )
+        identity = android_job.index("Assert clean Flutter client identity")
+        wrapper = android_job.index("scripts/release/build_flutter_client.sh apk")
+        self.assertLess(pub_get, restore)
+        self.assertLess(restore, identity)
+        self.assertLess(identity, wrapper)
+        self.assertIn("bash scripts/release/hermetic_build.sh restore", android_job)
+        self.assertIn(
+            "python3 scripts/release/flutter_client_build_identity.py apk --release",
+            android_job,
+        )
+
+    def test_android_workflows_use_wrapper_without_bare_flutter_apk_build(self):
+        for workflow_path in ANDROID_WORKFLOWS:
+            workflow = (ROOT / workflow_path).read_text(encoding="utf-8")
+            self.assertIn("build_flutter_client.sh apk", workflow, workflow_path)
+            self.assertNotRegex(
+                workflow,
+                r"(?m)^\s*(?:run:\s+)?flutter build apk(?:\s|$)",
+                workflow_path,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- fence Direct candidate retention by current network generation as a
  defense-in-depth invariant;
- route Android APK builds through the shared client/native identity
  wrapper;
- use a per-invocation identity snapshot for wrapper builds;
- preserve real dirty state without restoring or modifying developer
  worktrees;
- invalidate both Gradle and Cargo identity caches for direct native
  builds;
- verify client and native daemon provenance against the same commit.

## Build behavior

Wrapper/CI builds use an explicit per-invocation identity snapshot.

Direct local Android native builds do not scan historical snapshots and
cannot reuse a stale native library identity after HEAD, tracked diff or
untracked material changes.

The no-snapshot direct native task intentionally runs every time as a
correctness-first tradeoff. Snapshot builds preserve safe incremental
behavior.

## Validation

- Android build identity behavior tests: 18 passed;
- Cargo build-script refresh behavior passed;
- `cargo fmt --all --check` passed;
- workspace clippy passed;
- workspace serial suite passed;
- final Hard↔Hard exact sweep: 42/42 passed;
- targeted candidate refresh tests: 5/5 passed;
- punch deduplicator tests: 4/4 passed;
- Flutter Client workflow succeeded for commit
  `7ae4f84f92193eb5bb31a1d03edf93153edc2bb1`;
- Android arm64 APK contains matching client and native daemon static
  commit identity.

## Scope limits

This PR does not establish that the observed Android 35–54 ms tail
latency burst is fixed.

The Direct generation guard is defense-in-depth. A production-reachable
generation mismatch has not been demonstrated.

Physical/overlay synchronized ping tests, hotspot LAN/overlay controls
and runtime device identity verification remain outstanding.

Only Mac ↔ Windows overlay stability at approximately 2–3 ms has been
confirmed. This PR does not claim Android ↔ Windows has the same result.

## Non-goals

- no TUN runtime redesign;
- no WireGuard or relay protocol change;
- no probe-limit or 50 ms retry change;
- no Android Wi-Fi low-latency default change;
- no Phase 6 implementation.
