### PR TITLE
feat:集成Hard打洞可靠性修复

### DIFF
--- a/client/daemon/Cargo.toml
+++ b/client/daemon/Cargo.toml
@@ -41,7 +41,7 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/client/daemon/src/candidate_refresh/signals.rs
+++ b/client/daemon/src/candidate_refresh/signals.rs
@@ -199,6 +199,89 @@ pub(super) fn candidate_endpoints_from_report(
     (endpoints, sources)
 }
 
+/// The one client-side contract for every signal candidate list.
+///
+/// The control server accepts at most `MAX_SIGNAL_CANDIDATES` entries. Keep
+/// the raw/model counts separate from the effective wire count so diagnostics
+/// can explain a bounded 128/256-port model without accidentally publishing
+/// an over-limit JSON body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SignalCandidateContract {
+    pub(crate) requested_candidate_count: usize,
+    pub(crate) generated_candidate_count: usize,
+    pub(crate) deduplicated_candidate_count: usize,
+    pub(crate) signaled_candidate_count: usize,
+    pub(crate) cap: usize,
+    pub(crate) capped: bool,
+    pub(crate) candidate_source_count: usize,
+    pub(crate) reason: &'static str,
+}
+
+/// Normalize a candidate list at the control-plane serialization boundary.
+///
+/// This preserves the existing candidate ranking and fresh
+/// prediction/LAN reservations in `truncate_signal_candidates`; the extra
+/// work here is stable de-duplication before applying the shared cap and exact
+/// alignment of the source map with the emitted candidates.
+pub(crate) fn normalize_signal_candidates(
+    candidates: &[String],
+    candidate_sources: &HashMap<String, String>,
+) -> (Vec<String>, HashMap<String, String>, SignalCandidateContract) {
+    normalize_signal_candidates_with_counts(
+        candidates,
+        candidate_sources,
+        candidates.len(),
+        candidates.len(),
+    )
+}
+
+/// Normalize a signal list while retaining caller-supplied model counts for
+/// diagnostics. The count arguments are metadata only; the returned vectors
+/// are always the authoritative wire payload.
+pub(crate) fn normalize_signal_candidates_with_counts(
+    candidates: &[String],
+    candidate_sources: &HashMap<String, String>,
+    requested_candidate_count: usize,
+    generated_candidate_count: usize,
+) -> (Vec<String>, HashMap<String, String>, SignalCandidateContract) {
+    let mut normalized_candidates = Vec::with_capacity(candidates.len());
+    let mut seen = HashSet::with_capacity(candidates.len());
+    for endpoint in candidates {
+        if seen.insert(endpoint.clone()) {
+            normalized_candidates.push(endpoint.clone());
+        }
+    }
+
+    let deduplicated_candidate_count = normalized_candidates.len();
+    let deduplicated = deduplicated_candidate_count != candidates.len();
+    let mut normalized_sources = HashMap::with_capacity(deduplicated_candidate_count);
+    for endpoint in &normalized_candidates {
+        if let Some(source) = candidate_sources.get(endpoint) {
+            normalized_sources.insert(endpoint.clone(), source.clone());
+        }
+    }
+
+    let capped = deduplicated_candidate_count > MAX_SIGNAL_CANDIDATES;
+    truncate_signal_candidates(&mut normalized_candidates, &mut normalized_sources);
+    let reason = match (deduplicated, capped) {
+        (true, true) => "deduplicated_and_capped",
+        (true, false) => "deduplicated",
+        (false, true) => "capped",
+        (false, false) => "within_cap",
+    };
+    let contract = SignalCandidateContract {
+        requested_candidate_count,
+        generated_candidate_count,
+        deduplicated_candidate_count,
+        signaled_candidate_count: normalized_candidates.len(),
+        cap: MAX_SIGNAL_CANDIDATES,
+        capped,
+        candidate_source_count: normalized_sources.len(),
+        reason,
+    };
+    (normalized_candidates, normalized_sources, contract)
+}
+
 pub(super) fn compact_volatile_public_signal_candidates(
     candidates: &mut Vec<String>,
     candidate_sources: &mut HashMap<String, String>,

--- a/client/daemon/src/control/http/signal.rs
+++ b/client/daemon/src/control/http/signal.rs
@@ -50,6 +50,10 @@ pub(crate) fn prepare_signal_payload(
     probe_ephemeral_public_key: Option<&str>,
     signing_identity: Option<&SignalSigningIdentity>,
 ) -> Result<serde_json::Value> {
+    let (candidates, candidate_sources, _) = crate::candidate_refresh::normalize_signal_candidates(
+        candidates,
+        candidate_sources,
+    );
     // `candidate_generation` is the signal/candidate freshness revision, not
     // a declaration that this process rebound its UDP transport. A fresh
     // offer/answer (including a routine WireGuard rekey) deliberately gets a

--- a/client/daemon/src/lib.rs
+++ b/client/daemon/src/lib.rs
@@ -31,7 +31,7 @@
 
 pub mod acl;
 pub mod build_info;
-mod candidate_refresh;
+pub(crate) mod candidate_refresh;
 pub mod config;
 pub mod connection_timeline;
 pub mod control;
@@ -217,7 +217,7 @@ const CANDIDATE_REFRESH_NO_PUBLIC_RETRY_INTERVAL: Duration = Duration::from_secs
 /// Keep this large enough for a linear symmetric NAT to publish its observed
 /// STUN group plus the full predicted successor run. Air-like NATs can need
 /// the high-teens successor ports before a peer-reflexive path appears.
-const MAX_SIGNAL_CANDIDATES: usize = 96;
+pub(crate) const MAX_SIGNAL_CANDIDATES: usize = 96;
 /// Reserve a small part of the signaling budget for physical LAN host
 /// candidates. A hard-NAT prediction window can otherwise consume all 96
 /// entries and make same-LAN discovery impossible until a later refresh.

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -108,6 +108,80 @@ impl Drop for PendingHardHardSessionCancellation {
     }
 }
 
+#[derive(Clone)]
+struct HardHardCleanupDescriptor {
+    peer_id: String,
+    session_id: String,
+    session_token: String,
+    fresh_socket: crate::peer::HardHardFreshSocketIdentity,
+    expires_at_ms: u64,
+    cancellation: Arc<crate::PunchSessionCancellation>,
+}
+
+impl HardHardCleanupDescriptor {
+    fn from_record(record: &HardHardSessionRecord) -> Self {
+        Self {
+            peer_id: record.peer_id.clone(),
+            session_id: record.session_id.clone(),
+            session_token: record.session_token.clone(),
+            fresh_socket: record.fresh_socket.clone(),
+            expires_at_ms: record.expires_at_ms,
+            cancellation: record.cancellation.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct HardHardCleanupCompletion {
+    completed: Arc<std::sync::atomic::AtomicBool>,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl HardHardCleanupCompletion {
+    fn new() -> Self {
+        Self {
+            completed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            notify: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    fn finish(&self) {
+        self.completed
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    #[cfg(test)]
+    async fn wait(&self) {
+        loop {
+            if self
+                .completed
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                return;
+            }
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self
+                .completed
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct HardHardCleanupCompletionGuard(HardHardCleanupCompletion);
+
+impl Drop for HardHardCleanupCompletionGuard {
+    fn drop(&mut self) {
+        self.0.finish();
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HardHardInitiatorStart {
     /// A new Hard↔Hard measurement worker owns the punch session.
@@ -313,29 +387,16 @@ impl HardHardCoordination {
     }
 }
 
-#[cfg(test)]
-static HARD_HARD_TEST_NOW_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
 /// Override only the Hard↔Hard rendezvous clock for deterministic integration
 /// tests. Production builds do not contain this state, and all other runtime
 /// deadlines continue to use their existing constants and timers.
 #[cfg(test)]
 pub(crate) fn set_hard_hard_test_now_ms(now_ms: Option<u64>) {
-    HARD_HARD_TEST_NOW_MS.store(now_ms.unwrap_or(0), std::sync::atomic::Ordering::Release);
+    crate::peer::set_hard_hard_test_now_ms(now_ms);
 }
 
 fn hard_hard_now_ms() -> u64 {
-    #[cfg(test)]
-    {
-        let overridden = HARD_HARD_TEST_NOW_MS.load(std::sync::atomic::Ordering::Acquire);
-        if overridden != 0 {
-            return overridden;
-        }
-    }
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
+    crate::peer::hard_hard_now_ms()
 }
 
 fn hard_hard_session_token(session_id: u64) -> String {
@@ -1681,7 +1742,6 @@ pub(crate) async fn spawn_hard_hard_initiator(
             &measurement,
             plan,
         ) else {
-            peers.hard_hard_remove_session(&peer_id, "missing-primary").await;
             return;
         };
         peers
@@ -1742,17 +1802,25 @@ pub(crate) async fn spawn_hard_hard_initiator(
             created_at: Instant::now(),
             cancellation: cancellation.clone(),
         };
-        if cancellation.is_cancelled()
-            || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
-            || !peers.hard_hard_register_session(record).await
-        {
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+        let cleanup_descriptor = HardHardCleanupDescriptor::from_record(&record);
+        let registered = !cancellation.is_cancelled()
+            && peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
+            && peers.hard_hard_register_session(record).await;
+        if !registered {
             return;
         }
+        let _cleanup_completion =
+            spawn_hard_hard_session_cleanup(udp.clone(), peers.clone(), cleanup_descriptor.clone());
         if cancellation.is_cancelled()
             || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
         {
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         peers
@@ -1830,18 +1898,17 @@ pub(crate) async fn spawn_hard_hard_initiator(
                     "Hard↔Hard prediction was not accepted or was superseded; the measured socket was rolled back and Relay remains usable",
                 )
                 .await;
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         let handoff_ok = finalize_hard_hard_measurement(&mut measurement).await;
         if !handoff_ok {
-            udp.detach_hard_hard_sockets_for_token(
-                &peer_id,
-                &coordination.token,
-                None,
-                "hard_hard_handoff_failed",
-            )
-            .await;
             peers
                 .record_direct_event(
                     &peer_id,
@@ -1852,7 +1919,13 @@ pub(crate) async fn spawn_hard_hard_initiator(
                     "Hard↔Hard prediction reached the control plane but the measured socket lost ownership before handoff",
                 )
                 .await;
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         peers
@@ -1893,15 +1966,6 @@ pub(crate) async fn spawn_hard_hard_initiator(
                 ),
             )
             .await;
-        spawn_hard_hard_expiry_cleanup(
-            udp.clone(),
-            peers.clone(),
-            peer_id.clone(),
-            session_id.clone(),
-            primary_socket,
-            cancellation.clone(),
-            hard_hard_now_ms().saturating_add(HARD_HARD_SESSION_TTL.as_millis() as u64),
-        );
         // The initiator's exact-socket sweep starts only when the responder's
         // reciprocal prediction arrives.  Relay continues to carry data while
         // this short response fence is pending.
@@ -2107,7 +2171,6 @@ pub(crate) async fn spawn_hard_hard_responder(
             &measurement,
             current_plan,
         ) else {
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
             return;
         };
         peers
@@ -2188,16 +2251,28 @@ pub(crate) async fn spawn_hard_hard_responder(
             created_at: Instant::now(),
             cancellation: cancellation.clone(),
         };
-        if cancellation.is_cancelled()
-            || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
-            || !peers.hard_hard_register_session(record).await
-        {
+        let cleanup_descriptor = HardHardCleanupDescriptor::from_record(&record);
+        let registered = !cancellation.is_cancelled()
+            && peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
+            && peers.hard_hard_register_session(record).await;
+        if !registered {
             return;
         }
+        let _cleanup_completion = spawn_hard_hard_session_cleanup(
+            udp.clone(),
+            peers.clone(),
+            cleanup_descriptor.clone(),
+        );
         if cancellation.is_cancelled()
             || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
         {
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         peers
@@ -2260,17 +2335,16 @@ pub(crate) async fn spawn_hard_hard_responder(
                     "Hard↔Hard responder could not advertise its reciprocal prediction; Relay remains usable",
                 )
                 .await;
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         if !finalize_hard_hard_measurement(&mut measurement).await {
-            udp.detach_hard_hard_sockets_for_token(
-                &peer_id,
-                &coordination.token,
-                None,
-                "hard_hard_handoff_failed",
-            )
-            .await;
             peers
                 .record_direct_event(
                     &peer_id,
@@ -2281,7 +2355,13 @@ pub(crate) async fn spawn_hard_hard_responder(
                     "Hard↔Hard responder prediction reached the control plane but one or more measured sockets lost ownership before handoff",
                 )
                 .await;
-            peers.hard_hard_remove_session(&peer_id, &session_id).await;
+            let _ = peers
+                .hard_hard_retire_session(
+                    &cleanup_descriptor.peer_id,
+                    &cleanup_descriptor.session_id,
+                    &cleanup_descriptor.session_token,
+                )
+                .await;
             return;
         }
         peers
@@ -2340,17 +2420,7 @@ pub(crate) async fn spawn_hard_hard_responder(
         )
         .await;
         if swept {
-            if direct_on_fresh_socket || !peers.is_direct(&peer_id).await {
-                spawn_hard_hard_expiry_cleanup(
-                    cleanup_udp.clone(),
-                    peers.clone(),
-                    peer_id.clone(),
-                    session_id.clone(),
-                    confirmed_socket.clone(),
-                    cancellation,
-                    hard_hard_now_ms().saturating_add(HARD_HARD_SESSION_TTL.as_millis() as u64),
-                );
-            } else {
+            if !direct_on_fresh_socket && peers.is_direct(&peer_id).await {
                 peers
                     .record_direct_event(
                         &peer_id,
@@ -2364,13 +2434,13 @@ pub(crate) async fn spawn_hard_hard_responder(
                         ),
                     )
                     .await;
-                cleanup_udp
-                    .detach_hard_hard_socket_if_identity(
-                        &confirmed_socket,
-                        "hard_hard_direct_other_socket",
+                let _ = peers
+                    .hard_hard_retire_session(
+                        &cleanup_descriptor.peer_id,
+                        &cleanup_descriptor.session_id,
+                        &cleanup_descriptor.session_token,
                     )
                     .await;
-                peers.hard_hard_remove_session(&peer_id, &session_id).await;
             }
         } else {
             let authenticated_winner =
@@ -2394,29 +2464,7 @@ pub(crate) async fn spawn_hard_hard_responder(
             } else {
                 direct_on_fresh_socket.then_some(fresh_socket.clone())
             };
-            if let Some(retained_socket) = retained_socket {
-                // The encrypted validation worker owns the final Direct
-                // verdict.  The rendezvous task may finish first, so defer
-                // socket/session cleanup to the bounded expiry watcher.
-                spawn_hard_hard_expiry_cleanup(
-                    cleanup_udp.clone(),
-                    peers.clone(),
-                    peer_id.clone(),
-                    session_id.clone(),
-                    retained_socket,
-                    cancellation,
-                    hard_hard_now_ms()
-                        .saturating_add(HARD_HARD_SESSION_TTL.as_millis() as u64),
-                );
-            } else {
-                cleanup_udp
-                    .detach_hard_hard_sockets_for_token(
-                        &peer_id,
-                        &coordination.token,
-                        None,
-                        "hard_hard_sweep_failed",
-                    )
-                    .await;
+            if retained_socket.is_none() {
                 if peers.is_direct(&peer_id).await {
                     peers
                         .record_direct_event(
@@ -2432,7 +2480,13 @@ pub(crate) async fn spawn_hard_hard_responder(
                         )
                         .await;
                 }
-                peers.hard_hard_remove_session(&peer_id, &session_id).await;
+                let _ = peers
+                    .hard_hard_retire_session(
+                        &cleanup_descriptor.peer_id,
+                        &cleanup_descriptor.session_id,
+                        &cleanup_descriptor.session_token,
+                    )
+                    .await;
             }
         }
     });
@@ -2559,8 +2613,12 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         || session.is_cancelled()
         || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
     {
-        peers
-            .hard_hard_remove_session(&peer_id, &record.session_id)
+        let _ = peers
+            .hard_hard_retire_session(
+                &record.peer_id,
+                &record.session_id,
+                &record.session_token,
+            )
             .await;
         return HardHardRemoteStart::NotStarted;
     }
@@ -2596,17 +2654,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
     let direct_on_fresh_socket =
         hard_hard_exact_direct_confirmation_is_current(&cleanup_udp, &peers, &fresh_socket).await;
     if swept {
-        if direct_on_fresh_socket || !peers.is_direct(&peer_id).await {
-            spawn_hard_hard_expiry_cleanup(
-                cleanup_udp.clone(),
-                peers.clone(),
-                peer_id.clone(),
-                record.session_id.clone(),
-                fresh_socket.clone(),
-                record.cancellation,
-                record.expires_at_ms,
-            );
-        } else {
+        if !direct_on_fresh_socket && peers.is_direct(&peer_id).await {
             peers
                 .record_direct_event(
                     &peer_id,
@@ -2620,11 +2668,12 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
                     ),
                 )
                 .await;
-            cleanup_udp
-                .detach_hard_hard_socket_if_identity(&fresh_socket, "hard_hard_direct_other_socket")
-                .await;
             peers
-                .hard_hard_remove_session(&record.peer_id, &record.session_id)
+                .hard_hard_retire_session(
+                    &record.peer_id,
+                    &record.session_id,
+                    &record.session_token,
+                )
                 .await;
         }
     } else {
@@ -2645,29 +2694,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         } else {
             direct_on_fresh_socket.then_some(fresh_socket.clone())
         };
-        if let Some(retained_socket) = retained_socket {
-            // Give the encrypted validation worker the rest of the bounded
-            // Hard↔Hard lifetime to finish.  Expiry cleanup retains this
-            // exact socket only if Direct and authenticated evidence still
-            // agree; otherwise it detaches the whole session token.
-            spawn_hard_hard_expiry_cleanup(
-                cleanup_udp.clone(),
-                peers.clone(),
-                peer_id.clone(),
-                record.session_id.clone(),
-                retained_socket,
-                record.cancellation.clone(),
-                record.expires_at_ms,
-            );
-        } else {
-            cleanup_udp
-                .detach_hard_hard_sockets_for_token(
-                    &peer_id,
-                    &record.session_token,
-                    None,
-                    "hard_hard_sweep_failed",
-                )
-                .await;
+        if retained_socket.is_none() {
             if peers.is_direct(&peer_id).await {
                 peers
                     .record_direct_event(
@@ -2684,7 +2711,11 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
                     .await;
             }
             peers
-                .hard_hard_remove_session(&record.peer_id, &record.session_id)
+                .hard_hard_retire_session(
+                    &record.peer_id,
+                    &record.session_id,
+                    &record.session_token,
+                )
                 .await;
         }
     }
@@ -3349,49 +3380,124 @@ async fn birthday_terminal_report(
     Some(report)
 }
 
-fn spawn_hard_hard_expiry_cleanup(
+fn spawn_hard_hard_session_cleanup(
     udp: UdpTransport,
     peers: Arc<PeerManager>,
-    peer_id: String,
-    session_id: String,
-    fresh_socket: crate::peer::HardHardFreshSocketIdentity,
-    cancellation: Arc<crate::PunchSessionCancellation>,
-    expires_at_ms: u64,
-) {
+    descriptor: HardHardCleanupDescriptor,
+) -> HardHardCleanupCompletion {
+    let completion = HardHardCleanupCompletion::new();
+    let watcher_completion = completion.clone();
     tokio::spawn(async move {
-        let delay = expires_at_ms.saturating_sub(hard_hard_now_ms());
-        tokio::select! {
-            _ = sleep(Duration::from_millis(delay)) => {}
-            _ = cancellation.cancelled() => {}
-        }
-        let current_socket = peers
-            .hard_hard_fresh_socket_for_token(&peer_id, &fresh_socket.session_token)
+        let _completion_guard = HardHardCleanupCompletionGuard(watcher_completion);
+        if !peers
+            .hard_hard_claim_cleanup_owner(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
             .await
-            .unwrap_or_else(|| fresh_socket.clone());
-        let retain_fresh_socket =
-            hard_hard_exact_direct_socket_is_current_for_cleanup(&udp, &peers, &current_socket)
+        {
+            return;
+        }
+
+        let expiry_woke = if descriptor.cancellation.is_cancelled() {
+            false
+        } else {
+            let delay = descriptor
+                .expires_at_ms
+                .saturating_sub(hard_hard_now_ms());
+            tokio::select! {
+                biased;
+                _ = descriptor.cancellation.cancelled() => false,
+                _ = sleep(Duration::from_millis(delay)) => true,
+            }
+        };
+        let snapshot = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await;
+        let current_socket = snapshot
+            .as_ref()
+            .map(|record| record.fresh_socket.clone())
+            .unwrap_or_else(|| descriptor.fresh_socket.clone());
+        let retain_fresh_socket = expiry_woke
+            && snapshot.as_ref().is_some_and(|record| {
+                record.state != crate::peer::HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+            })
+            && !descriptor.cancellation.is_cancelled()
+            && hard_hard_exact_direct_socket_is_current_for_cleanup(&udp, &peers, &current_socket)
                 .await;
+
+        // The ledger is retired before any UDP cleanup await. This is the
+        // completion-fence boundary: no admission/fence query can revive the
+        // session, while the descriptor and token still own cleanup.
+        let _ = peers
+            .hard_hard_retire_session(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await;
+        #[cfg(test)]
+        peers
+            .pause_hard_hard_cleanup_for_test(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await;
+
         if retain_fresh_socket {
             udp.detach_hard_hard_sockets_for_token(
-                &peer_id,
-                &fresh_socket.session_token,
+                &descriptor.peer_id,
+                &descriptor.session_token,
                 Some(current_socket.socket_index),
                 "hard_hard_session_expired_losers",
             )
             .await;
         } else {
             udp.detach_hard_hard_sockets_for_token(
-                &peer_id,
-                &fresh_socket.session_token,
+                &descriptor.peer_id,
+                &descriptor.session_token,
                 None,
                 "hard_hard_session_expired",
             )
             .await;
-            udp.detach_hard_hard_socket_if_identity(&fresh_socket, "hard_hard_session_expired")
+            udp.detach_hard_hard_socket_if_identity(&current_socket, "hard_hard_session_expired")
                 .await;
+            if current_socket != descriptor.fresh_socket {
+                udp.detach_hard_hard_socket_if_identity(
+                    &descriptor.fresh_socket,
+                    "hard_hard_session_expired",
+                )
+                .await;
+            }
         }
-        peers.hard_hard_remove_session(&peer_id, &session_id).await;
+        udp.clear_hard_hard_pending_probes_for_token(
+            &descriptor.peer_id,
+            &descriptor.session_token,
+            retain_fresh_socket.then_some(current_socket.socket_index),
+        )
+        .await;
+        let _ = peers
+            .hard_hard_complete_session_cleanup(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await;
+        #[cfg(test)]
+        peers.signal_hard_hard_cleanup_completed_for_test(
+            &descriptor.peer_id,
+            &descriptor.session_id,
+            &descriptor.session_token,
+        );
     });
+    completion
 }
 
 #[cfg(test)]
@@ -3880,6 +3986,554 @@ mod hard_hard_tests {
             .peer_session_generation_sync(&identity.peer_id)
             .expect("exact fixture peer must have an active lifecycle generation");
         (peers, udp, identity, remote, peer_session_generation)
+    }
+
+    struct HardHardTestClockReset;
+
+    impl Drop for HardHardTestClockReset {
+        fn drop(&mut self) {
+            set_hard_hard_test_now_ms(None);
+        }
+    }
+
+    async fn seed_hard_hard_pending_probes(
+        udp: &UdpTransport,
+        identity: &crate::peer::HardHardFreshSocketIdentity,
+        count: usize,
+    ) -> PunchSendReport {
+        let localhost = "127.0.0.1".parse().unwrap();
+        let candidates = (0..count)
+            .map(|offset| {
+                SocketAddr::new(localhost, 41_000 + u16::try_from(offset).unwrap())
+            })
+            .collect::<Vec<_>>();
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peer_id = identity.peer_id.clone();
+            let token = identity.session_token.clone();
+            let socket_index = identity.socket_index;
+            async move {
+                udp.punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session(
+                    &peer_id,
+                    socket_index,
+                    candidates,
+                    Duration::ZERO,
+                    1,
+                    None,
+                    Some(&token),
+                )
+                .await
+            }
+        });
+        for _ in 0..128 {
+            if task.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(5)).await;
+        }
+        assert!(
+            task.is_finished(),
+            "test probe seeding must finish before pending-probe leases expire"
+        );
+        task.await
+            .expect("test probe seeding task must not panic")
+            .expect("test probe seeding must produce a report")
+    }
+
+    async fn wait_for_hard_hard_cleanup_owner(
+        peers: &PeerManager,
+        descriptor: &HardHardCleanupDescriptor,
+    ) {
+        for _ in 0..256 {
+            if peers
+                .hard_hard_cleanup_owner_claimed_for_test(
+                    &descriptor.peer_id,
+                    &descriptor.session_id,
+                    &descriptor.session_token,
+                )
+                .await
+            {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("Hard↔Hard cleanup watcher did not claim its exact owner");
+    }
+
+    async fn wait_for_hard_hard_cleanup_gate(
+        gate: &Arc<crate::peer::HardHardCleanupGate>,
+    ) {
+        let reached = gate.reached.notified();
+        tokio::pin!(reached);
+        let watchdog = async {
+            for _ in 0..512 {
+                tokio::task::yield_now().await;
+            }
+        };
+        tokio::pin!(watchdog);
+        tokio::select! {
+            _ = &mut reached => {}
+            _ = &mut watchdog => panic!("Hard↔Hard cleanup did not reach the test gate"),
+        }
+    }
+
+    async fn wait_for_hard_hard_cleanup_completion(completion: &HardHardCleanupCompletion) {
+        let wait = completion.wait();
+        tokio::pin!(wait);
+        let watchdog = async {
+            for _ in 0..64 {
+                tokio::time::advance(Duration::from_millis(100)).await;
+                tokio::task::yield_now().await;
+            }
+        };
+        tokio::pin!(watchdog);
+        tokio::select! {
+            _ = &mut wait => {}
+            _ = &mut watchdog => panic!("Hard↔Hard cleanup did not complete"),
+        }
+    }
+
+    async fn exercise_hard_hard_cleanup_cancellation(cancel_before_watcher: bool) {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(Some(4_000_000_000));
+        let _clock = HardHardTestClockReset;
+        let (peers, udp, identity, _remote, _peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let record = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "birthday-runtime-session",
+                &identity.session_token,
+            )
+            .await
+            .expect("Birthday fixture must expose its exact session record");
+        let descriptor = HardHardCleanupDescriptor::from_record(&record);
+        assert!(matches!(
+            peers.recovery_epoch_admit(&identity.peer_id).await,
+            crate::peer::RecoveryAdmission::Accepted { .. }
+        ));
+        let report = seed_hard_hard_pending_probes(&udp, &identity, 5).await;
+        assert_eq!(report.logical_probes_sent, 5, "{report:?}");
+        assert_eq!(report.physical_datagrams_sent, 5, "{report:?}");
+        assert_eq!(
+            udp.hard_hard_pending_probe_count_for_token_for_test(
+                &identity.peer_id,
+                &identity.session_token,
+            )
+            .await,
+            5
+        );
+
+        let (gate, _gate_guard) = peers.install_hard_hard_cleanup_gate_for_test(
+            &descriptor.peer_id,
+            &descriptor.session_id,
+            &descriptor.session_token,
+        );
+        if cancel_before_watcher {
+            assert!(!peers
+                .hard_hard_cleanup_owner_claimed_for_test(
+                    &descriptor.peer_id,
+                    &descriptor.session_id,
+                    &descriptor.session_token,
+                )
+                .await);
+            descriptor.cancellation.cancel_for_hard_hard_cleanup();
+        }
+        let completion = spawn_hard_hard_session_cleanup(udp.clone(), peers.clone(), descriptor.clone());
+        if !cancel_before_watcher {
+            wait_for_hard_hard_cleanup_owner(&peers, &descriptor).await;
+            assert_eq!(
+                peers
+                    .hard_hard_session_snapshot_for_cleanup(
+                        &descriptor.peer_id,
+                        &descriptor.session_id,
+                        &descriptor.session_token,
+                    )
+                    .await
+                    .expect("registered cleanup session must remain observable")
+                    .state,
+                HardHardSessionState::AwaitingPeer
+            );
+            descriptor.cancellation.cancel_for_hard_hard_cleanup();
+        }
+
+        wait_for_hard_hard_cleanup_gate(&gate).await;
+        let retiring = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await
+            .expect("retiring record must remain until UDP cleanup completes");
+        assert_eq!(retiring.state, HardHardSessionState::Retiring);
+        assert!(!peers.hard_hard_session_is_active(&descriptor.peer_id).await);
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+        assert_eq!(
+            udp.hard_hard_pending_probe_count_for_token_for_test(
+                &descriptor.peer_id,
+                &descriptor.session_token,
+            )
+            .await,
+            5
+        );
+        assert!(!udp
+            .hard_hard_socket_indices_for_token(&descriptor.peer_id, &descriptor.session_token)
+            .await
+            .is_empty());
+
+        gate.release.notify_waiters();
+        wait_for_hard_hard_cleanup_completion(&completion).await;
+        assert!(
+            peers
+                .hard_hard_session_snapshot_for_cleanup(
+                    &descriptor.peer_id,
+                    &descriptor.session_id,
+                    &descriptor.session_token,
+                )
+                .await
+                .is_none()
+        );
+        assert!(!peers
+            .hard_hard_cleanup_owner_claimed_for_test(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+        assert_eq!(
+            udp.hard_hard_pending_probe_count_for_token_for_test(
+                &descriptor.peer_id,
+                &descriptor.session_token,
+            )
+            .await,
+            0
+        );
+        assert!(udp
+            .hard_hard_socket_indices_for_token(&descriptor.peer_id, &descriptor.session_token)
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_cleanup_cancellation_before_watcher_registration_is_exact_and_complete() {
+        exercise_hard_hard_cleanup_cancellation(true).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_cleanup_cancellation_after_watcher_registration_is_exact_and_complete() {
+        exercise_hard_hard_cleanup_cancellation(false).await;
+    }
+
+    #[tokio::test]
+    async fn hard_hard_session_observers_do_not_prune_expired_records_and_cleanup_is_idempotent() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(Some(4_000_000_000));
+        let _clock = HardHardTestClockReset;
+        let (peers, udp, identity, _remote) = exact_socket_proof_fixture().await;
+        let record = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await
+            .expect("exact proof fixture must expose its session");
+        let cancellation = record.cancellation.clone();
+        assert!(peers.hard_hard_session_is_active(&identity.peer_id).await);
+        assert!(peers
+            .hard_hard_session_by_token(&identity.peer_id, &identity.session_token)
+            .await
+            .is_some());
+        assert!(peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await
+            .is_some());
+        assert!(!cancellation.is_cancelled());
+
+        set_hard_hard_test_now_ms(Some(record.expires_at_ms.saturating_add(1)));
+        assert!(!peers.hard_hard_session_is_active(&identity.peer_id).await);
+        assert!(peers
+            .hard_hard_session_by_token(&identity.peer_id, &identity.session_token)
+            .await
+            .is_none());
+        let expired_snapshot = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await
+            .expect("pure snapshots must not remove expired records");
+        assert_eq!(expired_snapshot.state, HardHardSessionState::AwaitingPeer);
+        assert!(!cancellation.is_cancelled());
+
+        assert!(peers
+            .hard_hard_retire_session(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await);
+        assert!(peers
+            .hard_hard_retire_session(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await);
+        assert!(!peers.hard_hard_session_is_active(&identity.peer_id).await);
+        assert!(peers
+            .hard_hard_complete_session_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await);
+        assert!(!peers
+            .hard_hard_complete_session_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await);
+        assert!(peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "proof-session",
+                &identity.session_token,
+            )
+            .await
+            .is_none());
+        udp.detach_all_dynamic_punch_sockets("test_cleanup_idempotence")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn hard_hard_late_cleanup_cannot_remove_replacement_session() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        let (peers, udp, old_identity, _remote) = exact_socket_proof_fixture().await;
+        let old = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &old_identity.peer_id,
+                "proof-session",
+                &old_identity.session_token,
+            )
+            .await
+            .expect("replacement fixture must expose its old session");
+        let mut replacement = old.clone();
+        replacement.session_id = "replacement-session".to_string();
+        replacement.session_token = "replacement-token".to_string();
+        replacement.fresh_socket.session_token = replacement.session_token.clone();
+        replacement.cancellation = Arc::new(crate::PunchSessionCancellation::default());
+        assert!(peers.hard_hard_register_session(replacement.clone()).await);
+        assert!(old.cancellation.is_cancelled());
+        assert_eq!(
+            peers
+                .hard_hard_session_snapshot_for_cleanup(
+                    &old.peer_id,
+                    &old.session_id,
+                    &old.session_token,
+                )
+                .await
+                .expect("old session must remain in Retiring state")
+                .state,
+            HardHardSessionState::Retiring
+        );
+        assert!(udp
+            .tag_hard_hard_socket(
+                &replacement.peer_id,
+                replacement.fresh_socket.socket_index,
+                &replacement.session_token,
+            )
+            .await);
+
+        let _ = peers
+            .hard_hard_retire_session(&old.peer_id, &old.session_id, &old.session_token)
+            .await;
+        udp.detach_hard_hard_sockets_for_token(
+            &old.peer_id,
+            &old.session_token,
+            None,
+            "test_old_token_cleanup",
+        )
+        .await;
+        udp.detach_hard_hard_socket_if_identity(
+            &old.fresh_socket,
+            "test_old_identity_cleanup",
+        )
+        .await;
+        udp.clear_hard_hard_pending_probes_for_token(&old.peer_id, &old.session_token, None)
+            .await;
+        assert!(peers
+            .hard_hard_complete_session_cleanup(&old.peer_id, &old.session_id, &old.session_token)
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+        assert!(peers
+            .hard_hard_session_by_token(&replacement.peer_id, &replacement.session_token)
+            .await
+            .is_some());
+        assert!(peers.hard_hard_session_is_active(&replacement.peer_id).await);
+        assert_eq!(
+            udp.hard_hard_socket_indices_for_token(
+                &replacement.peer_id,
+                &replacement.session_token,
+            )
+            .await,
+            vec![replacement.fresh_socket.socket_index]
+        );
+
+        assert!(peers
+            .hard_hard_retire_session(
+                &replacement.peer_id,
+                &replacement.session_id,
+                &replacement.session_token,
+            )
+            .await);
+        udp.detach_hard_hard_sockets_for_token(
+            &replacement.peer_id,
+            &replacement.session_token,
+            None,
+            "test_replacement_cleanup",
+        )
+        .await;
+        udp.clear_hard_hard_pending_probes_for_token(
+            &replacement.peer_id,
+            &replacement.session_token,
+            None,
+        )
+        .await;
+        assert!(peers
+            .hard_hard_complete_session_cleanup(
+                &replacement.peer_id,
+                &replacement.session_id,
+                &replacement.session_token,
+            )
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn hard_hard_token_cleanup_uses_exact_fallback_and_preserves_mismatched_token() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        let (peers, udp, identity, _remote) = exact_socket_proof_fixture().await;
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+            "test_token_mismatch_no_match",
+        )
+        .await;
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+        udp.detach_hard_hard_socket_if_identity(&identity, "test_exact_identity_fallback")
+            .await;
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+
+        let (socket_index, socket) = udp.bind_fresh_punch_socket().await.unwrap();
+        let socket_local_endpoint = socket.local_addr().unwrap();
+        let handoff = udp
+            .attach_dynamic_punch_socket(&identity.peer_id, socket_index, socket, 0, 2, None)
+            .await
+            .unwrap();
+        assert!(handoff
+            .commit_and_pin_for_test(&udp, &identity.peer_id, socket_index, 0, 2)
+            .await);
+        assert!(handoff.finalize().await);
+        assert!(udp
+            .tag_hard_hard_socket(&identity.peer_id, socket_index, "replacement-token")
+            .await);
+        let mut mismatched_identity = identity.clone();
+        mismatched_identity.socket_index = socket_index;
+        mismatched_identity.punch_generation = 2;
+        mismatched_identity.socket_local_endpoint = socket_local_endpoint;
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+            "test_old_token_does_not_match_replacement",
+        )
+        .await;
+        udp.detach_hard_hard_socket_if_identity(
+            &mismatched_identity,
+            "test_old_identity_does_not_match_replacement",
+        )
+        .await;
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            "replacement-token",
+            None,
+            "test_replacement_token_cleanup",
+        )
+        .await;
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+        peers
+            .clear_hard_hard_sessions(Some(&identity.peer_id))
+            .await;
+        udp.detach_all_dynamic_punch_sockets("test_token_mismatch_cleanup")
+            .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_expiry_retains_only_authenticated_current_direct_socket() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(Some(4_000_000_000));
+        let _clock = HardHardTestClockReset;
+        let (peers, udp, identity, remote, _peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        assert!(peers
+            .record_direct_success_for_generation_with_local_endpoint(
+                &identity.peer_id,
+                Some(remote),
+                identity.network_generation,
+                Some(identity.socket_local_endpoint),
+            )
+            .await);
+        assert!(
+            hard_hard_exact_direct_socket_is_current_for_cleanup(&udp, &peers, &identity).await
+        );
+        let record = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "birthday-runtime-session",
+                &identity.session_token,
+            )
+            .await
+            .unwrap();
+        let descriptor = HardHardCleanupDescriptor::from_record(&record);
+        set_hard_hard_test_now_ms(Some(record.expires_at_ms.saturating_add(1)));
+        let (gate, _gate_guard) = peers.install_hard_hard_cleanup_gate_for_test(
+            &descriptor.peer_id,
+            &descriptor.session_id,
+            &descriptor.session_token,
+        );
+        let completion = spawn_hard_hard_session_cleanup(udp.clone(), peers.clone(), descriptor.clone());
+        wait_for_hard_hard_cleanup_gate(&gate).await;
+        assert_eq!(
+            udp.hard_hard_socket_indices_for_token(&identity.peer_id, &identity.session_token)
+                .await,
+            vec![identity.socket_index]
+        );
+        gate.release.notify_waiters();
+        wait_for_hard_hard_cleanup_completion(&completion).await;
+        assert!(peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &descriptor.peer_id,
+                &descriptor.session_id,
+                &descriptor.session_token,
+            )
+            .await
+            .is_none());
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+        udp.detach_dynamic_socket_by_index(identity.socket_index, "test_retained_direct_cleanup")
+            .await;
+        assert_eq!(udp.dynamic_socket_count().await, 0);
     }
 
     async fn wait_for_birthday_worker_gate(

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -6,9 +6,9 @@
 // the existing authenticated ACK and PathSelector remain authoritative.
 
 use crate::udp::{
-    hard_hard_birthday_socket_count, hard_hard_birthday_wave_count,
-    update_birthday_sweep_counters, BirthdaySweepProgress, BirthdaySweepReport,
-    UdpProbeRxSnapshot,
+    apply_live_birthday_counters, hard_hard_birthday_socket_count, hard_hard_birthday_wave_count,
+    update_birthday_sweep_counters, BirthdaySweepFailureKind, BirthdaySweepProgress,
+    BirthdaySweepReport, UdpProbeRxSnapshot,
 };
 
 const HARD_HARD_SESSION_PREFIX: &str = "hh1";
@@ -2708,6 +2708,7 @@ async fn hard_hard_wait_and_sweep(
                 ..BirthdaySweepReport::default()
             },
             aggregate: PunchSendReport::default(),
+            ..BirthdaySweepProgress::default()
         }))
     });
     let delay = punch_at_ms.saturating_sub(hard_hard_now_ms());
@@ -2717,7 +2718,7 @@ async fn hard_hard_wait_and_sweep(
             _ = session.cancelled() => return false,
         }
     }
-    if peers.is_direct(&peer_id).await
+    if peers.is_direct_sync(&peer_id)
         || peers.current_network_generation_sync() != network_generation
         || (birthday_socket_indices.is_none()
             && !udp
@@ -2728,6 +2729,18 @@ async fn hard_hard_wait_and_sweep(
     {
         return false;
     }
+    // Capture receive/commit baselines before the lifecycle marker. The
+    // marker is intentionally nonblocking, and no diagnostics-map write is
+    // allowed to sit in front of the first scheduled UDP send.
+    let direct_commit_seq = peers.direct_commit_seq_sync(&peer_id);
+    let probe_rx_session_id = peers.probe_session_id_for_peer_try(&peer_id);
+    let probe_rx_before = udp
+        .probe_rx_snapshot_for_peer_session(
+            &peer_id,
+            network_generation,
+            probe_rx_session_id.as_deref(),
+        )
+        .await;
     let dispatch_at_ms = session.mark_first_send_started();
     peers
         .record_direct_event(
@@ -2747,15 +2760,6 @@ async fn hard_hard_wait_and_sweep(
                 hard_hard_now_ms(),
                 HARD_HARD_SWEEP_DEADLINE.as_millis(),
             ),
-        )
-        .await;
-    let direct_commit_seq = peers.direct_commit_seq_sync(&peer_id);
-    let probe_rx_session_id = peers.probe_session_id_for_peer(&peer_id).await;
-    let probe_rx_before = udp
-        .probe_rx_snapshot_for_peer_session(
-            &peer_id,
-            network_generation,
-            probe_rx_session_id.as_deref(),
         )
         .await;
     let mut report = None;
@@ -2798,13 +2802,20 @@ async fn hard_hard_wait_and_sweep(
         .await;
     let probe_rx_delta = probe_rx_after.delta_since(probe_rx_before);
     match (outcome, report) {
-        (PunchSessionOutcome::Completed, Some(Ok(report))) => {
-            let worker_failed = report.birthday.as_ref().is_some_and(|birthday| {
-                matches!(
-                    birthday.stop_reason.as_deref(),
-                    Some("send_error" | "worker_failed")
-                )
-            });
+        (PunchSessionOutcome::Completed, Some(Ok(mut report))) => {
+            let worker_failure_reason = report
+                .failure_kind
+                .map(BirthdaySweepFailureKind::stop_reason)
+                .or_else(|| {
+                    report.birthday.as_ref().and_then(|birthday| match birthday
+                        .stop_reason
+                        .as_deref()
+                    {
+                        Some(reason @ ("send_error" | "worker_failed")) => Some(reason),
+                        _ => None,
+                    })
+                });
+            let worker_failed = worker_failure_reason.is_some();
             let confirmation_identity = if birthday_socket_indices.is_some() {
                 peers
                     .hard_hard_fresh_socket_for_token(&peer_id, &session_token)
@@ -2862,6 +2873,18 @@ async fn hard_hard_wait_and_sweep(
                 .unwrap_or(false);
                 confirmed
             };
+            let session_stop_reason = if let Some(reason) = worker_failure_reason {
+                Some(reason.to_string())
+            } else if direct_confirmed {
+                None
+            } else {
+                Some("no_authenticated_direct_confirmation".to_string())
+            };
+            if let (Some(reason), Some(birthday)) =
+                (session_stop_reason.as_deref(), report.birthday.as_mut())
+            {
+                birthday.stop_reason = Some(reason.to_string());
+            }
             let mut per_socket_counts = report.per_socket_sent.clone();
             per_socket_counts.sort_by_key(|(socket_index, _)| *socket_index);
             let per_socket_sent = per_socket_counts
@@ -2878,11 +2901,24 @@ async fn hard_hard_wait_and_sweep(
                     targets.first().copied(),
                     Some(socket_index),
                     Some(report.unique_target_endpoints as usize),
-                    Some(report.packets_sent),
+                    Some(report.logical_probes_sent.max(report.packets_sent)),
                     format!(
-                        "origin={origin} mode={} sent={} received={} matched_ack={} authenticated_rx={} authenticated_ack_unmatched={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?} last_send_at_ms={:?} per_socket_sent={}{}",
+                        "origin={origin} mode={} sent={} logical_probes_attempted={} logical_probes_sent={} physical_datagrams_sent={} physical_send_errors={} targets_assigned={} targets_examined={} targets_attempted={} targets_cancelled={} received={} matched_ack={} authenticated_rx={} authenticated_ack_unmatched={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?} last_send_at_ms={:?} per_socket_sent={}{}",
                         if birthday_detail.is_some() { "birthday" } else { "predictable" },
                         report.packets_sent,
+                        report.logical_probes_attempted,
+                        report.logical_probes_sent.max(report.packets_sent),
+                        report.physical_datagrams_sent.max(
+                            per_socket_counts
+                                .iter()
+                                .map(|(_, sent)| *sent)
+                                .sum(),
+                        ),
+                        report.physical_send_errors,
+                        report.targets_assigned,
+                        report.targets_examined,
+                        report.targets_attempted,
+                        report.targets_cancelled,
                         probe_rx_delta.known_peer_ip_datagrams_received,
                         probe_rx_delta.probe_acks_received,
                         probe_rx_delta.authenticated_probe_packets_received,
@@ -2955,7 +2991,8 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         Some(report.packets_sent),
                         format!(
-                            "origin={origin} exact-socket sweep found no authenticated Direct confirmation within {:?}",
+                            "origin={origin} stop_reason={} exact-socket sweep found no authenticated Direct confirmation within {:?}",
+                            session_stop_reason.as_deref().unwrap_or("no_authenticated_direct_confirmation"),
                             HARD_HARD_DIRECT_CONFIRMATION_GRACE,
                         ),
                     )
@@ -2968,7 +3005,9 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         Some(report.packets_sent),
                         format!(
-                            "origin={origin} stage=sweep reason=no_authenticated_direct_confirmation budget_used={}",
+                            "origin={origin} stage=sweep reason={} stop_reason={} budget_used={}",
+                            session_stop_reason.as_deref().unwrap_or("no_authenticated_direct_confirmation"),
+                            session_stop_reason.as_deref().unwrap_or("no_authenticated_direct_confirmation"),
                             report.packets_sent,
                         ),
                     )
@@ -2977,45 +3016,14 @@ async fn hard_hard_wait_and_sweep(
             direct_confirmed
         }
         (PunchSessionOutcome::Completed, Some(Err(_error))) => {
-            if let Some(partial_report) = birthday_terminal_report(&birthday_progress, "send_error").await {
-                record_hard_hard_birthday_sweep_summary(
-                    &peers,
-                    &peer_id,
-                    network_generation,
-                    socket_index,
-                    targets.first().copied(),
-                    partial_report.unique_target_endpoints as usize,
-                    partial_report.packets_sent,
-                    origin,
-                    &partial_report,
-                    probe_rx_delta,
-                )
-                .await;
-            }
-            peers
-                    .record_direct_event(
-                        &peer_id,
-                        "hard_hard_sweep_failed",
-                        targets.first().copied(),
-                        Some(targets.len()),
-                        None,
-                        format!("origin={origin} exact-socket sweep failed before confirmation"),
-                    )
-                    .await;
-                peers
-                    .record_direct_event(
-                        &peer_id,
-                        "hard_hard_failed",
-                        targets.first().copied(),
-                        Some(targets.len()),
-                        None,
-                        format!("origin={origin} exact-socket sweep error stop_reason=send_error"),
-                    )
-                    .await;
-            false
-        }
-        (PunchSessionOutcome::DeadlineExceeded, _) => {
-            if let Some(partial_report) = birthday_terminal_report(&birthday_progress, "deadline").await {
+            let partial_report = birthday_terminal_report(&birthday_progress, "send_error").await;
+            let stop_reason = partial_report
+                .as_ref()
+                .and_then(|report| report.birthday.as_ref())
+                .and_then(|birthday| birthday.stop_reason.as_deref())
+                .unwrap_or("send_error")
+                .to_string();
+            if let Some(partial_report) = partial_report {
                 record_hard_hard_birthday_sweep_summary(
                     &peers,
                     &peer_id,
@@ -3038,11 +3046,8 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         None,
                         format!(
-                            "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason=deadline exact-socket sweep deadline elapsed before authenticated Direct confirmation",
-                            if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
-                            requested_level,
-                            targets.len(),
-                            birthday_waves_planned,
+                            "origin={origin} stop_reason={} exact-socket sweep failed before confirmation",
+                            stop_reason.as_str(),
                         ),
                     )
                     .await;
@@ -3054,8 +3059,65 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         None,
                         format!(
-                            "origin={origin} mode={} stage=sweep reason=deadline requested_level={} effective_target_count={} budget_ms={}",
+                            "origin={origin} exact-socket sweep error stop_reason={}",
+                            stop_reason.as_str(),
+                        ),
+                    )
+                    .await;
+            false
+        }
+        (PunchSessionOutcome::DeadlineExceeded, _) => {
+            let partial_report = birthday_terminal_report(&birthday_progress, "deadline").await;
+            let stop_reason = partial_report
+                .as_ref()
+                .and_then(|report| report.birthday.as_ref())
+                .and_then(|birthday| birthday.stop_reason.as_deref())
+                .unwrap_or("deadline")
+                .to_string();
+            if let Some(partial_report) = partial_report {
+                record_hard_hard_birthday_sweep_summary(
+                    &peers,
+                    &peer_id,
+                    network_generation,
+                    socket_index,
+                    targets.first().copied(),
+                    partial_report.unique_target_endpoints as usize,
+                    partial_report.packets_sent,
+                    origin,
+                    &partial_report,
+                    probe_rx_delta,
+                )
+                .await;
+            }
+            peers
+                    .record_direct_event(
+                        &peer_id,
+                        "hard_hard_sweep_failed",
+                        targets.first().copied(),
+                        Some(targets.len()),
+                        None,
+                        format!(
+                            "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason={} exact-socket sweep deadline elapsed before authenticated Direct confirmation",
                             if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
+                            requested_level,
+                            targets.len(),
+                            birthday_waves_planned,
+                            stop_reason.as_str(),
+                        ),
+                    )
+                    .await;
+                peers
+                    .record_direct_event(
+                        &peer_id,
+                        "hard_hard_failed",
+                        targets.first().copied(),
+                        Some(targets.len()),
+                        None,
+                        format!(
+                            "origin={origin} mode={} stage=sweep reason={} stop_reason={} requested_level={} effective_target_count={} budget_ms={}",
+                            if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
+                            stop_reason.as_str(),
+                            stop_reason.as_str(),
                             requested_level,
                             targets.len(),
                             HARD_HARD_SWEEP_DEADLINE.as_millis(),
@@ -3069,9 +3131,15 @@ async fn hard_hard_wait_and_sweep(
                 .cancellation_reason()
                 .map(PunchCancellationReason::label)
                 .unwrap_or("unknown");
-            if let Some(partial_report) =
-                birthday_terminal_report(&birthday_progress, "session_cancelled").await
-            {
+            let partial_report =
+                birthday_terminal_report(&birthday_progress, "session_cancelled").await;
+            let stop_reason = partial_report
+                .as_ref()
+                .and_then(|report| report.birthday.as_ref())
+                .and_then(|birthday| birthday.stop_reason.as_deref())
+                .unwrap_or("session_cancelled")
+                .to_string();
+            if let Some(partial_report) = partial_report {
                 record_hard_hard_birthday_sweep_summary(
                     &peers,
                     &peer_id,
@@ -3094,7 +3162,7 @@ async fn hard_hard_wait_and_sweep(
                     Some(targets.len()),
                     None,
                     format!(
-                        "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason=session_cancelled cancellation_reason={cancellation_reason}",
+                        "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason={} cancellation_reason={cancellation_reason}",
                         if birthday_socket_indices.is_some() {
                             "birthday"
                         } else {
@@ -3103,6 +3171,7 @@ async fn hard_hard_wait_and_sweep(
                         requested_level,
                         targets.len(),
                         birthday_waves_planned,
+                        stop_reason.as_str(),
                     ),
                 )
                 .await;
@@ -3114,12 +3183,14 @@ async fn hard_hard_wait_and_sweep(
                     Some(targets.len()),
                     None,
                     format!(
-                        "origin={origin} mode={} stage=sweep reason=session_cancelled cancellation_reason={cancellation_reason}",
+                        "origin={origin} mode={} stage=sweep reason={} stop_reason={} cancellation_reason={cancellation_reason}",
                         if birthday_socket_indices.is_some() {
                             "birthday"
                         } else {
                             "predictable"
                         },
+                        stop_reason.as_str(),
+                        stop_reason.as_str(),
                     ),
                 )
                 .await;
@@ -3138,12 +3209,16 @@ fn birthday_sweep_detail(report: &PunchSendReport) -> Option<String> {
         .map(|(socket_index, sent)| format!("{socket_index}:{sent}"))
         .collect::<Vec<_>>()
         .join(",");
-    let physical_datagrams_sent = per_socket_counts
-        .iter()
-        .map(|(_, sent)| *sent as usize)
-        .sum::<usize>();
+    let physical_datagrams_sent = usize::try_from(report.physical_datagrams_sent)
+        .unwrap_or(usize::MAX)
+        .max(
+            per_socket_counts
+                .iter()
+                .map(|(_, sent)| *sent as usize)
+                .sum::<usize>(),
+        );
     Some(format!(
-        "requested_level={} generated_candidate_count={} signaled_candidate_count={} effective_target_count={} requested_socket_count={} attached_socket_count={} usable_socket_count={} unavailable_socket_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_fully_completed={} waves_completed={} targets_assigned={} targets_attempted={} logical_probes_sent={} physical_datagrams_sent={} targets_budget_skipped={} targets_cancelled={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
+        "requested_level={} generated_candidate_count={} signaled_candidate_count={} effective_target_count={} requested_socket_count={} attached_socket_count={} usable_socket_count={} unavailable_socket_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_fully_completed={} waves_completed={} targets_assigned={} targets_examined={} targets_attempted={} logical_probes_attempted={} logical_probes_sent={} physical_datagrams_sent={} physical_send_errors={} targets_budget_skipped={} targets_cancelled={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
         birthday.requested_level,
         birthday.generated_candidate_count,
         birthday.signaled_candidate_count,
@@ -3159,9 +3234,12 @@ fn birthday_sweep_detail(report: &PunchSendReport) -> Option<String> {
         birthday.waves_fully_completed,
         birthday.waves_completed,
         birthday.targets_assigned,
+        birthday.targets_examined,
         birthday.targets_attempted,
+        birthday.logical_probes_attempted,
         birthday.logical_probes_sent,
         physical_datagrams_sent,
+        birthday.physical_send_errors,
         birthday.targets_budget_skipped,
         birthday.targets_cancelled,
         birthday.packets_planned,
@@ -3216,12 +3294,30 @@ async fn birthday_terminal_report(
     stop_reason: &str,
 ) -> Option<PunchSendReport> {
     let progress = progress.as_ref()?;
-    let current = progress.lock().await;
-    let mut report = current.aggregate.clone();
+    let (mut report, mut birthday, live) = {
+        let current = progress.lock().await;
+        (
+            current.aggregate.clone(),
+            current.birthday.clone(),
+            current.live.clone(),
+        )
+    };
+    let live_snapshot = live
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    apply_live_birthday_counters(&mut report, &live_snapshot);
     report.unique_target_endpoints =
         u32::try_from(report.sent_target_endpoints.len()).unwrap_or(u32::MAX);
-    let mut birthday = current.birthday.clone();
-    birthday.stop_reason = Some(stop_reason.to_string());
+    if birthday.stop_reason.is_none() {
+        birthday.stop_reason = Some(
+            report
+                .failure_kind
+                .map(BirthdaySweepFailureKind::stop_reason)
+                .unwrap_or(stop_reason)
+                .to_string(),
+        );
+    }
     birthday.waves_completed = birthday.waves_fully_completed;
     report.targets_assigned = report
         .targets_assigned
@@ -3450,6 +3546,7 @@ mod hard_hard_tests {
                 targets_cancelled: 94,
                 ..PunchSendReport::default()
             },
+            ..BirthdaySweepProgress::default()
         }));
 
         let report = birthday_terminal_report(&Some(progress), "worker_failed")
@@ -3467,6 +3564,98 @@ mod hard_hard_tests {
         assert_eq!(birthday.physical_datagrams_sent, 3);
         assert_eq!(birthday.targets_cancelled, 94);
         assert_eq!(birthday.stop_reason.as_deref(), Some("worker_failed"));
+    }
+
+    #[tokio::test]
+    async fn birthday_terminal_report_reads_in_flight_live_counters() {
+        let progress = Arc::new(tokio::sync::Mutex::new(BirthdaySweepProgress {
+            birthday: BirthdaySweepReport {
+                targets_assigned: 4,
+                waves_planned: 2,
+                waves_started: 1,
+                ..BirthdaySweepReport::default()
+            },
+            ..BirthdaySweepProgress::default()
+        }));
+        {
+            let live = {
+                let current = progress.lock().await;
+                current.live.clone()
+            };
+            let mut counters = live
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            counters.targets_assigned = 4;
+            counters.targets_examined = 3;
+            counters.targets_attempted = 1;
+            counters.targets_cancelled = 3;
+            counters.budget_skipped = 1;
+            counters.logical_probes_attempted = 1;
+            counters.logical_probes_sent = 1;
+            counters.physical_datagrams_sent = 2;
+            counters.physical_send_errors = 1;
+        }
+
+        let report = birthday_terminal_report(&Some(progress), "deadline")
+            .await
+            .expect("live birthday progress must produce a terminal report");
+        let birthday = report.birthday.as_ref().unwrap();
+        assert_eq!(report.targets_assigned, 4);
+        assert_eq!(report.targets_examined, 3);
+        assert_eq!(report.targets_attempted, 1);
+        assert_eq!(report.logical_probes_attempted, 1);
+        assert_eq!(report.logical_probes_sent, 1);
+        assert_eq!(report.physical_datagrams_sent, 2);
+        assert_eq!(report.physical_send_errors, 1);
+        assert_eq!(birthday.targets_examined, 3);
+        assert_eq!(birthday.logical_probes_attempted, 1);
+        assert_eq!(birthday.physical_send_errors, 1);
+        assert_eq!(birthday.targets_cancelled, 3);
+        assert_eq!(birthday.stop_reason.as_deref(), Some("deadline"));
+        assert!(report.logical_probes_sent <= report.logical_probes_attempted);
+        assert!(report.physical_datagrams_sent >= report.logical_probes_sent);
+        assert!(report.targets_attempted <= report.targets_examined);
+        assert!(report.targets_examined <= report.targets_assigned);
+    }
+
+    #[tokio::test]
+    async fn birthday_terminal_report_preserves_scheduler_failure_reason() {
+        let progress = Arc::new(tokio::sync::Mutex::new(BirthdaySweepProgress {
+            birthday: BirthdaySweepReport {
+                stop_reason: Some("worker_failed".to_string()),
+                ..BirthdaySweepReport::default()
+            },
+            aggregate: PunchSendReport {
+                failure_kind: Some(BirthdaySweepFailureKind::WorkerJoin),
+                worker_failed: true,
+                ..PunchSendReport::default()
+            },
+            ..BirthdaySweepProgress::default()
+        }));
+
+        let report = birthday_terminal_report(&Some(progress), "send_error")
+            .await
+            .expect("scheduler failure must remain observable");
+        assert_eq!(
+            report.birthday.unwrap().stop_reason.as_deref(),
+            Some("worker_failed")
+        );
+    }
+
+    #[test]
+    fn direct_confirmation_grace_is_bounded_after_busy_executor_regression() {
+        // The earlier one-second grace was insufficient in the full reciprocal
+        // birthday suite when validation and durable event work shared a busy
+        // executor. Keep the evidence-backed two-second lease, but retain the
+        // explicit outer 250ms bound so this is not an unbounded wait.
+        assert_eq!(HARD_HARD_DIRECT_CONFIRMATION_GRACE, Duration::from_secs(2));
+        assert!(
+            HARD_HARD_DIRECT_CONFIRMATION_GRACE + Duration::from_millis(250)
+                <= HARD_HARD_SWEEP_DEADLINE
+        );
+        // The 5ms poll is at most 400 timer intervals per grace lease, not a
+        // ready-notify hot loop.
+        assert!(HARD_HARD_DIRECT_CONFIRMATION_GRACE.as_millis() / 5 <= 400);
     }
 
     fn endpoint_for_test(port: u16) -> SocketAddr {

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -2110,6 +2110,8 @@ pub(crate) async fn spawn_hard_hard_responder(
     let cancellation = session.cancellation_handle();
     let session_id = coordination.encode();
     tokio::spawn(async move {
+        let mut pending_session_cancellation =
+            PendingHardHardSessionCancellation::new(cancellation.clone());
         let Some(mut measurement) = run_hard_hard_local_measurement(
             &udp,
             &peers,
@@ -2258,11 +2260,18 @@ pub(crate) async fn spawn_hard_hard_responder(
         if !registered {
             return;
         }
-        let _cleanup_completion = spawn_hard_hard_session_cleanup(
+        let cleanup_owner = session.clone_for_cleanup();
+        let _cleanup_completion = spawn_hard_hard_session_cleanup_with_owner(
             udp.clone(),
             peers.clone(),
             cleanup_descriptor.clone(),
+            Some(cleanup_owner),
         );
+        // The registered ledger record and its cleanup owner now cover the
+        // exact cancellation path. Before this handoff, dropping the
+        // responder task must cancel the shared handle so the provisional
+        // measurement guard cannot outlive a pre-ledger return.
+        pending_session_cancellation.disarm();
         if cancellation.is_cancelled()
             || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
         {
@@ -3385,10 +3394,25 @@ fn spawn_hard_hard_session_cleanup(
     peers: Arc<PeerManager>,
     descriptor: HardHardCleanupDescriptor,
 ) -> HardHardCleanupCompletion {
+    spawn_hard_hard_session_cleanup_with_owner(udp, peers, descriptor, None)
+}
+
+fn spawn_hard_hard_session_cleanup_with_owner(
+    udp: UdpTransport,
+    peers: Arc<PeerManager>,
+    descriptor: HardHardCleanupDescriptor,
+    cleanup_owner: Option<PunchSessionPermit>,
+) -> HardHardCleanupCompletion {
     let completion = HardHardCleanupCompletion::new();
     let watcher_completion = completion.clone();
     tokio::spawn(async move {
+        // Keep the exact punch-dedup record occupied until this cleanup task
+        // has completed both the token-scoped UDP cleanup and the ledger
+        // removal. This closes the window in which a peer-reflexive worker
+        // could otherwise claim a lower-priority ordinary punch after the
+        // Hard↔Hard worker released its short-lived permit.
         let _completion_guard = HardHardCleanupCompletionGuard(watcher_completion);
+        let _cleanup_owner = cleanup_owner;
         if !peers
             .hard_hard_claim_cleanup_owner(
                 &descriptor.peer_id,

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -1431,10 +1431,9 @@ async fn hard_hard_exact_direct_socket_is_current_for_cleanup(
 
 /// An authenticated Hard↔Hard winner may reach the encrypted validation
 /// worker just after the short rendezvous sweep expires. Keep that exact
-/// token-tagged socket alive until the normal bounded session cleanup gets a
-/// chance to see the Direct commit. The manager winner is written only by the
-/// authenticated admission path; accepting its exact socket here closes the
-/// manager-to-socket commit window without treating it as Direct proof.
+/// socket alive until the normal bounded session cleanup gets a chance to see
+/// the Direct commit; a winner with no socket-local authenticated evidence is
+/// still cleaned immediately by the caller.
 async fn hard_hard_authenticated_winner_for_cleanup(
     udp: &UdpTransport,
     peers: &PeerManager,
@@ -1450,7 +1449,7 @@ async fn hard_hard_authenticated_winner_for_cleanup(
     if identity.socket_index != winner
         || !peers.hard_hard_session_identity_is_current(&identity).await
         || !udp
-            .hard_hard_socket_identity_is_exact_session_socket(&identity)
+            .hard_hard_socket_identity_has_authenticated_evidence(&identity)
             .await
     {
         return None;
@@ -4036,41 +4035,9 @@ mod hard_hard_tests {
             .expect("fixture session must enter its single sweep");
         assert_eq!(sweeping.fresh_socket, identity);
 
-        // Stop at the exact manager-selected/socket-not-yet-committed seam.
-        // Production reaches this state only after authenticated Probe v2
-        // admission. Cleanup must preserve the exact token-tagged socket for
-        // the remainder of the bounded session, without accepting it as
-        // Direct proof.
-        let selected = peers
-            .hard_hard_select_winner(
-                &identity.peer_id,
-                &identity.session_token,
-                identity.socket_index,
-                identity.network_generation,
-                identity.punch_generation,
-                identity.socket_local_endpoint,
-            )
-            .await
-            .expect("authenticated manager selection must accept the exact socket");
-        assert_eq!(selected, identity);
-        assert!(udp
-            .hard_hard_socket_identity_is_exact_session_socket(&identity)
-            .await);
-        assert_eq!(
-            hard_hard_authenticated_winner_for_cleanup(
-                &udp,
-                &peers,
-                &identity.peer_id,
-                &identity.session_token,
-            )
-            .await,
-            Some(identity.clone()),
-            "timeout cleanup must not retire a manager-selected exact socket in the commit seam"
-        );
-
-        // `hard_hard_winner_selected` is a durable event. Holding the
-        // connection writer parks the production promotion at that await and
-        // proves socket evidence was committed before diagnostics can block.
+        // Both winner diagnostics are durable events. Holding the connection
+        // writer parks the production promotion only after its manager winner
+        // and UDP evidence/affinity/phase transaction is complete.
         let connections_writer = peers.hold_connections_writer_for_test().await;
         let socket_index = identity.socket_index;
         let network_generation = identity.network_generation;
@@ -4090,7 +4057,7 @@ mod hard_hard_tests {
         });
         for _ in 0..256 {
             if udp
-                .hard_hard_socket_identity_has_authenticated_evidence(&selected)
+                .hard_hard_socket_identity_has_authenticated_evidence(&identity)
                 .await
             {
                 break;
@@ -4098,8 +4065,14 @@ mod hard_hard_tests {
             tokio::task::yield_now().await;
         }
         assert!(udp
-            .hard_hard_socket_identity_has_authenticated_evidence(&selected)
+            .hard_hard_socket_identity_has_authenticated_evidence(&identity)
             .await);
+        assert_eq!(
+            peers
+                .hard_hard_winner_for_token(&identity.peer_id, &identity.session_token)
+                .await,
+            Some(identity.socket_index)
+        );
         assert!(
             !promotion.is_finished(),
             "durable diagnostics must still be waiting on the held connection writer"
@@ -4110,6 +4083,17 @@ mod hard_hard_tests {
                 .await
                 .expect("promotion must finish after diagnostics are released")
                 .expect("promotion task must not panic")
+        );
+        assert_eq!(
+            hard_hard_authenticated_winner_for_cleanup(
+                &udp,
+                &peers,
+                &identity.peer_id,
+                &identity.session_token,
+            )
+            .await,
+            Some(identity.clone()),
+            "cleanup retention requires the same transaction's authenticated socket evidence"
         );
 
         assert!(peers
@@ -4124,6 +4108,187 @@ mod hard_hard_tests {
             &identity.session_token,
             None,
             "test_winner_promotion_cleanup",
+        )
+        .await;
+        udp.clear_hard_hard_pending_probes_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+        )
+        .await;
+        assert!(peers
+            .hard_hard_complete_session_cleanup(
+                &identity.peer_id,
+                &sweeping.session_id,
+                &identity.session_token,
+            )
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn hard_hard_duplicate_registration_keeps_new_measurement_under_rollback_owner() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        let (peers, udp, identity, _remote, _peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let original = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                "birthday-runtime-session",
+                &identity.session_token,
+            )
+            .await
+            .expect("fixture must expose its authoritative session");
+        let duplicate_cancellation = Arc::new(crate::PunchSessionCancellation::default());
+        let mut duplicate = original.clone();
+        duplicate.fresh_socket.socket_index = identity.socket_index.saturating_add(100);
+        duplicate.fresh_socket.punch_generation = identity.punch_generation.saturating_add(1);
+        duplicate.fresh_socket.socket_local_endpoint = "127.0.0.1:45000".parse().unwrap();
+        duplicate.cancellation = duplicate_cancellation.clone();
+        duplicate.created_at = Instant::now();
+
+        {
+            let _rollback_owner =
+                PendingHardHardSessionCancellation::new(duplicate_cancellation.clone());
+            assert!(
+                !peers.hard_hard_register_session(duplicate).await,
+                "an existing session must not transfer its cleanup ownership to a duplicate measurement"
+            );
+        }
+        assert!(
+            duplicate_cancellation.is_cancelled(),
+            "the rejected duplicate measurement must keep its rollback cancellation armed"
+        );
+        let current = peers
+            .hard_hard_session_snapshot_for_cleanup(
+                &identity.peer_id,
+                &original.session_id,
+                &identity.session_token,
+            )
+            .await
+            .expect("the original session must remain authoritative");
+        assert_eq!(current.fresh_socket, original.fresh_socket);
+        assert!(Arc::ptr_eq(&current.cancellation, &original.cancellation));
+        assert!(!current.cancellation.is_cancelled());
+        assert_eq!(udp.dynamic_socket_count().await, 1);
+
+        assert!(peers
+            .hard_hard_retire_session(
+                &identity.peer_id,
+                &original.session_id,
+                &identity.session_token,
+            )
+            .await);
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+            "test_duplicate_registration_cleanup",
+        )
+        .await;
+        udp.clear_hard_hard_pending_probes_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+        )
+        .await;
+        assert!(peers
+            .hard_hard_complete_session_cleanup(
+                &identity.peer_id,
+                &original.session_id,
+                &identity.session_token,
+            )
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn hard_hard_winner_promotion_cancellation_before_commit_leaves_no_half_winner() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        let (peers, udp, identity, remote, _peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        udp.clear_authenticated_evidence_for_test(identity.socket_index)
+            .await;
+        let sweeping = peers
+            .hard_hard_begin_sweep(
+                &identity.peer_id,
+                &identity.session_token,
+                vec![remote],
+                90,
+                0,
+            )
+            .await
+            .expect("fixture session must enter its single sweep");
+
+        let winner_writer = peers.hold_hard_hard_winner_writer_for_test().await;
+        let socket_index = identity.socket_index;
+        let network_generation = identity.network_generation;
+        let promotion = tokio::spawn({
+            let udp = udp.clone();
+            let peer_id = identity.peer_id.clone();
+            let token = identity.session_token.clone();
+            async move {
+                udp.promote_hard_hard_winner_for_test(
+                    &peer_id,
+                    &token,
+                    socket_index,
+                    network_generation,
+                )
+                .await
+            }
+        });
+        for _ in 0..256 {
+            if udp.hard_hard_socket_state_is_locked_for_test() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            udp.hard_hard_socket_state_is_locked_for_test(),
+            "promotion must own the exact socket transaction before cancellation"
+        );
+        promotion.abort();
+        let cancelled = tokio::time::timeout(Duration::from_secs(1), promotion)
+            .await
+            .expect("aborted promotion must stop without waiting for the winner writer")
+            .expect_err("promotion must be cancelled at the pre-commit lock wait");
+        assert!(cancelled.is_cancelled());
+        drop(winner_writer);
+
+        assert_eq!(
+            peers
+                .hard_hard_winner_for_token(&identity.peer_id, &identity.session_token)
+                .await,
+            None,
+            "pre-commit cancellation must not strand a manager-only winner"
+        );
+        assert!(!udp
+            .hard_hard_socket_identity_has_authenticated_evidence(&identity)
+            .await);
+        assert_eq!(
+            hard_hard_authenticated_winner_for_cleanup(
+                &udp,
+                &peers,
+                &identity.peer_id,
+                &identity.session_token,
+            )
+            .await,
+            None,
+            "an unauthenticated pre-commit socket must never be preserved"
+        );
+
+        assert!(peers
+            .hard_hard_retire_session(
+                &identity.peer_id,
+                &sweeping.session_id,
+                &identity.session_token,
+            )
+            .await);
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+            "test_cancelled_winner_promotion_cleanup",
         )
         .await;
         udp.clear_hard_hard_pending_probes_for_token(

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -5,6 +5,12 @@
 // machinery. It does not introduce a second wire protocol or promote a path:
 // the existing authenticated ACK and PathSelector remain authoritative.
 
+use crate::udp::{
+    hard_hard_birthday_socket_count, hard_hard_birthday_wave_count,
+    update_birthday_sweep_counters, BirthdaySweepProgress, BirthdaySweepReport,
+    UdpProbeRxSnapshot,
+};
+
 const HARD_HARD_SESSION_PREFIX: &str = "hh1";
 const HARD_HARD_PUNCH_LEAD: Duration = Duration::from_millis(3_500);
 const HARD_HARD_MIN_RESPONSE_LEAD: Duration = Duration::from_millis(1_250);
@@ -12,7 +18,10 @@ const HARD_HARD_MIN_RESPONSE_LEAD: Duration = Duration::from_millis(1_250);
 /// ordinary Relay/backoff recovery owns all later retries.
 const HARD_HARD_SESSION_TTL: Duration = Duration::from_secs(8);
 const HARD_HARD_SWEEP_DEADLINE: Duration = Duration::from_secs(3);
-const HARD_HARD_DIRECT_CONFIRMATION_GRACE: Duration = Duration::from_secs(1);
+// The validation worker's individual ACK lease is 750ms.  Keep a bounded
+// second lease for scheduler/ingress handoff under a busy executor without
+// changing the send budget or any identity/generation fence.
+const HARD_HARD_DIRECT_CONFIRMATION_GRACE: Duration = Duration::from_secs(2);
 const HARD_HARD_SWEEP_INTERVAL: Duration = Duration::from_millis(20);
 const HARD_HARD_SWEEP_ATTEMPTS: u32 = 2;
 const HARD_HARD_MAX_PREDICTION_TARGETS: usize = 32;
@@ -742,6 +751,12 @@ fn hard_hard_initiator_response_record_matches(
         && current.remote_profile_generation == expected.remote_profile_generation
         && current.local_prediction_confidence == expected.local_prediction_confidence
         && current.remote_prediction_confidence == expected.remote_prediction_confidence
+        && current.requested_birthday_level == expected.requested_birthday_level
+        && current.generated_candidate_count == expected.generated_candidate_count
+        && current.signaled_candidate_count == expected.signaled_candidate_count
+        && current.birthday == expected.birthday
+        && current.requested_socket_indices == expected.requested_socket_indices
+        && current.requested_socket_count == expected.requested_socket_count
         && current.prediction_window == expected.prediction_window
         && current.remote_prediction == expected.remote_prediction
         && current.fresh_socket == expected.fresh_socket
@@ -995,6 +1010,37 @@ fn hard_hard_measurement_target_limit(measurement: &HardHardLocalMeasurement) ->
         HardHardLocalMeasurement::Birthday(result) => result
             .level
             .min(HARD_HARD_MAX_BIRTHDAY_TARGETS),
+    }
+}
+
+fn hard_hard_measurement_is_birthday(measurement: &HardHardLocalMeasurement) -> bool {
+    matches!(measurement, HardHardLocalMeasurement::Birthday(_))
+}
+
+fn hard_hard_measurement_requested_level(measurement: &HardHardLocalMeasurement) -> usize {
+    match measurement {
+        HardHardLocalMeasurement::Predictable { .. } => 0,
+        HardHardLocalMeasurement::Birthday(result) => result.requested_level,
+    }
+}
+
+fn hard_hard_measurement_socket_indices(measurement: &HardHardLocalMeasurement) -> Vec<usize> {
+    match measurement {
+        HardHardLocalMeasurement::Predictable { result, .. } => vec![result.socket_index],
+        HardHardLocalMeasurement::Birthday(result) => result
+            .sockets
+            .iter()
+            .map(|socket| socket.socket_index)
+            .collect(),
+    }
+}
+
+fn hard_hard_measurement_requested_socket_count(
+    measurement: &HardHardLocalMeasurement,
+) -> usize {
+    match measurement {
+        HardHardLocalMeasurement::Predictable { .. } => 1,
+        HardHardLocalMeasurement::Birthday(result) => result.requested_socket_count,
     }
 }
 
@@ -1262,7 +1308,8 @@ async fn hard_hard_wait_for_exact_direct_confirmation(
 ) -> bool {
     let deadline = Instant::now() + HARD_HARD_DIRECT_CONFIRMATION_GRACE;
     loop {
-        if session.is_cancelled() || !peers.hard_hard_session_identity_is_current(identity).await {
+        let session_current = peers.hard_hard_session_identity_is_current(identity).await;
+        if session.is_cancelled() || !session_current {
             return false;
         }
 
@@ -1288,20 +1335,13 @@ async fn hard_hard_wait_for_exact_direct_confirmation(
         if remaining.is_zero() {
             return false;
         }
-        if peers.is_direct_sync(&identity.peer_id) && manager_pair_matches {
-            tokio::select! {
-                _ = session.cancelled() => return false,
-                _ = sleep(remaining.min(Duration::from_millis(5))) => {}
-            }
-        } else {
-            tokio::select! {
-                _ = session.cancelled() => return false,
-                _ = peers.wait_for_direct_commit_or_timeout(
-                    &identity.peer_id,
-                    from_commit_seq,
-                    remaining,
-                ) => {}
-            }
+        // Poll the authoritative state on a short timer instead of waiting on
+        // the manager-wide commit Notify.  That Notify can be hot during
+        // reciprocal validation; repeatedly-ready notifications would let
+        // this future spin without ever yielding to its outer deadline.
+        tokio::select! {
+            _ = session.cancelled() => return false,
+            _ = sleep(remaining.min(Duration::from_millis(5))) => {}
         }
     }
 }
@@ -1656,6 +1696,9 @@ pub(crate) async fn spawn_hard_hard_initiator(
             &candidates,
             hard_hard_measurement_target_limit(&measurement),
         );
+        let requested_birthday_level = hard_hard_measurement_requested_level(&measurement);
+        let birthday = hard_hard_measurement_is_birthday(&measurement);
+        let requested_socket_indices = hard_hard_measurement_socket_indices(&measurement);
         let record = HardHardSessionRecord {
             session_id: session_id.clone(),
             session_token: coordination.token.clone(),
@@ -1668,6 +1711,13 @@ pub(crate) async fn spawn_hard_hard_initiator(
             remote_profile_generation: plan.remote_profile_generation,
             local_prediction_confidence: local_confidence,
             remote_prediction_confidence: 0,
+            requested_birthday_level,
+            generated_candidate_count: candidate_contract.generated_candidate_count,
+            signaled_candidate_count: candidate_contract.signaled_candidate_count,
+            birthday,
+            requested_socket_count:
+                hard_hard_measurement_requested_socket_count(&measurement),
+            requested_socket_indices,
             prediction_window,
             remote_prediction: Vec::new(),
             fresh_socket: primary_socket.clone(),
@@ -2090,6 +2140,9 @@ pub(crate) async fn spawn_hard_hard_responder(
         if prediction_window.is_empty() {
             return;
         }
+        let requested_birthday_level = hard_hard_measurement_requested_level(&measurement);
+        let birthday = hard_hard_measurement_is_birthday(&measurement);
+        let requested_socket_indices = hard_hard_measurement_socket_indices(&measurement);
         let record = HardHardSessionRecord {
             session_id: session_id.clone(),
             session_token: coordination.token.clone(),
@@ -2102,6 +2155,13 @@ pub(crate) async fn spawn_hard_hard_responder(
             remote_profile_generation: current_plan.remote_profile_generation,
             local_prediction_confidence: local_confidence,
             remote_prediction_confidence: coordination.local_prediction_confidence,
+            requested_birthday_level,
+            generated_candidate_count: candidate_contract.generated_candidate_count,
+            signaled_candidate_count: candidate_contract.signaled_candidate_count,
+            birthday,
+            requested_socket_count:
+                hard_hard_measurement_requested_socket_count(&measurement),
+            requested_socket_indices,
             prediction_window,
             remote_prediction: remote_prediction.clone(),
             fresh_socket: primary_socket.clone(),
@@ -2228,16 +2288,8 @@ pub(crate) async fn spawn_hard_hard_responder(
             )
             .await;
         let fresh_socket = primary_socket;
-        let birthday_socket_indices = match &measurement {
-            HardHardLocalMeasurement::Birthday(result) => Some(
-                result
-                    .sockets
-                    .iter()
-                    .map(|socket| socket.socket_index)
-                    .collect::<Vec<_>>(),
-            ),
-            HardHardLocalMeasurement::Predictable { .. } => None,
-        };
+        let birthday_socket_indices = birthday
+            .then(|| hard_hard_measurement_socket_indices(&measurement));
         let cleanup_udp = udp.clone();
         let swept = hard_hard_wait_and_sweep(
             udp,
@@ -2249,7 +2301,9 @@ pub(crate) async fn spawn_hard_hard_responder(
             birthday_socket_indices,
             coordination.token.clone(),
             remote_prediction,
-            hard_hard_measurement_target_limit(&measurement),
+            requested_birthday_level,
+            candidate_contract.generated_candidate_count,
+            candidate_contract.signaled_candidate_count,
             punch_at_ms,
             current_plan.local_network_generation,
             (
@@ -2495,9 +2549,9 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         return HardHardRemoteStart::NotStarted;
     }
     let fresh_socket = record.fresh_socket.clone();
-    let birthday_socket_indices = udp
-        .hard_hard_socket_indices_for_token(&peer_id, &record.session_token)
-        .await;
+    let birthday_socket_indices = record
+        .birthday
+        .then(|| record.requested_socket_indices.clone());
     let cleanup_udp = udp.clone();
     let swept = hard_hard_wait_and_sweep(
         udp,
@@ -2506,13 +2560,13 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         peer_id.clone(),
         peer_session_generation,
         fresh_socket.clone(),
-        (!birthday_socket_indices.is_empty()).then_some(birthday_socket_indices),
+        birthday_socket_indices,
         record.session_token.clone(),
         remote_prediction,
         record
-            .prediction_window
-            .len()
-            .min(HARD_HARD_MAX_BIRTHDAY_TARGETS),
+            .requested_birthday_level,
+        record.generated_candidate_count,
+        record.signaled_candidate_count,
         punch_at_ms,
         record.local_network_generation,
         (
@@ -2632,6 +2686,8 @@ async fn hard_hard_wait_and_sweep(
     session_token: String,
     targets: Vec<SocketAddr>,
     requested_level: usize,
+    generated_candidate_count: usize,
+    signaled_candidate_count: usize,
     punch_at_ms: u64,
     network_generation: u64,
     profile_generations: (u64, u64),
@@ -2639,7 +2695,20 @@ async fn hard_hard_wait_and_sweep(
 ) -> bool {
     let socket_index = fresh_socket.socket_index;
     let birthday_waves_planned = birthday_socket_indices.as_ref().map_or(1, |indices| {
-        if indices.len() > 1 { 2 } else { 1 }
+        hard_hard_birthday_wave_count(indices.len())
+    });
+    let birthday_progress = birthday_socket_indices.as_ref().map(|_| {
+        Arc::new(tokio::sync::Mutex::new(BirthdaySweepProgress {
+            birthday: BirthdaySweepReport {
+                requested_level,
+                generated_candidate_count,
+                signaled_candidate_count,
+                effective_target_count: targets.len().min(crate::MAX_SIGNAL_CANDIDATES),
+                requested_socket_count: hard_hard_birthday_socket_count(requested_level),
+                ..BirthdaySweepReport::default()
+            },
+            aggregate: PunchSendReport::default(),
+        }))
     });
     let delay = punch_at_ms.saturating_sub(hard_hard_now_ms());
     if delay > 0 {
@@ -2650,9 +2719,10 @@ async fn hard_hard_wait_and_sweep(
     }
     if peers.is_direct(&peer_id).await
         || peers.current_network_generation_sync() != network_generation
-        || !udp
-            .hard_hard_socket_identity_is_current(&fresh_socket)
-            .await
+        || (birthday_socket_indices.is_none()
+            && !udp
+                .hard_hard_socket_identity_is_current(&fresh_socket)
+                .await)
         || session.is_cancelled()
         || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
     {
@@ -2689,16 +2759,20 @@ async fn hard_hard_wait_and_sweep(
         )
         .await;
     let mut report = None;
+    let birthday_progress_for_work = birthday_progress.clone();
     let outcome = run_owned_punch_session_with_deadline(&session, HARD_HARD_SWEEP_DEADLINE, async {
         report = Some(if let Some(socket_indices) = birthday_socket_indices.clone() {
-            udp.punch_hard_hard_birthday_candidates(
+            udp.punch_hard_hard_birthday_candidates_with_metadata(
                 &peer_id,
                 socket_indices,
                 targets.clone(),
                 requested_level,
+                generated_candidate_count,
+                signaled_candidate_count,
                 peer_session_generation,
                 profile_generations,
                 &session_token,
+                birthday_progress_for_work,
             )
             .await
         } else {
@@ -2725,17 +2799,39 @@ async fn hard_hard_wait_and_sweep(
     let probe_rx_delta = probe_rx_after.delta_since(probe_rx_before);
     match (outcome, report) {
         (PunchSessionOutcome::Completed, Some(Ok(report))) => {
-            let direct_confirmed = if report.packets_sent == 0 {
+            let worker_failed = report.birthday.as_ref().is_some_and(|birthday| {
+                matches!(
+                    birthday.stop_reason.as_deref(),
+                    Some("send_error" | "worker_failed")
+                )
+            });
+            let confirmation_identity = if birthday_socket_indices.is_some() {
+                peers
+                    .hard_hard_fresh_socket_for_token(&peer_id, &session_token)
+                    .await
+                    .unwrap_or_else(|| fresh_socket.clone())
+            } else {
+                fresh_socket.clone()
+            };
+            let authenticated_winner_evidence = udp
+                .hard_hard_socket_identity_has_authenticated_evidence(&confirmation_identity)
+                .await;
+            let authenticated_winner_selected = peers
+                .hard_hard_winner_for_token(&peer_id, &session_token)
+                .await
+                .is_some_and(|winner| winner == confirmation_identity.socket_index);
+            // An authenticated exact-socket Probe can select the winner while
+            // the local worker is still before its first send.  A zero local
+            // send is not proof of failure when that evidence already exists;
+            // the bounded confirmation below still requires the authoritative
+            // Direct commit, selected pair, and every session fence.
+            let direct_confirmed = if worker_failed
+                || (report.packets_sent == 0
+                    && !authenticated_winner_evidence
+                    && !authenticated_winner_selected)
+            {
                 false
             } else {
-                let confirmation_identity = if birthday_socket_indices.is_some() {
-                    peers
-                        .hard_hard_fresh_socket_for_token(&peer_id, &session_token)
-                        .await
-                        .unwrap_or_else(|| fresh_socket.clone())
-                } else {
-                    fresh_socket.clone()
-                };
                 peers
                     .record_direct_event(
                         &peer_id,
@@ -2752,14 +2848,19 @@ async fn hard_hard_wait_and_sweep(
                         ),
                     )
                     .await;
-                hard_hard_wait_for_exact_direct_confirmation(
-                    &udp,
-                    &peers,
-                    &session,
-                    &confirmation_identity,
-                    direct_commit_seq,
+                let confirmed = tokio::time::timeout(
+                    HARD_HARD_DIRECT_CONFIRMATION_GRACE + Duration::from_millis(250),
+                    hard_hard_wait_for_exact_direct_confirmation(
+                        &udp,
+                        &peers,
+                        &session,
+                        &confirmation_identity,
+                        direct_commit_seq,
+                    ),
                 )
-                    .await
+                .await
+                .unwrap_or(false);
+                confirmed
             };
             let mut per_socket_counts = report.per_socket_sent.clone();
             per_socket_counts.sort_by_key(|(socket_index, _)| *socket_index);
@@ -2768,26 +2869,7 @@ async fn hard_hard_wait_and_sweep(
                 .map(|(socket_index, sent)| format!("{socket_index}:{sent}"))
                 .collect::<Vec<_>>()
                 .join(",");
-            let birthday_detail = report.birthday.as_ref().map(|birthday| {
-                format!(
-                    "requested_level={} effective_target_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_completed={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
-                    birthday.requested_level,
-                    birthday.effective_target_count,
-                    birthday.socket_count,
-                    birthday.degraded_reason.as_deref().unwrap_or("none"),
-                    birthday.waves_planned,
-                    birthday.waves_started,
-                    birthday.waves_completed,
-                    birthday.packets_planned,
-                    report.packets_sent,
-                    report.unique_target_endpoints,
-                    report.budget_skipped,
-                    per_socket_sent,
-                    report.first_send_at_ms,
-                    report.last_send_at_ms,
-                    birthday.stop_reason.as_deref().unwrap_or("unknown"),
-                )
-            });
+            let birthday_detail = birthday_sweep_detail(&report);
             peers
                 .record_direct_event_for_generation_with_socket(
                     &peer_id,
@@ -2818,26 +2900,19 @@ async fn hard_hard_wait_and_sweep(
                     ),
                 )
                 .await;
-            if let Some(detail) = birthday_detail.as_deref() {
-                peers
-                    .record_direct_event_for_generation_with_socket(
-                        &peer_id,
-                        network_generation,
-                        "hard_hard_birthday_sweep_summary",
-                        targets.first().copied(),
-                        Some(socket_index),
-                        Some(report.unique_target_endpoints as usize),
-                        Some(report.packets_sent),
-                        format!(
-                            "origin={origin} mode=birthday {detail} known_peer_ip_rx_delta={} authenticated_probe_rx_delta={} matched_probe_ack_rx_delta={} authenticated_probe_ack_unmatched_delta={}",
-                            probe_rx_delta.known_peer_ip_datagrams_received,
-                            probe_rx_delta.authenticated_probe_packets_received,
-                            probe_rx_delta.probe_acks_received,
-                            probe_rx_delta.authenticated_probe_acks_unmatched,
-                        ),
-                    )
-                    .await;
-            }
+            record_hard_hard_birthday_sweep_summary(
+                &peers,
+                &peer_id,
+                network_generation,
+                socket_index,
+                targets.first().copied(),
+                report.unique_target_endpoints as usize,
+                report.packets_sent,
+                origin,
+                &report,
+                probe_rx_delta,
+            )
+            .await;
             if direct_confirmed {
                 peers
                     .record_direct_event(
@@ -2901,17 +2976,30 @@ async fn hard_hard_wait_and_sweep(
             }
             direct_confirmed
         }
-        (PunchSessionOutcome::Completed, Some(Err(error))) => {
-                peers
+        (PunchSessionOutcome::Completed, Some(Err(_error))) => {
+            if let Some(partial_report) = birthday_terminal_report(&birthday_progress, "send_error").await {
+                record_hard_hard_birthday_sweep_summary(
+                    &peers,
+                    &peer_id,
+                    network_generation,
+                    socket_index,
+                    targets.first().copied(),
+                    partial_report.unique_target_endpoints as usize,
+                    partial_report.packets_sent,
+                    origin,
+                    &partial_report,
+                    probe_rx_delta,
+                )
+                .await;
+            }
+            peers
                     .record_direct_event(
                         &peer_id,
                         "hard_hard_sweep_failed",
                         targets.first().copied(),
                         Some(targets.len()),
                         None,
-                        format!(
-                            "origin={origin} exact-socket sweep failed before confirmation: {error}"
-                        ),
+                        format!("origin={origin} exact-socket sweep failed before confirmation"),
                     )
                     .await;
                 peers
@@ -2921,13 +3009,28 @@ async fn hard_hard_wait_and_sweep(
                         targets.first().copied(),
                         Some(targets.len()),
                         None,
-                        format!("origin={origin} exact-socket sweep error: {error}"),
+                        format!("origin={origin} exact-socket sweep error stop_reason=send_error"),
                     )
                     .await;
             false
         }
         (PunchSessionOutcome::DeadlineExceeded, _) => {
-                peers
+            if let Some(partial_report) = birthday_terminal_report(&birthday_progress, "deadline").await {
+                record_hard_hard_birthday_sweep_summary(
+                    &peers,
+                    &peer_id,
+                    network_generation,
+                    socket_index,
+                    targets.first().copied(),
+                    partial_report.unique_target_endpoints as usize,
+                    partial_report.packets_sent,
+                    origin,
+                    &partial_report,
+                    probe_rx_delta,
+                )
+                .await;
+            }
+            peers
                     .record_direct_event(
                         &peer_id,
                         "hard_hard_sweep_failed",
@@ -2966,6 +3069,23 @@ async fn hard_hard_wait_and_sweep(
                 .cancellation_reason()
                 .map(PunchCancellationReason::label)
                 .unwrap_or("unknown");
+            if let Some(partial_report) =
+                birthday_terminal_report(&birthday_progress, "session_cancelled").await
+            {
+                record_hard_hard_birthday_sweep_summary(
+                    &peers,
+                    &peer_id,
+                    network_generation,
+                    socket_index,
+                    targets.first().copied(),
+                    partial_report.unique_target_endpoints as usize,
+                    partial_report.packets_sent,
+                    origin,
+                    &partial_report,
+                    probe_rx_delta,
+                )
+                .await;
+            }
             peers
                 .record_direct_event(
                     &peer_id,
@@ -3007,6 +3127,113 @@ async fn hard_hard_wait_and_sweep(
         }
         _ => false,
     }
+}
+
+fn birthday_sweep_detail(report: &PunchSendReport) -> Option<String> {
+    let birthday = report.birthday.as_ref()?;
+    let mut per_socket_counts = report.per_socket_sent.clone();
+    per_socket_counts.sort_by_key(|(socket_index, _)| *socket_index);
+    let per_socket_sent = per_socket_counts
+        .iter()
+        .map(|(socket_index, sent)| format!("{socket_index}:{sent}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let physical_datagrams_sent = per_socket_counts
+        .iter()
+        .map(|(_, sent)| *sent as usize)
+        .sum::<usize>();
+    Some(format!(
+        "requested_level={} generated_candidate_count={} signaled_candidate_count={} effective_target_count={} requested_socket_count={} attached_socket_count={} usable_socket_count={} unavailable_socket_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_fully_completed={} waves_completed={} targets_assigned={} targets_attempted={} logical_probes_sent={} physical_datagrams_sent={} targets_budget_skipped={} targets_cancelled={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
+        birthday.requested_level,
+        birthday.generated_candidate_count,
+        birthday.signaled_candidate_count,
+        birthday.effective_target_count,
+        birthday.requested_socket_count,
+        birthday.attached_socket_count,
+        birthday.usable_socket_count,
+        birthday.unavailable_socket_count,
+        birthday.socket_count,
+        birthday.degraded_reason.as_deref().unwrap_or("none"),
+        birthday.waves_planned,
+        birthday.waves_started,
+        birthday.waves_fully_completed,
+        birthday.waves_completed,
+        birthday.targets_assigned,
+        birthday.targets_attempted,
+        birthday.logical_probes_sent,
+        physical_datagrams_sent,
+        birthday.targets_budget_skipped,
+        birthday.targets_cancelled,
+        birthday.packets_planned,
+        report.packets_sent,
+        report.unique_target_endpoints,
+        report.budget_skipped,
+        per_socket_sent,
+        report.first_send_at_ms,
+        report.last_send_at_ms,
+        birthday.stop_reason.as_deref().unwrap_or("unknown"),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_hard_hard_birthday_sweep_summary(
+    peers: &PeerManager,
+    peer_id: &str,
+    network_generation: u64,
+    socket_index: usize,
+    target: Option<SocketAddr>,
+    unique_target_count: usize,
+    packets_sent: u32,
+    origin: &str,
+    report: &PunchSendReport,
+    probe_rx_delta: UdpProbeRxSnapshot,
+) {
+    let Some(detail) = birthday_sweep_detail(report) else {
+        return;
+    };
+    peers
+        .record_direct_event_for_generation_with_socket(
+            peer_id,
+            network_generation,
+            "hard_hard_birthday_sweep_summary",
+            target,
+            Some(socket_index),
+            Some(unique_target_count),
+            Some(packets_sent),
+            format!(
+                "origin={origin} mode=birthday {detail} known_peer_ip_rx_delta={} authenticated_probe_rx_delta={} matched_probe_ack_rx_delta={} authenticated_probe_ack_unmatched_delta={}",
+                probe_rx_delta.known_peer_ip_datagrams_received,
+                probe_rx_delta.authenticated_probe_packets_received,
+                probe_rx_delta.probe_acks_received,
+                probe_rx_delta.authenticated_probe_acks_unmatched,
+            ),
+        )
+        .await;
+}
+
+async fn birthday_terminal_report(
+    progress: &Option<Arc<tokio::sync::Mutex<BirthdaySweepProgress>>>,
+    stop_reason: &str,
+) -> Option<PunchSendReport> {
+    let progress = progress.as_ref()?;
+    let current = progress.lock().await;
+    let mut report = current.aggregate.clone();
+    report.unique_target_endpoints =
+        u32::try_from(report.sent_target_endpoints.len()).unwrap_or(u32::MAX);
+    let mut birthday = current.birthday.clone();
+    birthday.stop_reason = Some(stop_reason.to_string());
+    birthday.waves_completed = birthday.waves_fully_completed;
+    report.targets_assigned = report
+        .targets_assigned
+        .max(u32::try_from(birthday.targets_assigned).unwrap_or(u32::MAX));
+    report.targets_cancelled = report.targets_cancelled.max(
+        report
+            .targets_assigned
+            .saturating_sub(report.targets_attempted),
+    );
+    update_birthday_sweep_counters(&mut birthday, &report);
+    report.birthday = Some(birthday);
+    Some(report)
 }
 
 fn spawn_hard_hard_expiry_cleanup(
@@ -3136,6 +3363,116 @@ mod hard_hard_tests {
         }
     }
 
+    #[test]
+    fn initiator_response_match_keeps_raw_birthday_level_after_candidate_cap() {
+        let endpoint = "198.51.100.20:41000".parse().unwrap();
+        let identity = crate::peer::HardHardFreshSocketIdentity {
+            peer_id: "peer-raw-level".to_string(),
+            session_token: "raw-level-token".to_string(),
+            network_generation: 3,
+            remote_candidate_epoch: 5,
+            local_profile_generation: 7,
+            remote_profile_generation: 11,
+            punch_generation: 13,
+            socket_index: 4_096,
+            socket_local_endpoint: endpoint,
+        };
+        let expected = HardHardSessionRecord {
+            session_id: "hh1:i:raw-level-token:3:5:7:11:90:0:0".to_string(),
+            session_token: identity.session_token.clone(),
+            peer_id: identity.peer_id.clone(),
+            initiator: true,
+            remote_network_generation: 0,
+            local_network_generation: identity.network_generation,
+            remote_candidate_epoch: identity.remote_candidate_epoch,
+            local_profile_generation: identity.local_profile_generation,
+            remote_profile_generation: identity.remote_profile_generation,
+            local_prediction_confidence: 90,
+            remote_prediction_confidence: 0,
+            requested_birthday_level: 128,
+            generated_candidate_count: 128,
+            signaled_candidate_count: 96,
+            birthday: true,
+            requested_socket_indices: vec![4_096, 4_097, 4_098, 4_099],
+            requested_socket_count: 4,
+            prediction_window: vec![endpoint; 96],
+            remote_prediction: Vec::new(),
+            fresh_socket: identity.clone(),
+            punch_at_ms: hard_hard_now_ms().saturating_add(5_000),
+            expires_at_ms: hard_hard_now_ms().saturating_add(30_000),
+            state: HardHardSessionState::AwaitingPeer,
+            attempt_count: 0,
+            created_at: Instant::now(),
+            cancellation: Arc::new(crate::PunchSessionCancellation::default()),
+        };
+        assert!(hard_hard_initiator_response_record_matches(&expected, &expected));
+
+        let mut capped_level = expected.clone();
+        capped_level.requested_birthday_level = capped_level.signaled_candidate_count;
+        assert!(!hard_hard_initiator_response_record_matches(
+            &capped_level,
+            &expected
+        ));
+
+        let mut replaced_socket = expected.clone();
+        replaced_socket.requested_socket_indices = vec![4_096, 4_097, 4_098, 5_000];
+        assert!(!hard_hard_initiator_response_record_matches(
+            &replaced_socket,
+            &expected
+        ));
+    }
+
+    #[tokio::test]
+    async fn birthday_terminal_report_preserves_partial_logical_and_physical_progress() {
+        let progress = Arc::new(tokio::sync::Mutex::new(BirthdaySweepProgress {
+            birthday: BirthdaySweepReport {
+                requested_level: 256,
+                generated_candidate_count: 256,
+                signaled_candidate_count: 96,
+                effective_target_count: 96,
+                requested_socket_count: 8,
+                attached_socket_count: 8,
+                usable_socket_count: 8,
+                socket_count: 8,
+                waves_planned: 2,
+                waves_started: 1,
+                waves_fully_completed: 0,
+                waves_completed: 0,
+                targets_assigned: 96,
+                ..BirthdaySweepReport::default()
+            },
+            aggregate: PunchSendReport {
+                packets_sent: 2,
+                per_socket_sent: vec![(4_096, 3)],
+                sent_target_endpoints: vec![endpoint_for_test(41000), endpoint_for_test(41001)],
+                targets_assigned: 96,
+                targets_attempted: 2,
+                targets_cancelled: 94,
+                ..PunchSendReport::default()
+            },
+        }));
+
+        let report = birthday_terminal_report(&Some(progress), "worker_failed")
+            .await
+            .expect("birthday progress must yield a terminal partial report");
+        let birthday = report
+            .birthday
+            .as_ref()
+            .expect("terminal report must retain Birthday details");
+        assert_eq!(birthday.requested_level, 256);
+        assert_eq!(birthday.signaled_candidate_count, 96);
+        assert_eq!(birthday.waves_fully_completed, 0);
+        assert_eq!(birthday.waves_completed, 0);
+        assert_eq!(birthday.logical_probes_sent, 2);
+        assert_eq!(birthday.physical_datagrams_sent, 3);
+        assert_eq!(birthday.targets_cancelled, 94);
+        assert_eq!(birthday.stop_reason.as_deref(), Some("worker_failed"));
+    }
+
+    fn endpoint_for_test(port: u16) -> SocketAddr {
+        SocketAddr::new("198.51.100.20".parse().unwrap(), port)
+    }
+
     async fn exact_socket_proof_fixture() -> (
         Arc<PeerManager>,
         UdpTransport,
@@ -3226,6 +3563,12 @@ mod hard_hard_tests {
                     remote_profile_generation: identity.remote_profile_generation,
                     local_prediction_confidence: 90,
                     remote_prediction_confidence: 90,
+                    requested_birthday_level: 0,
+                    generated_candidate_count: 1,
+                    signaled_candidate_count: 1,
+                    birthday: false,
+                    requested_socket_indices: vec![socket_index],
+                    requested_socket_count: 1,
                     prediction_window: vec![remote],
                     remote_prediction: vec![remote],
                     fresh_socket: identity.clone(),
@@ -3617,6 +3960,12 @@ mod hard_hard_tests {
                 remote_profile_generation: 4,
                 local_prediction_confidence: 90,
                 remote_prediction_confidence: 0,
+                requested_birthday_level: 0,
+                generated_candidate_count: 1,
+                signaled_candidate_count: 1,
+                birthday: false,
+                requested_socket_indices: vec![4_096],
+                requested_socket_count: 1,
                 prediction_window: vec!["198.51.100.1:40000".parse().unwrap()],
                 remote_prediction: Vec::new(),
                 fresh_socket: identity,

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -3900,6 +3900,25 @@ mod hard_hard_tests {
         }
     }
 
+    async fn wait_for_birthday_post_send_gate(
+        gate: &Arc<crate::udp::ProbePostSendGate>,
+    ) {
+        // Register the waiter before starting the production task: the hook
+        // uses notify_waiters, so an already-reached gate must not be lost.
+        let reached = gate.reached.notified();
+        let mut watchdog = tokio::spawn(async {
+            for _ in 0..128 {
+                tokio::task::yield_now().await;
+            }
+        });
+        tokio::select! {
+            _ = reached => {
+                watchdog.abort();
+            }
+            _ = &mut watchdog => panic!("production Birthday send did not reach the post-send gate"),
+        }
+    }
+
     fn assert_live_birthday_terminal_summary(
         events: &[crate::peer::DirectTraversalEventDiagnostics],
         stop_reason: &str,
@@ -3924,6 +3943,42 @@ mod hard_hard_tests {
         }
         assert!(
             summary.detail.contains(&format!("stop_reason={stop_reason}")),
+            "terminal summary has an unexpected stop reason: {}",
+            summary.detail
+        );
+    }
+
+    fn assert_post_send_race_summary(
+        events: &[crate::peer::DirectTraversalEventDiagnostics],
+        stop_reason: &str,
+        require_physical_error: bool,
+    ) {
+        let summary = events
+            .iter()
+            .find(|event| event.stage == "hard_hard_birthday_sweep_summary")
+            .expect("post-send race must emit a durable Birthday summary");
+        let count = |key: &str| {
+            summary
+                .detail
+                .split_whitespace()
+                .find_map(|field| field.strip_prefix(key)?.parse::<u64>().ok())
+                .unwrap_or_else(|| panic!("summary is missing {key}: {}", summary.detail))
+        };
+        if require_physical_error {
+            assert!(count("physical_send_errors=") >= 1);
+        } else {
+            assert!(count("physical_datagrams_sent=") >= 1);
+            assert!(count("logical_probes_sent=") >= 1);
+            assert!(count("unique_target_endpoints=") >= 1);
+            assert!(summary.detail.contains("per_socket_sent=") && !summary.detail.contains("per_socket_sent= "));
+            assert!(summary.detail.contains("first_send_at_ms=Some("));
+            assert!(summary.detail.contains("last_send_at_ms=Some("));
+        }
+        assert!(summary.detail.contains("waves_fully_completed=0"));
+        assert!(
+            summary
+                .detail
+                .contains(&format!("stop_reason={stop_reason}")),
             "terminal summary has an unexpected stop reason: {}",
             summary.detail
         );
@@ -4037,6 +4092,164 @@ mod hard_hard_tests {
             .any(|event| event.stage == "hard_hard_failed"));
         gate.release.notify_waiters();
         udp.detach_all_dynamic_punch_sockets("test_cancel_live_progress")
+            .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_birthday_post_send_deadline_preserves_live_progress() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(None);
+        let (peers, udp, identity, _remote, peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let remote: SocketAddr = "127.0.0.1:41002".parse().unwrap();
+        let session = PunchAttemptDeduplicator::default()
+            .claim(&identity.peer_id)
+            .await
+            .expect("test must own the production Hard↔Hard punch session");
+        let (gate, _gate_guard) = crate::udp::install_probe_post_send_gate_for_test();
+        let socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peers = peers.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_and_sweep(
+                    udp,
+                    peers,
+                    session,
+                    identity.peer_id.clone(),
+                    peer_session_generation,
+                    identity,
+                    Some(socket_indices),
+                    "birthday-runtime-token".to_string(),
+                    vec![remote],
+                    64,
+                    64,
+                    1,
+                    hard_hard_now_ms(),
+                    0,
+                    (1, 7),
+                    Some("probe-session-exact".to_string()),
+                    "test-post-send-deadline",
+                )
+                .await
+            }
+        });
+        wait_for_birthday_post_send_gate(&gate).await;
+        tokio::time::advance(HARD_HARD_SWEEP_DEADLINE).await;
+        tokio::task::yield_now().await;
+        assert!(!task.await.unwrap());
+
+        let events = peers.diagnostics().await[0].direct_events.clone();
+        assert_post_send_race_summary(&events, "deadline", false);
+        gate.release.notify_waiters();
+        udp.detach_all_dynamic_punch_sockets("test_post_send_deadline").await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_birthday_post_send_cancellation_preserves_live_progress() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(None);
+        let (peers, udp, identity, _remote, peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let remote: SocketAddr = "127.0.0.1:41003".parse().unwrap();
+        let session = PunchAttemptDeduplicator::default()
+            .claim(&identity.peer_id)
+            .await
+            .expect("test must own the production Hard↔Hard punch session");
+        let cancellation = session.cancellation_handle();
+        let (gate, _gate_guard) = crate::udp::install_probe_post_send_gate_for_test();
+        let socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peers = peers.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_and_sweep(
+                    udp,
+                    peers,
+                    session,
+                    identity.peer_id.clone(),
+                    peer_session_generation,
+                    identity,
+                    Some(socket_indices),
+                    "birthday-runtime-token".to_string(),
+                    vec![remote],
+                    64,
+                    64,
+                    1,
+                    hard_hard_now_ms(),
+                    0,
+                    (1, 7),
+                    Some("probe-session-exact".to_string()),
+                    "test-post-send-cancel",
+                )
+                .await
+            }
+        });
+        wait_for_birthday_post_send_gate(&gate).await;
+        cancellation.cancel_for_hard_hard_cleanup();
+        tokio::task::yield_now().await;
+        assert!(!task.await.unwrap());
+
+        let events = peers.diagnostics().await[0].direct_events.clone();
+        assert_post_send_race_summary(&events, "session_cancelled", false);
+        gate.release.notify_waiters();
+        udp.detach_all_dynamic_punch_sockets("test_post_send_cancellation")
+            .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_birthday_primary_send_error_is_recorded_before_cleanup_cancel() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(None);
+        let (peers, udp, identity, _remote, peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let remote: SocketAddr = "127.0.0.1:41004".parse().unwrap();
+        let session = PunchAttemptDeduplicator::default()
+            .claim(&identity.peer_id)
+            .await
+            .expect("test must own the production Hard↔Hard punch session");
+        let cancellation = session.cancellation_handle();
+        let _send_failures = udp.set_probe_send_failures_for_test([1]);
+        let (gate, _gate_guard) = crate::udp::install_probe_post_send_gate_for_test();
+        let socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peers = peers.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_and_sweep(
+                    udp,
+                    peers,
+                    session,
+                    identity.peer_id.clone(),
+                    peer_session_generation,
+                    identity,
+                    Some(socket_indices),
+                    "birthday-runtime-token".to_string(),
+                    vec![remote],
+                    64,
+                    64,
+                    1,
+                    hard_hard_now_ms(),
+                    0,
+                    (1, 7),
+                    Some("probe-session-exact".to_string()),
+                    "test-primary-error-cancel",
+                )
+                .await
+            }
+        });
+        wait_for_birthday_post_send_gate(&gate).await;
+        cancellation.cancel_for_hard_hard_cleanup();
+        tokio::task::yield_now().await;
+        assert!(!task.await.unwrap());
+
+        let events = peers.diagnostics().await[0].direct_events.clone();
+        assert_post_send_race_summary(&events, "session_cancelled", true);
+        gate.release.notify_waiters();
+        udp.detach_all_dynamic_punch_sockets("test_primary_error_cancel")
             .await;
     }
 

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -981,7 +981,13 @@ enum HardHardLocalMeasurement {
     Birthday(Box<HardHardBirthdayResult>),
 }
 
-type HardHardMeasurementPayload = (Vec<String>, HashMap<String, String>, u8, String);
+struct HardHardMeasurementPayload {
+    candidates: Vec<String>,
+    candidate_sources: HashMap<String, String>,
+    local_confidence: u8,
+    local_model: String,
+    candidate_contract: crate::candidate_refresh::SignalCandidateContract,
+}
 
 fn hard_hard_measurement_target_limit(measurement: &HardHardLocalMeasurement) -> usize {
     match measurement {
@@ -1115,12 +1121,23 @@ fn hard_hard_measurement_payload(
     match measurement {
         HardHardLocalMeasurement::Predictable { result, .. } => {
             let (candidates, sources) = hard_hard_prediction_payload(result, boot_epoch_ms)?;
-            Some((
+            let (candidates, sources, candidate_contract) =
+                crate::candidate_refresh::normalize_signal_candidates_with_counts(
+                    &candidates,
+                    &sources,
+                    result
+                        .predicted_ports
+                        .len()
+                        .min(HARD_HARD_MAX_PREDICTION_TARGETS),
+                    candidates.len(),
+                );
+            (!candidates.is_empty()).then_some(HardHardMeasurementPayload {
                 candidates,
-                sources,
-                result.model.confidence,
-                hard_hard_model_label(&result.model.kind).to_string(),
-            ))
+                candidate_sources: sources,
+                local_confidence: result.model.confidence,
+                local_model: hard_hard_model_label(&result.model.kind).to_string(),
+                candidate_contract,
+            })
         }
         HardHardLocalMeasurement::Birthday(result) => {
             let fresh_id = FreshPredictionId {
@@ -1141,14 +1158,51 @@ fn hard_hard_measurement_payload(
                 sources.insert(endpoint.clone(), source.clone());
                 candidates.push(endpoint);
             }
-            (!candidates.is_empty()).then_some((
+            let (candidates, sources, candidate_contract) =
+                crate::candidate_refresh::normalize_signal_candidates_with_counts(
+                    &candidates,
+                    &sources,
+                    result.requested_level,
+                    candidates.len(),
+                );
+            (!candidates.is_empty()).then_some(HardHardMeasurementPayload {
                 candidates,
-                sources,
-                result.model_confidence,
-                result.model_label.clone(),
-            ))
+                candidate_sources: sources,
+                local_confidence: result.model_confidence,
+                local_model: result.model_label.clone(),
+                candidate_contract,
+            })
         }
     }
+}
+
+async fn record_hard_hard_candidate_contract(
+    peers: &PeerManager,
+    peer_id: &str,
+    contract: crate::candidate_refresh::SignalCandidateContract,
+    signaling_accepted: bool,
+) {
+    peers
+        .record_direct_event(
+            peer_id,
+            "hard_hard_candidate_contract",
+            None,
+            Some(contract.signaled_candidate_count),
+            None,
+            format!(
+                "requested_candidate_count={} generated_candidate_count={} deduplicated_candidate_count={} signaled_candidate_count={} cap={} capped={} candidate_source_count={} reason={} signaling_result={}",
+                contract.requested_candidate_count,
+                contract.generated_candidate_count,
+                contract.deduplicated_candidate_count,
+                contract.signaled_candidate_count,
+                contract.cap,
+                contract.capped,
+                contract.candidate_source_count,
+                contract.reason,
+                if signaling_accepted { "accepted" } else { "failed" },
+            ),
+        )
+        .await;
 }
 
 fn hard_hard_measurement_primary_socket(
@@ -1549,8 +1603,13 @@ pub(crate) async fn spawn_hard_hard_initiator(
                 .await;
             return;
         }
-        let Some((candidates, candidate_sources, local_confidence, local_model)) =
-            hard_hard_measurement_payload(&measurement, signal.boot_epoch_ms)
+        let Some(HardHardMeasurementPayload {
+            candidates,
+            candidate_sources,
+            local_confidence,
+            local_model,
+            candidate_contract,
+        }) = hard_hard_measurement_payload(&measurement, signal.boot_epoch_ms)
         else {
             peers
                 .record_direct_event(
@@ -1686,6 +1745,13 @@ pub(crate) async fn spawn_hard_hard_initiator(
         } else {
             false
         };
+        record_hard_hard_candidate_contract(
+            &peers,
+            &peer_id,
+            candidate_contract,
+            advertised,
+        )
+        .await;
         if !advertised
             || peers.is_direct(&peer_id).await
             || cancellation.is_cancelled()
@@ -1962,8 +2028,13 @@ pub(crate) async fn spawn_hard_hard_responder(
                 .await;
             return;
         }
-        let Some((candidates, candidate_sources, local_confidence, local_model)) =
-            hard_hard_measurement_payload(&measurement, signal.boot_epoch_ms)
+        let Some(HardHardMeasurementPayload {
+            candidates,
+            candidate_sources,
+            local_confidence,
+            local_model,
+            candidate_contract,
+        }) = hard_hard_measurement_payload(&measurement, signal.boot_epoch_ms)
         else {
             return;
         };

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -3813,6 +3813,7 @@ mod hard_hard_tests {
 
     #[tokio::test(start_paused = true)]
     async fn direct_confirmation_grace_accepts_an_exact_commit_after_one_second() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
         let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
         let deduplicator = PunchAttemptDeduplicator::default();
         let session = deduplicator
@@ -3860,6 +3861,7 @@ mod hard_hard_tests {
 
     #[tokio::test]
     async fn direct_confirmation_start_does_not_wait_for_connection_writer() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
         let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
         let session = PunchAttemptDeduplicator::default()
             .claim("peer-exact-proof")
@@ -3914,6 +3916,7 @@ mod hard_hard_tests {
 
     #[tokio::test]
     async fn exact_probe_session_diagnostics_survive_connection_writer_contention() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
         let (peers, udp, identity, _remote) = exact_socket_proof_fixture().await;
         udp.update_peer_probe_rx_diagnostics(
             &identity.peer_id,
@@ -5352,6 +5355,7 @@ mod hard_hard_tests {
 
     #[tokio::test]
     async fn hard_hard_exact_proof_rejects_peer_global_direct_on_other_socket() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
         let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
         let other_local: SocketAddr = "127.0.0.1:41001".parse().unwrap();
         let commit_before = peers.direct_commit_seq_sync(&identity.peer_id);
@@ -5393,6 +5397,7 @@ mod hard_hard_tests {
 
     #[tokio::test]
     async fn hard_hard_exact_proof_requires_selected_pair_and_authenticated_evidence() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
         let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
         let commit_before = peers.direct_commit_seq_sync(&identity.peer_id);
         assert!(

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -1430,10 +1430,11 @@ async fn hard_hard_exact_direct_socket_is_current_for_cleanup(
 }
 
 /// An authenticated Hard↔Hard winner may reach the encrypted validation
-/// worker just after the short rendezvous sweep expires.  Keep that exact
-/// socket alive until the normal bounded session cleanup gets a chance to see
-/// the Direct commit; a winner with no authenticated evidence is still
-/// cleaned immediately by the caller.
+/// worker just after the short rendezvous sweep expires. Keep that exact
+/// token-tagged socket alive until the normal bounded session cleanup gets a
+/// chance to see the Direct commit. The manager winner is written only by the
+/// authenticated admission path; accepting its exact socket here closes the
+/// manager-to-socket commit window without treating it as Direct proof.
 async fn hard_hard_authenticated_winner_for_cleanup(
     udp: &UdpTransport,
     peers: &PeerManager,
@@ -1449,7 +1450,7 @@ async fn hard_hard_authenticated_winner_for_cleanup(
     if identity.socket_index != winner
         || !peers.hard_hard_session_identity_is_current(&identity).await
         || !udp
-            .hard_hard_socket_identity_has_authenticated_evidence(&identity)
+            .hard_hard_socket_identity_is_exact_session_socket(&identity)
             .await
     {
         return None;
@@ -4010,6 +4011,135 @@ mod hard_hard_tests {
             .peer_session_generation_sync(&identity.peer_id)
             .expect("exact fixture peer must have an active lifecycle generation");
         (peers, udp, identity, remote, peer_session_generation)
+    }
+
+    #[tokio::test]
+    async fn hard_hard_winner_promotion_commits_evidence_before_durable_diagnostics() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        let (peers, udp, identity, remote, _peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        udp.clear_authenticated_evidence_for_test(identity.socket_index)
+            .await;
+        assert!(!udp
+            .hard_hard_socket_identity_has_authenticated_evidence(&identity)
+            .await);
+
+        let sweeping = peers
+            .hard_hard_begin_sweep(
+                &identity.peer_id,
+                &identity.session_token,
+                vec![remote],
+                90,
+                0,
+            )
+            .await
+            .expect("fixture session must enter its single sweep");
+        assert_eq!(sweeping.fresh_socket, identity);
+
+        // Stop at the exact manager-selected/socket-not-yet-committed seam.
+        // Production reaches this state only after authenticated Probe v2
+        // admission. Cleanup must preserve the exact token-tagged socket for
+        // the remainder of the bounded session, without accepting it as
+        // Direct proof.
+        let selected = peers
+            .hard_hard_select_winner(
+                &identity.peer_id,
+                &identity.session_token,
+                identity.socket_index,
+                identity.network_generation,
+                identity.punch_generation,
+                identity.socket_local_endpoint,
+            )
+            .await
+            .expect("authenticated manager selection must accept the exact socket");
+        assert_eq!(selected, identity);
+        assert!(udp
+            .hard_hard_socket_identity_is_exact_session_socket(&identity)
+            .await);
+        assert_eq!(
+            hard_hard_authenticated_winner_for_cleanup(
+                &udp,
+                &peers,
+                &identity.peer_id,
+                &identity.session_token,
+            )
+            .await,
+            Some(identity.clone()),
+            "timeout cleanup must not retire a manager-selected exact socket in the commit seam"
+        );
+
+        // `hard_hard_winner_selected` is a durable event. Holding the
+        // connection writer parks the production promotion at that await and
+        // proves socket evidence was committed before diagnostics can block.
+        let connections_writer = peers.hold_connections_writer_for_test().await;
+        let socket_index = identity.socket_index;
+        let network_generation = identity.network_generation;
+        let promotion = tokio::spawn({
+            let udp = udp.clone();
+            let peer_id = identity.peer_id.clone();
+            let token = identity.session_token.clone();
+            async move {
+                udp.promote_hard_hard_winner_for_test(
+                    &peer_id,
+                    &token,
+                    socket_index,
+                    network_generation,
+                )
+                .await
+            }
+        });
+        for _ in 0..256 {
+            if udp
+                .hard_hard_socket_identity_has_authenticated_evidence(&selected)
+                .await
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(udp
+            .hard_hard_socket_identity_has_authenticated_evidence(&selected)
+            .await);
+        assert!(
+            !promotion.is_finished(),
+            "durable diagnostics must still be waiting on the held connection writer"
+        );
+        drop(connections_writer);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), promotion)
+                .await
+                .expect("promotion must finish after diagnostics are released")
+                .expect("promotion task must not panic")
+        );
+
+        assert!(peers
+            .hard_hard_retire_session(
+                &identity.peer_id,
+                &sweeping.session_id,
+                &identity.session_token,
+            )
+            .await);
+        udp.detach_hard_hard_sockets_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+            "test_winner_promotion_cleanup",
+        )
+        .await;
+        udp.clear_hard_hard_pending_probes_for_token(
+            &identity.peer_id,
+            &identity.session_token,
+            None,
+        )
+        .await;
+        assert!(peers
+            .hard_hard_complete_session_cleanup(
+                &identity.peer_id,
+                &sweeping.session_id,
+                &identity.session_token,
+            )
+            .await);
+        assert_eq!(udp.dynamic_socket_count().await, 0);
     }
 
     struct HardHardTestClockReset;

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -1308,13 +1308,15 @@ async fn hard_hard_wait_for_exact_direct_confirmation(
 ) -> bool {
     let deadline = Instant::now() + HARD_HARD_DIRECT_CONFIRMATION_GRACE;
     loop {
-        let session_current = peers.hard_hard_session_identity_is_current(identity).await;
+        let session_current = peers
+            .hard_hard_session_identity_is_current_for_confirmation(identity)
+            .await;
         if session.is_cancelled() || !session_current {
             return false;
         }
 
         let commit_advanced = peers.direct_commit_seq_sync(&identity.peer_id) != from_commit_seq;
-        let manager_pair_matches = peers.hard_hard_direct_pair_is_current(identity).await;
+        let manager_pair_matches = peers.direct_commit_pair_matches_sync(identity);
         if commit_advanced
             && manager_pair_matches
             && udp
@@ -1335,13 +1337,18 @@ async fn hard_hard_wait_for_exact_direct_confirmation(
         if remaining.is_zero() {
             return false;
         }
-        // Poll the authoritative state on a short timer instead of waiting on
-        // the manager-wide commit Notify.  That Notify can be hot during
-        // reciprocal validation; repeatedly-ready notifications would let
-        // this future spin without ever yielding to its outer deadline.
+        // Wait on the commit sequence notification rather than polling at a
+        // fixed cadence.  The sequence is re-checked after every wake, and
+        // `enable` closes the check-to-wait race because `notify_waiters`
+        // itself does not retain a permit for a not-yet-enabled waiter.
+        let notify = peers.direct_commit_notify();
+        let notified = notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
         tokio::select! {
             _ = session.cancelled() => return false,
-            _ = sleep(remaining.min(Duration::from_millis(5))) => {}
+            _ = notified => {}
+            _ = sleep(remaining) => return false,
         }
     }
 }
@@ -1589,6 +1596,11 @@ pub(crate) async fn spawn_hard_hard_initiator(
     let token = hard_hard_session_token(session.session_id());
     let coordination = hard_hard_coordination_from_plan(token, HardHardRole::Initiator, plan);
     let cancellation = session.cancellation_handle();
+    // Capture the authoritative Probe receive-session identity before the
+    // deadline-sensitive rendezvous task exists.  The sweep must not perform
+    // a best-effort try-read at punch time and accidentally attribute ACKs to
+    // the unscoped `None` bucket.
+    let probe_session_id = peers.probe_session_id_for_peer(&peer_id).await;
     bind_hard_hard_session_to_punch_invocation(invocation_shutdown_rx, cancellation.clone());
     tokio::spawn(async move {
         // Keep the dedup permit until the measured session is installed in the
@@ -1701,6 +1713,7 @@ pub(crate) async fn spawn_hard_hard_initiator(
         let requested_socket_indices = hard_hard_measurement_socket_indices(&measurement);
         let record = HardHardSessionRecord {
             session_id: session_id.clone(),
+            probe_session_id: probe_session_id.clone(),
             session_token: coordination.token.clone(),
             peer_id: peer_id.clone(),
             initiator: true,
@@ -2143,8 +2156,10 @@ pub(crate) async fn spawn_hard_hard_responder(
         let requested_birthday_level = hard_hard_measurement_requested_level(&measurement);
         let birthday = hard_hard_measurement_is_birthday(&measurement);
         let requested_socket_indices = hard_hard_measurement_socket_indices(&measurement);
+        let probe_session_id = peers.probe_session_id_for_peer(&peer_id).await;
         let record = HardHardSessionRecord {
             session_id: session_id.clone(),
+            probe_session_id: probe_session_id.clone(),
             session_token: coordination.token.clone(),
             peer_id: peer_id.clone(),
             initiator: false,
@@ -2310,6 +2325,7 @@ pub(crate) async fn spawn_hard_hard_responder(
                 current_plan.local_profile_generation,
                 current_plan.remote_profile_generation,
             ),
+            probe_session_id,
             "responder",
         )
         .await;
@@ -2573,6 +2589,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
             record.local_profile_generation,
             record.remote_profile_generation,
         ),
+        record.probe_session_id.clone(),
         "initiator",
     )
     .await;
@@ -2691,6 +2708,7 @@ async fn hard_hard_wait_and_sweep(
     punch_at_ms: u64,
     network_generation: u64,
     profile_generations: (u64, u64),
+    probe_session_id: Option<String>,
     origin: &'static str,
 ) -> bool {
     let socket_index = fresh_socket.socket_index;
@@ -2733,12 +2751,11 @@ async fn hard_hard_wait_and_sweep(
     // marker is intentionally nonblocking, and no diagnostics-map write is
     // allowed to sit in front of the first scheduled UDP send.
     let direct_commit_seq = peers.direct_commit_seq_sync(&peer_id);
-    let probe_rx_session_id = peers.probe_session_id_for_peer_try(&peer_id);
     let probe_rx_before = udp
         .probe_rx_snapshot_for_peer_session(
             &peer_id,
             network_generation,
-            probe_rx_session_id.as_deref(),
+            probe_session_id.as_deref(),
         )
         .await;
     let dispatch_at_ms = session.mark_first_send_started();
@@ -2797,7 +2814,7 @@ async fn hard_hard_wait_and_sweep(
         .probe_rx_snapshot_for_peer_session(
             &peer_id,
             network_generation,
-            probe_rx_session_id.as_deref(),
+            probe_session_id.as_deref(),
         )
         .await;
     let probe_rx_delta = probe_rx_after.delta_since(probe_rx_before);
@@ -2811,7 +2828,9 @@ async fn hard_hard_wait_and_sweep(
                         .stop_reason
                         .as_deref()
                     {
-                        Some(reason @ ("send_error" | "worker_failed")) => Some(reason),
+                        Some(reason) if BirthdaySweepFailureKind::from_stop_reason(reason).is_some() => {
+                            Some(reason)
+                        }
                         _ => None,
                     })
                 });
@@ -2903,18 +2922,16 @@ async fn hard_hard_wait_and_sweep(
                     Some(report.unique_target_endpoints as usize),
                     Some(report.logical_probes_sent.max(report.packets_sent)),
                     format!(
-                        "origin={origin} mode={} sent={} logical_probes_attempted={} logical_probes_sent={} physical_datagrams_sent={} physical_send_errors={} targets_assigned={} targets_examined={} targets_attempted={} targets_cancelled={} received={} matched_ack={} authenticated_rx={} authenticated_ack_unmatched={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?} last_send_at_ms={:?} per_socket_sent={}{}",
+                        "origin={origin} mode={} sent={} logical_probes_attempted={} logical_probes_sent={} logical_probe_send_failures={} physical_datagrams_sent={} physical_send_errors={} partial_physical_send_errors={} probe_path_errors={} targets_assigned={} targets_examined={} targets_attempted={} targets_cancelled={} received={} matched_ack={} authenticated_rx={} authenticated_ack_unmatched={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?} last_send_at_ms={:?} per_socket_sent={}{}",
                         if birthday_detail.is_some() { "birthday" } else { "predictable" },
                         report.packets_sent,
                         report.logical_probes_attempted,
                         report.logical_probes_sent.max(report.packets_sent),
-                        report.physical_datagrams_sent.max(
-                            per_socket_counts
-                                .iter()
-                                .map(|(_, sent)| *sent)
-                                .sum(),
-                        ),
+                        report.logical_probe_send_failures,
+                        report.physical_datagrams_sent,
                         report.physical_send_errors,
+                        report.partial_physical_send_errors,
+                        report.probe_path_errors,
                         report.targets_assigned,
                         report.targets_examined,
                         report.targets_attempted,
@@ -3209,16 +3226,12 @@ fn birthday_sweep_detail(report: &PunchSendReport) -> Option<String> {
         .map(|(socket_index, sent)| format!("{socket_index}:{sent}"))
         .collect::<Vec<_>>()
         .join(",");
-    let physical_datagrams_sent = usize::try_from(report.physical_datagrams_sent)
-        .unwrap_or(usize::MAX)
-        .max(
-            per_socket_counts
-                .iter()
-                .map(|(_, sent)| *sent as usize)
-                .sum::<usize>(),
-        );
+    let physical_datagrams_sent = per_socket_counts
+        .iter()
+        .map(|(_, sent)| *sent as usize)
+        .sum::<usize>();
     Some(format!(
-        "requested_level={} generated_candidate_count={} signaled_candidate_count={} effective_target_count={} requested_socket_count={} attached_socket_count={} usable_socket_count={} unavailable_socket_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_fully_completed={} waves_completed={} targets_assigned={} targets_examined={} targets_attempted={} logical_probes_attempted={} logical_probes_sent={} physical_datagrams_sent={} physical_send_errors={} targets_budget_skipped={} targets_cancelled={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
+        "requested_level={} generated_candidate_count={} signaled_candidate_count={} effective_target_count={} requested_socket_count={} attached_socket_count={} usable_socket_count={} unavailable_socket_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_fully_completed={} waves_completed={} targets_assigned={} targets_examined={} targets_attempted={} logical_probes_attempted={} logical_probes_sent={} logical_probe_send_failures={} physical_datagrams_sent={} physical_send_errors={} partial_physical_send_errors={} probe_path_errors={} failure_kind={:?} targets_budget_skipped={} targets_cancelled={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
         birthday.requested_level,
         birthday.generated_candidate_count,
         birthday.signaled_candidate_count,
@@ -3238,8 +3251,12 @@ fn birthday_sweep_detail(report: &PunchSendReport) -> Option<String> {
         birthday.targets_attempted,
         birthday.logical_probes_attempted,
         birthday.logical_probes_sent,
+        birthday.logical_probe_send_failures,
         physical_datagrams_sent,
         birthday.physical_send_errors,
+        birthday.partial_physical_send_errors,
+        report.probe_path_errors,
+        report.failure_kind,
         birthday.targets_budget_skipped,
         birthday.targets_cancelled,
         birthday.packets_planned,
@@ -3475,6 +3492,7 @@ mod hard_hard_tests {
         };
         let expected = HardHardSessionRecord {
             session_id: "hh1:i:raw-level-token:3:5:7:11:90:0:0".to_string(),
+            probe_session_id: None,
             session_token: identity.session_token.clone(),
             peer_id: identity.peer_id.clone(),
             initiator: true,
@@ -3582,18 +3600,22 @@ mod hard_hard_tests {
                 let current = progress.lock().await;
                 current.live.clone()
             };
-            let mut counters = live
+            let mut progress = live
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            counters.targets_assigned = 4;
-            counters.targets_examined = 3;
-            counters.targets_attempted = 1;
-            counters.targets_cancelled = 3;
-            counters.budget_skipped = 1;
-            counters.logical_probes_attempted = 1;
-            counters.logical_probes_sent = 1;
-            counters.physical_datagrams_sent = 2;
-            counters.physical_send_errors = 1;
+            progress.counters.targets_assigned = 4;
+            progress.counters.targets_examined = 3;
+            progress.counters.targets_attempted = 1;
+            progress.counters.targets_cancelled = 3;
+            progress.counters.budget_skipped = 1;
+            progress.counters.logical_probes_attempted = 1;
+            progress.counters.logical_probes_sent = 1;
+            progress.counters.physical_datagrams_sent = 2;
+            progress.counters.physical_send_errors = 1;
+            progress.sent_target_endpoints.insert(endpoint_for_test(41000));
+            progress.per_socket_sent.insert(4_096, 2);
+            progress.first_send_at_ms = Some(100);
+            progress.last_send_at_ms = Some(110);
         }
 
         let report = birthday_terminal_report(&Some(progress), "deadline")
@@ -3607,6 +3629,10 @@ mod hard_hard_tests {
         assert_eq!(report.logical_probes_sent, 1);
         assert_eq!(report.physical_datagrams_sent, 2);
         assert_eq!(report.physical_send_errors, 1);
+        assert_eq!(report.unique_target_endpoints, 1);
+        assert_eq!(report.per_socket_sent, vec![(4_096, 2)]);
+        assert_eq!(report.first_send_at_ms, Some(100));
+        assert_eq!(report.last_send_at_ms, Some(110));
         assert_eq!(birthday.targets_examined, 3);
         assert_eq!(birthday.logical_probes_attempted, 1);
         assert_eq!(birthday.physical_send_errors, 1);
@@ -3653,9 +3679,365 @@ mod hard_hard_tests {
             HARD_HARD_DIRECT_CONFIRMATION_GRACE + Duration::from_millis(250)
                 <= HARD_HARD_SWEEP_DEADLINE
         );
-        // The 5ms poll is at most 400 timer intervals per grace lease, not a
-        // ready-notify hot loop.
-        assert!(HARD_HARD_DIRECT_CONFIRMATION_GRACE.as_millis() / 5 <= 400);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn direct_confirmation_grace_accepts_an_exact_commit_after_one_second() {
+        let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
+        let deduplicator = PunchAttemptDeduplicator::default();
+        let session = deduplicator
+            .claim("peer-exact-proof")
+            .await
+            .expect("test must own the confirmation session");
+        let wait = tokio::spawn({
+            let peers = peers.clone();
+            let udp = udp.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_for_exact_direct_confirmation(
+                    &udp,
+                    &peers,
+                    &session,
+                    &identity,
+                    None,
+                )
+                .await
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!wait.is_finished(), "confirmation must still be pending");
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !wait.is_finished(),
+            "one second must not exhaust the two-second confirmation grace"
+        );
+
+        assert!(
+            peers
+                .record_direct_success_for_generation_with_local_endpoint(
+                    &identity.peer_id,
+                    Some(remote),
+                    identity.network_generation,
+                    Some(identity.socket_local_endpoint),
+                )
+                .await
+        );
+        assert!(wait.await.unwrap());
+        udp.detach_all_dynamic_punch_sockets("test_confirmation_grace").await;
+    }
+
+    #[tokio::test]
+    async fn direct_confirmation_start_does_not_wait_for_connection_writer() {
+        let (peers, udp, identity, remote) = exact_socket_proof_fixture().await;
+        let session = PunchAttemptDeduplicator::default()
+            .claim("peer-exact-proof")
+            .await
+            .expect("test must own the confirmation session");
+        let before_commit = peers.direct_commit_seq_sync(&identity.peer_id);
+        assert!(
+            peers
+                .record_direct_success_for_generation_with_local_endpoint(
+                    &identity.peer_id,
+                    Some(remote),
+                    identity.network_generation,
+                    Some(identity.socket_local_endpoint),
+                )
+                .await
+        );
+
+        let connection_writer = peers.hold_connections_writer_for_test().await;
+        let confirmed = tokio::time::timeout(
+            Duration::from_millis(100),
+            hard_hard_wait_for_exact_direct_confirmation(
+                &udp,
+                &peers,
+                &session,
+                &identity,
+                before_commit,
+            ),
+        )
+        .await
+        .expect("confirmation must not await the connection writer");
+        assert!(confirmed);
+        drop(connection_writer);
+
+        peers
+            .record_direct_event(
+                &identity.peer_id,
+                "hard_hard_failed",
+                Some(remote),
+                Some(1),
+                Some(1),
+                "lock contention terminal event",
+            )
+            .await;
+        assert!(peers
+            .diagnostics()
+            .await
+            .into_iter()
+            .flat_map(|peer| peer.direct_events)
+            .any(|event| event.stage == "hard_hard_failed"));
+        udp.detach_all_dynamic_punch_sockets("test_confirmation_writer").await;
+    }
+
+    #[tokio::test]
+    async fn exact_probe_session_diagnostics_survive_connection_writer_contention() {
+        let (peers, udp, identity, _remote) = exact_socket_proof_fixture().await;
+        udp.update_peer_probe_rx_diagnostics(
+            &identity.peer_id,
+            identity.network_generation,
+            Some("probe-session-exact"),
+            |snapshot| {
+                snapshot.authenticated_probe_acks_observed = 3;
+                snapshot.probe_acks_received = 2;
+            },
+        )
+        .await;
+
+        let connection_writer = peers.hold_connections_writer_for_test().await;
+        let snapshot = tokio::time::timeout(
+            Duration::from_millis(100),
+            udp.probe_rx_snapshot_for_peer_session(
+                &identity.peer_id,
+                identity.network_generation,
+                Some("probe-session-exact"),
+            ),
+        )
+        .await
+        .expect("exact session diagnostics must not consult connections");
+        drop(connection_writer);
+        assert_eq!(snapshot.authenticated_probe_acks_observed, 3);
+        assert_eq!(snapshot.probe_acks_received, 2);
+        udp.detach_all_dynamic_punch_sockets("test_probe_session_lock").await;
+    }
+
+    fn birthday_runtime_nat_profile() -> p2pnet_nat::NatProfile {
+        p2pnet_nat::NatProfile {
+            local_addr: "127.0.0.1:0".to_string(),
+            observations: Vec::new(),
+            udp_blocked: false,
+            public_endpoint: Some("198.51.100.10:40000".to_string()),
+            public_ip_stable: Some(true),
+            public_port_stable: Some(false),
+            port_preserved: Some(false),
+            port_delta: None,
+            likely_symmetric: Some(true),
+            mapping_behavior: p2pnet_nat::MappingBehavior::AddressOrPortDependent,
+            filtering_behavior: p2pnet_nat::FilteringBehavior::AddressOrPortDependent,
+            hairpin_behavior: p2pnet_nat::HairpinBehavior::Unknown,
+            mapping_lifetime: p2pnet_nat::MappingLifetime::Unknown,
+            prediction_candidate: false,
+            predicted_endpoints: Vec::new(),
+            birthday_candidate: true,
+            confidence: 70,
+        }
+    }
+
+    async fn exact_birthday_runtime_fixture() -> (
+        Arc<PeerManager>,
+        UdpTransport,
+        crate::peer::HardHardFreshSocketIdentity,
+        SocketAddr,
+        crate::peer::PeerSessionGeneration,
+    ) {
+        let (peers, udp, mut identity, remote) = exact_socket_proof_fixture().await;
+        let mut record = peers
+            .hard_hard_session_for_test(&identity.peer_id)
+            .await
+            .expect("exact fixture must install a session ledger record");
+
+        peers.update_nat_profile(birthday_runtime_nat_profile()).await;
+        let local_profile_generation = peers.current_local_profile_generation_sync();
+        let session_token = "birthday-runtime-token".to_string();
+        identity.session_token = session_token.clone();
+        identity.local_profile_generation = local_profile_generation;
+        record.session_id = "birthday-runtime-session".to_string();
+        record.session_token = session_token.clone();
+        record.probe_session_id = Some("probe-session-exact".to_string());
+        record.local_profile_generation = local_profile_generation;
+        record.requested_birthday_level = 64;
+        record.generated_candidate_count = 64;
+        record.signaled_candidate_count = 1;
+        record.birthday = true;
+        record.requested_socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        record.requested_socket_count = 2;
+        record.prediction_window = vec![remote];
+        record.remote_prediction = vec![remote];
+        record.fresh_socket = identity.clone();
+        record.punch_at_ms = hard_hard_now_ms();
+        record.expires_at_ms = record.punch_at_ms.saturating_add(30_000);
+        record.state = crate::peer::HardHardSessionState::AwaitingPeer;
+        record.attempt_count = 0;
+        record.cancellation = Arc::new(crate::PunchSessionCancellation::default());
+        assert!(peers.hard_hard_register_session(record).await);
+        assert!(
+            udp.tag_hard_hard_socket(&identity.peer_id, identity.socket_index, &session_token)
+                .await
+        );
+        let peer_session_generation = peers
+            .peer_session_generation_sync(&identity.peer_id)
+            .expect("exact fixture peer must have an active lifecycle generation");
+        (peers, udp, identity, remote, peer_session_generation)
+    }
+
+    async fn wait_for_birthday_worker_gate(
+        gate: &Arc<crate::udp::BirthdayWorkerCompletionGate>,
+    ) {
+        let reached = gate.reached.notified();
+        let mut watchdog = tokio::spawn(async {
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::advance(Duration::from_secs(1)).await;
+        });
+        tokio::select! {
+            _ = reached => {
+                watchdog.abort();
+            }
+            _ = &mut watchdog => panic!("production Birthday worker did not publish live progress"),
+        }
+    }
+
+    fn assert_live_birthday_terminal_summary(
+        events: &[crate::peer::DirectTraversalEventDiagnostics],
+        stop_reason: &str,
+    ) {
+        let summary = events
+            .iter()
+            .find(|event| event.stage == "hard_hard_birthday_sweep_summary")
+            .expect("terminal Birthday summary must be durable");
+        for field in [
+            "physical_datagrams_sent=",
+            "per_socket_sent=",
+            "first_send_at_ms=Some(",
+            "last_send_at_ms=Some(",
+            "unique_target_endpoints=1",
+            "waves_fully_completed=0",
+        ] {
+            assert!(
+                summary.detail.contains(field),
+                "terminal summary is missing {field}: {}",
+                summary.detail
+            );
+        }
+        assert!(
+            summary.detail.contains(&format!("stop_reason={stop_reason}")),
+            "terminal summary has an unexpected stop reason: {}",
+            summary.detail
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_birthday_deadline_snapshots_live_progress_at_production_entry() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(None);
+        let (peers, udp, identity, _remote, peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let remote: SocketAddr = "127.0.0.1:41000".parse().unwrap();
+        let session = PunchAttemptDeduplicator::default()
+            .claim(&identity.peer_id)
+            .await
+            .expect("test must own the production Hard↔Hard punch session");
+        let (gate, _gate_guard) = crate::udp::install_birthday_worker_completion_gate_for_test();
+        let socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peers = peers.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_and_sweep(
+                    udp,
+                    peers,
+                    session,
+                    identity.peer_id.clone(),
+                    peer_session_generation,
+                    identity,
+                    Some(socket_indices),
+                    "birthday-runtime-token".to_string(),
+                    vec![remote],
+                    64,
+                    64,
+                    1,
+                    hard_hard_now_ms(),
+                    0,
+                    (1, 7),
+                    Some("probe-session-exact".to_string()),
+                    "test-deadline",
+                )
+                .await
+            }
+        });
+        wait_for_birthday_worker_gate(&gate).await;
+        tokio::time::advance(HARD_HARD_SWEEP_DEADLINE).await;
+        tokio::task::yield_now().await;
+        assert!(!task.await.unwrap());
+
+        let events = peers.diagnostics().await[0].direct_events.clone();
+        assert_live_birthday_terminal_summary(&events, "deadline");
+        assert!(events
+            .iter()
+            .any(|event| event.stage == "hard_hard_sweep_failed"));
+        gate.release.notify_waiters();
+        udp.detach_all_dynamic_punch_sockets("test_deadline_live_progress")
+            .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hard_hard_birthday_cancellation_snapshots_live_progress_at_production_entry() {
+        let _serial = crate::tests::HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+        set_hard_hard_test_now_ms(None);
+        let (peers, udp, identity, _remote, peer_session_generation) =
+            exact_birthday_runtime_fixture().await;
+        let remote: SocketAddr = "127.0.0.1:41001".parse().unwrap();
+        let session = PunchAttemptDeduplicator::default()
+            .claim(&identity.peer_id)
+            .await
+            .expect("test must own the production Hard↔Hard punch session");
+        let cancellation = session.cancellation_handle();
+        let (gate, _gate_guard) = crate::udp::install_birthday_worker_completion_gate_for_test();
+        let socket_indices = vec![identity.socket_index, identity.socket_index + 1];
+        let task = tokio::spawn({
+            let udp = udp.clone();
+            let peers = peers.clone();
+            let identity = identity.clone();
+            async move {
+                hard_hard_wait_and_sweep(
+                    udp,
+                    peers,
+                    session,
+                    identity.peer_id.clone(),
+                    peer_session_generation,
+                    identity,
+                    Some(socket_indices),
+                    "birthday-runtime-token".to_string(),
+                    vec![remote],
+                    64,
+                    64,
+                    1,
+                    hard_hard_now_ms(),
+                    0,
+                    (1, 7),
+                    Some("probe-session-exact".to_string()),
+                    "test-cancel",
+                )
+                .await
+            }
+        });
+        wait_for_birthday_worker_gate(&gate).await;
+        cancellation.cancel_for_hard_hard_cleanup();
+        tokio::task::yield_now().await;
+        assert!(!task.await.unwrap());
+
+        let events = peers.diagnostics().await[0].direct_events.clone();
+        assert_live_birthday_terminal_summary(&events, "session_cancelled");
+        assert!(events
+            .iter()
+            .any(|event| event.stage == "hard_hard_failed"));
+        gate.release.notify_waiters();
+        udp.detach_all_dynamic_punch_sockets("test_cancel_live_progress")
+            .await;
     }
 
     fn endpoint_for_test(port: u16) -> SocketAddr {
@@ -3701,6 +4083,14 @@ mod hard_hard_tests {
                 .bind_remote_nat_profile_to_candidate_epoch("peer-exact-proof", 7)
                 .await
         );
+        assert!(
+            peers
+                .set_probe_session_id(
+                    "peer-exact-proof",
+                    Some("probe-session-exact".to_string()),
+                )
+                .await
+        );
 
         let (inbound_tx, _inbound_rx) = tokio::sync::mpsc::channel(8);
         let udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers.clone())
@@ -3742,6 +4132,7 @@ mod hard_hard_tests {
             peers
                 .hard_hard_register_session(crate::peer::HardHardSessionRecord {
                     session_id: "proof-session".to_string(),
+                    probe_session_id: Some("probe-session-exact".to_string()),
                     session_token: identity.session_token.clone(),
                     peer_id: identity.peer_id.clone(),
                     initiator: true,
@@ -4139,6 +4530,7 @@ mod hard_hard_tests {
             };
             crate::peer::HardHardSessionRecord {
                 session_id: format!("hh1:i:{token}:1:2:3:4:90:0:0"),
+                probe_session_id: None,
                 session_token: token.to_string(),
                 peer_id: peer_id.to_string(),
                 initiator: true,

--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -2170,6 +2170,7 @@ pub(crate) async fn spawn_hard_hard_responder(
         } else {
             false
         };
+        record_hard_hard_candidate_contract(&peers, &peer_id, candidate_contract, sent).await;
         if !sent
             || cancellation.is_cancelled()
             || !peers.peer_session_is_current_sync(&peer_id, peer_session_generation)
@@ -2248,6 +2249,7 @@ pub(crate) async fn spawn_hard_hard_responder(
             birthday_socket_indices,
             coordination.token.clone(),
             remote_prediction,
+            hard_hard_measurement_target_limit(&measurement),
             punch_at_ms,
             current_plan.local_network_generation,
             (
@@ -2507,6 +2509,10 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         (!birthday_socket_indices.is_empty()).then_some(birthday_socket_indices),
         record.session_token.clone(),
         remote_prediction,
+        record
+            .prediction_window
+            .len()
+            .min(HARD_HARD_MAX_BIRTHDAY_TARGETS),
         punch_at_ms,
         record.local_network_generation,
         (
@@ -2625,12 +2631,16 @@ async fn hard_hard_wait_and_sweep(
     birthday_socket_indices: Option<Vec<usize>>,
     session_token: String,
     targets: Vec<SocketAddr>,
+    requested_level: usize,
     punch_at_ms: u64,
     network_generation: u64,
     profile_generations: (u64, u64),
     origin: &'static str,
 ) -> bool {
     let socket_index = fresh_socket.socket_index;
+    let birthday_waves_planned = birthday_socket_indices.as_ref().map_or(1, |indices| {
+        if indices.len() > 1 { 2 } else { 1 }
+    });
     let delay = punch_at_ms.saturating_sub(hard_hard_now_ms());
     if delay > 0 {
         tokio::select! {
@@ -2657,10 +2667,12 @@ async fn hard_hard_wait_and_sweep(
             Some(targets.len()),
             None,
             format!(
-                "origin={origin} socket_count={} target_count={} attempt={} punch_at_ms={} local_clock_ms={} sweep_deadline_ms={}",
+                "origin={origin} mode={} socket_count={} target_count={} attempt={} waves_planned={} punch_at_ms={} local_clock_ms={} sweep_deadline_ms={}",
+                if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
                 birthday_socket_indices.as_ref().map_or(1, Vec::len),
                 targets.len(),
                 if birthday_socket_indices.is_some() { 1 } else { HARD_HARD_SWEEP_ATTEMPTS },
+                birthday_waves_planned,
                 punch_at_ms,
                 hard_hard_now_ms(),
                 HARD_HARD_SWEEP_DEADLINE.as_millis(),
@@ -2683,6 +2695,8 @@ async fn hard_hard_wait_and_sweep(
                 &peer_id,
                 socket_indices,
                 targets.clone(),
+                requested_level,
+                peer_session_generation,
                 profile_generations,
                 &session_token,
             )
@@ -2745,8 +2759,35 @@ async fn hard_hard_wait_and_sweep(
                     &confirmation_identity,
                     direct_commit_seq,
                 )
-                .await
+                    .await
             };
+            let mut per_socket_counts = report.per_socket_sent.clone();
+            per_socket_counts.sort_by_key(|(socket_index, _)| *socket_index);
+            let per_socket_sent = per_socket_counts
+                .iter()
+                .map(|(socket_index, sent)| format!("{socket_index}:{sent}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let birthday_detail = report.birthday.as_ref().map(|birthday| {
+                format!(
+                    "requested_level={} effective_target_count={} socket_count={} degraded_reason={} waves_planned={} waves_started={} waves_completed={} packets_planned={} packets_sent={} unique_target_endpoints={} budget_skipped={} per_socket_sent={} first_send_at_ms={:?} last_send_at_ms={:?} stop_reason={}",
+                    birthday.requested_level,
+                    birthday.effective_target_count,
+                    birthday.socket_count,
+                    birthday.degraded_reason.as_deref().unwrap_or("none"),
+                    birthday.waves_planned,
+                    birthday.waves_started,
+                    birthday.waves_completed,
+                    birthday.packets_planned,
+                    report.packets_sent,
+                    report.unique_target_endpoints,
+                    report.budget_skipped,
+                    per_socket_sent,
+                    report.first_send_at_ms,
+                    report.last_send_at_ms,
+                    birthday.stop_reason.as_deref().unwrap_or("unknown"),
+                )
+            });
             peers
                 .record_direct_event_for_generation_with_socket(
                     &peer_id,
@@ -2757,18 +2798,46 @@ async fn hard_hard_wait_and_sweep(
                     Some(report.unique_target_endpoints as usize),
                     Some(report.packets_sent),
                     format!(
-                        "origin={origin} sent={} received={} matched_ack={} authenticated_rx={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?}",
+                        "origin={origin} mode={} sent={} received={} matched_ack={} authenticated_rx={} authenticated_ack_unmatched={} target_count={} unique_targets={} budget_skipped={} first_send_at_ms={:?} last_send_at_ms={:?} per_socket_sent={}{}",
+                        if birthday_detail.is_some() { "birthday" } else { "predictable" },
                         report.packets_sent,
                         probe_rx_delta.known_peer_ip_datagrams_received,
                         probe_rx_delta.probe_acks_received,
                         probe_rx_delta.authenticated_probe_packets_received,
+                        probe_rx_delta.authenticated_probe_acks_unmatched,
                         targets.len(),
                         report.unique_target_endpoints,
                         report.budget_skipped,
                         report.first_send_at_ms,
+                        report.last_send_at_ms,
+                        per_socket_sent,
+                        birthday_detail
+                            .as_deref()
+                            .map(|detail| format!(" {detail}"))
+                            .unwrap_or_default(),
                     ),
                 )
                 .await;
+            if let Some(detail) = birthday_detail.as_deref() {
+                peers
+                    .record_direct_event_for_generation_with_socket(
+                        &peer_id,
+                        network_generation,
+                        "hard_hard_birthday_sweep_summary",
+                        targets.first().copied(),
+                        Some(socket_index),
+                        Some(report.unique_target_endpoints as usize),
+                        Some(report.packets_sent),
+                        format!(
+                            "origin={origin} mode=birthday {detail} known_peer_ip_rx_delta={} authenticated_probe_rx_delta={} matched_probe_ack_rx_delta={} authenticated_probe_ack_unmatched_delta={}",
+                            probe_rx_delta.known_peer_ip_datagrams_received,
+                            probe_rx_delta.authenticated_probe_packets_received,
+                            probe_rx_delta.probe_acks_received,
+                            probe_rx_delta.authenticated_probe_acks_unmatched,
+                        ),
+                    )
+                    .await;
+            }
             if direct_confirmed {
                 peers
                     .record_direct_event(
@@ -2866,7 +2935,11 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         None,
                         format!(
-                            "origin={origin} exact-socket sweep deadline elapsed before authenticated Direct confirmation"
+                            "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason=deadline exact-socket sweep deadline elapsed before authenticated Direct confirmation",
+                            if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
+                            requested_level,
+                            targets.len(),
+                            birthday_waves_planned,
                         ),
                     )
                     .await;
@@ -2878,14 +2951,60 @@ async fn hard_hard_wait_and_sweep(
                         Some(targets.len()),
                         None,
                         format!(
-                            "origin={origin} stage=sweep reason=deadline budget_ms={}",
-                            HARD_HARD_SWEEP_DEADLINE.as_millis()
+                            "origin={origin} mode={} stage=sweep reason=deadline requested_level={} effective_target_count={} budget_ms={}",
+                            if birthday_socket_indices.is_some() { "birthday" } else { "predictable" },
+                            requested_level,
+                            targets.len(),
+                            HARD_HARD_SWEEP_DEADLINE.as_millis(),
                         ),
                     )
                     .await;
             false
         }
-        (PunchSessionOutcome::Cancelled, _) => false,
+        (PunchSessionOutcome::Cancelled, _) => {
+            let cancellation_reason = session
+                .cancellation_reason()
+                .map(PunchCancellationReason::label)
+                .unwrap_or("unknown");
+            peers
+                .record_direct_event(
+                    &peer_id,
+                    "hard_hard_sweep_failed",
+                    targets.first().copied(),
+                    Some(targets.len()),
+                    None,
+                    format!(
+                        "origin={origin} mode={} requested_level={} effective_target_count={} waves_planned={} stop_reason=session_cancelled cancellation_reason={cancellation_reason}",
+                        if birthday_socket_indices.is_some() {
+                            "birthday"
+                        } else {
+                            "predictable"
+                        },
+                        requested_level,
+                        targets.len(),
+                        birthday_waves_planned,
+                    ),
+                )
+                .await;
+            peers
+                .record_direct_event(
+                    &peer_id,
+                    "hard_hard_failed",
+                    targets.first().copied(),
+                    Some(targets.len()),
+                    None,
+                    format!(
+                        "origin={origin} mode={} stage=sweep reason=session_cancelled cancellation_reason={cancellation_reason}",
+                        if birthday_socket_indices.is_some() {
+                            "birthday"
+                        } else {
+                            "predictable"
+                        },
+                    ),
+                )
+                .await;
+            false
+        }
         _ => false,
     }
 }

--- a/client/daemon/src/lib/punch_dedup.rs
+++ b/client/daemon/src/lib/punch_dedup.rs
@@ -40,6 +40,11 @@ struct PunchAttemptRecord {
     /// sweep. It gives a short, bounded protection interval to a rendezvous
     /// that has already reached its first-send edge.
     first_send_started_at_ms: Option<u64>,
+    /// Number of owners holding this dedup record. The primary worker may
+    /// hand one ownership reference to a Hard↔Hard cleanup watcher so a
+    /// lower-priority retry cannot claim the peer while the exact UDP/ledger
+    /// cleanup transaction is still in flight.
+    owner_count: usize,
     cancellation: Arc<PunchSessionCancellation>,
 }
 
@@ -229,6 +234,21 @@ impl PunchSessionPermit {
     fn mark_first_send_started(&self) -> u64 {
         self.owner
             .mark_first_send_started(&self.peer_id, self.session_id)
+    }
+
+    /// Keep the exact dedup record owned by a cleanup watcher after the
+    /// short-lived worker releases its own permit. This is intentionally a
+    /// synchronous handoff: no await can interleave between the worker's
+    /// release and the cleanup owner's claim of the same record.
+    pub(crate) fn clone_for_cleanup(&self) -> Self {
+        self.owner
+            .retain(&self.peer_id, self.session_id);
+        Self {
+            owner: self.owner.clone(),
+            peer_id: self.peer_id.clone(),
+            session_id: self.session_id,
+            cancellation: self.cancellation.clone(),
+        }
     }
 }
 
@@ -517,6 +537,7 @@ impl PunchAttemptDeduplicator {
                 network_generation,
                 punch_at_ms,
                 first_send_started_at_ms: None,
+                owner_count: 1,
                 cancellation: cancellation.clone(),
             },
         );
@@ -552,7 +573,31 @@ impl PunchAttemptDeduplicator {
             .get(peer_id)
             .is_some_and(|active| active.session_id == session_id)
         {
-            state.active.remove(peer_id);
+            let remove = state
+                .active
+                .get_mut(peer_id)
+                .map(|active| {
+                    active.owner_count = active.owner_count.saturating_sub(1);
+                    active.owner_count == 0
+                })
+                .unwrap_or(false);
+            if remove {
+                state.active.remove(peer_id);
+            }
+        }
+    }
+
+    fn retain(&self, peer_id: &str, session_id: u64) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(active) = state
+            .active
+            .get_mut(peer_id)
+            .filter(|active| active.session_id == session_id)
+        {
+            active.owner_count = active.owner_count.saturating_add(1);
         }
     }
 

--- a/client/daemon/src/lib/tests/part04.rs
+++ b/client/daemon/src/lib/tests/part04.rs
@@ -116,6 +116,82 @@ fn fresh_mapping_signal_payload_passes_control_plane_validation() {
 }
 
 #[test]
+fn signal_candidate_contract_deduplicates_and_caps_all_birthday_levels() {
+    for requested in [64usize, 128, 256] {
+        let candidates = (0..requested)
+            .map(|offset| format!("8.8.8.8:{}", 40_000 + offset))
+            .collect::<Vec<_>>();
+        let sources = candidates
+            .iter()
+            .map(|candidate| (candidate.clone(), "predicted".to_string()))
+            .collect::<HashMap<_, _>>();
+
+        let (effective, effective_sources, contract) =
+            crate::candidate_refresh::normalize_signal_candidates(&candidates, &sources);
+        let expected = requested.min(crate::MAX_SIGNAL_CANDIDATES);
+        assert_eq!(effective.len(), expected);
+        assert_eq!(contract.requested_candidate_count, requested);
+        assert_eq!(contract.generated_candidate_count, requested);
+        assert_eq!(contract.deduplicated_candidate_count, requested);
+        assert_eq!(contract.signaled_candidate_count, expected);
+        assert_eq!(contract.cap, crate::MAX_SIGNAL_CANDIDATES);
+        assert_eq!(contract.capped, requested > crate::MAX_SIGNAL_CANDIDATES);
+        assert!(effective_sources
+            .keys()
+            .all(|candidate| effective.contains(candidate)));
+    }
+
+    let duplicate = "8.8.4.4:41000".to_string();
+    let mut candidates = vec![duplicate.clone(), duplicate.clone()];
+    candidates.extend((0..62).map(|offset| format!("8.8.4.4:{}", 41_000 + offset)));
+    let sources = candidates
+        .iter()
+        .map(|candidate| (candidate.clone(), "stun_observed".to_string()))
+        .collect::<HashMap<_, _>>();
+    let (effective, effective_sources, contract) =
+        crate::candidate_refresh::normalize_signal_candidates(&candidates, &sources);
+    assert_eq!(effective.len(), 62);
+    assert_eq!(contract.deduplicated_candidate_count, 62);
+    assert!(!contract.capped);
+    assert_eq!(contract.reason, "deduplicated");
+    assert_eq!(effective_sources.len(), effective.len());
+}
+
+#[test]
+fn signal_payload_boundary_never_emits_more_than_server_cap() {
+    let candidates = (0..256usize)
+        .map(|offset| format!("8.8.8.8:{}", 42_000 + offset))
+        .collect::<Vec<_>>();
+    let sources = candidates
+        .iter()
+        .map(|candidate| (candidate.clone(), "birthday".to_string()))
+        .collect::<HashMap<_, _>>();
+    let payload = crate::control::prepare_signal_payload_for_test(
+        "node-a",
+        "node-b",
+        "peer_offer_fresh",
+        &candidates,
+        &sources,
+        b"handshake-bytes",
+        Some(1_000),
+        None,
+        Some("session-1"),
+        None,
+        None,
+    )
+    .expect("signal payload must build");
+    let json_candidates = payload["candidates"].as_array().unwrap();
+    let json_sources = payload["candidate_sources"].as_object().unwrap();
+    assert_eq!(json_candidates.len(), crate::MAX_SIGNAL_CANDIDATES);
+    assert!(json_sources.len() <= json_candidates.len());
+    assert!(json_sources.keys().all(|endpoint| {
+        json_candidates
+            .iter()
+            .any(|candidate| candidate.as_str() == Some(endpoint))
+    }));
+}
+
+#[test]
 fn fresh_mapping_signal_payload_without_public_ip_falls_back_to_unspecified_ip() {
     let mut result = sample_result();
     result.public_ip = None;

--- a/client/daemon/src/lib/tests/part04.rs
+++ b/client/daemon/src/lib/tests/part04.rs
@@ -158,6 +158,47 @@ fn signal_candidate_contract_deduplicates_and_caps_all_birthday_levels() {
 }
 
 #[test]
+fn shared_signal_candidate_cap_fixture_matches_daemon_constant() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../contracts/fixtures/signal_candidate_cap.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read shared cap fixture {path:?}: {error}"));
+    let fixture: serde_json::Value =
+        serde_json::from_str(&raw).expect("signal_candidate_cap.json must be valid JSON");
+    assert_eq!(
+        fixture["max_signal_candidates"].as_u64(),
+        Some(crate::MAX_SIGNAL_CANDIDATES as u64),
+        "Rust candidate cap must match the shared contract fixture"
+    );
+}
+
+#[test]
+fn high_priority_observed_and_fresh_candidates_survive_tail_cap() {
+    let observed = "8.8.8.8:41000".to_string();
+    let fresh = "1.1.1.1:42000".to_string();
+    let fresh_source = crate::fresh_prediction_source_label(FreshPredictionId {
+        boot_epoch: 1_742_987_654_321,
+        generation: 7,
+    });
+    let mut candidates = vec![observed.clone(), fresh.clone()];
+    candidates.extend((0..128).map(|index| format!("198.51.100.10:{}", 43000 + index)));
+    let mut sources = HashMap::new();
+    sources.insert(observed.clone(), "stun_observed".to_string());
+    sources.insert(fresh.clone(), fresh_source);
+    for candidate in candidates.iter().skip(2) {
+        sources.insert(candidate.clone(), "signaled".to_string());
+    }
+
+    let (effective, effective_sources, contract) =
+        crate::candidate_refresh::normalize_signal_candidates(&candidates, &sources);
+    assert_eq!(effective.len(), crate::MAX_SIGNAL_CANDIDATES);
+    assert!(effective.contains(&observed));
+    assert!(effective.contains(&fresh));
+    assert_eq!(effective_sources.len(), effective.len());
+    assert!(contract.capped);
+}
+
+#[test]
 fn signal_payload_boundary_never_emits_more_than_server_cap() {
     let candidates = (0..256usize)
         .map(|offset| format!("8.8.8.8:{}", 42_000 + offset))

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -4846,6 +4846,15 @@ async fn hard_hard_two_peer_duplicate_and_stale_signals_do_not_reopen_session() 
     set_hard_hard_test_now_ms(Some(now));
     let _clock = HardHardClockReset;
     let harness = build_two_peer_harness(false, false, false).await;
+    // Fence peer traffic before either production rendezvous worker exists.
+    // The test clock controls admission timestamps, but it cannot retime a
+    // Tokio sleep that a worker already armed. On a slower Windows runner the
+    // old post-response drop raced the natural 3.5s punch timer and sometimes
+    // produced a legitimate authenticated Direct path that cleanup correctly
+    // preserved. Starting disconnected makes the intended no-reachability
+    // scenario deterministic without weakening any cleanup assertion.
+    harness.link.set_drop_a_to_b(true);
+    harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;
     let response = wait_for_hard_hard_response_signal(&harness).await;
     let original_a = harness.udp_a.dynamic_socket_count().await;
@@ -4859,8 +4868,6 @@ async fn hard_hard_two_peer_duplicate_and_stale_signals_do_not_reopen_session() 
     // durable deliveries to reach a terminal state before installing the next
     // candidate generation. This prevents an old queued offer from racing the
     // direct test mutation below while preserving the real responder ordering.
-    harness.link.set_drop_a_to_b(true);
-    harness.link.set_drop_b_to_a(true);
     set_hard_hard_test_now_ms(Some(
         response
             .punch_at_ms

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -61,8 +61,40 @@ struct HarnessPorts {
 
 const A_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-16, -12, -8, -4];
 const B_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-12, -9, -6, -3];
-const A_PREDICTABLE_CANDIDATE_GUARD_OFFSETS: [i32; 5] = [-16, -12, -8, -4, 4];
-const B_PREDICTABLE_CANDIDATE_GUARD_OFFSETS: [i32; 5] = [-12, -9, -6, -3, 3];
+
+fn predictable_candidate_guard_offsets(mapped_offsets: &[i32; 4], step: i32) -> Vec<i32> {
+    let mut offsets = mapped_offsets.to_vec();
+    let last = *mapped_offsets.last().expect("predictable mapped samples");
+    for distance in 1..=p2pnet_nat::mapping::MAX_PREDICTED_PORTS {
+        let offset = last + step * distance as i32;
+        // The public link socket already owns offset zero.
+        if offset != 0 && !offsets.contains(&offset) {
+            offsets.push(offset);
+        }
+    }
+    offsets
+}
+
+#[test]
+fn hard_hard_predictable_candidate_guards_cover_complete_successor_windows() {
+    for (mapped_offsets, step) in [
+        (A_PREDICTABLE_MAPPED_OFFSETS, 4),
+        (B_PREDICTABLE_MAPPED_OFFSETS, 3),
+    ] {
+        let offsets = predictable_candidate_guard_offsets(&mapped_offsets, step);
+        assert!(mapped_offsets
+            .iter()
+            .all(|mapped| offsets.contains(mapped)));
+        let last = *mapped_offsets.last().unwrap();
+        for distance in 1..=p2pnet_nat::mapping::MAX_PREDICTED_PORTS {
+            let predicted = last + step * distance as i32;
+            if predicted != 0 {
+                assert!(offsets.contains(&predicted));
+            }
+        }
+        assert!(!offsets.contains(&0));
+    }
+}
 
 async fn reserve_predictable_public_endpoint(
     ip: IpAddr,
@@ -109,16 +141,18 @@ impl HarnessPorts {
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let (a_public, b_public, candidate_guards) = match mode {
             HarnessNatMode::Predictable => {
-                let (a_public, mut guards) = reserve_predictable_public_endpoint(
-                    ip,
-                    &A_PREDICTABLE_CANDIDATE_GUARD_OFFSETS,
-                )
-                .await;
-                let (b_public, b_guards) = reserve_predictable_public_endpoint(
-                    ip,
-                    &B_PREDICTABLE_CANDIDATE_GUARD_OFFSETS,
-                )
-                .await;
+                // Reserve the complete production-bounded successor windows,
+                // not only their top candidates. Otherwise Windows can assign
+                // a dynamic socket one of the later predicted target ports and
+                // let traffic bypass the synthetic NAT link entirely.
+                let a_offsets =
+                    predictable_candidate_guard_offsets(&A_PREDICTABLE_MAPPED_OFFSETS, 4);
+                let b_offsets =
+                    predictable_candidate_guard_offsets(&B_PREDICTABLE_MAPPED_OFFSETS, 3);
+                let (a_public, mut guards) =
+                    reserve_predictable_public_endpoint(ip, &a_offsets).await;
+                let (b_public, b_guards) =
+                    reserve_predictable_public_endpoint(ip, &b_offsets).await;
                 guards.extend(b_guards);
                 (a_public, b_public, guards)
             }
@@ -1818,6 +1852,95 @@ async fn wait_for_current_direct_diagnostics(
     .expect("current Direct diagnostics must become readable after the commit")
 }
 
+struct CurrentFreshDirect {
+    diagnostics: peer::PeerDiagnostics,
+    socket_index: usize,
+    socket_local_endpoint: SocketAddr,
+    predicted_ports: Vec<u16>,
+}
+
+async fn wait_for_current_fresh_direct(
+    peers: &PeerManager,
+    udp: &UdpTransport,
+    peer_id: &str,
+) -> CurrentFreshDirect {
+    let current = timeout(Duration::from_secs(1), async {
+        loop {
+            let diagnostics = peers
+                .diagnostic_with_path_selection(
+                    peer_id,
+                    true,
+                    false,
+                    Duration::ZERO,
+                    None,
+                )
+                .await
+                .map(|(_, diagnostics)| diagnostics);
+            let fresh = peers.fresh_mapping_for_peer(peer_id).await;
+            let affinity = udp.affinity_pin_for_test(peer_id).await;
+            let selected = udp
+                .socket_for_peer(Some(peer_id))
+                .await
+                .and_then(|(index, socket)| {
+                    socket
+                        .local_addr()
+                        .ok()
+                        .map(|local_endpoint| (index, local_endpoint))
+                });
+
+            if let (Some(diagnostics), Some(fresh), Some(affinity), Some(selected)) =
+                (diagnostics, fresh, affinity, selected)
+            {
+                let pair_local_endpoint = diagnostics
+                    .current_direct_pair
+                    .as_ref()
+                    .and_then(|pair| pair.local_endpoint.as_deref());
+                if diagnostics.state == ConnectionState::Direct
+                    && diagnostics.active_path == Some(NetworkPath::Direct)
+                    && affinity.socket_index == fresh.socket_index
+                    && selected.0 == fresh.socket_index
+                    && selected.1 == fresh.socket_local_endpoint
+                    && pair_local_endpoint
+                        == Some(fresh.socket_local_endpoint.to_string()).as_deref()
+                {
+                    return CurrentFreshDirect {
+                        diagnostics,
+                        socket_index: fresh.socket_index,
+                        socket_local_endpoint: fresh.socket_local_endpoint,
+                        predicted_ports: fresh.predicted_ports,
+                    };
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+
+    if let Ok(current) = current {
+        return current;
+    }
+
+    let diagnostics = peers
+        .diagnostic_with_path_selection(peer_id, true, false, Duration::ZERO, None)
+        .await
+        .map(|(_, diagnostics)| {
+            (
+                diagnostics.state,
+                diagnostics.active_path,
+                diagnostics.current_direct_pair,
+            )
+        });
+    let fresh = peers.fresh_mapping_for_peer(peer_id).await;
+    let affinity = udp.affinity_pin_for_test(peer_id).await;
+    let selected = udp
+        .socket_for_peer(Some(peer_id))
+        .await
+        .map(|(index, socket)| (index, socket.local_addr()));
+    panic!(
+        "fresh Direct socket state did not converge: peer={peer_id} diagnostics={diagnostics:#?} fresh={fresh:#?} affinity={affinity:#?} selected={selected:#?}"
+    );
+}
+
 async fn wait_for_stage(
     peers: &PeerManager,
     peer_id: &str,
@@ -2868,29 +2991,23 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
     assert!(sweep_detail.contains("exact_socket=true"));
     assert!(sweep_detail.contains("direct_confirmed=true"));
 
-    let peer_a = wait_for_current_direct_diagnostics(&harness.peers_a, HARD_HARD_B).await;
-    let peer_b = wait_for_current_direct_diagnostics(&harness.peers_b, HARD_HARD_A).await;
-    let fresh_a = harness
-        .peers_a
-        .fresh_mapping_for_peer(HARD_HARD_B)
-        .await
-        .expect("A must retain its measured fresh mapping");
-    let fresh_b = harness
-        .peers_b
-        .fresh_mapping_for_peer(HARD_HARD_A)
-        .await
-        .expect("B must retain its measured fresh mapping");
+    let fresh_direct_a =
+        wait_for_current_fresh_direct(&harness.peers_a, &harness.udp_a, HARD_HARD_B).await;
+    let fresh_direct_b =
+        wait_for_current_fresh_direct(&harness.peers_b, &harness.udp_b, HARD_HARD_A).await;
+    let peer_a = fresh_direct_a.diagnostics;
+    let peer_b = fresh_direct_b.diagnostics;
     for diagnostics in [&peer_a, &peer_b] {
         assert_eq!(diagnostics.state, ConnectionState::Direct);
         assert_eq!(diagnostics.active_path, Some(NetworkPath::Direct));
     }
 
-    let measured_a = fresh_a.socket_index;
-    let measured_b = fresh_b.socket_index;
-    assert!(!fresh_a.predicted_ports.is_empty());
-    assert!(!fresh_b.predicted_ports.is_empty());
+    let measured_a = fresh_direct_a.socket_index;
+    let measured_b = fresh_direct_b.socket_index;
+    assert!(!fresh_direct_a.predicted_ports.is_empty());
+    assert!(!fresh_direct_b.predicted_ports.is_empty());
     assert_eq!(
-        Some(fresh_a.socket_local_endpoint),
+        Some(fresh_direct_a.socket_local_endpoint),
         harness
             .udp_a
             .socket_for_peer(Some(HARD_HARD_B))
@@ -2898,7 +3015,7 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
             .and_then(|(_, socket)| socket.local_addr().ok())
     );
     assert_eq!(
-        Some(fresh_b.socket_local_endpoint),
+        Some(fresh_direct_b.socket_local_endpoint),
         harness
             .udp_b
             .socket_for_peer(Some(HARD_HARD_A))
@@ -2949,11 +3066,11 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
     );
     assert_eq!(
         current_pair_a.local_endpoint.as_deref(),
-        Some(fresh_a.socket_local_endpoint.to_string()).as_deref()
+        Some(fresh_direct_a.socket_local_endpoint.to_string()).as_deref()
     );
     assert_eq!(
         current_pair_b.local_endpoint.as_deref(),
-        Some(fresh_b.socket_local_endpoint.to_string()).as_deref()
+        Some(fresh_direct_b.socket_local_endpoint.to_string()).as_deref()
     );
     assert!(
         harness

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -2530,26 +2530,38 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
             .split_whitespace()
             .find_map(|field| field.strip_prefix(key)?.parse::<usize>().ok())
     };
-    let mut probe_summaries = 0;
+    let mut birthday_summaries = 0;
     for peers in [&harness.peers_a, &harness.peers_b] {
         for event in &peers.diagnostics().await[0].direct_events {
-            if event.stage != "hard_hard_probe_summary"
-                || !event.detail.contains("target_count=64")
+            if event.stage != "hard_hard_birthday_sweep_summary"
+                || !event.detail.contains("requested_level=64")
             {
                 continue;
             }
-            let sent = parse_count(&event.detail, "sent=").expect("probe summary must report sent");
-            let unique = parse_count(&event.detail, "unique_targets=")
-                .expect("probe summary must report unique targets");
-            let target_count =
-                parse_count(&event.detail, "target_count=").expect("probe summary must report target count");
-            assert!(sent <= target_count);
-            assert!(unique <= target_count);
-            assert_eq!(sent, unique, "birthday assignment must send each target once");
-            probe_summaries += 1;
+            let sent = parse_count(&event.detail, "packets_sent=")
+                .expect("birthday summary must report sent packets");
+            let unique = parse_count(&event.detail, "unique_target_endpoints=")
+                .expect("birthday summary must report unique target endpoints");
+            let effective_target_count = parse_count(&event.detail, "effective_target_count=")
+                .expect("birthday summary must report effective target count");
+            let packets_planned = parse_count(&event.detail, "packets_planned=")
+                .expect("birthday summary must report planned packets");
+            let waves_planned = parse_count(&event.detail, "waves_planned=")
+                .expect("birthday summary must report planned waves");
+            assert_eq!(waves_planned, 2);
+            assert_eq!(packets_planned, effective_target_count * 2);
+            assert!(sent <= packets_planned);
+            assert!(unique <= effective_target_count);
+            assert!(event.detail.contains("first_send_at_ms="));
+            assert!(event.detail.contains("last_send_at_ms="));
+            assert!(event.detail.contains("stop_reason="));
+            birthday_summaries += 1;
         }
     }
-    assert!(probe_summaries > 0, "production birthday sweep must report its bounded send count");
+    assert!(
+        birthday_summaries > 0,
+        "production birthday sweep must report its bounded send count"
+    );
 
     timeout(Duration::from_secs(1), async {
         loop {

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -384,9 +384,12 @@ struct NatPacketLink {
     _b_source: Arc<UdpSocket>,
     drop_a_to_b: Arc<AtomicBool>,
     drop_b_to_a: Arc<AtomicBool>,
+    hold_authenticated_punch: Arc<AtomicBool>,
     hold_ack: Arc<AtomicBool>,
     held_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
     held_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
+    held_punch_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
+    held_punch_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
     route_dynamic_socket: bool,
     worker: Option<tokio::task::JoinHandle<()>>,
 }
@@ -423,9 +426,12 @@ impl NatPacketLink {
         };
         let drop_a_to_b = Arc::new(AtomicBool::new(false));
         let drop_b_to_a = Arc::new(AtomicBool::new(false));
+        let hold_authenticated_punch = Arc::new(AtomicBool::new(false));
         let hold_ack = Arc::new(AtomicBool::new(false));
         let held_a_to_b = Arc::new(StdMutex::new(Vec::new()));
         let held_b_to_a = Arc::new(StdMutex::new(Vec::new()));
+        let held_punch_a_to_b = Arc::new(StdMutex::new(Vec::new()));
+        let held_punch_b_to_a = Arc::new(StdMutex::new(Vec::new()));
         let worker = Some(tokio::spawn(Self::run(
             a_public.clone(),
             b_public.clone(),
@@ -435,9 +441,12 @@ impl NatPacketLink {
             udp_b.clone(),
             drop_a_to_b.clone(),
             drop_b_to_a.clone(),
+            hold_authenticated_punch.clone(),
             hold_ack.clone(),
             held_a_to_b.clone(),
             held_b_to_a.clone(),
+            held_punch_a_to_b.clone(),
+            held_punch_b_to_a.clone(),
             primary_a,
             route_dynamic_socket,
         )));
@@ -448,9 +457,12 @@ impl NatPacketLink {
             _b_source: b_source,
             drop_a_to_b,
             drop_b_to_a,
+            hold_authenticated_punch,
             hold_ack,
             held_a_to_b,
             held_b_to_a,
+            held_punch_a_to_b,
+            held_punch_b_to_a,
             route_dynamic_socket,
             worker,
         }
@@ -514,9 +526,12 @@ impl NatPacketLink {
         udp_b: UdpTransport,
         drop_a_to_b: Arc<AtomicBool>,
         drop_b_to_a: Arc<AtomicBool>,
+        hold_authenticated_punch: Arc<AtomicBool>,
         hold_ack: Arc<AtomicBool>,
         held_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
         held_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
+        held_punch_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
+        held_punch_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
     ) {
@@ -530,6 +545,15 @@ impl NatPacketLink {
                         && Self::is_authenticated_ack(&a_buf[..len])
                     {
                         held_b_to_a
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .push(a_buf[..len].to_vec());
+                        continue;
+                    }
+                    if hold_authenticated_punch.load(Ordering::Acquire)
+                        && Self::is_authenticated_punch(&a_buf[..len])
+                    {
+                        held_punch_b_to_a
                             .lock()
                             .unwrap_or_else(|poisoned| poisoned.into_inner())
                             .push(a_buf[..len].to_vec());
@@ -560,6 +584,15 @@ impl NatPacketLink {
                             .push(b_buf[..len].to_vec());
                         continue;
                     }
+                    if hold_authenticated_punch.load(Ordering::Acquire)
+                        && Self::is_authenticated_punch(&b_buf[..len])
+                    {
+                        held_punch_a_to_b
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .push(b_buf[..len].to_vec());
+                        continue;
+                    }
                     // A's packet arrived at B's mapped public endpoint. Send
                     // from A_PUBLIC so B observes A's predicted source.
                     Self::forward(
@@ -581,12 +614,77 @@ impl NatPacketLink {
             .is_some_and(|identity| identity.kind == PunchPacketKind::Ack)
     }
 
+    fn is_authenticated_punch(data: &[u8]) -> bool {
+        peek_authenticated_punch_identity(data)
+            .is_some_and(|identity| identity.kind == PunchPacketKind::Punch)
+    }
+
     fn set_drop_a_to_b(&self, drop: bool) {
         self.drop_a_to_b.store(drop, Ordering::Release);
     }
 
     fn set_drop_b_to_a(&self, drop: bool) {
         self.drop_b_to_a.store(drop, Ordering::Release);
+    }
+
+    fn set_hold_authenticated_punch(&self, hold: bool) {
+        self.hold_authenticated_punch
+            .store(hold, Ordering::Release);
+    }
+
+    fn held_authenticated_punch_count(&self) -> usize {
+        self.held_punch_a_to_b
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+            + self
+                .held_punch_b_to_a
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .len()
+    }
+
+    async fn release_held_authenticated_punches(
+        &self,
+        udp_a: &UdpTransport,
+        udp_b: &UdpTransport,
+    ) {
+        let held_a_to_b = std::mem::take(
+            &mut *self
+                .held_punch_a_to_b
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        );
+        let held_b_to_a = std::mem::take(
+            &mut *self
+                .held_punch_b_to_a
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        );
+        for packet in held_a_to_b {
+            Self::forward(
+                &self._a_source,
+                &packet,
+                udp_b,
+                HARD_HARD_A,
+                None,
+                self.route_dynamic_socket,
+                &self.drop_a_to_b,
+            )
+            .await;
+        }
+        for packet in held_b_to_a {
+            Self::forward(
+                &self._b_source,
+                &packet,
+                udp_a,
+                HARD_HARD_B,
+                None,
+                self.route_dynamic_socket,
+                &self.drop_b_to_a,
+            )
+            .await;
+        }
     }
 
     fn set_hold_ack(&self, hold: bool) {
@@ -1550,6 +1648,16 @@ async fn wait_for_failed_attempt_cleanup(harness: &TwoPeerHarness) {
                     .peers_b
                     .hard_hard_session_is_active(HARD_HARD_A)
                     .await
+                && harness
+                    .peers_a
+                    .hard_hard_session_for_test(HARD_HARD_B)
+                    .await
+                    .is_none()
+                && harness
+                    .peers_b
+                    .hard_hard_session_for_test(HARD_HARD_A)
+                    .await
+                    .is_none()
                 && harness.udp_a.dynamic_socket_count().await == 0
                 && harness.udp_b.dynamic_socket_count().await == 0
                 && harness
@@ -2837,6 +2945,103 @@ async fn hard_hard_random_random_birthday_no_collision_cleans_up_without_direct(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_hard_birthday_production_cleanup_waits_for_udp_completion() {
+    let _serial = HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+    let now = hard_hard_now_for_test();
+    set_hard_hard_test_now_ms(Some(now));
+    let _clock = HardHardClockReset;
+    let harness = build_two_peer_harness_with_stun_mode(
+        true,
+        false,
+        false,
+        HarnessStunProfile::FULL_CAPACITY,
+        HarnessNatMode::HighEntropy,
+    )
+    .await;
+    harness.link.set_drop_a_to_b(true);
+    harness.link.set_drop_b_to_a(true);
+    trigger_initial_offer(&harness).await;
+
+    let record = timeout(Duration::from_secs(8), async {
+        loop {
+            if let Some(record) = harness.peers_b.hard_hard_session_for_test(HARD_HARD_A).await {
+                if record.state != peer::HardHardSessionState::Retiring
+                    && harness.udp_b.dynamic_socket_count().await > 0
+                    && harness
+                        .udp_b
+                        .hard_hard_pending_probe_count_for_test(HARD_HARD_A)
+                        .await
+                        > 0
+                {
+                    return record;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("production Birthday entry must expose a live socket and pending Probe");
+    let (gate, _gate_guard) = harness.peers_b.install_hard_hard_cleanup_gate_for_test(
+        &record.peer_id,
+        &record.session_id,
+        &record.session_token,
+    );
+    let reached = gate.reached.notified();
+    harness
+        .peers_b
+        .clear_hard_hard_sessions(Some(HARD_HARD_A))
+        .await;
+    timeout(Duration::from_secs(3), reached)
+        .await
+        .expect("production cleanup must reach the pre-UDP test gate");
+
+    let retiring = harness
+        .peers_b
+        .hard_hard_session_snapshot_for_cleanup(
+            &record.peer_id,
+            &record.session_id,
+            &record.session_token,
+        )
+        .await
+        .expect("Retiring ledger entry must remain until UDP cleanup completes");
+    assert_eq!(retiring.state, peer::HardHardSessionState::Retiring);
+    assert!(!harness
+        .peers_b
+        .hard_hard_session_is_active(HARD_HARD_A)
+        .await);
+    assert!(harness.udp_b.dynamic_socket_count().await > 0);
+    assert!(harness
+        .udp_b
+        .hard_hard_pending_probe_count_for_test(HARD_HARD_A)
+        .await
+        > 0);
+
+    let completed = gate.completed.notified();
+    gate.release.notify_waiters();
+    timeout(Duration::from_secs(5), completed)
+        .await
+        .expect("production cleanup must publish completion after UDP cleanup");
+    assert!(harness
+        .peers_b
+        .hard_hard_session_snapshot_for_cleanup(
+            &record.peer_id,
+            &record.session_id,
+            &record.session_token,
+        )
+        .await
+        .is_none());
+    assert_eq!(harness.udp_b.dynamic_socket_count().await, 0);
+    assert_eq!(
+        harness
+            .udp_b
+            .hard_hard_pending_probe_count_for_test(HARD_HARD_A)
+            .await,
+        0
+    );
+    harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hard_hard_random_random_unauthenticated_packet_cannot_win() {
     let _serial = HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
     let now = hard_hard_now_for_test();
@@ -3756,7 +3961,11 @@ async fn hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session() {
 
     // Keep ACK holding enabled while S2 is pending. This leaves S2's own
     // pending Probe-v2 transactions alive so replaying only S1's packets is a
-    // meaningful stale-ACK assertion rather than a post-success no-op.
+    // meaningful stale-ACK assertion rather than a post-success no-op.  Hold
+    // only authenticated Punch packets at the harness boundary so one side
+    // cannot select a winner before the other side has admitted its own S2
+    // pending probes; ACK packets remain held and are still replayed below.
+    harness.link.set_hold_authenticated_punch(true);
     sleep(Duration::from_millis(2_100)).await;
     trigger_retry_offer_with_current_candidates(&harness, &response_s1).await;
     let response_s2 = wait_for_hard_hard_response_signal_number(&harness, 2).await;
@@ -3778,7 +3987,7 @@ async fn hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session() {
     );
     let s2_probe_wait = timeout(Duration::from_secs(5), async {
         loop {
-            if harness.link.held_ack_count() > 0
+            if harness.link.held_authenticated_punch_count() > 0
                 && harness
                     .udp_a
                     .hard_hard_pending_probe_count_for_test(HARD_HARD_B)
@@ -3880,6 +4089,21 @@ async fn hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session() {
 
     harness.validation_enabled_a.store(true, Ordering::Release);
     harness.validation_enabled_b.store(true, Ordering::Release);
+    harness
+        .link
+        .release_held_authenticated_punches(&harness.udp_a, &harness.udp_b)
+        .await;
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if harness.link.held_ack_count() > 0 {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("S2 Punch release must produce held ACKs");
+    harness.link.set_hold_authenticated_punch(false);
     harness.link.set_hold_ack(false);
     let s2_acks = harness.link.take_held_acks();
     harness

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -17,12 +17,11 @@ use tokio::sync::{watch, Notify, Semaphore};
 const HARD_HARD_A: &str = "peer-a";
 const HARD_HARD_B: &str = "peer-b";
 
-/// The fixed public ports are the top-1 prediction from each configured STUN
-/// sequence. A fresh test allocation gets a disjoint block so the E2E tests
-/// remain safe when the workspace runs tests concurrently.
-static HARD_HARD_NEXT_PORT: AtomicU16 = AtomicU16::new(0);
+/// Every harness owns kernel-assigned loopback sockets. This counter only
+/// namespaces its temporary config directory; it is not a port allocator.
+static HARD_HARD_NEXT_HARNESS_ID: AtomicU64 = AtomicU64::new(1);
 static HARD_HARD_NEXT_SIGNAL_SEQ: AtomicU64 = AtomicU64::new(1);
-static HARD_HARD_E2E_SERIAL: Semaphore = Semaphore::const_new(1);
+pub(crate) static HARD_HARD_E2E_SERIAL: Semaphore = Semaphore::const_new(1);
 const HARD_HARD_E2E_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy)]
@@ -59,55 +58,82 @@ struct HarnessPorts {
 }
 
 impl HarnessPorts {
-    fn allocate_with_mode(stun: HarnessStunProfile, mode: HarnessNatMode) -> Self {
+    async fn allocate_with_mode(
+        stun: HarnessStunProfile,
+        mode: HarnessNatMode,
+    ) -> (Self, Arc<UdpSocket>, Arc<UdpSocket>, Vec<TestStunObserver>) {
         assert!((3..=4).contains(&stun.observer_count));
-        // Keep concurrent test processes on separate fixed-port blocks. The
-        // per-process atomic still spaces harnesses within one test binary;
-        // the PID slot prevents another binary from stealing 127.0.0.1's
-        // observer ports before that in-process allocator can help.
-        let process_base = 8_000u16.saturating_add(
-            (std::process::id() % 100) as u16 * 450,
-        );
-        let base = process_base.saturating_add(HARD_HARD_NEXT_PORT.fetch_add(300, Ordering::Relaxed));
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let (a_public_offset, b_public_offset, a_mapped, b_mapped) = match mode {
-            HarnessNatMode::Predictable => (
-                if stun.observer_count == 4 { 16 } else { 12 },
-                if stun.observer_count == 4 { 112 } else { 109 },
-                [base, base + 4, base + 8, base + 12],
-                [base + 100, base + 103, base + 106, base + 109],
-            ),
+        let a_public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
+        let b_public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
+        let a_public_addr = a_public.local_addr().unwrap();
+        let b_public_addr = b_public.local_addr().unwrap();
+        let mapped_ports = |public_port: u16, side: u16| match mode {
+            HarnessNatMode::Predictable => {
+                if side == 0 {
+                    [
+                        offset_port(public_port, -16),
+                        offset_port(public_port, -12),
+                        offset_port(public_port, -8),
+                        offset_port(public_port, -4),
+                    ]
+                } else {
+                    [
+                        offset_port(public_port, -12),
+                        offset_port(public_port, -9),
+                        offset_port(public_port, -6),
+                        offset_port(public_port, -3),
+                    ]
+                }
+            }
             // The first observed port is also the real public endpoint. The
             // remaining samples deliberately jump in both directions so the
             // production allocation model classifies this as HighEntropy,
             // while the birthday candidate set still contains the endpoint
             // that the fake NAT link owns.
-            HarnessNatMode::HighEntropy => (
-                12,
-                109,
-                [base + 12, base + 181, base + 43, base + 257],
-                [base + 109, base + 220, base + 137, base + 271],
-            ),
+            HarnessNatMode::HighEntropy => [
+                public_port,
+                offset_port(public_port, if side == 0 { 169 } else { 111 }),
+                offset_port(public_port, if side == 0 { 31 } else { 28 }),
+                offset_port(public_port, if side == 0 { 245 } else { 162 }),
+            ],
         };
-        Self {
-            a_public: SocketAddr::new(ip, base.saturating_add(a_public_offset)),
-            b_public: SocketAddr::new(ip, base.saturating_add(b_public_offset)),
-            a_observers: [
-                SocketAddr::new(ip, base.saturating_add(1)),
-                SocketAddr::new(ip, base.saturating_add(2)),
-                SocketAddr::new(ip, base.saturating_add(3)),
-                SocketAddr::new(ip, base.saturating_add(4)),
-            ],
-            b_observers: [
-                SocketAddr::new(ip, base.saturating_add(5)),
-                SocketAddr::new(ip, base.saturating_add(6)),
-                SocketAddr::new(ip, base.saturating_add(7)),
-                SocketAddr::new(ip, base.saturating_add(8)),
-            ],
-            a_mapped,
-            b_mapped,
+        let a_mapped = mapped_ports(a_public_addr.port(), 0);
+        let b_mapped = mapped_ports(b_public_addr.port(), 1);
+        let mut a_observer_list = Vec::with_capacity(4);
+        let mut b_observer_list = Vec::with_capacity(4);
+        let mut observers = Vec::with_capacity(8);
+        for mapped_port in a_mapped {
+            let observer = spawn_stun_observer(SocketAddr::new(ip, 0), mapped_port);
+            a_observer_list.push(observer.endpoint);
+            observers.push(observer);
         }
+        for mapped_port in b_mapped {
+            let observer = spawn_stun_observer(SocketAddr::new(ip, 0), mapped_port);
+            b_observer_list.push(observer.endpoint);
+            observers.push(observer);
+        }
+        let a_observers = a_observer_list.try_into().expect("four A observers");
+        let b_observers = b_observer_list.try_into().expect("four B observers");
+        (
+            Self {
+                a_public: a_public_addr,
+                b_public: b_public_addr,
+                a_observers,
+                b_observers,
+                a_mapped,
+                b_mapped,
+            },
+            a_public,
+            b_public,
+            observers,
+        )
     }
+}
+
+fn offset_port(port: u16, offset: i32) -> u16 {
+    let modulus = i32::from(u16::MAX);
+    (1 + (i32::from(port).saturating_sub(1) + offset).rem_euclid(modulus)) as u16
 }
 
 struct HardHardClockReset;
@@ -303,6 +329,7 @@ impl Drop for TestStunObserver {
 /// batch cap, and dynamic-socket inbound paths.
 fn spawn_stun_observer(bind: SocketAddr, mapped_port: u16) -> TestStunObserver {
     let socket = std::net::UdpSocket::bind(bind).unwrap();
+    let endpoint = socket.local_addr().unwrap();
     socket.set_nonblocking(true).unwrap();
     let requests = Arc::new(AtomicU16::new(0));
     let responses = Arc::new(AtomicU16::new(0));
@@ -342,7 +369,7 @@ fn spawn_stun_observer(bind: SocketAddr, mapped_port: u16) -> TestStunObserver {
         }
     });
     TestStunObserver {
-        endpoint: bind,
+        endpoint,
         requests,
         responses,
         shutdown,
@@ -370,24 +397,26 @@ struct HeldAcks {
 }
 
 impl NatPacketLink {
+    #[allow(clippy::too_many_arguments)]
     async fn new(
         ports: HarnessPorts,
+        a_public: Arc<UdpSocket>,
+        b_public: Arc<UdpSocket>,
         udp_a: UdpTransport,
         udp_b: UdpTransport,
         actual_public: Option<(SocketAddr, SocketAddr)>,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
     ) -> Self {
-        let a_public = Arc::new(UdpSocket::bind(ports.a_public).await.unwrap());
-        let b_public = Arc::new(UdpSocket::bind(ports.b_public).await.unwrap());
+        let has_separate_sources = actual_public.is_some();
         let (a_source_endpoint, b_source_endpoint) =
             actual_public.unwrap_or((ports.a_public, ports.b_public));
-        let a_source = if a_source_endpoint == ports.a_public {
+        let a_source = if !has_separate_sources {
             a_public.clone()
         } else {
             Arc::new(UdpSocket::bind(a_source_endpoint).await.unwrap())
         };
-        let b_source = if b_source_endpoint == ports.b_public {
+        let b_source = if !has_separate_sources {
             b_public.clone()
         } else {
             Arc::new(UdpSocket::bind(b_source_endpoint).await.unwrap())
@@ -906,14 +935,15 @@ async fn build_two_peer_harness_with_stun_mode(
     stun: HarnessStunProfile,
     nat_mode: HarnessNatMode,
 ) -> TwoPeerHarness {
-    let ports = HarnessPorts::allocate_with_mode(stun, nat_mode);
+    let (ports, a_public_socket, b_public_socket, stun_observers) =
+        HarnessPorts::allocate_with_mode(stun, nat_mode).await;
     let birthday_enabled = nat_mode == HarnessNatMode::HighEntropy;
     let a_identity = NodeIdentity::generate();
     let b_identity = NodeIdentity::generate();
     let root = std::env::temp_dir().join(format!(
         "p2wlan-phase-2-2-{}-{}",
         std::process::id(),
-        HARD_HARD_NEXT_PORT.load(Ordering::Relaxed)
+        HARD_HARD_NEXT_HARNESS_ID.fetch_add(1, Ordering::Relaxed)
     ));
     fs::create_dir_all(&root).unwrap();
     let path_a = root.join("peer-a.json");
@@ -1081,12 +1111,14 @@ async fn build_two_peer_harness_with_stun_mode(
     let primary_a = race_primary.then(|| udp_a.local_addr().unwrap());
     let actual_public = mapping_miss.then(|| {
         (
-            SocketAddr::new(ports.a_public.ip(), ports.a_public.port().saturating_add(1)),
-            SocketAddr::new(ports.b_public.ip(), ports.b_public.port().saturating_add(1)),
+            SocketAddr::new(ports.a_public.ip(), 0),
+            SocketAddr::new(ports.b_public.ip(), 0),
         )
     });
     let link = NatPacketLink::new(
         ports,
+        a_public_socket,
+        b_public_socket,
         udp_a.clone(),
         udp_b.clone(),
         actual_public,
@@ -1113,23 +1145,6 @@ async fn build_two_peer_harness_with_stun_mode(
             .run_control_event_loop(&mut relay_started, network_tx_b)
             .await;
     });
-    let mut stun_observers = ports
-        .a_observers
-        .iter()
-        .take(stun.observer_count)
-        .copied()
-        .zip(ports.a_mapped.iter().copied())
-        .map(|(bind, mapped)| spawn_stun_observer(bind, mapped))
-        .collect::<Vec<_>>();
-    stun_observers.extend(
-        ports
-            .b_observers
-            .iter()
-            .take(stun.observer_count)
-            .copied()
-            .zip(ports.b_mapped.iter().copied())
-            .map(|(bind, mapped)| spawn_stun_observer(bind, mapped)),
-    );
     tasks_a.append(&mut tasks_b);
     TwoPeerHarness {
         peers_a,
@@ -1324,6 +1339,39 @@ async fn wait_for_both_direct_compact(harness: &TwoPeerHarness) {
             summarize(harness.peers_b.diagnostics().await),
         );
     }
+}
+
+async fn wait_for_current_direct_diagnostics(
+    peers: &PeerManager,
+    peer_id: &str,
+) -> peer::PeerDiagnostics {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            // `diagnostics()` is deliberately nonblocking and may return its
+            // previous cached snapshot while a state commit owns the
+            // connections writer. Assertions about a just-observed Direct
+            // commit must use the current try-read snapshot instead of
+            // turning that intentional cache fallback into an Idle-vs-Direct
+            // failure under the standard parallel workspace load.
+            if let Some((_, diagnostics)) = peers
+                .diagnostic_with_path_selection(
+                    peer_id,
+                    true,
+                    false,
+                    Duration::ZERO,
+                    None,
+                )
+                .await
+            {
+                if diagnostics.state == ConnectionState::Direct {
+                    return diagnostics;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("current Direct diagnostics must become readable after the commit")
 }
 
 async fn wait_for_stage(
@@ -2060,6 +2108,7 @@ async fn hard_hard_response_network_generation_fence_precedes_punch_preemption()
         peers
             .hard_hard_register_session(peer::HardHardSessionRecord {
                 session_id: format!("hh1:i:{token}"),
+                probe_session_id: None,
                 session_token: token.clone(),
                 peer_id: HARD_HARD_B.to_string(),
                 initiator: true,
@@ -2436,8 +2485,7 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
         (&harness.peers_a, HARD_HARD_B, harness.link.b_public.local_addr().unwrap()),
         (&harness.peers_b, HARD_HARD_A, harness.link.a_public.local_addr().unwrap()),
     ] {
-        let diagnostics = peers.diagnostics().await;
-        let peer = &diagnostics[0];
+        let peer = wait_for_current_direct_diagnostics(peers, remote_id).await;
         assert_eq!(peer.state, ConnectionState::Direct);
         assert_eq!(peer.active_path, Some(NetworkPath::Direct));
         let observed = peer
@@ -2682,7 +2730,10 @@ async fn hard_hard_physical_send_error_reaches_one_consistent_terminal_reason() 
     // This is the production Hard birthday entry point. Fail its first
     // physical UDP send at the shared send abstraction; the socket itself is
     // left open so this cannot be mistaken for socket_unavailable.
-    harness.udp_a.set_probe_send_failures_for_test([1]);
+    let _send_failures = harness.udp_a.set_probe_send_failures_for_test(1..=512);
+    let _peer_send_failures = harness.udp_b.set_probe_send_failures_for_test(1..=512);
+    harness.link.set_drop_a_to_b(true);
+    harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;
 
     let summary = wait_for_stage(
@@ -2691,8 +2742,12 @@ async fn hard_hard_physical_send_error_reaches_one_consistent_terminal_reason() 
         "hard_hard_birthday_sweep_summary",
     )
     .await;
-    assert!(summary.detail.contains("physical_send_errors=1"));
-    assert!(summary.detail.contains("stop_reason=send_error"));
+    assert!(summary.detail.contains("physical_send_errors="));
+    assert!(
+        summary.detail.contains("stop_reason=send_error"),
+        "unexpected birthday summary: {}",
+        summary.detail
+    );
     assert!(!summary.detail.contains("stop_reason=socket_unavailable"));
 
     let sweep_failed = wait_for_stage(&harness.peers_a, HARD_HARD_B, "hard_hard_sweep_failed")
@@ -2889,6 +2944,71 @@ async fn hard_hard_random_random_unauthenticated_packet_cannot_win() {
     valid_harness.shutdown().await;
 }
 
+async fn install_direct_scheduler_birthday_session(
+    peers: &Arc<PeerManager>,
+    peer_id: &str,
+    token: &str,
+    plan: peer::HardHardPlanSnapshot,
+    result: &crate::udp::HardHardBirthdayResult,
+) {
+    let socket = result
+        .sockets
+        .first()
+        .expect("a Birthday scheduler session needs one exact socket");
+    let identity = peer::HardHardFreshSocketIdentity {
+        peer_id: peer_id.to_string(),
+        session_token: token.to_string(),
+        network_generation: plan.local_network_generation,
+        remote_candidate_epoch: plan.remote_candidate_epoch,
+        local_profile_generation: plan.local_profile_generation,
+        remote_profile_generation: plan.remote_profile_generation,
+        punch_generation: socket.punch_generation,
+        socket_index: socket.socket_index,
+        socket_local_endpoint: socket.socket_local_endpoint,
+    };
+    let now = hard_hard_now_for_test();
+    assert!(
+        peers
+            .hard_hard_register_session(peer::HardHardSessionRecord {
+                session_id: format!("birthday-scheduler-{token}"),
+                probe_session_id: None,
+                session_token: token.to_string(),
+                peer_id: peer_id.to_string(),
+                initiator: true,
+                remote_network_generation: 0,
+                local_network_generation: plan.local_network_generation,
+                remote_candidate_epoch: plan.remote_candidate_epoch,
+                local_profile_generation: plan.local_profile_generation,
+                remote_profile_generation: plan.remote_profile_generation,
+                local_prediction_confidence: 90,
+                remote_prediction_confidence: 0,
+                requested_birthday_level: result.requested_level,
+                generated_candidate_count: result.requested_level,
+                signaled_candidate_count: result
+                    .candidate_endpoints
+                    .len()
+                    .min(crate::MAX_SIGNAL_CANDIDATES),
+                birthday: true,
+                requested_socket_indices: result
+                    .sockets
+                    .iter()
+                    .map(|socket| socket.socket_index)
+                    .collect(),
+                requested_socket_count: result.requested_socket_count,
+                prediction_window: result.candidate_endpoints.clone(),
+                remote_prediction: Vec::new(),
+                fresh_socket: identity,
+                punch_at_ms: now,
+                expires_at_ms: now.saturating_add(30_000),
+                state: peer::HardHardSessionState::AwaitingPeer,
+                attempt_count: 0,
+                created_at: Instant::now(),
+                cancellation: Arc::new(crate::PunchSessionCancellation::default()),
+            })
+            .await
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hard_hard_birthday_levels_report_requested_and_actual_socket_counts() {
     let _serial = HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
@@ -2935,6 +3055,14 @@ async fn hard_hard_birthday_levels_report_requested_and_actual_socket_counts() {
             .peers_a
             .peer_session_generation_sync(HARD_HARD_B)
             .expect("production scheduler test requires the live peer session");
+        install_direct_scheduler_birthday_session(
+            &harness.peers_a,
+            HARD_HARD_B,
+            &format!("level-{requested_level}"),
+            plan,
+            &result,
+        )
+        .await;
         let scheduler_report = harness
             .udp_a
             .punch_hard_hard_birthday_candidates_with_metadata(
@@ -3063,6 +3191,14 @@ async fn hard_hard_birthday_levels_report_requested_and_actual_socket_counts() {
         .peers_a
         .peer_session_generation_sync(HARD_HARD_B)
         .expect("production scheduler cap test requires the live peer session");
+    install_direct_scheduler_birthday_session(
+        &harness.peers_a,
+        HARD_HARD_B,
+        token,
+        plan,
+        &result,
+    )
+    .await;
     let scheduler_targets = (0..256usize)
         .map(|index| {
             SocketAddr::new(
@@ -3803,6 +3939,7 @@ async fn hard_hard_manager_peer_isolation_keeps_unrelated_session_authoritative(
         };
         peer::HardHardSessionRecord {
             session_id: format!("hh1:i:{token}"),
+            probe_session_id: None,
             session_token: token.to_string(),
             peer_id: peer_id.to_string(),
             initiator: true,
@@ -3887,6 +4024,7 @@ async fn hard_hard_manager_sticky_winner_rejects_delayed_authenticated_socket() 
     let endpoint_b: SocketAddr = "127.0.0.1:31101".parse().unwrap();
     let record = peer::HardHardSessionRecord {
         session_id: "hh1:i:sticky-token".to_string(),
+        probe_session_id: None,
         session_token: "sticky-token".to_string(),
         peer_id: "peer-sticky".to_string(),
         initiator: true,

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -61,6 +61,8 @@ struct HarnessPorts {
 
 const A_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-16, -12, -8, -4];
 const B_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-12, -9, -6, -3];
+const PREDICTABLE_RESERVATION_FIRST_PORT: u16 = 20_000;
+const PREDICTABLE_RESERVATION_STRIDE: u16 = 128;
 
 fn predictable_candidate_guard_offsets(mapped_offsets: &[i32; 4], step: i32) -> Vec<i32> {
     let mut offsets = mapped_offsets.to_vec();
@@ -77,6 +79,14 @@ fn predictable_candidate_guard_offsets(mapped_offsets: &[i32; 4], step: i32) -> 
 
 #[test]
 fn hard_hard_predictable_candidate_guards_cover_complete_successor_windows() {
+    let min_offset = A_PREDICTABLE_MAPPED_OFFSETS
+        .into_iter()
+        .chain(B_PREDICTABLE_MAPPED_OFFSETS)
+        .min()
+        .unwrap();
+    let max_offset = 4 * (p2pnet_nat::mapping::MAX_PREDICTED_PORTS as i32 - 1);
+    assert!(i32::from(PREDICTABLE_RESERVATION_STRIDE) > max_offset - min_offset);
+
     for (mapped_offsets, step) in [
         (A_PREDICTABLE_MAPPED_OFFSETS, 4),
         (B_PREDICTABLE_MAPPED_OFFSETS, 3),
@@ -100,11 +110,30 @@ async fn reserve_predictable_public_endpoint(
     ip: IpAddr,
     candidate_offsets: &[i32],
 ) -> (Arc<UdpSocket>, Vec<Arc<UdpSocket>>) {
-    const RESERVATION_RETRIES: usize = 64;
+    const RESERVATION_RETRIES: u16 = 64;
 
-    'reserve: for _ in 0..RESERVATION_RETRIES {
-        let public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
-        let public_port = public.local_addr().unwrap().port();
+    'reserve: for attempt in 0..RESERVATION_RETRIES {
+        // Windows commonly assigns consecutive `bind(0)` ports. Once the A
+        // side owns its complete guard window, repeatedly asking the kernel
+        // for B's base can therefore keep landing inside that same window.
+        // Scan explicit, non-overlapping fixture windows instead. Every port
+        // is still bound and ownership-checked before the harness starts.
+        let public_port = PREDICTABLE_RESERVATION_FIRST_PORT
+            .checked_add(PREDICTABLE_RESERVATION_STRIDE * attempt)
+            .expect("predictable reservation port range");
+        let public_endpoint = SocketAddr::new(ip, public_port);
+        let public = match UdpSocket::bind(public_endpoint).await {
+            Ok(socket) => Arc::new(socket),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                continue;
+            }
+            Err(error) => panic!("bind predictable public endpoint {public_endpoint}: {error}"),
+        };
         let mut guards = Vec::with_capacity(candidate_offsets.len());
         for offset in candidate_offsets {
             let endpoint = SocketAddr::new(ip, offset_port(public_port, *offset));
@@ -123,7 +152,7 @@ async fn reserve_predictable_public_endpoint(
         }
         return (public, guards);
     }
-    panic!("could not reserve a kernel-selected predictable candidate set");
+    panic!("could not reserve a predictable candidate fixture set");
 }
 
 impl HarnessPorts {
@@ -1218,6 +1247,8 @@ async fn install_test_daemon_udp(
     PeerReflexiveIngress,
     Arc<AtomicBool>,
     Vec<tokio::task::JoinHandle<()>>,
+    tokio::task::JoinHandle<()>,
+    tokio::task::JoinHandle<()>,
 ) {
     let peers = daemon.peers.clone();
     let (udp_inbound_tx, udp_inbound_rx) = mpsc::channel(256);
@@ -1279,12 +1310,9 @@ async fn install_test_daemon_udp(
         validation_ingress,
         peer_reflexive_ingress,
         validation_enabled,
-        vec![
-            udp_reader,
-            wg_reader,
-            validation_worker,
-            peer_reflexive_worker,
-        ],
+        vec![udp_reader, wg_reader],
+        validation_worker,
+        peer_reflexive_worker,
     )
 }
 
@@ -1555,10 +1583,24 @@ async fn build_two_peer_harness_with_stun_mode(
         advance_clock_on_response,
     );
 
-    let (udp_a, _validation_a, _prflx_a, validation_enabled_a, mut tasks_a) =
-        install_test_daemon_udp(&mut daemon_a, HARD_HARD_A, "10.20.0.1", &wg_a).await;
-    let (udp_b, _validation_b, _prflx_b, validation_enabled_b, mut tasks_b) =
-        install_test_daemon_udp(&mut daemon_b, HARD_HARD_B, "10.20.0.2", &wg_b).await;
+    let (
+        udp_a,
+        _validation_a,
+        _prflx_a,
+        validation_enabled_a,
+        mut tasks_a,
+        validation_task_a,
+        peer_reflexive_task_a,
+    ) = install_test_daemon_udp(&mut daemon_a, HARD_HARD_A, "10.20.0.1", &wg_a).await;
+    let (
+        udp_b,
+        _validation_b,
+        _prflx_b,
+        validation_enabled_b,
+        mut tasks_b,
+        validation_task_b,
+        peer_reflexive_task_b,
+    ) = install_test_daemon_udp(&mut daemon_b, HARD_HARD_B, "10.20.0.2", &wg_b).await;
     let primary_a = race_primary.then(|| udp_a.local_addr().unwrap());
     let actual_public = mapping_miss.then(|| {
         (
@@ -1616,8 +1658,8 @@ async fn build_two_peer_harness_with_stun_mode(
         shutdown_b,
         control_tasks: vec![control_task_a, control_task_b],
         udp_tasks: tasks_a,
-        validation_tasks: Vec::new(),
-        peer_reflexive_tasks: Vec::new(),
+        validation_tasks: vec![validation_task_a, validation_task_b],
+        peer_reflexive_tasks: vec![peer_reflexive_task_a, peer_reflexive_task_b],
         link,
         _candidate_guards: candidate_guards,
         validation_enabled_a,
@@ -2961,6 +3003,16 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
     set_hard_hard_test_now_ms(Some(now));
     let _clock = HardHardClockReset;
     let harness = build_two_peer_harness_with_stun(true, false, false, stun).await;
+    // Keep this scenario scoped to the production Hard-Hard path. The
+    // peer-reflexive worker also owns an ordinary primary-socket fast punch;
+    // under a loaded libtest runtime that independent path can legitimately
+    // become Direct first and turn this exact-socket test into the competing
+    // primary scenario covered separately below. The encrypted-validation
+    // workers remain live, so Hard-Hard still has to prove the real dynamic
+    // socket through the complete Request/ACK path.
+    for task in &harness.peer_reflexive_tasks {
+        task.abort();
+    }
     trigger_initial_offer(&harness).await;
     wait_for_both_direct(&harness).await;
     // Reciprocal exact-socket traffic can promote both peers before the

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -59,33 +59,85 @@ struct HarnessPorts {
     b_mapped: [u16; 4],
 }
 
+const A_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-16, -12, -8, -4];
+const B_PREDICTABLE_MAPPED_OFFSETS: [i32; 4] = [-12, -9, -6, -3];
+const A_PREDICTABLE_CANDIDATE_GUARD_OFFSETS: [i32; 5] = [-16, -12, -8, -4, 4];
+const B_PREDICTABLE_CANDIDATE_GUARD_OFFSETS: [i32; 5] = [-12, -9, -6, -3, 3];
+
+async fn reserve_predictable_public_endpoint(
+    ip: IpAddr,
+    candidate_offsets: &[i32],
+) -> (Arc<UdpSocket>, Vec<Arc<UdpSocket>>) {
+    const RESERVATION_RETRIES: usize = 64;
+
+    'reserve: for _ in 0..RESERVATION_RETRIES {
+        let public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
+        let public_port = public.local_addr().unwrap().port();
+        let mut guards = Vec::with_capacity(candidate_offsets.len());
+        for offset in candidate_offsets {
+            let endpoint = SocketAddr::new(ip, offset_port(public_port, *offset));
+            match UdpSocket::bind(endpoint).await {
+                Ok(socket) => guards.push(Arc::new(socket)),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied
+                    ) =>
+                {
+                    continue 'reserve;
+                }
+                Err(error) => panic!("bind predictable candidate guard {endpoint}: {error}"),
+            }
+        }
+        return (public, guards);
+    }
+    panic!("could not reserve a kernel-selected predictable candidate set");
+}
+
 impl HarnessPorts {
     async fn allocate_with_mode(
         stun: HarnessStunProfile,
         mode: HarnessNatMode,
-    ) -> (Self, Arc<UdpSocket>, Arc<UdpSocket>, Vec<TestStunObserver>) {
+    ) -> (
+        Self,
+        Arc<UdpSocket>,
+        Arc<UdpSocket>,
+        Vec<TestStunObserver>,
+        Vec<Arc<UdpSocket>>,
+    ) {
         assert!((3..=4).contains(&stun.observer_count));
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let a_public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
-        let b_public = Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap());
+        let (a_public, b_public, candidate_guards) = match mode {
+            HarnessNatMode::Predictable => {
+                let (a_public, mut guards) = reserve_predictable_public_endpoint(
+                    ip,
+                    &A_PREDICTABLE_CANDIDATE_GUARD_OFFSETS,
+                )
+                .await;
+                let (b_public, b_guards) = reserve_predictable_public_endpoint(
+                    ip,
+                    &B_PREDICTABLE_CANDIDATE_GUARD_OFFSETS,
+                )
+                .await;
+                guards.extend(b_guards);
+                (a_public, b_public, guards)
+            }
+            HarnessNatMode::HighEntropy => (
+                Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap()),
+                Arc::new(UdpSocket::bind(SocketAddr::new(ip, 0)).await.unwrap()),
+                Vec::new(),
+            ),
+        };
         let a_public_addr = a_public.local_addr().unwrap();
         let b_public_addr = b_public.local_addr().unwrap();
         let mapped_ports = |public_port: u16, side: u16| match mode {
             HarnessNatMode::Predictable => {
                 if side == 0 {
-                    [
-                        offset_port(public_port, -16),
-                        offset_port(public_port, -12),
-                        offset_port(public_port, -8),
-                        offset_port(public_port, -4),
-                    ]
+                    A_PREDICTABLE_MAPPED_OFFSETS
+                        .map(|offset| offset_port(public_port, offset))
                 } else {
-                    [
-                        offset_port(public_port, -12),
-                        offset_port(public_port, -9),
-                        offset_port(public_port, -6),
-                        offset_port(public_port, -3),
-                    ]
+                    B_PREDICTABLE_MAPPED_OFFSETS
+                        .map(|offset| offset_port(public_port, offset))
                 }
             }
             // The first observed port is also the real public endpoint. The
@@ -129,6 +181,7 @@ impl HarnessPorts {
             a_public,
             b_public,
             observers,
+            candidate_guards,
         )
     }
 }
@@ -1039,6 +1092,7 @@ struct TwoPeerHarness {
     validation_tasks: Vec<tokio::task::JoinHandle<()>>,
     peer_reflexive_tasks: Vec<tokio::task::JoinHandle<()>>,
     link: NatPacketLink,
+    _candidate_guards: Vec<Arc<UdpSocket>>,
     validation_enabled_a: Arc<AtomicBool>,
     validation_enabled_b: Arc<AtomicBool>,
     stun_observers: Vec<TestStunObserver>,
@@ -1296,7 +1350,7 @@ async fn build_two_peer_harness_with_stun_mode(
     stun: HarnessStunProfile,
     nat_mode: HarnessNatMode,
 ) -> TwoPeerHarness {
-    let (ports, a_public_socket, b_public_socket, stun_observers) =
+    let (ports, a_public_socket, b_public_socket, stun_observers, candidate_guards) =
         HarnessPorts::allocate_with_mode(stun, nat_mode).await;
     let birthday_enabled = nat_mode == HarnessNatMode::HighEntropy;
     let a_identity = NodeIdentity::generate();
@@ -1531,6 +1585,7 @@ async fn build_two_peer_harness_with_stun_mode(
         validation_tasks: Vec::new(),
         peer_reflexive_tasks: Vec::new(),
         link,
+        _candidate_guards: candidate_guards,
         validation_enabled_a,
         validation_enabled_b,
         stun_observers,
@@ -2813,10 +2868,8 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
     assert!(sweep_detail.contains("exact_socket=true"));
     assert!(sweep_detail.contains("direct_confirmed=true"));
 
-    let diagnostics_a = harness.peers_a.diagnostics().await;
-    let diagnostics_b = harness.peers_b.diagnostics().await;
-    let peer_a = &diagnostics_a[0];
-    let peer_b = &diagnostics_b[0];
+    let peer_a = wait_for_current_direct_diagnostics(&harness.peers_a, HARD_HARD_B).await;
+    let peer_b = wait_for_current_direct_diagnostics(&harness.peers_b, HARD_HARD_A).await;
     let fresh_a = harness
         .peers_a
         .fresh_mapping_for_peer(HARD_HARD_B)
@@ -2827,7 +2880,7 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
         .fresh_mapping_for_peer(HARD_HARD_A)
         .await
         .expect("B must retain its measured fresh mapping");
-    for diagnostics in [peer_a, peer_b] {
+    for diagnostics in [&peer_a, &peer_b] {
         assert_eq!(diagnostics.state, ConnectionState::Direct);
         assert_eq!(diagnostics.active_path, Some(NetworkPath::Direct));
     }
@@ -4846,14 +4899,9 @@ async fn hard_hard_two_peer_duplicate_and_stale_signals_do_not_reopen_session() 
     set_hard_hard_test_now_ms(Some(now));
     let _clock = HardHardClockReset;
     let harness = build_two_peer_harness(false, false, false).await;
-    // Windows allocates loopback ephemeral ports predictably enough that a
-    // production candidate window can occasionally hit the peer's real test
-    // socket directly, bypassing the synthetic NAT link and its drop flags.
-    // Keep the real probe registration, successful-send telemetry and cleanup
-    // path, but stop these test datagrams at the shared cfg(test) send seam.
-    // The RAII guards restore normal sending before the next exact test.
-    let _blackhole_a = harness.udp_a.blackhole_probe_sends_for_test();
-    let _blackhole_b = harness.udp_b.blackhole_probe_sends_for_test();
+    // The predictable harness reserves every signaled candidate port, so a
+    // Windows ephemeral dynamic socket cannot bypass these NAT drop flags by
+    // binding one of the synthetic public targets directly.
     harness.link.set_drop_a_to_b(true);
     harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -20,7 +20,7 @@ const HARD_HARD_B: &str = "peer-b";
 /// The fixed public ports are the top-1 prediction from each configured STUN
 /// sequence. A fresh test allocation gets a disjoint block so the E2E tests
 /// remain safe when the workspace runs tests concurrently.
-static HARD_HARD_NEXT_PORT: AtomicU16 = AtomicU16::new(30_000);
+static HARD_HARD_NEXT_PORT: AtomicU16 = AtomicU16::new(0);
 static HARD_HARD_NEXT_SIGNAL_SEQ: AtomicU64 = AtomicU64::new(1);
 static HARD_HARD_E2E_SERIAL: Semaphore = Semaphore::const_new(1);
 const HARD_HARD_E2E_TIMEOUT: Duration = Duration::from_secs(30);
@@ -61,7 +61,14 @@ struct HarnessPorts {
 impl HarnessPorts {
     fn allocate_with_mode(stun: HarnessStunProfile, mode: HarnessNatMode) -> Self {
         assert!((3..=4).contains(&stun.observer_count));
-        let base = HARD_HARD_NEXT_PORT.fetch_add(300, Ordering::Relaxed);
+        // Keep concurrent test processes on separate fixed-port blocks. The
+        // per-process atomic still spaces harnesses within one test binary;
+        // the PID slot prevents another binary from stealing 127.0.0.1's
+        // observer ports before that in-process allocator can help.
+        let process_base = 8_000u16.saturating_add(
+            (std::process::id() % 100) as u16 * 450,
+        );
+        let base = process_base.saturating_add(HARD_HARD_NEXT_PORT.fetch_add(300, Ordering::Relaxed));
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let (a_public_offset, b_public_offset, a_mapped, b_mapped) = match mode {
             HarnessNatMode::Predictable => (
@@ -2063,6 +2070,12 @@ async fn hard_hard_response_network_generation_fence_precedes_punch_preemption()
                 remote_profile_generation: plan.remote_profile_generation,
                 local_prediction_confidence: 95,
                 remote_prediction_confidence: 0,
+                requested_birthday_level: 0,
+                generated_candidate_count: 1,
+                signaled_candidate_count: 1,
+                birthday: false,
+                requested_socket_indices: vec![4096],
+                requested_socket_count: 1,
                 prediction_window: vec![remote_prediction],
                 remote_prediction: Vec::new(),
                 fresh_socket: peer::HardHardFreshSocketIdentity {
@@ -2530,33 +2543,95 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
             .split_whitespace()
             .find_map(|field| field.strip_prefix(key)?.parse::<usize>().ok())
     };
-    let mut birthday_summaries = 0;
-    for peers in [&harness.peers_a, &harness.peers_b] {
-        for event in &peers.diagnostics().await[0].direct_events {
-            if event.stage != "hard_hard_birthday_sweep_summary"
-                || !event.detail.contains("requested_level=64")
-            {
-                continue;
+    // Read the durable connection ring, not the non-blocking diagnostics
+    // cache. A reciprocal Direct promotion can still own the connections
+    // writer when this assertion runs; the cache is allowed to return its
+    // previous snapshot in that narrow interval.
+    let birthday_events = timeout(HARD_HARD_E2E_TIMEOUT, async {
+        loop {
+            for (peers, peer_id) in [
+                (&harness.peers_a, HARD_HARD_B),
+                (&harness.peers_b, HARD_HARD_A),
+            ] {
+                if let Some(connection) = peers.get_connection(peer_id).await {
+                    let events = connection
+                        .direct_events
+                        .into_iter()
+                        .filter(|event| {
+                            event.stage == "hard_hard_birthday_sweep_summary"
+                                && event.detail.contains("requested_level=64")
+                        })
+                        .collect::<Vec<_>>();
+                    if !events.is_empty() {
+                        return events;
+                    }
+                }
             }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("production birthday sweep must report its bounded send count");
+    let mut birthday_summaries = 0;
+    for event in &birthday_events {
             let sent = parse_count(&event.detail, "packets_sent=")
                 .expect("birthday summary must report sent packets");
             let unique = parse_count(&event.detail, "unique_target_endpoints=")
                 .expect("birthday summary must report unique target endpoints");
             let effective_target_count = parse_count(&event.detail, "effective_target_count=")
                 .expect("birthday summary must report effective target count");
+            let generated_candidate_count = parse_count(&event.detail, "generated_candidate_count=")
+                .expect("birthday summary must report generated candidates");
+            let signaled_candidate_count = parse_count(&event.detail, "signaled_candidate_count=")
+                .expect("birthday summary must report signaled candidates");
+            let requested_socket_count = parse_count(&event.detail, "requested_socket_count=")
+                .expect("birthday summary must report requested sockets");
+            let attached_socket_count = parse_count(&event.detail, "attached_socket_count=")
+                .expect("birthday summary must report attached sockets");
+            let usable_socket_count = parse_count(&event.detail, "usable_socket_count=")
+                .expect("birthday summary must report usable sockets");
+            let unavailable_socket_count =
+                parse_count(&event.detail, "unavailable_socket_count=")
+                    .expect("birthday summary must report unavailable sockets");
             let packets_planned = parse_count(&event.detail, "packets_planned=")
                 .expect("birthday summary must report planned packets");
             let waves_planned = parse_count(&event.detail, "waves_planned=")
                 .expect("birthday summary must report planned waves");
+            let waves_started = parse_count(&event.detail, "waves_started=")
+                .expect("birthday summary must report started waves");
+            let waves_fully_completed = parse_count(&event.detail, "waves_fully_completed=")
+                .expect("birthday summary must report fully completed waves");
+            let targets_assigned = parse_count(&event.detail, "targets_assigned=")
+                .expect("birthday summary must report assigned targets");
+            let targets_attempted = parse_count(&event.detail, "targets_attempted=")
+                .expect("birthday summary must report attempted targets");
+            let logical_probes_sent = parse_count(&event.detail, "logical_probes_sent=")
+                .expect("birthday summary must report logical probes");
+            let physical_datagrams_sent =
+                parse_count(&event.detail, "physical_datagrams_sent=")
+                    .expect("birthday summary must report physical datagrams");
+            let targets_cancelled = parse_count(&event.detail, "targets_cancelled=")
+                .expect("birthday summary must report cancelled targets");
             assert_eq!(waves_planned, 2);
             assert_eq!(packets_planned, effective_target_count * 2);
             assert!(sent <= packets_planned);
             assert!(unique <= effective_target_count);
+            assert!(generated_candidate_count >= signaled_candidate_count);
+            assert_eq!(signaled_candidate_count, effective_target_count);
+            assert_eq!(requested_socket_count, 2);
+            assert!(attached_socket_count <= requested_socket_count);
+            assert!(usable_socket_count <= attached_socket_count);
+            assert_eq!(unavailable_socket_count, requested_socket_count - usable_socket_count);
+            assert!(waves_fully_completed <= waves_started);
+            assert!(waves_started <= waves_planned);
+            assert!(targets_attempted <= targets_assigned);
+            assert!(logical_probes_sent <= effective_target_count * 2);
+            assert!(physical_datagrams_sent >= logical_probes_sent);
+            assert_eq!(targets_cancelled, targets_assigned - targets_attempted);
             assert!(event.detail.contains("first_send_at_ms="));
             assert!(event.detail.contains("last_send_at_ms="));
             assert!(event.detail.contains("stop_reason="));
             birthday_summaries += 1;
-        }
     }
     assert!(
         birthday_summaries > 0,
@@ -2663,12 +2738,19 @@ async fn hard_hard_random_random_unauthenticated_packet_cannot_win() {
     harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;
     let _ = wait_for_hard_hard_response_signal(&harness).await;
-    wait_for_stage(&harness.peers_a, HARD_HARD_B, "hard_hard_sweep_started").await;
-    let (_, speculative_socket) = harness
-        .udp_a
-        .socket_for_peer(Some(HARD_HARD_B))
-        .await
-        .expect("birthday sweep must expose a speculative socket");
+    // The exact dynamic socket is durable production state; the diagnostic
+    // ring is intentionally bounded and may evict `hard_hard_sweep_started`
+    // after a 128-probe burst before this test's polling task runs.
+    let (_, speculative_socket) = timeout(HARD_HARD_E2E_TIMEOUT, async {
+        loop {
+            if let Some(socket) = harness.udp_a.socket_for_peer(Some(HARD_HARD_B)).await {
+                return socket;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("birthday sweep must expose a speculative socket");
     let injector = UdpSocket::bind("127.0.0.1:0".parse::<SocketAddr>().unwrap())
         .await
         .unwrap();
@@ -2705,38 +2787,44 @@ async fn hard_hard_random_random_unauthenticated_packet_cannot_win() {
     // birthday path without pausing or dropping its legal validation evidence.
     trigger_initial_offer(&valid_harness).await;
     wait_for_both_direct_compact(&valid_harness).await;
-    assert!(
-        valid_harness
-            .peers_a
-            .diagnostics()
-            .await
-            .iter()
-            .find(|peer| peer.node_id == HARD_HARD_B)
-            .is_some_and(|peer| {
-                peer.state == ConnectionState::Direct
-                    && peer.active_path == Some(NetworkPath::Direct)
-                    && peer.current_direct_pair.as_ref().is_some_and(|pair| {
-                        pair.source == peer::CandidatePairSource::PeerReflexive
+    let valid_a_connection = timeout(HARD_HARD_E2E_TIMEOUT, async {
+        loop {
+            if let Some(connection) = valid_harness.peers_a.get_connection(HARD_HARD_B).await {
+                if connection.state == ConnectionState::Direct
+                    && connection.active_path() == Some(NetworkPath::Direct)
+                    && connection.candidate_pairs.iter().any(|pair| {
+                        pair.state == peer::CandidatePairState::Selected
+                            && pair.source == peer::CandidatePairSource::PeerReflexive
                     })
-            }),
-        "a fresh production session must promote an authenticated peer-reflexive birthday pair",
-    );
-    assert!(
-        valid_harness
-            .peers_b
-            .diagnostics()
-            .await
-            .iter()
-            .find(|peer| peer.node_id == HARD_HARD_A)
-            .is_some_and(|peer| {
-                peer.state == ConnectionState::Direct
-                    && peer.active_path == Some(NetworkPath::Direct)
-                    && peer.current_direct_pair.as_ref().is_some_and(|pair| {
-                        pair.source == peer::CandidatePairSource::PeerReflexive
+                {
+                    return connection;
+                }
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("a fresh production session must promote an authenticated peer-reflexive birthday pair");
+    assert_eq!(valid_a_connection.state, ConnectionState::Direct);
+    let valid_b_connection = timeout(HARD_HARD_E2E_TIMEOUT, async {
+        loop {
+            if let Some(connection) = valid_harness.peers_b.get_connection(HARD_HARD_A).await {
+                if connection.state == ConnectionState::Direct
+                    && connection.active_path() == Some(NetworkPath::Direct)
+                    && connection.candidate_pairs.iter().any(|pair| {
+                        pair.state == peer::CandidatePairState::Selected
+                            && pair.source == peer::CandidatePairSource::PeerReflexive
                     })
-            }),
-        "the reciprocal production session must promote an authenticated peer-reflexive birthday pair",
-    );
+                {
+                    return connection;
+                }
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the reciprocal production session must promote an authenticated peer-reflexive birthday pair");
+    assert_eq!(valid_b_connection.state, ConnectionState::Direct);
     valid_harness.shutdown().await;
 }
 
@@ -2777,6 +2865,59 @@ async fn hard_hard_birthday_levels_report_requested_and_actual_socket_counts() {
         assert_eq!(result.level, requested_level);
         assert_eq!(result.requested_socket_count, expected_socket_count);
         assert_eq!(result.sockets.len(), expected_socket_count);
+        let plan = harness
+            .peers_a
+            .hard_hard_plan_for_peer(HARD_HARD_B)
+            .await
+            .expect("production scheduler test requires the live Hard plan");
+        let peer_session_generation = harness
+            .peers_a
+            .peer_session_generation_sync(HARD_HARD_B)
+            .expect("production scheduler test requires the live peer session");
+        let scheduler_report = harness
+            .udp_a
+            .punch_hard_hard_birthday_candidates_with_metadata(
+                HARD_HARD_B,
+                result
+                    .sockets
+                    .iter()
+                    .map(|socket| socket.socket_index)
+                    .collect(),
+                result.candidate_endpoints.clone(),
+                requested_level,
+                requested_level,
+                requested_level.min(crate::MAX_SIGNAL_CANDIDATES),
+                peer_session_generation,
+                (
+                    plan.local_profile_generation,
+                    plan.remote_profile_generation,
+                ),
+                &format!("level-{requested_level}"),
+                None,
+            )
+            .await
+            .expect("production Birthday scheduler must return a bounded report");
+        let scheduler_birthday = scheduler_report
+            .birthday
+            .as_ref()
+            .expect("Birthday scheduler must expose its report");
+        assert_eq!(scheduler_birthday.requested_level, requested_level);
+        assert_eq!(
+            scheduler_birthday.generated_candidate_count,
+            requested_level
+        );
+        assert_eq!(
+            scheduler_birthday.signaled_candidate_count,
+            requested_level.min(crate::MAX_SIGNAL_CANDIDATES)
+        );
+        assert_eq!(
+            scheduler_birthday.effective_target_count,
+            requested_level.min(crate::MAX_SIGNAL_CANDIDATES)
+        );
+        assert_eq!(
+            scheduler_birthday.requested_socket_count,
+            expected_socket_count
+        );
         for socket in &result.sockets {
             assert!(socket.guard.finalize().await);
         }
@@ -2852,6 +2993,65 @@ async fn hard_hard_birthday_levels_report_requested_and_actual_socket_counts() {
     assert_eq!(result.requested_socket_count, 8);
     assert_eq!(result.level, 128);
     assert_eq!(result.sockets.len(), 4);
+    let plan = harness
+        .peers_a
+        .hard_hard_plan_for_peer(HARD_HARD_B)
+        .await
+        .expect("production scheduler cap test requires the live Hard plan");
+    let peer_session_generation = harness
+        .peers_a
+        .peer_session_generation_sync(HARD_HARD_B)
+        .expect("production scheduler cap test requires the live peer session");
+    let scheduler_targets = (0..256usize)
+        .map(|index| {
+            SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                41_000 + u16::try_from(index).expect("test target port fits in u16"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let scheduler_report = harness
+        .udp_a
+        .punch_hard_hard_birthday_candidates_with_metadata(
+            HARD_HARD_B,
+            result
+                .sockets
+                .iter()
+                .map(|socket| socket.socket_index)
+                .collect(),
+            scheduler_targets,
+            256,
+            256,
+            crate::MAX_SIGNAL_CANDIDATES,
+            peer_session_generation,
+            (
+                plan.local_profile_generation,
+                plan.remote_profile_generation,
+            ),
+            token,
+            None,
+        )
+        .await
+        .expect("production Birthday scheduler must retain the raw 256 request");
+    let scheduler_birthday = scheduler_report
+        .birthday
+        .as_ref()
+        .expect("Birthday scheduler cap test must expose its report");
+    assert_eq!(scheduler_birthday.requested_level, 256);
+    assert_eq!(scheduler_birthday.generated_candidate_count, 256);
+    assert_eq!(
+        scheduler_birthday.signaled_candidate_count,
+        crate::MAX_SIGNAL_CANDIDATES
+    );
+    assert_eq!(
+        scheduler_birthday.effective_target_count,
+        crate::MAX_SIGNAL_CANDIDATES
+    );
+    assert_eq!(scheduler_birthday.requested_socket_count, 8);
+    assert_eq!(scheduler_birthday.attached_socket_count, 4);
+    assert_eq!(scheduler_birthday.usable_socket_count, 4);
+    assert_eq!(scheduler_birthday.unavailable_socket_count, 4);
+    assert_eq!(scheduler_birthday.waves_planned, 2);
     let diagnostics = harness.peers_a.diagnostics().await;
     assert!(diagnostics[0].direct_events.iter().any(|event| {
         event.stage == "hard_hard_birthday_degraded"
@@ -3552,6 +3752,12 @@ async fn hard_hard_manager_peer_isolation_keeps_unrelated_session_authoritative(
             remote_profile_generation: 1,
             local_prediction_confidence: 90,
             remote_prediction_confidence: 0,
+            requested_birthday_level: 0,
+            generated_candidate_count: 1,
+            signaled_candidate_count: 1,
+            birthday: false,
+            requested_socket_indices: vec![socket_index],
+            requested_socket_count: 1,
             prediction_window: vec![socket_local_endpoint],
             remote_prediction: Vec::new(),
             fresh_socket: identity,
@@ -3630,6 +3836,12 @@ async fn hard_hard_manager_sticky_winner_rejects_delayed_authenticated_socket() 
         remote_profile_generation: 1,
         local_prediction_confidence: 90,
         remote_prediction_confidence: 0,
+        requested_birthday_level: 0,
+        generated_candidate_count: 1,
+        signaled_candidate_count: 1,
+        birthday: false,
+        requested_socket_indices: vec![4100],
+        requested_socket_count: 1,
         prediction_window: vec![endpoint_a],
         remote_prediction: Vec::new(),
         fresh_socket: peer::HardHardFreshSocketIdentity {

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -4846,13 +4846,14 @@ async fn hard_hard_two_peer_duplicate_and_stale_signals_do_not_reopen_session() 
     set_hard_hard_test_now_ms(Some(now));
     let _clock = HardHardClockReset;
     let harness = build_two_peer_harness(false, false, false).await;
-    // Fence peer traffic before either production rendezvous worker exists.
-    // The test clock controls admission timestamps, but it cannot retime a
-    // Tokio sleep that a worker already armed. On a slower Windows runner the
-    // old post-response drop raced the natural 3.5s punch timer and sometimes
-    // produced a legitimate authenticated Direct path that cleanup correctly
-    // preserved. Starting disconnected makes the intended no-reachability
-    // scenario deterministic without weakening any cleanup assertion.
+    // Windows allocates loopback ephemeral ports predictably enough that a
+    // production candidate window can occasionally hit the peer's real test
+    // socket directly, bypassing the synthetic NAT link and its drop flags.
+    // Keep the real probe registration, successful-send telemetry and cleanup
+    // path, but stop these test datagrams at the shared cfg(test) send seam.
+    // The RAII guards restore normal sending before the next exact test.
+    let _blackhole_a = harness.udp_a.blackhole_probe_sends_for_test();
+    let _blackhole_b = harness.udp_b.blackhole_probe_sends_for_test();
     harness.link.set_drop_a_to_b(true);
     harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -2603,13 +2603,20 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
                 .expect("birthday summary must report fully completed waves");
             let targets_assigned = parse_count(&event.detail, "targets_assigned=")
                 .expect("birthday summary must report assigned targets");
+            let targets_examined = parse_count(&event.detail, "targets_examined=")
+                .expect("birthday summary must report examined targets");
             let targets_attempted = parse_count(&event.detail, "targets_attempted=")
                 .expect("birthday summary must report attempted targets");
+            let logical_probes_attempted =
+                parse_count(&event.detail, "logical_probes_attempted=")
+                    .expect("birthday summary must report logical attempts");
             let logical_probes_sent = parse_count(&event.detail, "logical_probes_sent=")
                 .expect("birthday summary must report logical probes");
             let physical_datagrams_sent =
                 parse_count(&event.detail, "physical_datagrams_sent=")
                     .expect("birthday summary must report physical datagrams");
+            let physical_send_errors = parse_count(&event.detail, "physical_send_errors=")
+                .expect("birthday summary must report physical send errors");
             let targets_cancelled = parse_count(&event.detail, "targets_cancelled=")
                 .expect("birthday summary must report cancelled targets");
             assert_eq!(waves_planned, 2);
@@ -2624,9 +2631,13 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
             assert_eq!(unavailable_socket_count, requested_socket_count - usable_socket_count);
             assert!(waves_fully_completed <= waves_started);
             assert!(waves_started <= waves_planned);
+            assert!(targets_examined <= targets_assigned);
             assert!(targets_attempted <= targets_assigned);
+            assert!(targets_attempted <= targets_examined);
+            assert!(logical_probes_sent <= logical_probes_attempted);
             assert!(logical_probes_sent <= effective_target_count * 2);
             assert!(physical_datagrams_sent >= logical_probes_sent);
+            assert!(physical_send_errors <= effective_target_count * 2);
             assert_eq!(targets_cancelled, targets_assigned - targets_attempted);
             assert!(event.detail.contains("first_send_at_ms="));
             assert!(event.detail.contains("last_send_at_ms="));
@@ -2650,6 +2661,56 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
     })
     .await
     .expect("birthday losers must detach after the authenticated winner is selected");
+    harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_hard_physical_send_error_reaches_one_consistent_terminal_reason() {
+    let _serial = HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
+    let now = hard_hard_now_for_test();
+    set_hard_hard_test_now_ms(Some(now));
+    let _clock = HardHardClockReset;
+    let harness = build_two_peer_harness_with_stun_mode(
+        true,
+        false,
+        false,
+        HarnessStunProfile::FULL_CAPACITY,
+        HarnessNatMode::HighEntropy,
+    )
+    .await;
+
+    // This is the production Hard birthday entry point. Fail its first
+    // physical UDP send at the shared send abstraction; the socket itself is
+    // left open so this cannot be mistaken for socket_unavailable.
+    harness.udp_a.set_probe_send_failures_for_test([1]);
+    trigger_initial_offer(&harness).await;
+
+    let summary = wait_for_stage(
+        &harness.peers_a,
+        HARD_HARD_B,
+        "hard_hard_birthday_sweep_summary",
+    )
+    .await;
+    assert!(summary.detail.contains("physical_send_errors=1"));
+    assert!(summary.detail.contains("stop_reason=send_error"));
+    assert!(!summary.detail.contains("stop_reason=socket_unavailable"));
+
+    let sweep_failed = wait_for_stage(&harness.peers_a, HARD_HARD_B, "hard_hard_sweep_failed")
+        .await;
+    let hard_failed = wait_for_stage(&harness.peers_a, HARD_HARD_B, "hard_hard_failed").await;
+    assert!(sweep_failed.detail.contains("stop_reason=send_error"));
+    assert!(hard_failed.detail.contains("stop_reason=send_error"));
+
+    let summary_count = harness
+        .peers_a
+        .get_connection(HARD_HARD_B)
+        .await
+        .unwrap()
+        .direct_events
+        .iter()
+        .filter(|event| event.stage == "hard_hard_birthday_sweep_summary")
+        .count();
+    assert_eq!(summary_count, 1, "one session must emit one final birthday summary");
     harness.shutdown().await;
 }
 

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -432,6 +432,8 @@ impl NatPacketLink {
         let held_b_to_a = Arc::new(StdMutex::new(Vec::new()));
         let held_punch_a_to_b = Arc::new(StdMutex::new(Vec::new()));
         let held_punch_b_to_a = Arc::new(StdMutex::new(Vec::new()));
+        let a_to_b_routes = Arc::new(StdMutex::new(HashMap::new()));
+        let b_to_a_routes = Arc::new(StdMutex::new(HashMap::new()));
         let worker = Some(tokio::spawn(Self::run(
             a_public.clone(),
             b_public.clone(),
@@ -447,6 +449,8 @@ impl NatPacketLink {
             held_b_to_a.clone(),
             held_punch_a_to_b.clone(),
             held_punch_b_to_a.clone(),
+            a_to_b_routes.clone(),
+            b_to_a_routes.clone(),
             primary_a,
             route_dynamic_socket,
         )));
@@ -476,9 +480,9 @@ impl NatPacketLink {
         primary: Option<SocketAddr>,
         _route_dynamic_socket: bool,
         dropped: &AtomicBool,
-    ) {
+    ) -> Option<SocketAddr> {
         if dropped.load(Ordering::Acquire) {
-            return;
+            return None;
         }
         // `primary` models the exact NAT mapping which originated the
         // competing ordinary punch. Route the reply only to that owner: a
@@ -486,8 +490,11 @@ impl NatPacketLink {
         // ACK expectation first and make the intended primary winner depend on
         // platform task scheduling.
         if let Some(primary) = primary {
-            let _ = source_socket.send_to(data, primary).await;
-            return;
+            return source_socket
+                .send_to(data, primary)
+                .await
+                .ok()
+                .map(|_| primary);
         }
         // Once a Hard↔Hard winner is selected, use its exact affinity pin.
         // Before that transaction completes, an authenticated probe or the
@@ -501,18 +508,99 @@ impl NatPacketLink {
         if has_dynamic_socket {
             if let Some((_, socket)) = target_udp.socket_for_peer(Some(target_peer)).await {
                 if let Ok(target) = socket.local_addr() {
-                    let _ = source_socket.send_to(data, target).await;
+                    return source_socket
+                        .send_to(data, target)
+                        .await
+                        .ok()
+                        .map(|_| target);
                 }
-                return;
             }
+            return None;
         }
         let sockets = target_udp
             .dynamic_sockets_for_peer_for_test(target_peer)
             .await;
         if let Some((_, socket)) = sockets.into_iter().min_by_key(|(index, _)| *index) {
             if let Ok(target) = socket.local_addr() {
-                let _ = source_socket.send_to(data, target).await;
+                return source_socket
+                    .send_to(data, target)
+                    .await
+                    .ok()
+                    .map(|_| target);
             }
+        }
+        None
+    }
+
+    async fn forward_to_endpoint(
+        source_socket: &UdpSocket,
+        data: &[u8],
+        target: SocketAddr,
+        dropped: &AtomicBool,
+    ) -> bool {
+        if dropped.load(Ordering::Acquire) {
+            return false;
+        }
+        source_socket.send_to(data, target).await.is_ok()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn forward_with_route(
+        source_socket: &UdpSocket,
+        data: &[u8],
+        source: SocketAddr,
+        target_udp: &UdpTransport,
+        target_peer: &str,
+        primary: Option<SocketAddr>,
+        route_dynamic_socket: bool,
+        dropped: &AtomicBool,
+        routes: &StdMutex<HashMap<SocketAddr, SocketAddr>>,
+    ) {
+        // The fake public endpoint has no kernel NAT table. Remember which
+        // local socket emitted the packet so a response from the selected
+        // peer socket returns to that exact socket, even if another punch
+        // ACK changes affinity before the response is forwarded.
+        let sticky_target = if primary.is_none() {
+            routes
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .get(&source)
+                .copied()
+        } else {
+            None
+        };
+        let target = if let Some(sticky_target) = sticky_target {
+            if Self::forward_to_endpoint(source_socket, data, sticky_target, dropped).await {
+                Some(sticky_target)
+            } else {
+                Self::forward(
+                    source_socket,
+                    data,
+                    target_udp,
+                    target_peer,
+                    primary,
+                    route_dynamic_socket,
+                    dropped,
+                )
+                .await
+            }
+        } else {
+            Self::forward(
+                source_socket,
+                data,
+                target_udp,
+                target_peer,
+                primary,
+                route_dynamic_socket,
+                dropped,
+            )
+            .await
+        };
+        if let Some(target) = target {
+            routes
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(source, target);
         }
     }
 
@@ -532,6 +620,8 @@ impl NatPacketLink {
         held_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
         held_punch_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
         held_punch_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
+        a_to_b_routes: Arc<StdMutex<HashMap<SocketAddr, SocketAddr>>>,
+        b_to_a_routes: Arc<StdMutex<HashMap<SocketAddr, SocketAddr>>>,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
     ) {
@@ -540,7 +630,7 @@ impl NatPacketLink {
         loop {
             tokio::select! {
                 result = a_public.recv_from(&mut a_buf) => {
-                    let Ok((len, _)) = result else { return; };
+                    let Ok((len, source)) = result else { return; };
                     if hold_ack.load(Ordering::Acquire)
                         && Self::is_authenticated_ack(&a_buf[..len])
                     {
@@ -563,18 +653,20 @@ impl NatPacketLink {
                     // from B_PUBLIC so A observes the real reciprocal NAT
                     // source, and optionally duplicate it to A's primary
                     // socket for the competing-Direct race test.
-                    Self::forward(
+                    Self::forward_with_route(
                         &b_source,
                         &a_buf[..len],
+                        source,
                         &udp_a,
                         HARD_HARD_B,
                         primary_a,
                         route_dynamic_socket,
                         &drop_b_to_a,
+                        b_to_a_routes.as_ref(),
                     ).await;
                 }
                 result = b_public.recv_from(&mut b_buf) => {
-                    let Ok((len, _)) = result else { return; };
+                    let Ok((len, source)) = result else { return; };
                     if hold_ack.load(Ordering::Acquire)
                         && Self::is_authenticated_ack(&b_buf[..len])
                     {
@@ -595,14 +687,16 @@ impl NatPacketLink {
                     }
                     // A's packet arrived at B's mapped public endpoint. Send
                     // from A_PUBLIC so B observes A's predicted source.
-                    Self::forward(
+                    Self::forward_with_route(
                         &a_source,
                         &b_buf[..len],
+                        source,
                         &udp_b,
                         HARD_HARD_A,
                         None,
                         route_dynamic_socket,
                         &drop_a_to_b,
+                        a_to_b_routes.as_ref(),
                     ).await;
                 }
             }

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -1929,6 +1929,18 @@ async fn wait_for_injected_offer_disposition(
 }
 
 async fn wait_for_failed_attempt_cleanup(harness: &TwoPeerHarness) {
+    // Capture the expected identities before retirement removes the ledger.
+    // Timeout diagnostics compare tokens without ever printing them.
+    let expected_a = harness
+        .peers_a
+        .hard_hard_session_for_test(HARD_HARD_B)
+        .await
+        .map(|record| (record.session_id, record.session_token));
+    let expected_b = harness
+        .peers_b
+        .hard_hard_session_for_test(HARD_HARD_A)
+        .await
+        .map(|record| (record.session_id, record.session_token));
     let result = timeout(HARD_HARD_E2E_TIMEOUT, async {
         loop {
             let clean = !harness
@@ -1987,8 +1999,86 @@ async fn wait_for_failed_attempt_cleanup(harness: &TwoPeerHarness) {
             .udp_b
             .hard_hard_pending_probe_count_for_test(HARD_HARD_A)
             .await;
+        let a_session = harness
+            .peers_a
+            .hard_hard_session_for_test(HARD_HARD_B)
+            .await
+            .map(|record| {
+                (
+                    record.state,
+                    record.cancellation.is_cancelled(),
+                    record.expires_at_ms,
+                    record.fresh_socket.socket_index,
+                    expected_a
+                        .as_ref()
+                        .is_some_and(|(_, token)| token == &record.session_token),
+                )
+            });
+        let b_session = harness
+            .peers_b
+            .hard_hard_session_for_test(HARD_HARD_A)
+            .await
+            .map(|record| {
+                (
+                    record.state,
+                    record.cancellation.is_cancelled(),
+                    record.expires_at_ms,
+                    record.fresh_socket.socket_index,
+                    expected_b
+                        .as_ref()
+                        .is_some_and(|(_, token)| token == &record.session_token),
+                )
+            });
+        let a_cleanup_owner = if let Some((session_id, token)) = expected_a.as_ref() {
+            harness
+                .peers_a
+                .hard_hard_cleanup_owner_claimed_for_test(HARD_HARD_B, session_id, token)
+                .await
+        } else {
+            false
+        };
+        let b_cleanup_owner = if let Some((session_id, token)) = expected_b.as_ref() {
+            harness
+                .peers_b
+                .hard_hard_cleanup_owner_claimed_for_test(HARD_HARD_A, session_id, token)
+                .await
+        } else {
+            false
+        };
+        let a_winner = if let Some((_, token)) = expected_a.as_ref() {
+            harness
+                .peers_a
+                .hard_hard_winner_for_token(HARD_HARD_B, token)
+                .await
+        } else {
+            None
+        };
+        let b_winner = if let Some((_, token)) = expected_b.as_ref() {
+            harness
+                .peers_b
+                .hard_hard_winner_for_token(HARD_HARD_A, token)
+                .await
+        } else {
+            None
+        };
+        let a_udp = harness
+            .udp_a
+            .hard_hard_udp_lifecycle_snapshot_for_test(
+                HARD_HARD_B,
+                expected_a.as_ref().map(|(_, token)| token.as_str()),
+            )
+            .await;
+        let b_udp = harness
+            .udp_b
+            .hard_hard_udp_lifecycle_snapshot_for_test(
+                HARD_HARD_A,
+                expected_b.as_ref().map(|(_, token)| token.as_str()),
+            )
+            .await;
         panic!(
-            "failed Hard↔Hard attempt cleanup: A active={a_active} sockets={a_sockets} pending={a_pending}; B active={b_active} sockets={b_sockets} pending={b_pending}"
+            "failed Hard↔Hard attempt cleanup:\nA active={a_active} direct={} sockets={a_sockets} pending={a_pending} session(state,cancelled,expires_at_ms,socket,token_match)={a_session:?} cleanup_owner={a_cleanup_owner} winner={a_winner:?} udp={a_udp:#?}\nB active={b_active} direct={} sockets={b_sockets} pending={b_pending} session(state,cancelled,expires_at_ms,socket,token_match)={b_session:?} cleanup_owner={b_cleanup_owner} winner={b_winner:?} udp={b_udp:#?}",
+            harness.peers_a.is_direct(HARD_HARD_B).await,
+            harness.peers_b.is_direct(HARD_HARD_A).await,
         );
     }
 }

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -10,7 +10,9 @@ use p2pnet_nat::{
     peek_authenticated_punch_identity, HairpinBehavior, MappingBehavior, MappingLifetime,
     NatProfile, PunchPacketKind, StunAttribute, StunMessage, StunObservation,
 };
-use p2pnet_wireguard::{HandshakeInitiator, HandshakeResponder, TransportSession};
+use p2pnet_wireguard::{
+    HandshakeInitiator, HandshakeResponder, TransportKeyPair, TransportSession,
+};
 use tokio::net::UdpSocket;
 use tokio::sync::{watch, Notify, Semaphore};
 
@@ -394,6 +396,49 @@ struct NatPacketLink {
     worker: Option<tokio::task::JoinHandle<()>>,
 }
 
+#[derive(Clone)]
+struct NatRouteTable {
+    outbound: Arc<StdMutex<HashMap<SocketAddr, SocketAddr>>>,
+    response: Arc<StdMutex<HashMap<(SocketAddr, NatResponseKey), SocketAddr>>>,
+}
+
+impl NatRouteTable {
+    fn new() -> Self {
+        Self {
+            outbound: Arc::new(StdMutex::new(HashMap::new())),
+            response: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NatPacketRole {
+    Request,
+    Response,
+    Other,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum NatResponseKey {
+    Generic,
+    AuthenticatedPunch {
+        generation: u64,
+        nonce: [u8; 8],
+    },
+    DirectValidation {
+        generation: u64,
+        request_id: u16,
+        sequence: u8,
+        owner_token: u64,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct NatPacketClassification {
+    role: NatPacketRole,
+    response_key: NatResponseKey,
+}
+
 struct HeldAcks {
     a_to_b: Vec<Vec<u8>>,
     b_to_a: Vec<Vec<u8>>,
@@ -407,6 +452,8 @@ impl NatPacketLink {
         b_public: Arc<UdpSocket>,
         udp_a: UdpTransport,
         udp_b: UdpTransport,
+        a_keys: TransportKeyPair,
+        b_keys: TransportKeyPair,
         actual_public: Option<(SocketAddr, SocketAddr)>,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
@@ -432,8 +479,8 @@ impl NatPacketLink {
         let held_b_to_a = Arc::new(StdMutex::new(Vec::new()));
         let held_punch_a_to_b = Arc::new(StdMutex::new(Vec::new()));
         let held_punch_b_to_a = Arc::new(StdMutex::new(Vec::new()));
-        let a_to_b_routes = Arc::new(StdMutex::new(HashMap::new()));
-        let b_to_a_routes = Arc::new(StdMutex::new(HashMap::new()));
+        let a_to_b_routes = NatRouteTable::new();
+        let b_to_a_routes = NatRouteTable::new();
         let worker = Some(tokio::spawn(Self::run(
             a_public.clone(),
             b_public.clone(),
@@ -449,6 +496,8 @@ impl NatPacketLink {
             held_b_to_a.clone(),
             held_punch_a_to_b.clone(),
             held_punch_b_to_a.clone(),
+            b_keys,
+            a_keys,
             a_to_b_routes.clone(),
             b_to_a_routes.clone(),
             primary_a,
@@ -544,6 +593,68 @@ impl NatPacketLink {
         source_socket.send_to(data, target).await.is_ok()
     }
 
+    async fn endpoint_is_live(
+        target_udp: &UdpTransport,
+        target_peer: &str,
+        endpoint: SocketAddr,
+        route_dynamic_socket: bool,
+    ) -> bool {
+        if !route_dynamic_socket && target_udp.local_addr().ok() == Some(endpoint) {
+            return true;
+        }
+        target_udp
+            .dynamic_sockets_for_peer_for_test(target_peer)
+            .await
+            .into_iter()
+            .any(|(_, socket)| socket.local_addr().ok() == Some(endpoint))
+    }
+
+    fn classify_packet(
+        data: &[u8],
+        receiver_keys: &TransportKeyPair,
+    ) -> NatPacketClassification {
+        if let Some(identity) = peek_authenticated_punch_identity(data) {
+            let response_key = data
+                .get(6..14)
+                .and_then(|nonce| <[u8; 8]>::try_from(nonce).ok())
+                .map(|nonce| NatResponseKey::AuthenticatedPunch {
+                    generation: identity.generation,
+                    nonce,
+                })
+                .unwrap_or(NatResponseKey::Generic);
+            return NatPacketClassification {
+                role: match identity.kind {
+                    PunchPacketKind::Punch => NatPacketRole::Request,
+                    PunchPacketKind::Ack => NatPacketRole::Response,
+                },
+                response_key,
+            };
+        }
+        let mut decoder = TransportSession::new(receiver_keys.clone());
+        match decoder
+            .decrypt_from_bytes(data)
+            .ok()
+            .and_then(|packet| crate::transport::parse_direct_validation_token(&packet))
+        {
+            Some(token) => NatPacketClassification {
+                role: match token.kind {
+                    crate::transport::DirectValidationKind::Request => NatPacketRole::Request,
+                    crate::transport::DirectValidationKind::Ack => NatPacketRole::Response,
+                },
+                response_key: NatResponseKey::DirectValidation {
+                    generation: token.generation,
+                    request_id: token.request_id,
+                    sequence: token.sequence,
+                    owner_token: token.owner_token,
+                },
+            },
+            None => NatPacketClassification {
+                role: NatPacketRole::Other,
+                response_key: NatResponseKey::Generic,
+            },
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn forward_with_route(
         source_socket: &UdpSocket,
@@ -554,25 +665,73 @@ impl NatPacketLink {
         primary: Option<SocketAddr>,
         route_dynamic_socket: bool,
         dropped: &AtomicBool,
-        routes: &StdMutex<HashMap<SocketAddr, SocketAddr>>,
+        routes: &NatRouteTable,
+        reverse_routes: &NatRouteTable,
+        classification: NatPacketClassification,
     ) {
-        // The fake public endpoint has no kernel NAT table. Remember which
-        // local socket emitted the packet so a response from the selected
-        // peer socket returns to that exact socket, even if another punch
-        // ACK changes affinity before the response is forwarded.
+        // The fake public endpoint has no kernel NAT table. Keep the selected
+        // target separately for requests and responses: a dynamic socket can
+        // be both the source of a new request and the receiver of an earlier
+        // request, so one flat source->target map cannot represent both flows.
         let sticky_target = if primary.is_none() {
-            routes
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .get(&source)
-                .copied()
+            match classification.role {
+                NatPacketRole::Response => routes
+                    .response
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(&(source, classification.response_key))
+                    .copied(),
+                NatPacketRole::Request | NatPacketRole::Other => routes
+                    .outbound
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(&source)
+                    .copied(),
+            }
         } else {
             None
         };
-        let target = if let Some(sticky_target) = sticky_target {
-            if Self::forward_to_endpoint(source_socket, data, sticky_target, dropped).await {
-                Some(sticky_target)
-            } else {
+        let target = match (classification.role, sticky_target) {
+            (NatPacketRole::Response, Some(sticky_target)) => {
+                if Self::endpoint_is_live(
+                    target_udp,
+                    target_peer,
+                    sticky_target,
+                    route_dynamic_socket,
+                )
+                .await
+                    && Self::forward_to_endpoint(source_socket, data, sticky_target, dropped).await
+                {
+                    Some(sticky_target)
+                } else {
+                    None
+                }
+            }
+            (_, Some(sticky_target)) => {
+                if Self::endpoint_is_live(
+                    target_udp,
+                    target_peer,
+                    sticky_target,
+                    route_dynamic_socket,
+                )
+                .await
+                    && Self::forward_to_endpoint(source_socket, data, sticky_target, dropped).await
+                {
+                    Some(sticky_target)
+                } else {
+                    Self::forward(
+                        source_socket,
+                        data,
+                        target_udp,
+                        target_peer,
+                        primary,
+                        route_dynamic_socket,
+                        dropped,
+                    )
+                    .await
+                }
+            }
+            (_, None) => {
                 Self::forward(
                     source_socket,
                     data,
@@ -584,23 +743,25 @@ impl NatPacketLink {
                 )
                 .await
             }
-        } else {
-            Self::forward(
-                source_socket,
-                data,
-                target_udp,
-                target_peer,
-                primary,
-                route_dynamic_socket,
-                dropped,
-            )
-            .await
         };
         if let Some(target) = target {
             routes
+                .outbound
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .insert(source, target);
+            reverse_routes
+                .outbound
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(target, source);
+            if classification.role == NatPacketRole::Request {
+                reverse_routes
+                    .response
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .insert((target, classification.response_key), source);
+            }
         }
     }
 
@@ -620,8 +781,10 @@ impl NatPacketLink {
         held_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
         held_punch_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
         held_punch_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
-        a_to_b_routes: Arc<StdMutex<HashMap<SocketAddr, SocketAddr>>>,
-        b_to_a_routes: Arc<StdMutex<HashMap<SocketAddr, SocketAddr>>>,
+        a_to_b_keys: TransportKeyPair,
+        b_to_a_keys: TransportKeyPair,
+        a_to_b_routes: NatRouteTable,
+        b_to_a_routes: NatRouteTable,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
     ) {
@@ -653,6 +816,7 @@ impl NatPacketLink {
                     // from B_PUBLIC so A observes the real reciprocal NAT
                     // source, and optionally duplicate it to A's primary
                     // socket for the competing-Direct race test.
+                    let classification = Self::classify_packet(&a_buf[..len], &b_to_a_keys);
                     Self::forward_with_route(
                         &b_source,
                         &a_buf[..len],
@@ -662,7 +826,9 @@ impl NatPacketLink {
                         primary_a,
                         route_dynamic_socket,
                         &drop_b_to_a,
-                        b_to_a_routes.as_ref(),
+                        &b_to_a_routes,
+                        &a_to_b_routes,
+                        classification,
                     ).await;
                 }
                 result = b_public.recv_from(&mut b_buf) => {
@@ -687,6 +853,7 @@ impl NatPacketLink {
                     }
                     // A's packet arrived at B's mapped public endpoint. Send
                     // from A_PUBLIC so B observes A's predicted source.
+                    let classification = Self::classify_packet(&b_buf[..len], &a_to_b_keys);
                     Self::forward_with_route(
                         &a_source,
                         &b_buf[..len],
@@ -696,7 +863,9 @@ impl NatPacketLink {
                         None,
                         route_dynamic_socket,
                         &drop_a_to_b,
-                        a_to_b_routes.as_ref(),
+                        &a_to_b_routes,
+                        &b_to_a_routes,
+                        classification,
                     ).await;
                 }
             }
@@ -1266,6 +1435,8 @@ async fn build_two_peer_harness_with_stun_mode(
         .consume_initiation_and_respond(&initiation)
         .unwrap();
     let a_keys = a_handshake.consume_response(&response).unwrap();
+    let a_keys_for_link = a_keys.clone();
+    let b_keys_for_link = b_keys.clone();
     let wg_a = daemon_a.transport.clone();
     let wg_b = daemon_b.transport.clone();
     wg_a.add_session(HARD_HARD_B, TransportSession::new(a_keys))
@@ -1313,6 +1484,8 @@ async fn build_two_peer_harness_with_stun_mode(
         b_public_socket,
         udp_a.clone(),
         udp_b.clone(),
+        a_keys_for_link,
+        b_keys_for_link,
         actual_public,
         primary_a,
         nat_mode == HarnessNatMode::HighEntropy,
@@ -1525,8 +1698,32 @@ async fn wait_for_both_direct_compact(harness: &TwoPeerHarness) {
                 })
                 .collect::<Vec<_>>()
         };
+        let events_a = summarize_hard_hard_diagnostics(&harness.peers_a, HARD_HARD_B).await;
+        let events_b = summarize_hard_hard_diagnostics(&harness.peers_b, HARD_HARD_A).await;
+        let session_a = harness
+            .peers_a
+            .hard_hard_session_for_test(HARD_HARD_B)
+            .await;
+        let session_b = harness
+            .peers_b
+            .hard_hard_session_for_test(HARD_HARD_A)
+            .await;
+        let sockets_a = harness
+            .udp_a
+            .dynamic_sockets_for_peer_for_test(HARD_HARD_B)
+            .await
+            .into_iter()
+            .map(|(index, socket)| (index, socket.local_addr().ok()))
+            .collect::<Vec<_>>();
+        let sockets_b = harness
+            .udp_b
+            .dynamic_sockets_for_peer_for_test(HARD_HARD_A)
+            .await
+            .into_iter()
+            .map(|(index, socket)| (index, socket.local_addr().ok()))
+            .collect::<Vec<_>>();
         panic!(
-            "birthday peers did not both become Direct: A={:?} B={:?}",
+            "birthday peers did not both become Direct: A={:?} B={:?}\nA events={events_a:#?}\nB events={events_b:#?}\nA session={session_a:#?}\nB session={session_b:#?}\nA sockets={sockets_a:?}\nB sockets={sockets_b:?}",
             summarize(harness.peers_a.diagnostics().await),
             summarize(harness.peers_b.diagnostics().await),
         );
@@ -2736,7 +2933,7 @@ async fn hard_hard_random_random_birthday_collision_is_full_production_e2e() {
                 .iter()
                 .filter(|event| event.stage.starts_with("hard_hard_"))
                 .map(|event| (event.stage.as_str(), event.detail.as_str()))
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>(),
         );
         let affinity_socket = if remote_id == HARD_HARD_B {
             harness

--- a/client/daemon/src/peer/connection/core.rs
+++ b/client/daemon/src/peer/connection/core.rs
@@ -246,6 +246,12 @@ pub struct PeerConnection {
     /// dynamic-socket eviction can re-verify "is this peer Direct?" under its
     /// own socket-state lock without awaiting the async manager there.
     direct_cache: Option<Arc<std::sync::Mutex<HashSet<String>>>>,
+    /// Manager-owned lock-free snapshot of the exact pair selected by the
+    /// latest Direct commit. It is cleared with the Direct-set mirror on any
+    /// non-Direct transition so a generic state change cannot resurrect a
+    /// stale Hard↔Hard pair.
+    direct_pair_cache:
+        Option<Arc<std::sync::Mutex<HashMap<String, DirectCommitPairSnapshot>>>>,
 }
 
 impl PeerConnection {
@@ -390,6 +396,7 @@ impl PeerConnection {
             path_events: Vec::new(),
             direct_events: Vec::new(),
             direct_cache: None,
+            direct_pair_cache: None,
         }
     }
 
@@ -509,20 +516,36 @@ impl PeerConnection {
     /// connection's state, so the UDP layer can re-verify the nonevictable
     /// set inside its socket-state lock.
     fn sync_direct_cache(&self) {
-        let Some(cache) = &self.direct_cache else {
-            return;
-        };
-        let mut cache = cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.state == ConnectionState::Direct {
-            cache.insert(self.node_id.clone());
-        } else {
-            cache.remove(&self.node_id);
+        if let Some(cache) = &self.direct_cache {
+            let mut cache = cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            if self.state == ConnectionState::Direct {
+                cache.insert(self.node_id.clone());
+            } else {
+                cache.remove(&self.node_id);
+            }
+        }
+        if self.state != ConnectionState::Direct {
+            if let Some(cache) = &self.direct_pair_cache {
+                cache
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .remove(&self.node_id);
+            }
         }
     }
 
     /// Attach the manager's synchronous Direct-set mirror (manager-owned).
     pub(crate) fn attach_direct_cache(&mut self, cache: Arc<std::sync::Mutex<HashSet<String>>>) {
         self.direct_cache = Some(cache);
+        self.sync_direct_cache();
+    }
+
+    /// Attach the manager's lock-free exact Direct-pair mirror.
+    pub(crate) fn attach_direct_pair_cache(
+        &mut self,
+        cache: Arc<std::sync::Mutex<HashMap<String, DirectCommitPairSnapshot>>>,
+    ) {
+        self.direct_pair_cache = Some(cache);
         self.sync_direct_cache();
     }
 

--- a/client/daemon/src/peer/connection/events.rs
+++ b/client/daemon/src/peer/connection/events.rs
@@ -390,6 +390,7 @@ fn is_protected_direct_event_stage(stage: &str) -> bool {
             | "hard_hard_sweep_started"
             | "hard_hard_direct_validation_started"
             | "hard_hard_probe_summary"
+            | "hard_hard_birthday_sweep_summary"
             | "hard_hard_sweep_completed"
             | "hard_hard_sweep_failed"
             | "hard_hard_failed"

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -63,6 +63,7 @@ impl PeerManager {
             c0_pair_ledgers: Arc::new(RwLock::new(HashMap::new())),
             direct_commit_seq_mirror: Arc::new(std::sync::Mutex::new(HashMap::new())),
             direct_commit_notify: Arc::new(Notify::new()),
+            direct_commit_pair_mirror: Arc::new(std::sync::Mutex::new(HashMap::new())),
             relay_confirm_seq_mirror: Arc::new(std::sync::Mutex::new(HashMap::new())),
             relay_confirm_notify: Arc::new(Notify::new()),
             relay_probe_expectations: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -550,6 +551,17 @@ impl PeerManager {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .active_generation(node_id)
+    }
+
+    /// Hold the connection writer for deterministic lock-contention tests.
+    /// Production code never needs to expose this guard; the test-only helper
+    /// makes it possible to prove timing-sensitive paths do not await this
+    /// lock.
+    #[cfg(test)]
+    pub(crate) async fn hold_connections_writer_for_test(
+        &self,
+    ) -> tokio::sync::RwLockWriteGuard<'_, HashMap<String, PeerConnection>> {
+        self.connections.write().await
     }
 
     #[cfg(test)]

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -32,6 +32,8 @@ impl PeerManager {
             peer_membership: Arc::new(std::sync::Mutex::new(PeerMembershipState::default())),
             #[cfg(test)]
             authenticated_probe_verify_gate: Arc::new(std::sync::Mutex::new(None)),
+            #[cfg(test)]
+            hard_hard_cleanup_gate: Arc::new(std::sync::Mutex::new(None)),
             diagnostics_cache: Arc::new(std::sync::Mutex::new(None)),
             ip_to_node: Arc::new(RwLock::new(HashMap::new())),
             network_generation: Arc::new(RwLock::new(0)),
@@ -46,6 +48,7 @@ impl PeerManager {
             punch_generations: Arc::new(RwLock::new(HashMap::new())),
             local_fresh_mappings: Arc::new(RwLock::new(HashMap::new())),
             hard_hard_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            hard_hard_cleanup_owners: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             hard_hard_winners: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             fresh_mapping_history: Arc::new(std::sync::Mutex::new(HashMap::new())),
             remote_fresh_generations: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -438,6 +438,23 @@ mod diagnostics_tests {
         .await;
         assert!(started.is_ok(), "sweep start must not await the writer");
 
+        let validation_started = tokio::time::timeout(
+            Duration::from_millis(100),
+            manager.record_direct_event(
+                "peer-hard-lock",
+                "hard_hard_direct_validation_started",
+                None,
+                Some(64),
+                Some(1),
+                "confirmation grace must not await the writer",
+            ),
+        )
+        .await;
+        assert!(
+            validation_started.is_ok(),
+            "Direct confirmation start must not await the writer"
+        );
+
         let mut terminal = Box::pin(manager.record_direct_event(
             "peer-hard-lock",
             "hard_hard_birthday_sweep_summary",

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -403,4 +403,67 @@ mod diagnostics_tests {
 
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn hard_sweep_started_is_nonblocking_but_terminal_summary_is_durable() {
+        let config = Config::generate_default("http://ctrl.test", "default").unwrap();
+        let manager = PeerManager::new(config);
+        manager
+            .add_peer(&crate::control::PeerInfo {
+                node_id: "peer-hard-lock".to_string(),
+                device_name: String::new(),
+                app_version: "0.2.0-test".to_string(),
+                public_key: "pk-hard-lock".to_string(),
+                endpoint: "127.0.0.1:41000".to_string(),
+                nat_type: "Unknown".to_string(),
+                virtual_ip: "10.20.0.9".to_string(),
+                online: true,
+                last_seen: 1,
+                relay_rtt_ms: None,
+            })
+            .await;
+
+        let connection_writer = manager.connections.write().await;
+        let started = tokio::time::timeout(
+            Duration::from_millis(100),
+            manager.record_direct_event(
+                "peer-hard-lock",
+                "hard_hard_sweep_started",
+                None,
+                Some(64),
+                None,
+                "first-send timing marker",
+            ),
+        )
+        .await;
+        assert!(started.is_ok(), "sweep start must not await the writer");
+
+        let mut terminal = Box::pin(manager.record_direct_event(
+            "peer-hard-lock",
+            "hard_hard_birthday_sweep_summary",
+            None,
+            Some(1),
+            Some(1),
+            "stop_reason=send_error physical_send_errors=1",
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut terminal)
+                .await
+                .is_err(),
+            "terminal summary must remain durable and wait for the writer"
+        );
+        drop(connection_writer);
+        tokio::time::timeout(Duration::from_secs(1), terminal)
+            .await
+            .expect("terminal summary must finish after the writer is released");
+
+        let connection = manager
+            .get_connection("peer-hard-lock")
+            .await
+            .expect("test peer must remain in the manager");
+        assert!(connection
+            .direct_events
+            .iter()
+            .any(|event| event.stage == "hard_hard_birthday_sweep_summary"));
+    }
 }

--- a/client/daemon/src/peer/manager/direct_success.rs
+++ b/client/daemon/src/peer/manager/direct_success.rs
@@ -243,6 +243,18 @@ impl PeerManager {
                 conn.direct_health.record_success();
             }
             conn.clear_direct_reclaim_window();
+            self.publish_direct_commit_pair(
+                node_id,
+                generation,
+                conn.remote_candidate_epoch(),
+                local_endpoint,
+            );
+            // Publish the Direct-set mirror before waking confirmation
+            // waiters. The pair snapshot and the active-state bit must be
+            // visible together; otherwise a waiter can wake on the sequence
+            // bump between these two writes, observe a non-Direct peer, and
+            // miss the only notification for this commit.
+            conn.transition(ConnectionState::Direct);
             if direct_confirmation_changed {
                 // The direct-commit sequence is bumped inside the SAME
                 // network-epoch critical section as the state transition, so
@@ -262,7 +274,6 @@ impl PeerManager {
                     ),
                 );
             }
-            conn.transition(ConnectionState::Direct);
             // Keep the persisted selector in lock-step with the Direct
             // promotion.  The current encrypted-confirmed Direct pair wins
             // past relay-first business gating; only an explicit current

--- a/client/daemon/src/peer/manager/hard_hard.rs
+++ b/client/daemon/src/peer/manager/hard_hard.rs
@@ -511,6 +511,40 @@ impl PeerManager {
                 == Some(identity.remote_profile_generation)
     }
 
+    /// Confirmation-time session fence that never waits on `connections`.
+    /// The full asynchronous predicate above remains the cleanup/diagnostic
+    /// authority; the grace timer uses this version because the Direct commit
+    /// mirror and UDP socket proof already carry the state that was validated
+    /// under the connection writer.  A connection-map writer therefore cannot
+    /// delay the confirmation start or consume its bounded grace.
+    pub(crate) async fn hard_hard_session_identity_is_current_for_confirmation(
+        &self,
+        identity: &HardHardFreshSocketIdentity,
+    ) -> bool {
+        let now = unix_time_millis();
+        let record = self
+            .hard_hard_sessions
+            .lock()
+            .await
+            .values()
+            .find(|record| {
+                record.peer_id == identity.peer_id
+                    && record.session_token == identity.session_token
+                    && record.expires_at_ms >= now
+            })
+            .cloned();
+        let Some(record) = record else {
+            return false;
+        };
+        record.local_network_generation == identity.network_generation
+            && record.remote_candidate_epoch == identity.remote_candidate_epoch
+            && record.local_profile_generation == identity.local_profile_generation
+            && record.remote_profile_generation == identity.remote_profile_generation
+            && record.fresh_socket == *identity
+            && self.current_network_generation_sync() == identity.network_generation
+            && self.current_local_profile_generation_sync() == identity.local_profile_generation
+    }
+
     /// Return true when the current authoritative Direct state selected a pair
     /// on this socket's exact local endpoint and current candidate epoch.  The
     /// UDP layer separately proves affinity and authenticated socket evidence;

--- a/client/daemon/src/peer/manager/hard_hard.rs
+++ b/client/daemon/src/peer/manager/hard_hard.rs
@@ -190,6 +190,12 @@ impl PeerManager {
                 && existing.remote_candidate_epoch == record.remote_candidate_epoch
                 && existing.local_profile_generation == record.local_profile_generation
                 && existing.remote_profile_generation == record.remote_profile_generation
+                && existing.requested_birthday_level == record.requested_birthday_level
+                && existing.generated_candidate_count == record.generated_candidate_count
+                && existing.signaled_candidate_count == record.signaled_candidate_count
+                && existing.birthday == record.birthday
+                && existing.requested_socket_indices == record.requested_socket_indices
+                && existing.requested_socket_count == record.requested_socket_count
                 && existing.prediction_window == record.prediction_window);
         } else {
             // One live session per peer.  A newer fresh measurement supersedes

--- a/client/daemon/src/peer/manager/hard_hard.rs
+++ b/client/daemon/src/peer/manager/hard_hard.rs
@@ -7,6 +7,29 @@
 const MAX_HARD_HARD_SESSIONS: usize = 16;
 const MAX_HARD_HARD_PREDICTION_TARGETS: usize = 256;
 
+#[cfg(test)]
+static HARD_HARD_TEST_NOW_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn set_hard_hard_test_now_ms(now_ms: Option<u64>) {
+    HARD_HARD_TEST_NOW_MS.store(now_ms.unwrap_or(0), std::sync::atomic::Ordering::Release);
+}
+
+pub(crate) fn hard_hard_now_ms() -> u64 {
+    #[cfg(test)]
+    {
+        let overridden = HARD_HARD_TEST_NOW_MS.load(std::sync::atomic::Ordering::Acquire);
+        if overridden != 0 {
+            return overridden;
+        }
+    }
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HardHardResponseAdmission {
     Ready,
@@ -166,26 +189,31 @@ impl PeerManager {
         &self,
         record: HardHardSessionRecord,
     ) -> bool {
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let mut cancelled = Vec::new();
-        let mut expired_winners = Vec::new();
+        let mut retired_winners = Vec::new();
         let mut duplicate_result = None;
         let mut sessions = self.hard_hard_sessions.lock().await;
         let expired_keys = sessions
             .iter()
-            .filter(|(_, existing)| existing.expires_at_ms < now)
+            .filter(|(_, existing)| {
+                existing.state != HardHardSessionState::Retiring
+                    && existing.expires_at_ms < now
+            })
             .map(|(key, _)| key.clone())
             .collect::<Vec<_>>();
         for key in expired_keys {
-            if let Some(existing) = sessions.remove(&key) {
-                expired_winners.push((existing.peer_id.clone(), existing.session_token.clone()));
-                cancelled.push(existing.cancellation);
+            if let Some(existing) = sessions.get_mut(&key) {
+                existing.state = HardHardSessionState::Retiring;
+                retired_winners.push((existing.peer_id.clone(), existing.session_token.clone()));
+                cancelled.push(existing.cancellation.clone());
             }
         }
         let key = (record.peer_id.clone(), record.session_id.clone());
         let winner_key = (record.peer_id.clone(), record.session_token.clone());
         if let Some(existing) = sessions.get(&key) {
-            duplicate_result = Some(existing.initiator == record.initiator
+            duplicate_result = Some(existing.state != HardHardSessionState::Retiring
+                && existing.initiator == record.initiator
                 && existing.local_network_generation == record.local_network_generation
                 && existing.remote_candidate_epoch == record.remote_candidate_epoch
                 && existing.local_profile_generation == record.local_profile_generation
@@ -202,34 +230,48 @@ impl PeerManager {
             // every older response fence before it can reuse an exact socket.
             let replaced_keys = sessions
                 .iter()
-                .filter(|(key, _)| key.0 == record.peer_id)
+                .filter(|(key, existing)| {
+                    key.0 == record.peer_id
+                        && existing.state != HardHardSessionState::Retiring
+                })
                 .map(|(key, _)| key.clone())
                 .collect::<Vec<_>>();
             for old_key in replaced_keys {
-                if let Some(existing) = sessions.remove(&old_key) {
-                    cancelled.push(existing.cancellation);
+                if let Some(existing) = sessions.get_mut(&old_key) {
+                    existing.state = HardHardSessionState::Retiring;
+                    retired_winners
+                        .push((existing.peer_id.clone(), existing.session_token.clone()));
+                    cancelled.push(existing.cancellation.clone());
                 }
             }
-            if sessions.len() >= MAX_HARD_HARD_SESSIONS {
+            let active_count = sessions
+                .values()
+                .filter(|session| session.state != HardHardSessionState::Retiring)
+                .count();
+            if active_count >= MAX_HARD_HARD_SESSIONS {
                 if let Some(oldest_key) = sessions
                     .iter()
+                    .filter(|(_, session)| session.state != HardHardSessionState::Retiring)
                     .min_by_key(|(_, session)| session.created_at)
                     .map(|(key, _)| key.clone())
                 {
-                    if let Some(existing) = sessions.remove(&oldest_key) {
-                        cancelled.push(existing.cancellation);
+                    if let Some(existing) = sessions.get_mut(&oldest_key) {
+                        existing.state = HardHardSessionState::Retiring;
+                        retired_winners
+                            .push((existing.peer_id.clone(), existing.session_token.clone()));
+                        cancelled.push(existing.cancellation.clone());
                     }
                 }
             }
             sessions.insert(key, record);
         }
         drop(sessions);
-        if duplicate_result.is_none() || !expired_winners.is_empty() {
+        if duplicate_result.is_none() || !retired_winners.is_empty() {
             let mut winners = self.hard_hard_winners.lock().await;
             if duplicate_result.is_none() {
                 winners.remove(&winner_key);
             }
-            for key in expired_winners {
+            for key in retired_winners {
                 winners.remove(&key);
             }
         }
@@ -242,19 +284,15 @@ impl PeerManager {
     /// A live session suppresses a second initiator while its bounded socket
     /// and pending ACK evidence are still authoritative.
     pub(crate) async fn hard_hard_session_is_active(&self, peer_id: &str) -> bool {
-        let now = unix_time_millis();
-        let mut sessions = self.hard_hard_sessions.lock().await;
-        let expired_keys = sessions
-            .iter()
-            .filter(|((owner, _), record)| owner == peer_id && record.expires_at_ms < now)
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        for key in expired_keys {
-            if let Some(record) = sessions.remove(&key) {
-                record.cancellation.cancel_for_hard_hard_cleanup();
-            }
-        }
-        sessions.keys().any(|(owner, _)| owner == peer_id)
+        let now = hard_hard_now_ms();
+        self.hard_hard_sessions.lock().await.iter().any(
+            |((owner, _), record)| {
+                owner == peer_id
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+                    && record.expires_at_ms >= now
+            },
+        )
     }
 
     /// Snapshot one live Hard↔Hard record for the deterministic two-peer
@@ -275,6 +313,61 @@ impl PeerManager {
             .cloned()
     }
 
+    /// Pure exact snapshot used by the cleanup owner. Unlike the admission
+    /// getters this intentionally includes a Retiring record so a cleanup
+    /// task can retain the latest winner identity without reviving it.
+    pub(crate) async fn hard_hard_session_snapshot_for_cleanup(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> Option<HardHardSessionRecord> {
+        self.hard_hard_sessions
+            .lock()
+            .await
+            .get(&(peer_id.to_string(), session_id.to_string()))
+            .filter(|record| {
+                record.peer_id == peer_id && record.session_token == session_token
+            })
+            .cloned()
+    }
+
+    /// Claim the single cleanup watcher for one exact session. The claim is
+    /// separate from the session ledger so duplicate signal handling cannot
+    /// spawn a second old cleanup owner.
+    pub(crate) async fn hard_hard_claim_cleanup_owner(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> bool {
+        self.hard_hard_cleanup_owners
+            .lock()
+            .await
+            .insert((
+                peer_id.to_string(),
+                session_id.to_string(),
+                session_token.to_string(),
+            ))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn hard_hard_cleanup_owner_claimed_for_test(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> bool {
+        self.hard_hard_cleanup_owners
+            .lock()
+            .await
+            .contains(&(
+                peer_id.to_string(),
+                session_id.to_string(),
+                session_token.to_string(),
+            ))
+    }
+
     /// Look up a session by the stable token carried by either direction of
     /// the compact envelope.  The response swaps the directional generation
     /// fields, so reconstructing the initiator's full encoded string from the
@@ -284,21 +377,18 @@ impl PeerManager {
         peer_id: &str,
         token: &str,
     ) -> Option<HardHardSessionRecord> {
-        let now = unix_time_millis();
-        let mut sessions = self.hard_hard_sessions.lock().await;
-        let expired_keys = sessions
+        let now = hard_hard_now_ms();
+        self.hard_hard_sessions
+            .lock()
+            .await
             .iter()
-            .filter(|(_, existing)| existing.expires_at_ms < now)
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        for key in expired_keys {
-            if let Some(existing) = sessions.remove(&key) {
-                existing.cancellation.cancel_for_hard_hard_cleanup();
-            }
-        }
-        sessions
-            .iter()
-            .find(|((owner, _), record)| owner == peer_id && record.session_token == token)
+            .find(|((owner, _), record)| {
+                owner == peer_id
+                    && record.session_token == token
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+                    && record.expires_at_ms >= now
+            })
             .map(|(_, record)| record.clone())
     }
 
@@ -317,25 +407,58 @@ impl PeerManager {
         punch_generation: u64,
         socket_local_endpoint: SocketAddr,
     ) -> Option<HardHardFreshSocketIdentity> {
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let key = (peer_id.to_string(), token.to_string());
+        let eligible = self
+            .hard_hard_sessions
+            .lock()
+            .await
+            .values()
+            .any(|record| {
+                record.peer_id == peer_id
+                    && record.session_token == token
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+                    && record.expires_at_ms >= now
+                    && record.local_network_generation == network_generation
+                    && (record.state == HardHardSessionState::Sweeping
+                        || (!record.initiator && record.state == HardHardSessionState::AwaitingPeer))
+            });
+        if !eligible {
+            return None;
+        }
+        let inserted_winner = {
+            let mut winners = self.hard_hard_winners.lock().await;
+            if let Some(existing) = winners.get(&key) {
+                if *existing != socket_index {
+                    return None;
+                }
+                false
+            } else {
+                winners.insert(key.clone(), socket_index);
+                true
+            }
+        };
         let mut sessions = self.hard_hard_sessions.lock().await;
-        let record = sessions.values_mut().find(|record| {
+        let Some(record) = sessions.values_mut().find(|record| {
             record.peer_id == peer_id
                 && record.session_token == token
+                && record.state != HardHardSessionState::Retiring
+                && !record.cancellation.is_cancelled()
                 && record.expires_at_ms >= now
                 && record.local_network_generation == network_generation
                 && (record.state == HardHardSessionState::Sweeping
                     || (!record.initiator && record.state == HardHardSessionState::AwaitingPeer))
-        })?;
-        let mut winners = self.hard_hard_winners.lock().await;
-        if let Some(existing) = winners.get(&key) {
-            if *existing != socket_index {
-                return None;
+        }) else {
+            drop(sessions);
+            if inserted_winner {
+                self.hard_hard_winners
+                    .lock()
+                    .await
+                    .remove(&key);
             }
-        } else {
-            winners.insert(key, socket_index);
-        }
+            return None;
+        };
         record.fresh_socket.socket_index = socket_index;
         record.fresh_socket.punch_generation = punch_generation.max(1);
         record.fresh_socket.socket_local_endpoint = socket_local_endpoint;
@@ -382,21 +505,17 @@ impl PeerManager {
         token: &str,
         current_remote_candidate_epoch: u64,
     ) -> HardHardResponseAdmission {
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let mut sessions = self.hard_hard_sessions.lock().await;
-        let expired_keys = sessions
-            .iter()
-            .filter(|(_, existing)| existing.expires_at_ms < now)
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        for key in expired_keys {
-            if let Some(existing) = sessions.remove(&key) {
-                existing.cancellation.cancel_for_hard_hard_cleanup();
-            }
-        }
         let Some((_, record)) = sessions
             .iter_mut()
-            .find(|((owner, _), record)| owner == peer_id && record.session_token == token)
+            .find(|((owner, _), record)| {
+                owner == peer_id
+                    && record.session_token == token
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+                    && record.expires_at_ms >= now
+            })
         else {
             return HardHardResponseAdmission::Rejected;
         };
@@ -429,21 +548,13 @@ impl PeerManager {
         peer_id: &str,
         token: &str,
     ) -> bool {
-        let now = unix_time_millis();
-        let mut sessions = self.hard_hard_sessions.lock().await;
-        let expired_keys = sessions
-            .iter()
-            .filter(|(_, existing)| existing.expires_at_ms < now)
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        for key in expired_keys {
-            if let Some(existing) = sessions.remove(&key) {
-                existing.cancellation.cancel_for_hard_hard_cleanup();
-            }
-        }
+        let now = hard_hard_now_ms();
+        let sessions = self.hard_hard_sessions.lock().await;
         sessions.values().any(|record| {
             record.peer_id == peer_id
                 && record.session_token == token
+                && record.state != HardHardSessionState::Retiring
+                && !record.cancellation.is_cancelled()
                 && record.expires_at_ms >= now
             })
     }
@@ -457,24 +568,16 @@ impl PeerManager {
         &self,
         identity: &HardHardFreshSocketIdentity,
     ) -> bool {
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let record = {
-            let mut sessions = self.hard_hard_sessions.lock().await;
-            let expired_keys = sessions
-                .iter()
-                .filter(|(_, existing)| existing.expires_at_ms < now)
-                .map(|(key, _)| key.clone())
-                .collect::<Vec<_>>();
-            for key in expired_keys {
-                if let Some(existing) = sessions.remove(&key) {
-                    existing.cancellation.cancel_for_hard_hard_cleanup();
-                }
-            }
+            let sessions = self.hard_hard_sessions.lock().await;
             sessions
                 .values()
                 .find(|record| {
                     record.peer_id == identity.peer_id
                         && record.session_token == identity.session_token
+                        && record.state != HardHardSessionState::Retiring
+                        && !record.cancellation.is_cancelled()
                         && record.expires_at_ms >= now
                 })
                 .cloned()
@@ -521,7 +624,7 @@ impl PeerManager {
         &self,
         identity: &HardHardFreshSocketIdentity,
     ) -> bool {
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let record = self
             .hard_hard_sessions
             .lock()
@@ -530,6 +633,8 @@ impl PeerManager {
             .find(|record| {
                 record.peer_id == identity.peer_id
                     && record.session_token == identity.session_token
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
                     && record.expires_at_ms >= now
             })
             .cloned();
@@ -601,21 +706,17 @@ impl PeerManager {
         {
             return None;
         }
-        let now = unix_time_millis();
+        let now = hard_hard_now_ms();
         let mut sessions = self.hard_hard_sessions.lock().await;
-        let expired_keys = sessions
-            .iter()
-            .filter(|(_, existing)| existing.expires_at_ms < now)
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        for key in expired_keys {
-            if let Some(existing) = sessions.remove(&key) {
-                existing.cancellation.cancel_for_hard_hard_cleanup();
-            }
-        }
         let (_, record) = sessions
             .iter_mut()
-            .find(|((owner, _), record)| owner == peer_id && record.session_token == token)?;
+            .find(|((owner, _), record)| {
+                owner == peer_id
+                    && record.session_token == token
+                    && record.state != HardHardSessionState::Retiring
+                    && !record.cancellation.is_cancelled()
+                    && record.expires_at_ms >= now
+            })?;
         if record.state != HardHardSessionState::AwaitingPeer || record.attempt_count >= 1 {
             return None;
         }
@@ -635,30 +736,152 @@ impl PeerManager {
         Some(record.clone())
     }
 
-    pub(crate) async fn hard_hard_remove_session(&self, peer_id: &str, session_id: &str) {
-        let removed_token = if let Some(record) = self
-            .hard_hard_sessions
+    /// Move one exact session into the cleanup phase.  Retirement is a
+    /// synchronous ownership handoff: the record remains in the ledger until
+    /// the transport owner confirms that token-scoped socket/pending cleanup
+    /// is complete.  Repeating the request is harmless.
+    pub(crate) async fn hard_hard_retire_session(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> bool {
+        let cancellation = {
+            let mut sessions = self.hard_hard_sessions.lock().await;
+            let Some(record) = sessions
+                .get_mut(&(peer_id.to_string(), session_id.to_string()))
+                .filter(|record| record.session_token == session_token)
+            else {
+                return false;
+            };
+            record.state = HardHardSessionState::Retiring;
+            record.cancellation.clone()
+        };
+        self.hard_hard_winners
             .lock()
             .await
-            .remove(&(peer_id.to_string(), session_id.to_string()))
-        {
-            let token = record.session_token.clone();
-            record.cancellation.cancel_for_hard_hard_cleanup();
-            Some(token)
-        } else {
-            None
+            .remove(&(peer_id.to_string(), session_token.to_string()));
+        cancellation.cancel_for_hard_hard_cleanup();
+        true
+    }
+
+    /// Remove an exact retired record after the UDP cleanup transaction has
+    /// completed.  A stale cleanup can never delete a replacement because the
+    /// session ID and token are both checked while holding the ledger lock.
+    pub(crate) async fn hard_hard_complete_session_cleanup(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> bool {
+        let removed = {
+            let mut sessions = self.hard_hard_sessions.lock().await;
+            let key = (peer_id.to_string(), session_id.to_string());
+            sessions.get(&key).is_some_and(|record| {
+                record.session_token == session_token
+                    && record.state == HardHardSessionState::Retiring
+            }) && sessions.remove(&key).is_some()
         };
-        if let Some(token) = removed_token {
+        if removed {
             self.hard_hard_winners
                 .lock()
                 .await
-                .remove(&(peer_id.to_string(), token));
+                .remove(&(peer_id.to_string(), session_token.to_string()));
+            self.hard_hard_cleanup_owners
+                .lock()
+                .await
+                .remove(&(
+                    peer_id.to_string(),
+                    session_id.to_string(),
+                    session_token.to_string(),
+                ));
+        }
+        removed
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_hard_hard_cleanup_gate_for_test(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) -> (Arc<HardHardCleanupGate>, HardHardCleanupGateGuard) {
+        let gate = Arc::new(HardHardCleanupGate {
+            reached: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+            completed: tokio::sync::Notify::new(),
+        });
+        let mut slot = self
+            .hard_hard_cleanup_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = slot.replace(HardHardCleanupGateRegistration {
+            peer_id: peer_id.to_string(),
+            session_id: session_id.to_string(),
+            session_token: session_token.to_string(),
+            gate: gate.clone(),
+        });
+        drop(slot);
+        (
+            gate.clone(),
+            HardHardCleanupGateGuard {
+                slot: self.hard_hard_cleanup_gate.clone(),
+                installed: gate,
+                previous,
+            },
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn pause_hard_hard_cleanup_for_test(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) {
+        let gate = self
+            .hard_hard_cleanup_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|registration| {
+                registration.peer_id == peer_id
+                    && registration.session_id == session_id
+                    && registration.session_token == session_token
+            })
+            .map(|registration| registration.gate.clone());
+        if let Some(gate) = gate {
+            gate.reached.notify_one();
+            gate.release.notified().await;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn signal_hard_hard_cleanup_completed_for_test(
+        &self,
+        peer_id: &str,
+        session_id: &str,
+        session_token: &str,
+    ) {
+        let gate = self
+            .hard_hard_cleanup_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|registration| {
+                registration.peer_id == peer_id
+                    && registration.session_id == session_id
+                    && registration.session_token == session_token
+            })
+            .map(|registration| registration.gate.clone());
+        if let Some(gate) = gate {
+            gate.completed.notify_one();
         }
     }
 
     pub(crate) async fn clear_hard_hard_sessions(&self, peer_id: Option<&str>) {
         let mut sessions = self.hard_hard_sessions.lock().await;
-        let cancelled = match peer_id {
+        let retiring = match peer_id {
             Some(peer_id) => sessions
                 .iter()
                 .filter(|((owner, _), _)| owner == peer_id)
@@ -666,34 +889,27 @@ impl PeerManager {
                 .collect::<Vec<_>>(),
             None => sessions.keys().cloned().collect::<Vec<_>>(),
         };
-        let removed_tokens = cancelled
+        let retired_tokens = retiring
             .iter()
             .filter_map(|key| sessions.get(key).map(|record| (key.0.clone(), record.session_token.clone())))
             .collect::<Vec<_>>();
-        let mut cancellations = Vec::with_capacity(cancelled.len());
-        for key in cancelled {
-            if let Some(record) = sessions.remove(&key) {
-                cancellations.push(record.cancellation);
+        let mut cancellations = Vec::with_capacity(retired_tokens.len());
+        for key in retiring {
+            if let Some(record) = sessions.get_mut(&key) {
+                if record.state != HardHardSessionState::Retiring {
+                    record.state = HardHardSessionState::Retiring;
+                    cancellations.push(record.cancellation.clone());
+                }
             }
         }
         drop(sessions);
         let mut winners = self.hard_hard_winners.lock().await;
-        for key in removed_tokens {
+        for key in retired_tokens {
             winners.remove(&key);
-        }
-        if let Some(peer_id) = peer_id {
-            winners.retain(|(owner, _), _| owner != peer_id);
         }
         drop(winners);
         for cancellation in cancellations {
             cancellation.cancel_for_hard_hard_cleanup();
         }
     }
-}
-
-fn unix_time_millis() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
 }

--- a/client/daemon/src/peer/manager/hard_hard.rs
+++ b/client/daemon/src/peer/manager/hard_hard.rs
@@ -192,7 +192,6 @@ impl PeerManager {
         let now = hard_hard_now_ms();
         let mut cancelled = Vec::new();
         let mut retired_winners = Vec::new();
-        let mut duplicate_result = None;
         let mut sessions = self.hard_hard_sessions.lock().await;
         let expired_keys = sessions
             .iter()
@@ -211,20 +210,13 @@ impl PeerManager {
         }
         let key = (record.peer_id.clone(), record.session_id.clone());
         let winner_key = (record.peer_id.clone(), record.session_token.clone());
-        if let Some(existing) = sessions.get(&key) {
-            duplicate_result = Some(existing.state != HardHardSessionState::Retiring
-                && existing.initiator == record.initiator
-                && existing.local_network_generation == record.local_network_generation
-                && existing.remote_candidate_epoch == record.remote_candidate_epoch
-                && existing.local_profile_generation == record.local_profile_generation
-                && existing.remote_profile_generation == record.remote_profile_generation
-                && existing.requested_birthday_level == record.requested_birthday_level
-                && existing.generated_candidate_count == record.generated_candidate_count
-                && existing.signaled_candidate_count == record.signaled_candidate_count
-                && existing.birthday == record.birthday
-                && existing.requested_socket_indices == record.requested_socket_indices
-                && existing.requested_socket_count == record.requested_socket_count
-                && existing.prediction_window == record.prediction_window);
+        // `true` means THIS record became the authoritative owner. An exact
+        // duplicate is accepted by the control-plane state machine, but it
+        // must not make a second measurement believe it owns the existing
+        // record's cleanup watcher. Returning false keeps that measurement's
+        // provisional guard armed so its token-tagged socket rolls back.
+        let inserted = if sessions.contains_key(&key) {
+            false
         } else {
             // One live session per peer.  A newer fresh measurement supersedes
             // every older response fence before it can reuse an exact socket.
@@ -264,11 +256,12 @@ impl PeerManager {
                 }
             }
             sessions.insert(key, record);
-        }
+            true
+        };
         drop(sessions);
-        if duplicate_result.is_none() || !retired_winners.is_empty() {
+        if inserted || !retired_winners.is_empty() {
             let mut winners = self.hard_hard_winners.lock().await;
-            if duplicate_result.is_none() {
+            if inserted {
                 winners.remove(&winner_key);
             }
             for key in retired_winners {
@@ -278,7 +271,7 @@ impl PeerManager {
         for cancellation in cancelled {
             cancellation.cancel_for_hard_hard_cleanup();
         }
-        duplicate_result.unwrap_or(true)
+        inserted
     }
 
     /// A live session suppresses a second initiator while its bounded socket
@@ -409,12 +402,14 @@ impl PeerManager {
     ) -> Option<HardHardFreshSocketIdentity> {
         let now = hard_hard_now_ms();
         let key = (peer_id.to_string(), token.to_string());
-        let eligible = self
-            .hard_hard_sessions
-            .lock()
-            .await
-            .values()
-            .any(|record| {
+        // Keep the session record locked through the sticky-winner update.
+        // Every other path either takes `hard_hard_sessions` first or drops
+        // it before touching `hard_hard_winners`, so this ordering cannot
+        // deadlock. More importantly, cancellation can no longer leave a
+        // winner map entry behind after the eligible-session check but before
+        // the exact fresh-socket identity is committed to the record.
+        let mut sessions = self.hard_hard_sessions.lock().await;
+        let record = sessions.values_mut().find(|record| {
                 record.peer_id == peer_id
                     && record.session_token == token
                     && record.state != HardHardSessionState::Retiring
@@ -423,42 +418,15 @@ impl PeerManager {
                     && record.local_network_generation == network_generation
                     && (record.state == HardHardSessionState::Sweeping
                         || (!record.initiator && record.state == HardHardSessionState::AwaitingPeer))
-            });
-        if !eligible {
-            return None;
+            })?;
+        let mut winners = self.hard_hard_winners.lock().await;
+        if let Some(existing) = winners.get(&key) {
+            if *existing != socket_index {
+                return None;
+            }
+        } else {
+            winners.insert(key, socket_index);
         }
-        let inserted_winner = {
-            let mut winners = self.hard_hard_winners.lock().await;
-            if let Some(existing) = winners.get(&key) {
-                if *existing != socket_index {
-                    return None;
-                }
-                false
-            } else {
-                winners.insert(key.clone(), socket_index);
-                true
-            }
-        };
-        let mut sessions = self.hard_hard_sessions.lock().await;
-        let Some(record) = sessions.values_mut().find(|record| {
-            record.peer_id == peer_id
-                && record.session_token == token
-                && record.state != HardHardSessionState::Retiring
-                && !record.cancellation.is_cancelled()
-                && record.expires_at_ms >= now
-                && record.local_network_generation == network_generation
-                && (record.state == HardHardSessionState::Sweeping
-                    || (!record.initiator && record.state == HardHardSessionState::AwaitingPeer))
-        }) else {
-            drop(sessions);
-            if inserted_winner {
-                self.hard_hard_winners
-                    .lock()
-                    .await
-                    .remove(&key);
-            }
-            return None;
-        };
         record.fresh_socket.socket_index = socket_index;
         record.fresh_socket.punch_generation = punch_generation.max(1);
         record.fresh_socket.socket_local_endpoint = socket_local_endpoint;
@@ -491,6 +459,14 @@ impl PeerManager {
             .await
             .get(&(peer_id.to_string(), token.to_string()))
             .copied()
+    }
+
+    /// Hold the sticky-winner writer for deterministic cancellation tests.
+    #[cfg(test)]
+    pub(crate) async fn hold_hard_hard_winner_writer_for_test(
+        &self,
+    ) -> tokio::sync::MutexGuard<'_, HashMap<(String, String), usize>> {
+        self.hard_hard_winners.lock().await
     }
 
     /// Admit the one expected reciprocal response after the remote candidate

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -819,17 +819,28 @@ impl PeerManager {
         sent_probes: Option<u32>,
         detail: impl Into<String>,
     ) {
-        // Diagnostics must never become a back-pressure point for the control
-        // event loop.  A direct probe, candidate handover or relay renewal may
-        // briefly own the connection map while it commits state; waiting here
-        // would stop the loop from consuming ControlHealthy and new signals.
-        // The typed timeline event below remains authoritative when the map is
-        // contended, and the per-peer ring is best-effort for this diagnostic
-        // path.
+        // Ordinary diagnostics must never become a back-pressure point for the
+        // control event loop. A direct probe, candidate handover or relay
+        // renewal may briefly own the connection map while it commits state;
+        // the typed timeline event below remains authoritative when that map
+        // is contended. Hard↔Hard lifecycle markers are the exception: they
+        // are bounded acceptance evidence and use the durable branch below.
         let generation = self.current_network_generation_sync();
         let stage = stage.into();
         let detail = detail.into();
-        if let Ok(mut connections) = self.connections.try_write() {
+        if Self::direct_event_requires_durable_ring(&stage) {
+            let mut connections = self.connections.write().await;
+            if let Some(conn) = connections.get_mut(node_id) {
+                conn.record_direct_event(
+                    generation,
+                    stage.clone(),
+                    endpoint,
+                    candidate_count,
+                    sent_probes,
+                    detail.clone(),
+                );
+            }
+        } else if let Ok(mut connections) = self.connections.try_write() {
             if let Some(conn) = connections.get_mut(node_id) {
                 conn.record_direct_event(
                     generation,
@@ -869,7 +880,20 @@ impl PeerManager {
     ) {
         let stage = stage.into();
         let detail = detail.into();
-        if let Ok(mut connections) = self.connections.try_write() {
+        if Self::direct_event_requires_durable_ring(&stage) {
+            let mut connections = self.connections.write().await;
+            if let Some(conn) = connections.get_mut(node_id) {
+                conn.record_direct_event_with_socket(
+                    generation,
+                    stage.clone(),
+                    endpoint,
+                    socket_index,
+                    candidate_count,
+                    sent_probes,
+                    detail.clone(),
+                );
+            }
+        } else if let Ok(mut connections) = self.connections.try_write() {
             if let Some(conn) = connections.get_mut(node_id) {
                 conn.record_direct_event_with_socket(
                     generation,
@@ -892,6 +916,24 @@ impl PeerManager {
             sent_probes,
             &detail,
         );
+    }
+
+    /// Hard↔Hard terminal and lifecycle markers are acceptance evidence, not
+    /// best-effort trace noise.  Wait for the connection writer for these
+    /// bounded events so reciprocal validation cannot silently drop the final
+    /// summary/failure while high-volume ordinary diagnostics remain
+    /// non-blocking.
+    fn direct_event_requires_durable_ring(stage: &str) -> bool {
+        matches!(
+            stage,
+            "hard_hard_sweep_started"
+                | "hard_hard_direct_validation_started"
+                | "hard_hard_probe_summary"
+                | "hard_hard_birthday_sweep_summary"
+                | "hard_hard_sweep_completed"
+                | "hard_hard_sweep_failed"
+                | "hard_hard_failed"
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -369,6 +369,7 @@ impl PeerManager {
         // Keep the synchronous Direct-set mirror attached to every connection
         // so its `transition` keeps the UDP eviction's nonevictable set fresh.
         conn.attach_direct_cache(self.direct_peers.clone());
+        conn.attach_direct_pair_cache(self.direct_commit_pair_mirror.clone());
 
         let old_virtual_ip = conn.virtual_ip.clone();
         let old_public_key = conn.public_key.clone();
@@ -922,14 +923,14 @@ impl PeerManager {
     /// Hard↔Hard terminal markers are acceptance evidence, not best-effort
     /// trace noise. Wait for the connection writer for these bounded events so
     /// reciprocal validation cannot silently drop the final summary/failure.
-    /// `hard_hard_sweep_started` is deliberately excluded: it runs on the
-    /// punch-at deadline path and must not hold the first UDP send behind the
-    /// connection writer.
+    /// `hard_hard_sweep_started` and
+    /// `hard_hard_direct_validation_started` are deliberately excluded: both
+    /// run on the punch-at/confirmation timing path and must not hold the
+    /// first UDP send or confirmation grace behind the connection writer.
     fn direct_event_requires_durable_ring(stage: &str) -> bool {
         matches!(
             stage,
-            "hard_hard_direct_validation_started"
-                | "hard_hard_probe_summary"
+            "hard_hard_probe_summary"
                 | "hard_hard_birthday_sweep_summary"
                 | "hard_hard_sweep_completed"
                 | "hard_hard_sweep_failed"
@@ -1424,23 +1425,6 @@ impl PeerManager {
             .await
             .get(node_id)
             .and_then(|connection| connection.probe_session_id.clone())
-    }
-
-    /// Best-effort session snapshot for a deadline-sensitive send path. A
-    /// diagnostics/control writer may be holding the connection map exactly
-    /// at punch time; returning `None` keeps that unrelated writer from
-    /// delaying the first UDP datagram. The receive counter key remains
-    /// generation-scoped, so this only reduces optional ACK attribution when
-    /// the snapshot is contended.
-    pub(crate) fn probe_session_id_for_peer_try(&self, node_id: &str) -> Option<String> {
-        self.connections
-            .try_read()
-            .ok()
-            .and_then(|connections| {
-                connections
-                    .get(node_id)
-                    .and_then(|connection| connection.probe_session_id.clone())
-            })
     }
 
     /// Return role-tagged Probe-v2 keys for inbound authentication. Only an

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -920,9 +920,10 @@ impl PeerManager {
         );
     }
 
-    /// Hard↔Hard terminal markers are acceptance evidence, not best-effort
-    /// trace noise. Wait for the connection writer for these bounded events so
-    /// reciprocal validation cannot silently drop the final summary/failure.
+    /// Hard↔Hard winner and terminal markers are acceptance evidence, not
+    /// best-effort trace noise. Wait for the connection writer for these
+    /// bounded events so reciprocal validation cannot silently drop the
+    /// selected-socket or final summary/failure evidence.
     /// `hard_hard_sweep_started` and
     /// `hard_hard_direct_validation_started` are deliberately excluded: both
     /// run on the punch-at/confirmation timing path and must not hold the
@@ -935,6 +936,7 @@ impl PeerManager {
                 | "hard_hard_sweep_completed"
                 | "hard_hard_sweep_failed"
                 | "hard_hard_failed"
+                | "hard_hard_winner_selected"
         )
     }
 

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -823,8 +823,9 @@ impl PeerManager {
         // control event loop. A direct probe, candidate handover or relay
         // renewal may briefly own the connection map while it commits state;
         // the typed timeline event below remains authoritative when that map
-        // is contended. Hard↔Hard lifecycle markers are the exception: they
-        // are bounded acceptance evidence and use the durable branch below.
+        // is contended. Hard↔Hard terminal markers remain durable, while the
+        // pre-send sweep marker is intentionally best-effort so it cannot
+        // delay the first UDP datagram.
         let generation = self.current_network_generation_sync();
         let stage = stage.into();
         let detail = detail.into();
@@ -918,16 +919,16 @@ impl PeerManager {
         );
     }
 
-    /// Hard↔Hard terminal and lifecycle markers are acceptance evidence, not
-    /// best-effort trace noise.  Wait for the connection writer for these
-    /// bounded events so reciprocal validation cannot silently drop the final
-    /// summary/failure while high-volume ordinary diagnostics remain
-    /// non-blocking.
+    /// Hard↔Hard terminal markers are acceptance evidence, not best-effort
+    /// trace noise. Wait for the connection writer for these bounded events so
+    /// reciprocal validation cannot silently drop the final summary/failure.
+    /// `hard_hard_sweep_started` is deliberately excluded: it runs on the
+    /// punch-at deadline path and must not hold the first UDP send behind the
+    /// connection writer.
     fn direct_event_requires_durable_ring(stage: &str) -> bool {
         matches!(
             stage,
-            "hard_hard_sweep_started"
-                | "hard_hard_direct_validation_started"
+            "hard_hard_direct_validation_started"
                 | "hard_hard_probe_summary"
                 | "hard_hard_birthday_sweep_summary"
                 | "hard_hard_sweep_completed"
@@ -1423,6 +1424,23 @@ impl PeerManager {
             .await
             .get(node_id)
             .and_then(|connection| connection.probe_session_id.clone())
+    }
+
+    /// Best-effort session snapshot for a deadline-sensitive send path. A
+    /// diagnostics/control writer may be holding the connection map exactly
+    /// at punch time; returning `None` keeps that unrelated writer from
+    /// delaying the first UDP datagram. The receive counter key remains
+    /// generation-scoped, so this only reduces optional ACK attribution when
+    /// the snapshot is contended.
+    pub(crate) fn probe_session_id_for_peer_try(&self, node_id: &str) -> Option<String> {
+        self.connections
+            .try_read()
+            .ok()
+            .and_then(|connections| {
+                connections
+                    .get(node_id)
+                    .and_then(|connection| connection.probe_session_id.clone())
+            })
     }
 
     /// Return role-tagged Probe-v2 keys for inbound authentication. Only an

--- a/client/daemon/src/peer/manager/recovery_epoch.rs
+++ b/client/daemon/src/peer/manager/recovery_epoch.rs
@@ -1369,6 +1369,52 @@ impl PeerManager {
             .copied()
     }
 
+    /// Publish the exact local endpoint and remote candidate epoch selected by
+    /// an authoritative Direct commit.  The caller holds the shared network
+    /// epoch gate and the connection writer, so this snapshot is ordered with
+    /// the corresponding Direct state transition and commit sequence bump.
+    pub(crate) fn publish_direct_commit_pair(
+        &self,
+        peer_id: &str,
+        generation: u64,
+        remote_candidate_epoch: u64,
+        local_endpoint: Option<SocketAddr>,
+    ) {
+        self.direct_commit_pair_mirror
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(
+                peer_id.to_string(),
+                DirectCommitPairSnapshot {
+                    generation,
+                    remote_candidate_epoch,
+                    local_endpoint,
+                },
+            );
+    }
+
+    /// Check the latest exact Direct pair without touching the async
+    /// connection map.  `is_direct_sync` is checked separately from the pair
+    /// snapshot so a transition to Relay/Closed cannot leave a stale exact
+    /// pair looking current.
+    pub(crate) fn direct_commit_pair_matches_sync(
+        &self,
+        identity: &HardHardFreshSocketIdentity,
+    ) -> bool {
+        if !self.is_direct_sync(&identity.peer_id) {
+            return false;
+        }
+        self.direct_commit_pair_mirror
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&identity.peer_id)
+            .is_some_and(|snapshot| {
+                snapshot.generation == identity.network_generation
+                    && snapshot.remote_candidate_epoch == identity.remote_candidate_epoch
+                    && snapshot.local_endpoint == Some(identity.socket_local_endpoint)
+            })
+    }
+
     /// Bump the direct-commit sequence for a peer and wake every waiters.
     /// Must be called inside the network-epoch critical section together
     /// with the Direct state transition.

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -47,6 +47,19 @@ pub(crate) struct HardHardSessionRecord {
     pub(crate) remote_profile_generation: u64,
     pub(crate) local_prediction_confidence: u8,
     pub(crate) remote_prediction_confidence: u8,
+    /// Original Birthday level selected before candidate signaling is capped.
+    /// Zero denotes the predictable fresh-mapping lane, which has no Birthday
+    /// level.  This local ledger value is authoritative for the reciprocal
+    /// response path; it is never reconstructed from the signaled window.
+    pub(crate) requested_birthday_level: usize,
+    pub(crate) generated_candidate_count: usize,
+    pub(crate) signaled_candidate_count: usize,
+    pub(crate) birthday: bool,
+    /// Exact dynamic sockets created for this session.  A later scheduler
+    /// snapshot may find only a subset still attached/usable; it must never
+    /// replace a missing member with a pool socket.
+    pub(crate) requested_socket_indices: Vec<usize>,
+    pub(crate) requested_socket_count: usize,
     pub(crate) prediction_window: Vec<SocketAddr>,
     pub(crate) remote_prediction: Vec<SocketAddr>,
     pub(crate) fresh_socket: HardHardFreshSocketIdentity,

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -12,6 +12,7 @@
 pub(crate) enum HardHardSessionState {
     AwaitingPeer,
     Sweeping,
+    Retiring,
 }
 
 /// Exact identity of the dedicated socket that produced one synchronized
@@ -87,6 +88,45 @@ pub(crate) struct HardHardSessionRecord {
     pub(crate) attempt_count: u8,
     pub(crate) created_at: Instant,
     pub(crate) cancellation: Arc<crate::PunchSessionCancellation>,
+}
+
+#[cfg(test)]
+pub(crate) struct HardHardCleanupGate {
+    pub(crate) reached: tokio::sync::Notify,
+    pub(crate) release: tokio::sync::Notify,
+    pub(crate) completed: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+struct HardHardCleanupGateRegistration {
+    peer_id: String,
+    session_id: String,
+    session_token: String,
+    gate: Arc<HardHardCleanupGate>,
+}
+
+#[cfg(test)]
+pub(crate) struct HardHardCleanupGateGuard {
+    slot: Arc<std::sync::Mutex<Option<HardHardCleanupGateRegistration>>>,
+    installed: Arc<HardHardCleanupGate>,
+    previous: Option<HardHardCleanupGateRegistration>,
+}
+
+#[cfg(test)]
+impl Drop for HardHardCleanupGateGuard {
+    fn drop(&mut self) {
+        let mut slot = self
+            .slot
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot
+            .as_ref()
+            .is_some_and(|registration| Arc::ptr_eq(&registration.gate, &self.installed))
+        {
+            *slot = self.previous.take();
+        }
+        self.installed.release.notify_waiters();
+    }
 }
 
 /// Hard ceiling for remote identity tombstones retained after `PeerLeft`.
@@ -263,6 +303,9 @@ pub struct PeerManager {
     peer_membership: Arc<std::sync::Mutex<PeerMembershipState>>,
     #[cfg(test)]
     authenticated_probe_verify_gate: AuthenticatedProbeVerifyGateSlot,
+    #[cfg(test)]
+    hard_hard_cleanup_gate:
+        Arc<std::sync::Mutex<Option<HardHardCleanupGateRegistration>>>,
     /// Last complete diagnostics snapshot.  Diagnostics must never turn a
     /// contended connection writer into a false empty roster; the snapshot is
     /// only a fallback while the live lock is unavailable.
@@ -318,6 +361,9 @@ pub struct PeerManager {
     /// measured.  Entries are short-lived and bounded; they are not a path
     /// selector or a Direct authority.
     hard_hard_sessions: Arc<tokio::sync::Mutex<HashMap<(String, String), HardHardSessionRecord>>>,
+    /// Exact cleanup ownership claims. A duplicate registration must not
+    /// start a second watcher that could later race a replacement session.
+    hard_hard_cleanup_owners: Arc<tokio::sync::Mutex<HashSet<(String, String, String)>>>,
     /// First authenticated socket selected by a bounded Hard↔Hard session.
     /// Kept outside the wire/session record so old test fixtures and the
     /// compact envelope remain compatible while a late packet cannot replace

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -31,9 +31,27 @@ pub(crate) struct HardHardFreshSocketIdentity {
     pub(crate) socket_local_endpoint: SocketAddr,
 }
 
+/// Lock-free snapshot of the pair selected by the latest authoritative Direct
+/// commit.  The snapshot is published while the network-epoch gate and the
+/// connection writer are held, then consumed by the Hard↔Hard confirmation
+/// wait without reacquiring the connection map.  The Direct-set mirror still
+/// supplies the active/inactive bit; this value only proves the exact local
+/// endpoint and remote candidate epoch of the commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DirectCommitPairSnapshot {
+    pub(crate) generation: u64,
+    pub(crate) remote_candidate_epoch: u64,
+    pub(crate) local_endpoint: Option<SocketAddr>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct HardHardSessionRecord {
     pub(crate) session_id: String,
+    /// Authoritative Probe receive-session identity captured before the
+    /// punch-at deadline path.  Hard↔Hard diagnostics reuse this exact value
+    /// before and after the sweep, even if the connection map is contended at
+    /// punch time; the full value is never emitted in diagnostics.
+    pub(crate) probe_session_id: Option<String>,
     pub(crate) session_token: String,
     pub(crate) peer_id: String,
     pub(crate) initiator: bool,
@@ -396,6 +414,11 @@ pub struct PeerManager {
     /// Wake-up for any direct-commit bump.  Waiters re-check the peer's
     /// sequence after waking.
     direct_commit_notify: Arc<Notify>,
+    /// Lock-free exact pair selected by the latest Direct commit.  Hard↔Hard
+    /// confirmation reads this beside `direct_commit_seq_mirror` so a
+    /// contended connection writer cannot delay the grace timer.
+    direct_commit_pair_mirror:
+        Arc<std::sync::Mutex<HashMap<String, DirectCommitPairSnapshot>>>,
     /// Lock-free per-peer relay-confirm sequence mirror.  Bumped (and notified)
     /// whenever a peer's forced-relay encrypted probe/ACK confirms the relay
     /// path, so the outbound actor can flush a waiting first packet the moment

--- a/client/daemon/src/udp.rs
+++ b/client/daemon/src/udp.rs
@@ -4,7 +4,7 @@
 //! ID. This module is the direct UDP sink: it resolves each peer endpoint from
 //! `PeerManager` and sends the encrypted datagram to that socket address.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},

--- a/client/daemon/src/udp.rs
+++ b/client/daemon/src/udp.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex as StdMutex,
 };
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 

--- a/client/daemon/src/udp/admission.rs
+++ b/client/daemon/src/udp/admission.rs
@@ -3,28 +3,20 @@ use probe_budget::{
 };
 
 #[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProbeSendTestAction {
-    Fail,
-    Blackhole,
-}
-
-#[cfg(test)]
-#[derive(Debug)]
-struct ProbeSendTestHook {
-    action: ProbeSendTestAction,
-    selected_attempts: Option<HashSet<usize>>,
+#[derive(Debug, Default)]
+struct ProbeSendFailureHook {
+    fail_on_attempts: HashSet<usize>,
     physical_send_attempt: usize,
 }
 
 #[cfg(test)]
-pub(crate) struct ProbeSendTestGuard {
-    hook: Arc<std::sync::Mutex<Option<ProbeSendTestHook>>>,
+pub(crate) struct ProbeSendFailureGuard {
+    hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
     enabled: Arc<AtomicBool>,
 }
 
 #[cfg(test)]
-impl Drop for ProbeSendTestGuard {
+impl Drop for ProbeSendFailureGuard {
     fn drop(&mut self) {
         *self.hook.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
         self.enabled.store(false, Ordering::Release);
@@ -1085,36 +1077,32 @@ impl UdpTransport {
         peer_addr: SocketAddr,
     ) -> std::io::Result<usize> {
         #[cfg(test)]
-        match self.probe_send_action_for_test() {
-            Some(ProbeSendTestAction::Fail) => {
-                return Err(std::io::Error::other(
-                    "test-injected physical probe send failure",
-                ));
-            }
-            Some(ProbeSendTestAction::Blackhole) => return Ok(bytes.len()),
-            None => {}
+        if self.should_fail_probe_send_for_test() {
+            return Err(std::io::Error::other(
+                "test-injected physical probe send failure",
+            ));
         }
         socket.send_to(bytes, peer_addr).await
     }
 
     #[cfg(test)]
-    fn probe_send_action_for_test(&self) -> Option<ProbeSendTestAction> {
+    fn should_fail_probe_send_for_test(&self) -> bool {
         if !self
-            .probe_send_test_hook_enabled
+            .probe_send_failure_hook_enabled
             .load(std::sync::atomic::Ordering::Acquire)
         {
-            return None;
+            return false;
         }
         let mut hook = self
-            .probe_send_test_hook
+            .probe_send_failure_hook
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let hook = hook.as_mut()?;
+        let Some(hook) = hook.as_mut() else {
+            return false;
+        };
         hook.physical_send_attempt = hook.physical_send_attempt.saturating_add(1);
-        match hook.selected_attempts.as_ref() {
-            Some(selected) if !selected.contains(&hook.physical_send_attempt) => None,
-            _ => Some(hook.action),
-        }
+        hook.fail_on_attempts
+            .contains(&hook.physical_send_attempt)
     }
 
     /// Send an authenticated ICE-style nominated connectivity check for a direct trial.

--- a/client/daemon/src/udp/admission.rs
+++ b/client/daemon/src/udp/admission.rs
@@ -9,16 +9,32 @@ struct ProbeSendFailureHook {
     physical_send_attempt: usize,
 }
 
+#[cfg(test)]
+pub(crate) struct ProbeSendFailureGuard {
+    hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
+    enabled: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+impl Drop for ProbeSendFailureGuard {
+    fn drop(&mut self) {
+        *self.hook.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        self.enabled.store(false, Ordering::Release);
+    }
+}
+
 #[derive(Debug)]
 struct ProbeSendFailure {
     error: DaemonError,
+    kind: ProbeSendFailureKind,
     physical_send_errors: u8,
 }
 
 impl ProbeSendFailure {
-    fn new(error: DaemonError) -> Self {
+    fn new(kind: ProbeSendFailureKind, error: DaemonError) -> Self {
         Self {
             error,
+            kind,
             physical_send_errors: 0,
         }
     }
@@ -26,6 +42,7 @@ impl ProbeSendFailure {
     fn with_physical_send_error(error: DaemonError) -> Self {
         Self {
             error,
+            kind: ProbeSendFailureKind::PhysicalSend,
             physical_send_errors: 1,
         }
     }
@@ -576,6 +593,31 @@ impl UdpTransport {
         ))
     }
 
+    /// Classify an exact dynamic-socket lookup failure without substituting a
+    /// pool socket.  This is used by the bounded Hard↔Hard scheduler so a
+    /// detached member, a revoked owner and a stale network generation remain
+    /// distinguishable in the terminal report.
+    pub(crate) async fn classify_dynamic_socket_failure_kind(
+        &self,
+        peer_id: &str,
+        socket_index: usize,
+    ) -> ProbeSendFailureKind {
+        if socket_index < DYNAMIC_SOCKET_INDEX_BASE {
+            return ProbeSendFailureKind::SocketUnavailable;
+        }
+        let state = self.socket_state.lock().await;
+        let Some(dynamic) = state.dynamic.get(&socket_index) else {
+            return ProbeSendFailureKind::SocketUnavailable;
+        };
+        if dynamic.peer_id != peer_id || !dynamic.phase.is_usable() {
+            return ProbeSendFailureKind::SocketRevoked;
+        }
+        if dynamic.network_generation != self.peers.current_network_generation_sync() {
+            return ProbeSendFailureKind::NetworkGenerationChanged;
+        }
+        ProbeSendFailureKind::SocketUnavailable
+    }
+
     /// Send one authenticated/legacy probe from an explicit socket.
     ///
     /// This is the shared core for pool sockets and dedicated punch sockets:
@@ -653,6 +695,7 @@ impl UdpTransport {
             use_candidate,
             purpose,
             hard_hard_session_token,
+            false,
         )
         .await
         .map_err(|failure| failure.error)
@@ -668,6 +711,7 @@ impl UdpTransport {
         use_candidate: bool,
         purpose: PendingProbePurpose,
         hard_hard_session_token: Option<&str>,
+        require_exact_dynamic_owner: bool,
     ) -> std::result::Result<ProbeSendResult, ProbeSendFailure> {
         let remote_candidate_epoch = match peer_id {
             Some(peer_id) => self
@@ -751,9 +795,12 @@ impl UdpTransport {
                 let nonce = decode_punch_packet(&bytes)
                     .map(|packet| packet.nonce)
                     .ok_or_else(|| {
-                        ProbeSendFailure::new(DaemonError::Network(
-                            "failed to create UDP probe".to_string(),
-                        ))
+                        ProbeSendFailure::new(
+                            ProbeSendFailureKind::ProbeEncodingFailed,
+                            DaemonError::Network(
+                                "failed to create UDP probe".to_string(),
+                            ),
+                        )
                     })?;
                 (bytes.to_vec(), nonce, false, true, None, None)
             };
@@ -782,9 +829,12 @@ impl UdpTransport {
                 None => 0,
             };
             if current_remote_candidate_epoch != remote_candidate_epoch {
-                return Err(ProbeSendFailure::new(DaemonError::Network(
-                    "probe invalidated: remote candidate generation changed".to_string(),
-                )));
+                return Err(ProbeSendFailure::new(
+                    ProbeSendFailureKind::CandidateEpochChanged,
+                    DaemonError::Network(
+                        "probe invalidated: remote candidate generation changed".to_string(),
+                    ),
+                ));
             }
             let state = self.socket_state.lock().await;
             if self.peers.current_network_generation_sync() != generation {
@@ -792,9 +842,12 @@ impl UdpTransport {
                     "Probe to {} invalidated: the network generation changed while the packet was built",
                     peer_addr
                 );
-                return Err(ProbeSendFailure::new(DaemonError::Network(
-                    "probe invalidated: network generation changed".to_string(),
-                )));
+                return Err(ProbeSendFailure::new(
+                    ProbeSendFailureKind::NetworkGenerationChanged,
+                    DaemonError::Network(
+                        "probe invalidated: network generation changed".to_string(),
+                    ),
+                ));
             }
             let current_cleanup_epoch = peer_id
                 .and_then(|peer_id| state.probe_cleanup_epochs.get(peer_id).copied())
@@ -804,9 +857,44 @@ impl UdpTransport {
                     "Probe to {} invalidated: the peer was cleaned up while the packet was built (epoch {cleanup_epoch} -> {current_cleanup_epoch})",
                     peer_addr
                 );
-                return Err(ProbeSendFailure::new(DaemonError::Network(
-                    "probe invalidated: peer cleanup raced the send".to_string(),
-                )));
+                return Err(ProbeSendFailure::new(
+                    ProbeSendFailureKind::PeerSessionChanged,
+                    DaemonError::Network("probe invalidated: peer cleanup raced the send".to_string()),
+                ));
+            }
+            if require_exact_dynamic_owner && socket_index >= DYNAMIC_SOCKET_INDEX_BASE {
+                let Some(peer_id) = peer_id else {
+                    return Err(ProbeSendFailure::new(
+                        ProbeSendFailureKind::SocketRevoked,
+                        DaemonError::Network(
+                            "probe invalidated: dynamic socket has no peer owner".to_string(),
+                        ),
+                    ));
+                };
+                let Some(dynamic) = state.dynamic.get(&socket_index) else {
+                    return Err(ProbeSendFailure::new(
+                        ProbeSendFailureKind::SocketUnavailable,
+                        DaemonError::Network(format!(
+                            "UDP socket pool member {socket_index} is unavailable"
+                        )),
+                    ));
+                };
+                if dynamic.peer_id != peer_id || !dynamic.phase.is_usable() {
+                    return Err(ProbeSendFailure::new(
+                        ProbeSendFailureKind::SocketRevoked,
+                        DaemonError::Network(format!(
+                            "UDP socket pool member {socket_index} is no longer owned by peer"
+                        )),
+                    ));
+                }
+                if dynamic.network_generation != generation {
+                    return Err(ProbeSendFailure::new(
+                        ProbeSendFailureKind::NetworkGenerationChanged,
+                        DaemonError::Network(
+                            "probe invalidated: dynamic socket generation changed".to_string(),
+                        ),
+                    ));
+                }
             }
             let send_lease = if socket_index >= DYNAMIC_SOCKET_INDEX_BASE {
                 state.dynamic.get(&socket_index).map(|entry| {

--- a/client/daemon/src/udp/admission.rs
+++ b/client/daemon/src/udp/admission.rs
@@ -3,20 +3,28 @@ use probe_budget::{
 };
 
 #[cfg(test)]
-#[derive(Debug, Default)]
-struct ProbeSendFailureHook {
-    fail_on_attempts: HashSet<usize>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeSendTestAction {
+    Fail,
+    Blackhole,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct ProbeSendTestHook {
+    action: ProbeSendTestAction,
+    selected_attempts: Option<HashSet<usize>>,
     physical_send_attempt: usize,
 }
 
 #[cfg(test)]
-pub(crate) struct ProbeSendFailureGuard {
-    hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
+pub(crate) struct ProbeSendTestGuard {
+    hook: Arc<std::sync::Mutex<Option<ProbeSendTestHook>>>,
     enabled: Arc<AtomicBool>,
 }
 
 #[cfg(test)]
-impl Drop for ProbeSendFailureGuard {
+impl Drop for ProbeSendTestGuard {
     fn drop(&mut self) {
         *self.hook.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
         self.enabled.store(false, Ordering::Release);
@@ -1077,32 +1085,36 @@ impl UdpTransport {
         peer_addr: SocketAddr,
     ) -> std::io::Result<usize> {
         #[cfg(test)]
-        if self.should_fail_probe_send_for_test() {
-            return Err(std::io::Error::other(
-                "test-injected physical probe send failure",
-            ));
+        match self.probe_send_action_for_test() {
+            Some(ProbeSendTestAction::Fail) => {
+                return Err(std::io::Error::other(
+                    "test-injected physical probe send failure",
+                ));
+            }
+            Some(ProbeSendTestAction::Blackhole) => return Ok(bytes.len()),
+            None => {}
         }
         socket.send_to(bytes, peer_addr).await
     }
 
     #[cfg(test)]
-    fn should_fail_probe_send_for_test(&self) -> bool {
+    fn probe_send_action_for_test(&self) -> Option<ProbeSendTestAction> {
         if !self
-            .probe_send_failure_hook_enabled
+            .probe_send_test_hook_enabled
             .load(std::sync::atomic::Ordering::Acquire)
         {
-            return false;
+            return None;
         }
         let mut hook = self
-            .probe_send_failure_hook
+            .probe_send_test_hook
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(hook) = hook.as_mut() else {
-            return false;
-        };
+        let hook = hook.as_mut()?;
         hook.physical_send_attempt = hook.physical_send_attempt.saturating_add(1);
-        hook.fail_on_attempts
-            .contains(&hook.physical_send_attempt)
+        match hook.selected_attempts.as_ref() {
+            Some(selected) if !selected.contains(&hook.physical_send_attempt) => None,
+            _ => Some(hook.action),
+        }
     }
 
     /// Send an authenticated ICE-style nominated connectivity check for a direct trial.

--- a/client/daemon/src/udp/admission.rs
+++ b/client/daemon/src/udp/admission.rs
@@ -696,6 +696,7 @@ impl UdpTransport {
             purpose,
             hard_hard_session_token,
             false,
+            None,
         )
         .await
         .map_err(|failure| failure.error)
@@ -712,6 +713,7 @@ impl UdpTransport {
         purpose: PendingProbePurpose,
         hard_hard_session_token: Option<&str>,
         require_exact_dynamic_owner: bool,
+        live_recorder: Option<BirthdayLiveRecorder>,
     ) -> std::result::Result<ProbeSendResult, ProbeSendFailure> {
         let remote_candidate_epoch = match peer_id {
             Some(peer_id) => self
@@ -951,14 +953,35 @@ impl UdpTransport {
             send_lease
         };
 
-        if let Err(error) = self.send_probe_datagram(&socket, &bytes, peer_addr).await {
-            self.pending_probes.lock().await.remove(&nonce);
-            self.clear_hard_hard_pending_probe_token(nonce).await;
-            return Err(ProbeSendFailure::with_physical_send_error(DaemonError::Network(
-                format!("UDP probe send to {peer_addr} failed: {error}"),
-            )));
-        }
-        let first_send_at_ms = Some(monotonic_millis());
+        let first_send_at_ms = match self.send_probe_datagram(&socket, &bytes, peer_addr).await {
+            Ok(_) => {
+                let sent_at_ms = monotonic_millis();
+                // This is the physical send commit point.  It must precede
+                // the test gate, diagnostics update, lease cleanup, and every
+                // other follow-up await so a cancelled worker cannot lose a
+                // datagram that the kernel already accepted.
+                if let Some(recorder) = live_recorder.as_ref() {
+                    recorder.record_primary_success(socket_index, peer_addr, sent_at_ms);
+                }
+                #[cfg(test)]
+                wait_for_probe_post_send_gate_for_test().await;
+                Some(sent_at_ms)
+            }
+            Err(error) => {
+                // The primary send failed, but the physical error must still
+                // survive a cancellation racing the pending-probe cleanup.
+                if let Some(recorder) = live_recorder.as_ref() {
+                    recorder.record_primary_error();
+                }
+                #[cfg(test)]
+                wait_for_probe_post_send_gate_for_test().await;
+                self.pending_probes.lock().await.remove(&nonce);
+                self.clear_hard_hard_pending_probe_token(nonce).await;
+                return Err(ProbeSendFailure::with_physical_send_error(DaemonError::Network(
+                    format!("UDP probe send to {peer_addr} failed: {error}"),
+                )));
+            }
+        };
         // The send completed: release the in-flight send lease.  The pending
         // entry itself keeps the detach waiting until the ACK arrives or the
         // bounded drain timeout expires.
@@ -984,6 +1007,9 @@ impl UdpTransport {
             {
                 Ok(_) => {
                     datagrams_sent = datagrams_sent.saturating_add(1);
+                    if let Some(recorder) = live_recorder.as_ref() {
+                        recorder.record_compatibility_success(socket_index, monotonic_millis());
+                    }
                     self.update_socket_diagnostics(socket_index, |metrics| {
                         metrics.probes_sent += 1
                     })
@@ -1013,6 +1039,9 @@ impl UdpTransport {
                 }
                 Err(err) => {
                     physical_send_errors = physical_send_errors.saturating_add(1);
+                    if let Some(recorder) = live_recorder.as_ref() {
+                        recorder.record_compatibility_error();
+                    }
                     debug!(
                         "Failed to send compatibility legacy UDP punch probe to peer {} at {}: {}",
                         peer_id.unwrap_or("unknown"),

--- a/client/daemon/src/udp/admission.rs
+++ b/client/daemon/src/udp/admission.rs
@@ -2,6 +2,35 @@ use probe_budget::{
     RelayBackoffHeartbeatReservation, RelayBackoffHeartbeatReservationRejection,
 };
 
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct ProbeSendFailureHook {
+    fail_on_attempts: HashSet<usize>,
+    physical_send_attempt: usize,
+}
+
+#[derive(Debug)]
+struct ProbeSendFailure {
+    error: DaemonError,
+    physical_send_errors: u8,
+}
+
+impl ProbeSendFailure {
+    fn new(error: DaemonError) -> Self {
+        Self {
+            error,
+            physical_send_errors: 0,
+        }
+    }
+
+    fn with_physical_send_error(error: DaemonError) -> Self {
+        Self {
+            error,
+            physical_send_errors: 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ProbeSendResult {
     nonce: ProbeNonce,
@@ -17,6 +46,9 @@ struct ProbeSendResult {
     /// Wall-clock timestamp sampled immediately after the first successful
     /// kernel send.  This is deliberately not the dispatch timestamp.
     first_send_at_ms: Option<u64>,
+    /// Physical sends which returned an error during this logical probe. A
+    /// compatibility-copy failure can coexist with a successful primary.
+    physical_send_errors: u8,
 }
 
 impl UdpTransport {
@@ -613,6 +645,30 @@ impl UdpTransport {
         purpose: PendingProbePurpose,
         hard_hard_session_token: Option<&str>,
     ) -> Result<ProbeSendResult> {
+        self.send_probe_on_socket_result_with_hard_hard_token_classified(
+            socket_index,
+            socket,
+            peer_id,
+            peer_addr,
+            use_candidate,
+            purpose,
+            hard_hard_session_token,
+        )
+        .await
+        .map_err(|failure| failure.error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn send_probe_on_socket_result_with_hard_hard_token_classified(
+        &self,
+        socket_index: usize,
+        socket: Arc<UdpSocket>,
+        peer_id: Option<&str>,
+        peer_addr: SocketAddr,
+        use_candidate: bool,
+        purpose: PendingProbePurpose,
+        hard_hard_session_token: Option<&str>,
+    ) -> std::result::Result<ProbeSendResult, ProbeSendFailure> {
         let remote_candidate_epoch = match peer_id {
             Some(peer_id) => self
                 .peers
@@ -695,7 +751,9 @@ impl UdpTransport {
                 let nonce = decode_punch_packet(&bytes)
                     .map(|packet| packet.nonce)
                     .ok_or_else(|| {
-                        DaemonError::Network("failed to create UDP probe".to_string())
+                        ProbeSendFailure::new(DaemonError::Network(
+                            "failed to create UDP probe".to_string(),
+                        ))
                     })?;
                 (bytes.to_vec(), nonce, false, true, None, None)
             };
@@ -724,9 +782,9 @@ impl UdpTransport {
                 None => 0,
             };
             if current_remote_candidate_epoch != remote_candidate_epoch {
-                return Err(DaemonError::Network(
+                return Err(ProbeSendFailure::new(DaemonError::Network(
                     "probe invalidated: remote candidate generation changed".to_string(),
-                ));
+                )));
             }
             let state = self.socket_state.lock().await;
             if self.peers.current_network_generation_sync() != generation {
@@ -734,9 +792,9 @@ impl UdpTransport {
                     "Probe to {} invalidated: the network generation changed while the packet was built",
                     peer_addr
                 );
-                return Err(DaemonError::Network(
+                return Err(ProbeSendFailure::new(DaemonError::Network(
                     "probe invalidated: network generation changed".to_string(),
-                ));
+                )));
             }
             let current_cleanup_epoch = peer_id
                 .and_then(|peer_id| state.probe_cleanup_epochs.get(peer_id).copied())
@@ -746,9 +804,9 @@ impl UdpTransport {
                     "Probe to {} invalidated: the peer was cleaned up while the packet was built (epoch {cleanup_epoch} -> {current_cleanup_epoch})",
                     peer_addr
                 );
-                return Err(DaemonError::Network(
+                return Err(ProbeSendFailure::new(DaemonError::Network(
                     "probe invalidated: peer cleanup raced the send".to_string(),
-                ));
+                )));
             }
             let send_lease = if socket_index >= DYNAMIC_SOCKET_INDEX_BASE {
                 state.dynamic.get(&socket_index).map(|entry| {
@@ -805,11 +863,11 @@ impl UdpTransport {
             send_lease
         };
 
-        if let Err(error) = socket.send_to(&bytes, peer_addr).await {
+        if let Err(error) = self.send_probe_datagram(&socket, &bytes, peer_addr).await {
             self.pending_probes.lock().await.remove(&nonce);
             self.clear_hard_hard_pending_probe_token(nonce).await;
-            return Err(DaemonError::Network(format!(
-                "UDP probe send to {peer_addr} failed: {error}"
+            return Err(ProbeSendFailure::with_physical_send_error(DaemonError::Network(
+                format!("UDP probe send to {peer_addr} failed: {error}"),
             )));
         }
         let first_send_at_ms = Some(monotonic_millis());
@@ -830,8 +888,12 @@ impl UdpTransport {
         }
 
         let mut datagrams_sent = 1u8;
+        let mut physical_send_errors = 0u8;
         if let Some(legacy_probe) = compat_legacy_probe.clone() {
-            match socket.send_to(&legacy_probe, peer_addr).await {
+            match self
+                .send_probe_datagram(&socket, &legacy_probe, peer_addr)
+                .await
+            {
                 Ok(_) => {
                     datagrams_sent = datagrams_sent.saturating_add(1);
                     self.update_socket_diagnostics(socket_index, |metrics| {
@@ -862,6 +924,7 @@ impl UdpTransport {
                     }
                 }
                 Err(err) => {
+                    physical_send_errors = physical_send_errors.saturating_add(1);
                     debug!(
                         "Failed to send compatibility legacy UDP punch probe to peer {} at {}: {}",
                         peer_id.unwrap_or("unknown"),
@@ -886,7 +949,43 @@ impl UdpTransport {
             datagrams_sent,
             socket_index,
             first_send_at_ms,
+            physical_send_errors,
         })
+    }
+
+    async fn send_probe_datagram(
+        &self,
+        socket: &UdpSocket,
+        bytes: &[u8],
+        peer_addr: SocketAddr,
+    ) -> std::io::Result<usize> {
+        #[cfg(test)]
+        if self.should_fail_probe_send_for_test() {
+            return Err(std::io::Error::other(
+                "test-injected physical probe send failure",
+            ));
+        }
+        socket.send_to(bytes, peer_addr).await
+    }
+
+    #[cfg(test)]
+    fn should_fail_probe_send_for_test(&self) -> bool {
+        if !self
+            .probe_send_failure_hook_enabled
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return false;
+        }
+        let mut hook = self
+            .probe_send_failure_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(hook) = hook.as_mut() else {
+            return false;
+        };
+        hook.physical_send_attempt = hook.physical_send_attempt.saturating_add(1);
+        hook.fail_on_attempts
+            .contains(&hook.physical_send_attempt)
     }
 
     /// Send an authenticated ICE-style nominated connectivity check for a direct trial.

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -124,9 +124,9 @@ pub struct UdpTransport {
     /// disabled by default; tests can fail selected send attempts at the
     /// shared UDP send abstraction without closing or replacing the socket.
     #[cfg(test)]
-    probe_send_test_hook: Arc<std::sync::Mutex<Option<ProbeSendTestHook>>>,
+    probe_send_failure_hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
     #[cfg(test)]
-    probe_send_test_hook_enabled: Arc<AtomicBool>,
+    probe_send_failure_hook_enabled: Arc<AtomicBool>,
     /// One-shot lifecycle linearization seam used only by the remote-restart
     /// race regression.
     #[cfg(test)]
@@ -224,9 +224,9 @@ impl UdpTransport {
             #[cfg(test)]
             heartbeat_send_gate: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
-            probe_send_test_hook: Arc::new(std::sync::Mutex::new(None)),
+            probe_send_failure_hook: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
-            probe_send_test_hook_enabled: Arc::new(AtomicBool::new(false)),
+            probe_send_failure_hook_enabled: Arc::new(AtomicBool::new(false)),
             #[cfg(test)]
             remote_incarnation_cleanup_gate: Arc::new(std::sync::Mutex::new(None)),
             authenticated_punch_replay: Arc::new(Mutex::new(HashMap::new())),
@@ -281,47 +281,22 @@ impl UdpTransport {
     pub(crate) fn set_probe_send_failures_for_test(
         &self,
         fail_on_attempts: impl IntoIterator<Item = usize>,
-    ) -> ProbeSendTestGuard {
+    ) -> ProbeSendFailureGuard {
         let fail_on_attempts = fail_on_attempts.into_iter().collect::<HashSet<_>>();
         let mut hook = self
-            .probe_send_test_hook
+            .probe_send_failure_hook
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *hook = Some(ProbeSendTestHook {
-            action: ProbeSendTestAction::Fail,
-            selected_attempts: Some(fail_on_attempts.clone()),
+        *hook = Some(ProbeSendFailureHook {
+            fail_on_attempts: fail_on_attempts.clone(),
             physical_send_attempt: 0,
         });
         drop(hook);
-        self.probe_send_test_hook_enabled
+        self.probe_send_failure_hook_enabled
             .store(!fail_on_attempts.is_empty(), Ordering::Release);
-        ProbeSendTestGuard {
-            hook: self.probe_send_test_hook.clone(),
-            enabled: self.probe_send_test_hook_enabled.clone(),
-        }
-    }
-
-    /// Report every probe datagram as accepted without entering the kernel.
-    /// This keeps the production pending-probe and telemetry path intact while
-    /// deterministic no-reachability tests avoid platform ephemeral-port
-    /// collisions that can bypass their synthetic NAT link.
-    #[cfg(test)]
-    pub(crate) fn blackhole_probe_sends_for_test(&self) -> ProbeSendTestGuard {
-        let mut hook = self
-            .probe_send_test_hook
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *hook = Some(ProbeSendTestHook {
-            action: ProbeSendTestAction::Blackhole,
-            selected_attempts: None,
-            physical_send_attempt: 0,
-        });
-        drop(hook);
-        self.probe_send_test_hook_enabled
-            .store(true, Ordering::Release);
-        ProbeSendTestGuard {
-            hook: self.probe_send_test_hook.clone(),
-            enabled: self.probe_send_test_hook_enabled.clone(),
+        ProbeSendFailureGuard {
+            hook: self.probe_send_failure_hook.clone(),
+            enabled: self.probe_send_failure_hook_enabled.clone(),
         }
     }
 

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -281,17 +281,23 @@ impl UdpTransport {
     pub(crate) fn set_probe_send_failures_for_test(
         &self,
         fail_on_attempts: impl IntoIterator<Item = usize>,
-    ) {
+    ) -> ProbeSendFailureGuard {
+        let fail_on_attempts = fail_on_attempts.into_iter().collect::<HashSet<_>>();
         let mut hook = self
             .probe_send_failure_hook
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         *hook = Some(ProbeSendFailureHook {
-            fail_on_attempts: fail_on_attempts.into_iter().collect(),
+            fail_on_attempts: fail_on_attempts.clone(),
             physical_send_attempt: 0,
         });
+        drop(hook);
         self.probe_send_failure_hook_enabled
-            .store(true, Ordering::Release);
+            .store(!fail_on_attempts.is_empty(), Ordering::Release);
+        ProbeSendFailureGuard {
+            hook: self.probe_send_failure_hook.clone(),
+            enabled: self.probe_send_failure_hook_enabled.clone(),
+        }
     }
 
     /// Add up to `count - 1` ephemeral sockets for an explicitly enabled
@@ -448,7 +454,7 @@ impl UdpTransport {
     /// generation.  The key is derived from the authenticated Probe-v2 source
     /// identity (or a matched pending probe for legacy compatibility), never
     /// from an unauthenticated source address.
-    async fn update_peer_probe_rx_diagnostics(
+    pub(crate) async fn update_peer_probe_rx_diagnostics(
         &self,
         peer_id: &str,
         generation: u64,

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -124,9 +124,9 @@ pub struct UdpTransport {
     /// disabled by default; tests can fail selected send attempts at the
     /// shared UDP send abstraction without closing or replacing the socket.
     #[cfg(test)]
-    probe_send_failure_hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
+    probe_send_test_hook: Arc<std::sync::Mutex<Option<ProbeSendTestHook>>>,
     #[cfg(test)]
-    probe_send_failure_hook_enabled: Arc<AtomicBool>,
+    probe_send_test_hook_enabled: Arc<AtomicBool>,
     /// One-shot lifecycle linearization seam used only by the remote-restart
     /// race regression.
     #[cfg(test)]
@@ -224,9 +224,9 @@ impl UdpTransport {
             #[cfg(test)]
             heartbeat_send_gate: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
-            probe_send_failure_hook: Arc::new(std::sync::Mutex::new(None)),
+            probe_send_test_hook: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
-            probe_send_failure_hook_enabled: Arc::new(AtomicBool::new(false)),
+            probe_send_test_hook_enabled: Arc::new(AtomicBool::new(false)),
             #[cfg(test)]
             remote_incarnation_cleanup_gate: Arc::new(std::sync::Mutex::new(None)),
             authenticated_punch_replay: Arc::new(Mutex::new(HashMap::new())),
@@ -281,22 +281,47 @@ impl UdpTransport {
     pub(crate) fn set_probe_send_failures_for_test(
         &self,
         fail_on_attempts: impl IntoIterator<Item = usize>,
-    ) -> ProbeSendFailureGuard {
+    ) -> ProbeSendTestGuard {
         let fail_on_attempts = fail_on_attempts.into_iter().collect::<HashSet<_>>();
         let mut hook = self
-            .probe_send_failure_hook
+            .probe_send_test_hook
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *hook = Some(ProbeSendFailureHook {
-            fail_on_attempts: fail_on_attempts.clone(),
+        *hook = Some(ProbeSendTestHook {
+            action: ProbeSendTestAction::Fail,
+            selected_attempts: Some(fail_on_attempts.clone()),
             physical_send_attempt: 0,
         });
         drop(hook);
-        self.probe_send_failure_hook_enabled
+        self.probe_send_test_hook_enabled
             .store(!fail_on_attempts.is_empty(), Ordering::Release);
-        ProbeSendFailureGuard {
-            hook: self.probe_send_failure_hook.clone(),
-            enabled: self.probe_send_failure_hook_enabled.clone(),
+        ProbeSendTestGuard {
+            hook: self.probe_send_test_hook.clone(),
+            enabled: self.probe_send_test_hook_enabled.clone(),
+        }
+    }
+
+    /// Report every probe datagram as accepted without entering the kernel.
+    /// This keeps the production pending-probe and telemetry path intact while
+    /// deterministic no-reachability tests avoid platform ephemeral-port
+    /// collisions that can bypass their synthetic NAT link.
+    #[cfg(test)]
+    pub(crate) fn blackhole_probe_sends_for_test(&self) -> ProbeSendTestGuard {
+        let mut hook = self
+            .probe_send_test_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *hook = Some(ProbeSendTestHook {
+            action: ProbeSendTestAction::Blackhole,
+            selected_attempts: None,
+            physical_send_attempt: 0,
+        });
+        drop(hook);
+        self.probe_send_test_hook_enabled
+            .store(true, Ordering::Release);
+        ProbeSendTestGuard {
+            hook: self.probe_send_test_hook.clone(),
+            enabled: self.probe_send_test_hook_enabled.clone(),
         }
     }
 

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -120,6 +120,13 @@ pub struct UdpTransport {
     /// the worker re-validates its ownership before the actual send.
     #[cfg(test)]
     heartbeat_send_gate: Arc<std::sync::Mutex<Option<Arc<HeartbeatSendGate>>>>,
+    /// Test-only physical-send seam. It is absent from production builds and
+    /// disabled by default; tests can fail selected send attempts at the
+    /// shared UDP send abstraction without closing or replacing the socket.
+    #[cfg(test)]
+    probe_send_failure_hook: Arc<std::sync::Mutex<Option<ProbeSendFailureHook>>>,
+    #[cfg(test)]
+    probe_send_failure_hook_enabled: Arc<AtomicBool>,
     /// One-shot lifecycle linearization seam used only by the remote-restart
     /// race regression.
     #[cfg(test)]
@@ -217,6 +224,10 @@ impl UdpTransport {
             #[cfg(test)]
             heartbeat_send_gate: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
+            probe_send_failure_hook: Arc::new(std::sync::Mutex::new(None)),
+            #[cfg(test)]
+            probe_send_failure_hook_enabled: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
             remote_incarnation_cleanup_gate: Arc::new(std::sync::Mutex::new(None)),
             authenticated_punch_replay: Arc::new(Mutex::new(HashMap::new())),
             authenticated_punch_rate: Arc::new(Mutex::new(HashMap::new())),
@@ -262,6 +273,25 @@ impl UdpTransport {
     fn with_heartbeat_send_gate(mut self, gate: Arc<HeartbeatSendGate>) -> Self {
         self.heartbeat_send_gate = Arc::new(std::sync::Mutex::new(Some(gate)));
         self
+    }
+
+    /// Fail the selected one-based physical send attempts in tests. The hook
+    /// is deliberately cfg(test), opt-in and scoped to this transport clone.
+    #[cfg(test)]
+    pub(crate) fn set_probe_send_failures_for_test(
+        &self,
+        fail_on_attempts: impl IntoIterator<Item = usize>,
+    ) {
+        let mut hook = self
+            .probe_send_failure_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *hook = Some(ProbeSendFailureHook {
+            fail_on_attempts: fail_on_attempts.into_iter().collect(),
+            physical_send_attempt: 0,
+        });
+        self.probe_send_failure_hook_enabled
+            .store(true, Ordering::Release);
     }
 
     /// Add up to `count - 1` ephemeral sockets for an explicitly enabled

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -1222,6 +1222,41 @@ impl UdpTransport {
         self.hard_hard_probe_bindings.lock().await.remove(&nonce);
     }
 
+    /// Remove pending probes owned by one exact Hard↔Hard token.  The token
+    /// binding is local-only, so this remains session-scoped even when the
+    /// dynamic socket entry was already removed or its token tag was lost.
+    /// Pending probes on an explicitly retained Direct socket are left in the
+    /// ordinary pending table but lose their Hard↔Hard ownership binding.
+    pub(crate) async fn clear_hard_hard_pending_probes_for_token(
+        &self,
+        peer_id: &str,
+        token: &str,
+        preserve_socket_index: Option<usize>,
+    ) {
+        let token_nonces = self
+            .hard_hard_probe_bindings
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, bound_token)| bound_token.as_str() == token)
+            .map(|(nonce, _)| *nonce)
+            .collect::<HashSet<_>>();
+        if token_nonces.is_empty() {
+            return;
+        }
+        self.pending_probes.lock().await.retain(|nonce, pending| {
+            pending.peer_id.as_deref() != Some(peer_id)
+                || !token_nonces.contains(nonce)
+                || preserve_socket_index == Some(pending.socket_index)
+        });
+        self.hard_hard_probe_bindings
+            .lock()
+            .await
+            .retain(|nonce, bound_token| {
+                bound_token.as_str() != token || !token_nonces.contains(nonce)
+            });
+    }
+
     async fn prune_hard_hard_probe_bindings(&self) {
         let pending = self.pending_probes.lock().await;
         let mut bindings = self.hard_hard_probe_bindings.lock().await;
@@ -1246,6 +1281,23 @@ impl UdpTransport {
             .filter(|(nonce, probe)| {
                 probe.peer_id.as_deref() == Some(peer_id)
                     && hard_hard_bindings.contains_key(*nonce)
+            })
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn hard_hard_pending_probe_count_for_token_for_test(
+        &self,
+        peer_id: &str,
+        token: &str,
+    ) -> usize {
+        let pending = self.pending_probes.lock().await;
+        let hard_hard_bindings = self.hard_hard_probe_bindings.lock().await;
+        pending
+            .iter()
+            .filter(|(nonce, probe)| {
+                probe.peer_id.as_deref() == Some(peer_id)
+                    && hard_hard_bindings.get(*nonce).is_some_and(|bound| bound == token)
             })
             .count()
     }

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -1302,6 +1302,98 @@ impl UdpTransport {
             .count()
     }
 
+    /// Redacted lifecycle evidence for deterministic Hard↔Hard timeout
+    /// diagnostics. Tokens and nonces never leave this method; only an
+    /// equality bit and a short process-local digest are exposed.
+    #[cfg(test)]
+    pub(crate) async fn hard_hard_udp_lifecycle_snapshot_for_test(
+        &self,
+        peer_id: &str,
+        expected_token: Option<&str>,
+    ) -> HardHardUdpLifecycleSnapshot {
+        let token_digest = |token: &str| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(token, &mut hasher);
+            format!("{:08x}", std::hash::Hasher::finish(&hasher) as u32)
+        };
+        let mut dynamic_sockets = {
+            let state = self.socket_state.lock().await;
+            let selected = state.affinity.get(peer_id).map(|pin| pin.socket_index);
+            state
+                .dynamic
+                .values()
+                .filter(|entry| entry.peer_id == peer_id)
+                .map(|entry| HardHardDynamicSocketLifecycleSnapshot {
+                    socket_index: entry.socket_index,
+                    phase: entry.phase,
+                    network_generation: entry.network_generation,
+                    punch_generation: entry.punch_generation,
+                    token_present: entry.hard_hard_session_token.is_some(),
+                    token_matches_expected: expected_token.is_some_and(|expected| {
+                        entry.hard_hard_session_token.as_deref() == Some(expected)
+                    }),
+                    token_digest: entry
+                        .hard_hard_session_token
+                        .as_deref()
+                        .map(token_digest),
+                    authenticated_evidence: entry.authenticated_evidence,
+                    outstanding_send_leases: entry.send_leases.outstanding(),
+                    pending_probe_count: 0,
+                    reader_finished: entry.reader.is_finished(),
+                    affinity_selected: selected == Some(entry.socket_index),
+                })
+                .collect::<Vec<_>>()
+        };
+        dynamic_sockets.sort_by_key(|entry| entry.socket_index);
+        let dynamic_indices = dynamic_sockets
+            .iter()
+            .map(|entry| entry.socket_index)
+            .collect::<HashSet<_>>();
+
+        let now = Instant::now();
+        let pending = self.pending_probes.lock().await;
+        let bindings = self.hard_hard_probe_bindings.lock().await;
+        let mut pending_probes = pending
+            .iter()
+            .filter_map(|(nonce, probe)| {
+                let binding = bindings.get(nonce);
+                let peer_matches = probe.peer_id.as_deref() == Some(peer_id);
+                let token_matches_expected = expected_token
+                    .zip(binding.map(String::as_str))
+                    .is_some_and(|(expected, actual)| expected == actual);
+                (peer_matches
+                    && (binding.is_some() || dynamic_indices.contains(&probe.socket_index))
+                    || token_matches_expected)
+                    .then_some(HardHardPendingProbeLifecycleSnapshot {
+                        socket_index: probe.socket_index,
+                        token_matches_expected,
+                        peer_matches,
+                        expired: probe.is_expired(now),
+                        binding_present: binding.is_some(),
+                    })
+            })
+            .collect::<Vec<_>>();
+        pending_probes.sort_by_key(|probe| probe.socket_index);
+        for socket in &mut dynamic_sockets {
+            socket.pending_probe_count = pending_probes
+                .iter()
+                .filter(|probe| probe.socket_index == socket.socket_index)
+                .count();
+        }
+        let orphan_probe_bindings = bindings
+            .keys()
+            .filter(|nonce| !pending.contains_key(*nonce))
+            .count();
+
+        HardHardUdpLifecycleSnapshot {
+            peer_id: peer_id.to_string(),
+            expected_token_present: expected_token.is_some(),
+            dynamic_sockets,
+            pending_probes,
+            orphan_probe_bindings,
+        }
+    }
+
     /// Attach the local control-plane node ID used by authenticated UDP Probe v2.
     pub fn with_local_node_id(mut self, node_id: impl Into<String>) -> Self {
         self.local_node_id = Some(node_id.into());

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -692,7 +692,8 @@ impl UdpTransport {
                 .collect::<Vec<_>>()
         };
         for entry in losers {
-            self.detach_dynamic_entry(entry, "hard_hard_loser_socket").await;
+            self.detach_dynamic_entry(entry, "hard_hard_loser_socket")
+                .await;
         }
         self.peers
             .record_direct_event_for_generation_with_socket(
@@ -1268,8 +1269,11 @@ impl UdpTransport {
             };
             let local_endpoint = socket.local_addr().ok();
             let Some(local_endpoint) = local_endpoint else {
-                self.detach_dynamic_socket_by_index(socket_index, "hard_hard_birthday_no_local_endpoint")
-                    .await;
+                self.detach_dynamic_socket_by_index(
+                    socket_index,
+                    "hard_hard_birthday_no_local_endpoint",
+                )
+                .await;
                 for attached_socket in &attached {
                     self.detach_dynamic_socket_by_index(
                         attached_socket.0,
@@ -1315,7 +1319,13 @@ impl UdpTransport {
                     });
                 }
             };
-            attached.push((socket_index, socket, guard, punch_generation, local_endpoint));
+            attached.push((
+                socket_index,
+                socket,
+                guard,
+                punch_generation,
+                local_endpoint,
+            ));
         }
 
         if capacity_rejected {
@@ -1395,8 +1405,11 @@ impl UdpTransport {
             || self.peers.is_direct(peer_id).await
         {
             for attached_socket in &attached {
-                self.detach_dynamic_socket_by_index(attached_socket.0, "hard_hard_birthday_superseded")
-                    .await;
+                self.detach_dynamic_socket_by_index(
+                    attached_socket.0,
+                    "hard_hard_birthday_superseded",
+                )
+                .await;
             }
             return Err(FreshMappingRejection::Superseded);
         }
@@ -1434,12 +1447,8 @@ impl UdpTransport {
         observed_ports.dedup();
         let local_model = infer_allocation_model(&observations_by_socket[0]);
         let model_label = local_model.kind.label().to_string();
-        let candidate_endpoints = hard_hard_birthday_candidates(
-            public_ip,
-            &observed_ports,
-                    level,
-                    session_token,
-        );
+        let candidate_endpoints =
+            hard_hard_birthday_candidates(public_ip, &observed_ports, level, session_token);
         if candidate_endpoints.len() != level {
             for attached_socket in &attached {
                 self.detach_dynamic_socket_by_index(
@@ -1456,8 +1465,7 @@ impl UdpTransport {
         // every earlier guard fail its finalize revalidation.  The remaining
         // guards use the no-affinity speculative commit below and are still
         // protected by the same generation/cancellation fences.
-        for (position, (socket_index, _, guard, punch_generation, _)) in
-            attached.iter().enumerate()
+        for (position, (socket_index, _, guard, punch_generation, _)) in attached.iter().enumerate()
         {
             let committed = if position == 0 {
                 guard
@@ -1482,7 +1490,11 @@ impl UdpTransport {
                     .await
                     .committed
             };
-            if !committed || !self.tag_hard_hard_socket(peer_id, *socket_index, session_token).await {
+            if !committed
+                || !self
+                    .tag_hard_hard_socket(peer_id, *socket_index, session_token)
+                    .await
+            {
                 for attached_socket in &attached {
                     self.detach_dynamic_socket_by_index(
                         attached_socket.0,
@@ -1516,15 +1528,17 @@ impl UdpTransport {
             .await;
         let sockets = attached
             .into_iter()
-            .map(|(socket_index, _, guard, punch_generation, socket_local_endpoint)| {
-                HardHardBirthdaySocket {
-                    punch_generation,
-                    socket_index,
-                    socket_local_endpoint,
-                    guard,
-                }
-        })
-        .collect();
+            .map(
+                |(socket_index, _, guard, punch_generation, socket_local_endpoint)| {
+                    HardHardBirthdaySocket {
+                        punch_generation,
+                        socket_index,
+                        socket_local_endpoint,
+                        guard,
+                    }
+                },
+            )
+            .collect();
         Ok(HardHardBirthdayResult {
             requested_level,
             requested_socket_count,
@@ -2346,7 +2360,8 @@ impl UdpTransport {
         } else {
             None
         };
-        let mut effective_targets = Vec::with_capacity(targets.len().min(crate::MAX_SIGNAL_CANDIDATES));
+        let mut effective_targets =
+            Vec::with_capacity(targets.len().min(crate::MAX_SIGNAL_CANDIDATES));
         for target in targets {
             if target.port() == 0 || effective_targets.contains(&target) {
                 continue;
@@ -2361,11 +2376,7 @@ impl UdpTransport {
         // and session-token scoped; a detached member becomes unavailable and
         // can never be replaced by a pool socket.
         let socket_snapshot = self
-            .hard_hard_socket_snapshot_for_token(
-                peer_id,
-                session_token,
-                &requested_socket_indices,
-            )
+            .hard_hard_socket_snapshot_for_token(peer_id, session_token, &requested_socket_indices)
             .await;
         let socket_plan = hard_hard_birthday_socket_plan(requested_level, socket_snapshot);
         let attached_socket_count = socket_plan.attached_socket_count;
@@ -2391,12 +2402,14 @@ impl UdpTransport {
             ..BirthdaySweepReport::default()
         };
         if usable_socket_count == 1 {
-            birthday.degraded_reason = Some(if requested_socket_count > 1 {
-                "partial_socket_unavailable"
-            } else {
-                "single_socket"
-            }
-            .to_string());
+            birthday.degraded_reason = Some(
+                if requested_socket_count > 1 {
+                    "partial_socket_unavailable"
+                } else {
+                    "single_socket"
+                }
+                .to_string(),
+            );
         } else if usable_socket_count > 0 && usable_socket_count < requested_socket_count {
             birthday.degraded_reason = Some("partial_socket_unavailable".to_string());
         }
@@ -2408,7 +2421,10 @@ impl UdpTransport {
             aggregate.birthday = Some(birthday);
             publish_birthday_sweep_progress(
                 &progress,
-                aggregate.birthday.as_ref().expect("birthday report just set"),
+                aggregate
+                    .birthday
+                    .as_ref()
+                    .expect("birthday report just set"),
                 &aggregate,
             )
             .await;
@@ -2416,11 +2432,15 @@ impl UdpTransport {
         }
         if effective_socket_indices.is_empty() {
             birthday.stop_reason = Some("socket_unavailable".to_string());
+            aggregate.failure_kind = Some(BirthdaySweepFailureKind::SocketUnavailable);
             update_birthday_sweep_counters(&mut birthday, &aggregate);
             aggregate.birthday = Some(birthday);
             publish_birthday_sweep_progress(
                 &progress,
-                aggregate.birthday.as_ref().expect("birthday report just set"),
+                aggregate
+                    .birthday
+                    .as_ref()
+                    .expect("birthday report just set"),
                 &aggregate,
             )
             .await;
@@ -2452,6 +2472,17 @@ impl UdpTransport {
                     .await
                 {
                     birthday.stop_reason = Some(reason.to_string());
+                    if let Some(failure_kind) = BirthdaySweepFailureKind::from_stop_reason(reason) {
+                        aggregate.failure_kind = combine_birthday_failure_kind(
+                            aggregate.failure_kind,
+                            Some(failure_kind),
+                        );
+                        update_birthday_sweep_counters(&mut birthday, &aggregate);
+                        publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
+                        return Err(DaemonError::Network(format!(
+                            "hard-hard birthday stopped: {reason}"
+                        )));
+                    }
                     break;
                 }
             }
@@ -2520,8 +2551,7 @@ impl UdpTransport {
             // A JoinError has no return payload, so normalize the wave's
             // assigned count from the scheduler plan and retain every target
             // not reached by a returned worker as cancelled progress.
-            wave_report.targets_assigned =
-                u32::try_from(wave_assigned_count).unwrap_or(u32::MAX);
+            wave_report.targets_assigned = u32::try_from(wave_assigned_count).unwrap_or(u32::MAX);
             wave_report.targets_cancelled = wave_report.targets_cancelled.max(
                 u32::try_from(wave_assigned_count)
                     .unwrap_or(u32::MAX)
@@ -2546,8 +2576,7 @@ impl UdpTransport {
             }
             if !wave_fully_completed {
                 birthday.stop_reason = Some(
-                    self
-                    .hard_hard_birthday_stop_reason(
+                    self.hard_hard_birthday_stop_reason(
                         peer_id,
                         session_token,
                         profile_fence,
@@ -2600,10 +2629,39 @@ impl UdpTransport {
                 break;
             }
             if wave_report.packets_sent == 0 && wave_report.budget_skipped == 0 {
-                birthday.stop_reason = Some("socket_unavailable".to_string());
-                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
-                break;
+                // A physical send failure is local to the logical target.
+                // Keep the bounded scheduler alive so a later target (or the
+                // rotated second wave) can still establish the path.  Only a
+                // wave that made no logical attempt and had no physical error
+                // is an unavailable-socket verdict.
+                if wave_report.logical_probes_attempted == 0
+                    && wave_report.physical_send_errors == 0
+                {
+                    birthday.stop_reason = Some("socket_unavailable".to_string());
+                    aggregate.failure_kind = Some(BirthdaySweepFailureKind::SocketUnavailable);
+                    publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
+                    break;
+                }
             }
+        }
+
+        // Do not turn one or more transient target send failures into an
+        // early scheduler abort.  The terminal send verdict is only emitted
+        // after every bounded wave has had its chance and every logical Probe
+        // attempted by this session failed at the physical send boundary.
+        if birthday.stop_reason.is_none()
+            && aggregate.logical_probes_attempted > 0
+            && aggregate.logical_probes_sent == 0
+            && aggregate.logical_probe_send_failures > 0
+            && aggregate.physical_send_errors > 0
+        {
+            aggregate.failure_kind = Some(BirthdaySweepFailureKind::Send);
+            birthday.stop_reason = Some("send_error".to_string());
+            update_birthday_sweep_counters(&mut birthday, &aggregate);
+            publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
+            return Err(DaemonError::Network(
+                "hard-hard birthday probes all failed at the physical send boundary".to_string(),
+            ));
         }
 
         if birthday.stop_reason.is_none() {
@@ -2615,7 +2673,10 @@ impl UdpTransport {
         aggregate.birthday = Some(birthday);
         publish_birthday_sweep_progress(
             &progress,
-            aggregate.birthday.as_ref().expect("birthday report just set"),
+            aggregate
+                .birthday
+                .as_ref()
+                .expect("birthday report just set"),
             &aggregate,
         )
         .await;
@@ -2722,17 +2783,20 @@ impl UdpTransport {
         profile_fence: Option<(u64, u64)>,
         hard_hard_session_token: Option<&str>,
     ) -> Result<PunchSendReport> {
-        self.punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
-            peer_id,
-            socket_index,
-            candidates,
-            probe_interval,
-            attempts,
-            profile_fence,
-            hard_hard_session_token,
-            None,
-        )
-        .await
+        let mut report = self
+            .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
+                peer_id,
+                socket_index,
+                candidates,
+                probe_interval,
+                attempts,
+                profile_fence,
+                hard_hard_session_token,
+                None,
+            )
+            .await?;
+        finalize_physical_send_failure(&mut report);
+        Ok(report)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2745,15 +2809,20 @@ impl UdpTransport {
         attempts: u32,
         profile_fence: Option<(u64, u64)>,
         hard_hard_session_token: Option<&str>,
-        live: Option<Arc<StdMutex<LiveBirthdayCounters>>>,
+        live: Option<Arc<StdMutex<LiveBirthdayProgress>>>,
     ) -> Result<PunchSendReport> {
         let Some((index, socket, _lease)) = self
             .resolve_dynamic_socket_index_for_send(peer_id, socket_index)
             .await
         else {
+            let failure_kind = self
+                .classify_dynamic_socket_failure_kind(peer_id, socket_index)
+                .await;
             return Ok(PunchSendReport {
                 targets_assigned: u32::try_from(candidates.len()).unwrap_or(u32::MAX),
                 targets_cancelled: u32::try_from(candidates.len()).unwrap_or(u32::MAX),
+                probe_path_errors: 1,
+                failure_kind: Some(BirthdaySweepFailureKind::from_probe_failure(failure_kind)),
                 ..PunchSendReport::default()
             });
         };
@@ -2782,14 +2851,17 @@ impl UdpTransport {
         attempts: u32,
         profile_fence: Option<(u64, u64)>,
         hard_hard_session_token: Option<&str>,
-        live: Option<Arc<StdMutex<LiveBirthdayCounters>>>,
+        live: Option<Arc<StdMutex<LiveBirthdayProgress>>>,
     ) -> Result<PunchSendReport> {
         let schedule = build_probe_schedule(&candidates, probe_interval, attempts);
         let mut packets_sent = 0u32;
         let mut logical_probes_attempted = 0u32;
         let mut logical_probes_sent = 0u32;
+        let mut logical_probe_send_failures = 0u32;
         let mut physical_datagrams_sent = 0u32;
         let mut physical_send_errors = 0u32;
+        let mut partial_physical_send_errors = 0u32;
+        let mut probe_path_errors = 0u32;
         let mut budget_skipped = 0u32;
         let mut last_budget_reason = None;
         let mut sent_endpoints = HashSet::new();
@@ -2814,6 +2886,10 @@ impl UdpTransport {
                     "Aborting dynamic-socket punch for peer {peer_id}: network generation changed mid-session"
                 );
                 target_processing_completed = false;
+                failure_kind = combine_birthday_failure_kind(
+                    failure_kind,
+                    Some(BirthdaySweepFailureKind::NetworkGenerationChanged),
+                );
                 break;
             }
             if !round.delay_before.is_zero() {
@@ -2843,6 +2919,10 @@ impl UdpTransport {
                         "Aborting dynamic-socket punch for peer {peer_id}: network generation changed before candidate send"
                     );
                     target_processing_completed = false;
+                    failure_kind = combine_birthday_failure_kind(
+                        failure_kind,
+                        Some(BirthdaySweepFailureKind::NetworkGenerationChanged),
+                    );
                     break;
                 }
                 if self
@@ -2856,22 +2936,38 @@ impl UdpTransport {
                         "Aborting dynamic-socket punch for peer {peer_id}: remote candidate epoch changed before candidate send"
                     );
                     target_processing_completed = false;
+                    failure_kind = combine_birthday_failure_kind(
+                        failure_kind,
+                        Some(BirthdaySweepFailureKind::CandidateEpochChanged),
+                    );
                     break;
                 }
                 if let Some((local_profile_generation, remote_profile_generation)) = profile_fence {
-                    let profile_current = self
-                        .peers
-                        .hard_hard_plan_for_peer(peer_id)
-                        .await
-                        .is_some_and(|plan| {
-                            plan.local_profile_generation == local_profile_generation
-                                && plan.remote_profile_generation == remote_profile_generation
-                        });
-                    if !profile_current {
+                    let current_plan = self.peers.hard_hard_plan_for_peer(peer_id).await;
+                    let profile_failure = match current_plan {
+                        Some(plan)
+                            if plan.local_profile_generation == local_profile_generation
+                                && plan.remote_profile_generation == remote_profile_generation =>
+                        {
+                            None
+                        }
+                        Some(plan) if plan.local_profile_generation != local_profile_generation => {
+                            Some(ProbeSendFailureKind::LocalProfileGenerationChanged)
+                        }
+                        Some(_) => Some(ProbeSendFailureKind::RemoteProfileGenerationChanged),
+                        None => Some(ProbeSendFailureKind::PeerSessionChanged),
+                    };
+                    if let Some(profile_failure) = profile_failure {
                         trace!(
                             "Aborting dynamic-socket punch for peer {peer_id}: Hard↔Hard profile generation changed before candidate send"
                         );
                         target_processing_completed = false;
+                        failure_kind = combine_birthday_failure_kind(
+                            failure_kind,
+                            Some(BirthdaySweepFailureKind::from_probe_failure(
+                                profile_failure,
+                            )),
+                        );
                         break;
                     }
                 }
@@ -2885,6 +2981,12 @@ impl UdpTransport {
                             "Aborting dynamic-socket Hard↔Hard punch for peer {peer_id}: session token was retired"
                         );
                         target_processing_completed = false;
+                        failure_kind = combine_birthday_failure_kind(
+                            failure_kind,
+                            Some(BirthdaySweepFailureKind::from_probe_failure(
+                                ProbeSendFailureKind::SessionRetired,
+                            )),
+                        );
                         break;
                     }
                 }
@@ -2963,6 +3065,7 @@ impl UdpTransport {
                         false,
                         PendingProbePurpose::ConnectivityCheck,
                         hard_hard_session_token,
+                        true,
                     )
                     .await
                 {
@@ -2971,10 +3074,18 @@ impl UdpTransport {
                         logical_probes_sent = logical_probes_sent.saturating_add(1);
                         let successful_datagrams = u32::from(sent.datagrams_sent);
                         let failed_datagrams = u32::from(sent.physical_send_errors);
+                        let actual_socket_index = sent.socket_index;
+                        let successful_send_at_ms = sent.first_send_at_ms;
                         physical_datagrams_sent =
                             physical_datagrams_sent.saturating_add(successful_datagrams);
-                        physical_send_errors = physical_send_errors.saturating_add(failed_datagrams);
-                        update_live_birthday_counters(&live, |counters| {
+                        physical_send_errors =
+                            physical_send_errors.saturating_add(failed_datagrams);
+                        if failed_datagrams > 0 {
+                            partial_physical_send_errors =
+                                partial_physical_send_errors.saturating_add(failed_datagrams);
+                        }
+                        update_live_birthday_progress(&live, |progress| {
+                            let counters = &mut progress.counters;
                             counters.logical_probes_sent =
                                 counters.logical_probes_sent.saturating_add(1);
                             counters.physical_datagrams_sent = counters
@@ -2983,23 +3094,41 @@ impl UdpTransport {
                             counters.physical_send_errors = counters
                                 .physical_send_errors
                                 .saturating_add(failed_datagrams);
+                            counters.partial_physical_send_errors = counters
+                                .partial_physical_send_errors
+                                .saturating_add(failed_datagrams);
+                            if successful_datagrams > 0 {
+                                progress.sent_target_endpoints.insert(candidate);
+                                let sent = progress
+                                    .per_socket_sent
+                                    .entry(actual_socket_index)
+                                    .or_default();
+                                *sent = sent.saturating_add(successful_datagrams);
+                                if let Some(sent_at_ms) = successful_send_at_ms {
+                                    progress.first_send_at_ms = Some(
+                                        progress
+                                            .first_send_at_ms
+                                            .map_or(sent_at_ms, |first| first.min(sent_at_ms)),
+                                    );
+                                    progress.last_send_at_ms = Some(
+                                        progress
+                                            .last_send_at_ms
+                                            .map_or(sent_at_ms, |last| last.max(sent_at_ms)),
+                                    );
+                                }
+                            }
                         });
-                        if sent.physical_send_errors > 0 {
-                            failure_kind = combine_birthday_failure_kind(
-                                failure_kind,
-                                Some(BirthdaySweepFailureKind::Send),
-                            );
-                        }
                         if let Some(sent_at_ms) = sent.first_send_at_ms {
                             first_send_at_ms.get_or_insert(sent_at_ms);
                             last_send_at_ms = Some(
-                                last_send_at_ms
-                                    .map_or(sent_at_ms, |last| last.max(sent_at_ms)),
+                                last_send_at_ms.map_or(sent_at_ms, |last| last.max(sent_at_ms)),
                             );
                         }
                         per_socket_sent =
                             per_socket_sent.saturating_add(u32::from(sent.datagrams_sent));
-                        sent_endpoints.insert(candidate);
+                        if successful_datagrams > 0 {
+                            sent_endpoints.insert(candidate);
+                        }
                         self.peers
                             .record_direct_probe_sent(peer_id, candidate)
                             .await;
@@ -3012,22 +3141,40 @@ impl UdpTransport {
                         }
                     }
                     Err(failure) => {
-                        physical_send_errors = physical_send_errors.saturating_add(u32::from(
-                            failure.physical_send_errors,
-                        ));
-                        update_live_birthday_counters(&live, |counters| {
-                            counters.physical_send_errors = counters
-                                .physical_send_errors
-                                .saturating_add(u32::from(failure.physical_send_errors));
-                        });
-                        failure_kind = combine_birthday_failure_kind(
-                            failure_kind,
-                            Some(BirthdaySweepFailureKind::Send),
-                        );
+                        let failed_datagrams = u32::from(failure.physical_send_errors);
+                        if failure.kind == ProbeSendFailureKind::PhysicalSend
+                            && failed_datagrams > 0
+                        {
+                            physical_send_errors =
+                                physical_send_errors.saturating_add(failed_datagrams);
+                            logical_probe_send_failures =
+                                logical_probe_send_failures.saturating_add(1);
+                            update_live_birthday_counters(&live, |counters| {
+                                counters.logical_probe_send_failures =
+                                    counters.logical_probe_send_failures.saturating_add(1);
+                                counters.physical_send_errors = counters
+                                    .physical_send_errors
+                                    .saturating_add(failed_datagrams);
+                            });
+                        } else {
+                            probe_path_errors = probe_path_errors.saturating_add(1);
+                            update_live_birthday_counters(&live, |counters| {
+                                counters.probe_path_errors =
+                                    counters.probe_path_errors.saturating_add(1);
+                            });
+                            failure_kind = combine_birthday_failure_kind(
+                                failure_kind,
+                                Some(BirthdaySweepFailureKind::from_probe_failure(failure.kind)),
+                            );
+                            target_processing_completed = false;
+                        }
                         debug!(
-                            "Dynamic-socket punch to peer {peer_id} candidate {candidate} failed: {}",
-                            failure.error
+                            "Dynamic-socket punch to peer {peer_id} candidate {candidate} failed kind={:?}: {}",
+                            failure.kind, failure.error
                         );
+                        if failure.kind != ProbeSendFailureKind::PhysicalSend {
+                            break 'schedule;
+                        }
                     }
                 }
             }
@@ -3047,12 +3194,17 @@ impl UdpTransport {
                 )
                 .await;
         }
+        #[cfg(test)]
+        wait_for_birthday_worker_completion_gate_for_test().await;
         Ok(PunchSendReport {
             packets_sent,
             logical_probes_attempted,
             logical_probes_sent,
+            logical_probe_send_failures,
             physical_datagrams_sent,
             physical_send_errors,
+            partial_physical_send_errors,
+            probe_path_errors,
             unique_target_endpoints: u32::try_from(sent_endpoints.len()).unwrap_or(u32::MAX),
             first_send_at_ms,
             per_socket_sent: (per_socket_sent > 0)
@@ -3071,6 +3223,21 @@ impl UdpTransport {
             failure_kind,
             ..PunchSendReport::default()
         })
+    }
+}
+
+/// The standalone exact-socket API returns a complete report to its caller,
+/// so it performs the terminal all-physical-failure classification itself.
+/// Birthday workers intentionally do not call this helper: their scheduler
+/// must first give every target and bounded wave an opportunity to send.
+fn finalize_physical_send_failure(report: &mut PunchSendReport) {
+    if report.failure_kind.is_none()
+        && report.logical_probes_attempted > 0
+        && report.logical_probes_sent == 0
+        && report.logical_probe_send_failures > 0
+        && report.physical_send_errors > 0
+    {
+        report.failure_kind = Some(BirthdaySweepFailureKind::Send);
     }
 }
 
@@ -3244,8 +3411,11 @@ fn record_birthday_worker_result(
             *wave_fully_completed = false;
             *failure_kind = combine_birthday_failure_kind(
                 *failure_kind,
-                Some(BirthdaySweepFailureKind::Send),
+                Some(BirthdaySweepFailureKind::from_probe_failure(
+                    ProbeSendFailureKind::ProbeRegistrationFailed,
+                )),
             );
+            wave_report.probe_path_errors = wave_report.probe_path_errors.saturating_add(1);
             wave_report.targets_cancelled = wave_report
                 .targets_cancelled
                 .saturating_add(u32::try_from(assigned_count).unwrap_or(u32::MAX));
@@ -3266,46 +3436,65 @@ fn combine_birthday_failure_kind(
     right: Option<BirthdaySweepFailureKind>,
 ) -> Option<BirthdaySweepFailureKind> {
     match (left, right) {
-        (Some(BirthdaySweepFailureKind::WorkerJoin), _)
-        | (_, Some(BirthdaySweepFailureKind::WorkerJoin)) => {
-            Some(BirthdaySweepFailureKind::WorkerJoin)
+        (None, value) | (value, None) => value,
+        (Some(left), Some(right)) => {
+            if birthday_failure_priority(right) > birthday_failure_priority(left) {
+                Some(right)
+            } else {
+                Some(left)
+            }
         }
-        (Some(BirthdaySweepFailureKind::Send), _) | (_, Some(BirthdaySweepFailureKind::Send)) => {
-            Some(BirthdaySweepFailureKind::Send)
-        }
-        (None, None) => None,
+    }
+}
+
+const fn birthday_failure_priority(kind: BirthdaySweepFailureKind) -> u8 {
+    match kind {
+        BirthdaySweepFailureKind::WorkerJoin => 100,
+        BirthdaySweepFailureKind::NetworkGenerationChanged => 90,
+        BirthdaySweepFailureKind::CandidateEpochChanged => 80,
+        BirthdaySweepFailureKind::ProfileGenerationChanged => 70,
+        BirthdaySweepFailureKind::PeerSessionChanged => 60,
+        BirthdaySweepFailureKind::SessionRetired => 50,
+        BirthdaySweepFailureKind::SocketRevoked => 40,
+        BirthdaySweepFailureKind::SocketUnavailable => 30,
+        BirthdaySweepFailureKind::ProbeRegistrationFailed => 20,
+        BirthdaySweepFailureKind::ProbeEncodingFailed => 10,
+        BirthdaySweepFailureKind::Send => 1,
     }
 }
 
 fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSendReport) {
     let source_logical_sent = source.logical_probes_sent.max(source.packets_sent);
-    let source_logical_attempted = source
-        .logical_probes_attempted
-        .max(source_logical_sent);
+    let source_logical_attempted = source.logical_probes_attempted.max(source_logical_sent);
     let source_targets_examined = source.targets_examined.max(source.targets_attempted);
-    let source_physical_datagrams_sent = source.physical_datagrams_sent.max(
-        source
-            .per_socket_sent
-            .iter()
-            .map(|(_, sent)| *sent)
-            .sum(),
-    );
-    destination.packets_sent = destination
-        .packets_sent
-        .saturating_add(source_logical_sent);
+    let source_physical_datagrams_sent = source
+        .physical_datagrams_sent
+        .max(source.per_socket_sent.iter().map(|(_, sent)| *sent).sum());
+    destination.packets_sent = destination.packets_sent.saturating_add(source_logical_sent);
     destination.logical_probes_sent = destination
         .logical_probes_sent
         .saturating_add(source_logical_sent);
     destination.logical_probes_attempted = destination
         .logical_probes_attempted
         .saturating_add(source_logical_attempted);
+    destination.logical_probe_send_failures = destination
+        .logical_probe_send_failures
+        .saturating_add(source.logical_probe_send_failures);
     destination.physical_datagrams_sent = destination
         .physical_datagrams_sent
         .saturating_add(source_physical_datagrams_sent);
     destination.physical_send_errors = destination
         .physical_send_errors
         .saturating_add(source.physical_send_errors);
-    destination.budget_skipped = destination.budget_skipped.saturating_add(source.budget_skipped);
+    destination.partial_physical_send_errors = destination
+        .partial_physical_send_errors
+        .saturating_add(source.partial_physical_send_errors);
+    destination.probe_path_errors = destination
+        .probe_path_errors
+        .saturating_add(source.probe_path_errors);
+    destination.budget_skipped = destination
+        .budget_skipped
+        .saturating_add(source.budget_skipped);
     destination.targets_assigned = destination
         .targets_assigned
         .saturating_add(source.targets_assigned);
@@ -3323,12 +3512,10 @@ fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSend
     } else {
         destination.target_processing_completed &= source.target_processing_completed;
     }
-    destination.worker_failed |= source.worker_failed
-        || source.failure_kind == Some(BirthdaySweepFailureKind::WorkerJoin);
-    destination.failure_kind = combine_birthday_failure_kind(
-        destination.failure_kind,
-        source.failure_kind,
-    );
+    destination.worker_failed |=
+        source.worker_failed || source.failure_kind == Some(BirthdaySweepFailureKind::WorkerJoin);
+    destination.failure_kind =
+        combine_birthday_failure_kind(destination.failure_kind, source.failure_kind);
     destination.epoch_budget_exhausted |= source.epoch_budget_exhausted;
     destination.candidate_iteration_capped |= source.candidate_iteration_capped;
     destination.first_send_at_ms = match (destination.first_send_at_ms, source.first_send_at_ms) {
@@ -3357,6 +3544,18 @@ fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSend
             destination.per_socket_sent.push((socket_index, sent));
         }
     }
+    normalize_physical_send_dimensions(destination);
+}
+
+/// Keep the terminal/live physical-send invariant exact after reports from
+/// several workers have been merged.  Every production Hard↔Hard physical
+/// send records the actual socket, so the histogram is the authoritative
+/// successful-datagram total rather than a lower/upper-bound diagnostic.
+fn normalize_physical_send_dimensions(report: &mut PunchSendReport) {
+    report
+        .per_socket_sent
+        .sort_unstable_by_key(|(socket_index, _)| *socket_index);
+    report.physical_datagrams_sent = report.per_socket_sent.iter().map(|(_, sent)| *sent).sum();
 }
 
 pub(crate) fn update_birthday_sweep_counters(
@@ -3367,61 +3566,103 @@ pub(crate) fn update_birthday_sweep_counters(
         .targets_assigned
         .max(aggregate.targets_assigned as usize);
     birthday.targets_attempted = aggregate.targets_attempted as usize;
-    birthday.targets_examined = aggregate
-        .targets_examined
-        .max(aggregate.targets_attempted) as usize;
+    birthday.targets_examined =
+        aggregate.targets_examined.max(aggregate.targets_attempted) as usize;
     let logical_probes_sent = aggregate.logical_probes_sent.max(aggregate.packets_sent);
-    birthday.logical_probes_attempted = aggregate
-        .logical_probes_attempted
-        .max(logical_probes_sent) as usize;
+    birthday.logical_probes_attempted =
+        aggregate.logical_probes_attempted.max(logical_probes_sent) as usize;
     birthday.logical_probes_sent = logical_probes_sent as usize;
-    birthday.physical_datagrams_sent = aggregate.physical_datagrams_sent.max(
-        aggregate
-            .per_socket_sent
-            .iter()
-            .map(|(_, sent)| *sent)
-            .sum(),
-    ) as usize;
+    birthday.logical_probe_send_failures = aggregate.logical_probe_send_failures as usize;
+    birthday.physical_datagrams_sent = aggregate
+        .per_socket_sent
+        .iter()
+        .map(|(_, sent)| *sent)
+        .sum::<u32>() as usize;
     birthday.physical_send_errors = aggregate.physical_send_errors as usize;
+    birthday.partial_physical_send_errors = aggregate.partial_physical_send_errors as usize;
     birthday.targets_budget_skipped = aggregate.budget_skipped as usize;
     birthday.targets_cancelled = aggregate.targets_cancelled as usize;
 }
 
 fn update_live_birthday_counters(
-    live: &Option<Arc<StdMutex<LiveBirthdayCounters>>>,
+    live: &Option<Arc<StdMutex<LiveBirthdayProgress>>>,
     update: impl FnOnce(&mut LiveBirthdayCounters),
+) {
+    update_live_birthday_progress(live, |progress| update(&mut progress.counters));
+}
+
+fn update_live_birthday_progress(
+    live: &Option<Arc<StdMutex<LiveBirthdayProgress>>>,
+    update: impl FnOnce(&mut LiveBirthdayProgress),
 ) {
     let Some(live) = live else {
         return;
     };
-    let mut counters = live.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-    update(&mut counters);
+    let mut progress = live.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    update(&mut progress);
 }
 
 pub(crate) fn apply_live_birthday_counters(
     report: &mut PunchSendReport,
-    live: &LiveBirthdayCounters,
+    live: &LiveBirthdayProgress,
 ) {
-    report.targets_assigned = report.targets_assigned.max(live.targets_assigned);
-    report.targets_examined = report.targets_examined.max(live.targets_examined);
-    report.targets_attempted = report.targets_attempted.max(live.targets_attempted);
-    report.targets_cancelled = report.targets_cancelled.max(live.targets_cancelled);
-    report.budget_skipped = report.budget_skipped.max(live.budget_skipped);
+    let counters = &live.counters;
+    report.targets_assigned = report.targets_assigned.max(counters.targets_assigned);
+    report.targets_examined = report.targets_examined.max(counters.targets_examined);
+    report.targets_attempted = report.targets_attempted.max(counters.targets_attempted);
+    report.targets_cancelled = report.targets_cancelled.max(counters.targets_cancelled);
+    report.budget_skipped = report.budget_skipped.max(counters.budget_skipped);
     report.logical_probes_sent = report
         .logical_probes_sent
-        .max(live.logical_probes_sent)
+        .max(counters.logical_probes_sent)
         .max(report.packets_sent);
     report.logical_probes_attempted = report
         .logical_probes_attempted
-        .max(live.logical_probes_attempted)
+        .max(counters.logical_probes_attempted)
         .max(report.logical_probes_sent);
+    report.logical_probe_send_failures = report
+        .logical_probe_send_failures
+        .max(counters.logical_probe_send_failures);
     report.packets_sent = report.packets_sent.max(report.logical_probes_sent);
     report.physical_datagrams_sent = report
         .physical_datagrams_sent
-        .max(live.physical_datagrams_sent);
+        .max(counters.physical_datagrams_sent);
     report.physical_send_errors = report
         .physical_send_errors
-        .max(live.physical_send_errors);
+        .max(counters.physical_send_errors);
+    report.partial_physical_send_errors = report
+        .partial_physical_send_errors
+        .max(counters.partial_physical_send_errors);
+    report.probe_path_errors = report.probe_path_errors.max(counters.probe_path_errors);
+    for endpoint in &live.sent_target_endpoints {
+        if !report.sent_target_endpoints.contains(endpoint) {
+            report.sent_target_endpoints.push(*endpoint);
+        }
+    }
+    report.unique_target_endpoints =
+        u32::try_from(report.sent_target_endpoints.len()).unwrap_or(u32::MAX);
+    for (socket_index, sent) in &live.per_socket_sent {
+        if let Some((_, existing)) = report
+            .per_socket_sent
+            .iter_mut()
+            .find(|(index, _)| index == socket_index)
+        {
+            *existing = (*existing).max(*sent);
+        } else {
+            report.per_socket_sent.push((*socket_index, *sent));
+        }
+    }
+    report.first_send_at_ms = match (report.first_send_at_ms, live.first_send_at_ms) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (None, right) => right,
+        (left, None) => left,
+    };
+    report.last_send_at_ms = match (report.last_send_at_ms, live.last_send_at_ms) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (None, right) => right,
+        (left, None) => left,
+    };
+    normalize_physical_send_dimensions(report);
 }
 
 async fn publish_birthday_sweep_progress(
@@ -3895,8 +4136,7 @@ impl ProvisionalSocketGuard {
         {
             return refused;
         }
-        let Some(generation_fence) = state.committed_punch_generations.get(peer_id).copied()
-        else {
+        let Some(generation_fence) = state.committed_punch_generations.get(peer_id).copied() else {
             return refused;
         };
         let evidence_at_commit = state
@@ -4016,12 +4256,9 @@ impl ProvisionalSocketGuard {
                             // socket's generation fence but intentionally do
                             // not own the peer affinity pin.
                             punch_generation != 0
-                                && state
-                                    .dynamic
-                                    .get(&self.socket_index)
-                                    .is_some_and(|entry| {
-                                        entry.phase == DynamicSocketPhase::CommittedPendingHandoff
-                                    })
+                                && state.dynamic.get(&self.socket_index).is_some_and(|entry| {
+                                    entry.phase == DynamicSocketPhase::CommittedPendingHandoff
+                                })
                         }
                     }
                 });
@@ -4106,8 +4343,8 @@ impl UdpTransport {
             if entry.phase == DynamicSocketPhase::Finalized {
                 return None;
             }
-            let has_post_commit_evidence = entry.authenticated_evidence
-                > outcome.evidence_at_commit;
+            let has_post_commit_evidence =
+                entry.authenticated_evidence > outcome.evidence_at_commit;
             if has_post_commit_evidence {
                 state
                     .dynamic
@@ -4237,7 +4474,7 @@ mod birthday_tests {
         hard_hard_birthday_packets_planned, hard_hard_birthday_socket_plan,
         hard_hard_birthday_wave_assignments, hard_hard_birthday_wave_count,
         record_birthday_worker_result, BirthdaySweepFailureKind, HardHardSocketSnapshot,
-        PunchSendReport,
+        ProbeSendFailureKind, PunchSendReport,
     };
     use crate::error::DaemonError;
     use p2pnet_nat::mapping::AllocationModelKind;
@@ -4255,10 +4492,13 @@ mod birthday_tests {
                 token,
             );
             assert_eq!(candidates.len(), level);
-            assert!(candidates.iter().all(|candidate| {
-                candidate.ip() == public_ip && candidate.port() != 0
-            }));
-            let unique = candidates.iter().map(SocketAddr::port).collect::<HashSet<_>>();
+            assert!(candidates
+                .iter()
+                .all(|candidate| { candidate.ip() == public_ip && candidate.port() != 0 }));
+            let unique = candidates
+                .iter()
+                .map(SocketAddr::port)
+                .collect::<HashSet<_>>();
             assert_eq!(unique.len(), level);
             assert!(level < usize::from(u16::MAX));
         }
@@ -4272,6 +4512,52 @@ mod birthday_tests {
             AllocationModelKind::Unknown.label(),
             AllocationModelKind::HighEntropy.label()
         );
+    }
+
+    #[test]
+    fn probe_failure_kinds_keep_precise_terminal_stop_reasons() {
+        let cases = [
+            (ProbeSendFailureKind::PhysicalSend, "send_error"),
+            (
+                ProbeSendFailureKind::NetworkGenerationChanged,
+                "network_generation_changed",
+            ),
+            (
+                ProbeSendFailureKind::CandidateEpochChanged,
+                "candidate_epoch_changed",
+            ),
+            (
+                ProbeSendFailureKind::LocalProfileGenerationChanged,
+                "profile_generation_changed",
+            ),
+            (
+                ProbeSendFailureKind::RemoteProfileGenerationChanged,
+                "profile_generation_changed",
+            ),
+            (
+                ProbeSendFailureKind::PeerSessionChanged,
+                "peer_session_changed",
+            ),
+            (ProbeSendFailureKind::SessionRetired, "session_retired"),
+            (ProbeSendFailureKind::SocketUnavailable, "socket_unavailable"),
+            (ProbeSendFailureKind::SocketRevoked, "socket_revoked"),
+            (
+                ProbeSendFailureKind::ProbeRegistrationFailed,
+                "probe_registration_failed",
+            ),
+            (
+                ProbeSendFailureKind::ProbeEncodingFailed,
+                "probe_encoding_failed",
+            ),
+        ];
+        for (probe_failure, stop_reason) in cases {
+            let failure = BirthdaySweepFailureKind::from_probe_failure(probe_failure);
+            assert_eq!(failure.stop_reason(), stop_reason);
+            assert_eq!(
+                BirthdaySweepFailureKind::from_stop_reason(stop_reason),
+                Some(failure)
+            );
+        }
     }
 
     #[test]
@@ -4343,7 +4629,10 @@ mod birthday_tests {
         assert_eq!(partial.usable_socket_count, 1);
         assert_eq!(partial.unavailable_socket_count, 1);
         assert_eq!(partial.usable_socket_indices, vec![41]);
-        assert_eq!(hard_hard_birthday_wave_count(partial.usable_socket_count), 1);
+        assert_eq!(
+            hard_hard_birthday_wave_count(partial.usable_socket_count),
+            1
+        );
 
         let detached = hard_hard_birthday_socket_plan(
             64,
@@ -4364,7 +4653,10 @@ mod birthday_tests {
         assert_eq!(detached.usable_socket_count, 0);
         assert_eq!(detached.unavailable_socket_count, 2);
         assert!(detached.usable_socket_indices.is_empty());
-        assert_eq!(hard_hard_birthday_wave_count(detached.usable_socket_count), 0);
+        assert_eq!(
+            hard_hard_birthday_wave_count(detached.usable_socket_count),
+            0
+        );
 
         let full = hard_hard_birthday_socket_plan(
             128,
@@ -4407,14 +4699,17 @@ mod birthday_tests {
             &mut wave_report,
             &mut wave_fully_completed,
             &mut failure_kind,
-            Ok((2, Ok(PunchSendReport {
-                packets_sent: 1,
-                per_socket_sent: vec![(41, 2)],
-                targets_assigned: 2,
-                targets_attempted: 2,
-                target_processing_completed: true,
-                ..PunchSendReport::default()
-            }))),
+            Ok((
+                2,
+                Ok(PunchSendReport {
+                    packets_sent: 1,
+                    per_socket_sent: vec![(41, 2)],
+                    targets_assigned: 2,
+                    targets_attempted: 2,
+                    target_processing_completed: true,
+                    ..PunchSendReport::default()
+                }),
+            )),
         );
         assert_eq!(wave_report.packets_sent, 1);
         assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
@@ -4425,17 +4720,26 @@ mod birthday_tests {
             &mut wave_report,
             &mut wave_fully_completed,
             &mut failure_kind,
-            Ok((3, Err(DaemonError::Network("injected worker error".to_string())))),
+            Ok((
+                3,
+                Err(DaemonError::Network("injected worker error".to_string())),
+            )),
         );
         assert_eq!(wave_report.packets_sent, 1);
         assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
         assert_eq!(wave_report.targets_cancelled, 3);
+        assert_eq!(wave_report.probe_path_errors, 1);
         assert!(!wave_fully_completed);
-        assert_eq!(failure_kind, Some(BirthdaySweepFailureKind::Send));
+        assert_eq!(
+            failure_kind,
+            Some(BirthdaySweepFailureKind::ProbeRegistrationFailed)
+        );
 
         let handle = tokio::spawn(async { std::future::pending::<()>().await });
         handle.abort();
-        let join_error = handle.await.expect_err("aborted worker must yield JoinError");
+        let join_error = handle
+            .await
+            .expect_err("aborted worker must yield JoinError");
         record_birthday_worker_result(
             &mut wave_report,
             &mut wave_fully_completed,

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -9,6 +9,8 @@ const MEASUREMENT_SOFTWARE_TAG: &str = "P2WLAN/0.2";
 /// immediately.  Bound the handshake so a broken runtime/task cannot leave a
 /// fresh-mapping generation waiting forever before its first STUN request.
 const DYNAMIC_READER_READY_TIMEOUT: Duration = Duration::from_secs(1);
+const HARD_HARD_BIRTHDAY_WAVE_INTERVAL: Duration = Duration::from_millis(20);
+const HARD_HARD_BIRTHDAY_WAVES: usize = 2;
 
 /// Adaptive-prediction learner state for one network generation, scoped by
 /// destination so a stride learned toward STUN observers is not blindly applied
@@ -2251,66 +2253,256 @@ impl UdpTransport {
     }
 
     /// Fan a bounded Hard↔Hard birthday window across the committed candidate
-    /// sockets. Each target is sent once from exactly one socket, so the
-    /// physical datagram count is the negotiated 64/128/256 level rather than
-    /// a socket-count Cartesian product.
+    /// sockets in up to two deterministic waves. Each wave sends every target
+    /// from exactly one socket; the second wave rotates the socket assignment
+    /// so a target is retried from a different source port without creating a
+    /// socket-count Cartesian product.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn punch_hard_hard_birthday_candidates(
         &self,
         peer_id: &str,
         socket_indices: Vec<usize>,
         targets: Vec<SocketAddr>,
+        requested_level: usize,
+        peer_session_generation: crate::peer::PeerSessionGeneration,
         profile_fence: (u64, u64),
         session_token: &str,
     ) -> Result<PunchSendReport> {
-        if socket_indices.is_empty() || targets.is_empty() {
-            return Ok(PunchSendReport::default());
-        }
-        let mut assignments = hard_hard_birthday_assignments(socket_indices.len(), targets);
-        let mut workers = JoinSet::new();
-        for (socket_position, socket_index) in socket_indices.into_iter().enumerate() {
-            let assigned = std::mem::take(&mut assignments[socket_position]);
-            if assigned.is_empty() {
+        let mut effective_targets = Vec::with_capacity(targets.len().min(crate::MAX_SIGNAL_CANDIDATES));
+        for target in targets {
+            if target.port() == 0 || effective_targets.contains(&target) {
                 continue;
             }
-            let transport = self.clone();
-            let peer_id = peer_id.to_string();
-            let session_token = session_token.to_string();
-            workers.spawn(async move {
-                transport
-                    .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session(
-                        &peer_id,
-                        socket_index,
-                        assigned,
-                        Duration::from_millis(20),
-                        1,
-                        Some(profile_fence),
-                        Some(&session_token),
+            effective_targets.push(target);
+            if effective_targets.len() == crate::MAX_SIGNAL_CANDIDATES {
+                break;
+            }
+        }
+        let mut effective_socket_indices = Vec::with_capacity(socket_indices.len());
+        for socket_index in socket_indices {
+            if !effective_socket_indices.contains(&socket_index) {
+                effective_socket_indices.push(socket_index);
+            }
+        }
+
+        let waves_planned = hard_hard_birthday_wave_count(effective_socket_indices.len());
+        let mut birthday = BirthdaySweepReport {
+            requested_level,
+            effective_target_count: effective_targets.len(),
+            waves_planned,
+            packets_planned: hard_hard_birthday_packets_planned(
+                effective_socket_indices.len(),
+                effective_targets.len(),
+            ),
+            ..BirthdaySweepReport::default()
+        };
+        let mut aggregate = PunchSendReport::default();
+        if effective_targets.is_empty() {
+            birthday.stop_reason = Some("empty_targets".to_string());
+            aggregate.birthday = Some(birthday);
+            return Ok(aggregate);
+        }
+        if effective_socket_indices.is_empty() {
+            birthday.stop_reason = Some("socket_unavailable".to_string());
+            aggregate.birthday = Some(birthday);
+            return Ok(aggregate);
+        }
+
+        // Keep the first-wave launch timing identical to the existing
+        // one-shot path. Each worker still resolves its exact socket
+        // fail-closed immediately before it can send; a fully detached set is
+        // reported as `socket_unavailable` after that wave.
+        birthday.socket_count = effective_socket_indices.len();
+        if birthday.socket_count == 1 {
+            birthday.degraded_reason = Some("single_socket".to_string());
+        }
+        birthday.waves_planned = hard_hard_birthday_wave_count(effective_socket_indices.len());
+        birthday.packets_planned = hard_hard_birthday_packets_planned(
+            birthday.socket_count,
+            birthday.effective_target_count,
+        );
+
+        let network_generation_at_start = self.peers.current_network_generation_sync();
+        let remote_candidate_epoch_at_start = self
+            .peers
+            .current_remote_candidate_epoch(peer_id)
+            .await
+            .unwrap_or_default();
+        let direct_commit_seq_at_start = self.peers.direct_commit_seq_sync(peer_id);
+        for wave in 0..birthday.waves_planned {
+            if wave > 0 {
+                sleep(HARD_HARD_BIRTHDAY_WAVE_INTERVAL).await;
+            }
+            if wave > 0 {
+                if let Some(reason) = self
+                    .hard_hard_birthday_stop_reason(
+                        peer_id,
+                        session_token,
+                        profile_fence,
+                        peer_session_generation,
+                        network_generation_at_start,
+                        remote_candidate_epoch_at_start,
+                        direct_commit_seq_at_start,
                     )
                     .await
-            });
+                {
+                    birthday.stop_reason = Some(reason.to_string());
+                    break;
+                }
+            }
+
+            birthday.waves_started = birthday.waves_started.saturating_add(1);
+            let mut assignments = hard_hard_birthday_wave_assignments(
+                effective_socket_indices.len(),
+                effective_targets.clone(),
+                wave,
+            );
+            let mut workers = JoinSet::new();
+            for (socket_position, socket_index) in
+                effective_socket_indices.iter().copied().enumerate()
+            {
+                let assigned = std::mem::take(&mut assignments[socket_position]);
+                if assigned.is_empty() {
+                    continue;
+                }
+                let transport = self.clone();
+                let peer_id = peer_id.to_string();
+                let session_token = session_token.to_string();
+                workers.spawn(async move {
+                    transport
+                        .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session(
+                            &peer_id,
+                            socket_index,
+                            assigned,
+                            HARD_HARD_BIRTHDAY_WAVE_INTERVAL,
+                            1,
+                            Some(profile_fence),
+                            Some(&session_token),
+                        )
+                        .await
+                });
+            }
+
+            let mut wave_report = PunchSendReport::default();
+            let mut worker_failed = false;
+            while let Some(joined) = workers.join_next().await {
+                let Ok(result) = joined else {
+                    worker_failed = true;
+                    continue;
+                };
+                let report = result?;
+                merge_punch_send_reports(&mut wave_report, report);
+            }
+            if worker_failed {
+                birthday.stop_reason = Some("send_error".to_string());
+                break;
+            }
+            birthday.waves_completed = birthday.waves_completed.saturating_add(1);
+            merge_punch_send_reports(&mut aggregate, wave_report.clone());
+            if let Some(reason) = self
+                .hard_hard_birthday_stop_reason(
+                    peer_id,
+                    session_token,
+                    profile_fence,
+                    peer_session_generation,
+                    network_generation_at_start,
+                    remote_candidate_epoch_at_start,
+                    direct_commit_seq_at_start,
+                )
+                .await
+            {
+                birthday.stop_reason = Some(reason.to_string());
+                break;
+            }
+            if wave_report.epoch_budget_exhausted {
+                birthday.stop_reason = Some("epoch_budget_exhausted".to_string());
+                break;
+            }
+            if wave_report.candidate_iteration_capped {
+                birthday.stop_reason = Some("candidate_iteration_capped".to_string());
+                break;
+            }
+            if wave_report.packets_sent == 0 && wave_report.budget_skipped > 0 {
+                birthday.stop_reason = Some("budget_exhausted".to_string());
+                break;
+            }
+            if wave_report.packets_sent == 0 && wave_report.budget_skipped == 0 {
+                birthday.stop_reason = Some("socket_unavailable".to_string());
+                break;
+            }
         }
-        let mut aggregate = PunchSendReport::default();
-        while let Some(joined) = workers.join_next().await {
-            let Ok(result) = joined else {
-                continue;
-            };
-            let report = result?;
-            aggregate.packets_sent = aggregate.packets_sent.saturating_add(report.packets_sent);
-            aggregate.unique_target_endpoints = aggregate
-                .unique_target_endpoints
-                .saturating_add(report.unique_target_endpoints);
-            aggregate.budget_skipped = aggregate.budget_skipped.saturating_add(report.budget_skipped);
-            aggregate.epoch_budget_exhausted |= report.epoch_budget_exhausted;
-            aggregate.candidate_iteration_capped |= report.candidate_iteration_capped;
-            aggregate.first_send_at_ms = match (aggregate.first_send_at_ms, report.first_send_at_ms) {
-                (Some(left), Some(right)) => Some(left.min(right)),
-                (None, right) => right,
-                (left, None) => left,
-            };
-            aggregate.per_socket_sent.extend(report.per_socket_sent);
+
+        if birthday.stop_reason.is_none() {
+            birthday.stop_reason = Some("completed".to_string());
         }
+        aggregate.unique_target_endpoints =
+            u32::try_from(aggregate.sent_target_endpoints.len()).unwrap_or(u32::MAX);
+        aggregate.birthday = Some(birthday);
         Ok(aggregate)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn hard_hard_birthday_stop_reason(
+        &self,
+        peer_id: &str,
+        session_token: &str,
+        profile_fence: (u64, u64),
+        peer_session_generation: crate::peer::PeerSessionGeneration,
+        network_generation: u64,
+        remote_candidate_epoch: u64,
+        direct_commit_seq: Option<u64>,
+    ) -> Option<&'static str> {
+        if self
+            .peers
+            .hard_hard_winner_for_token(peer_id, session_token)
+            .await
+            .is_some()
+        {
+            return Some("winner_selected");
+        }
+        if self.peers.is_direct_sync(peer_id) {
+            return Some("direct_confirmed");
+        }
+        if self.peers.current_network_generation_sync() != network_generation {
+            return Some("network_generation_changed");
+        }
+        if !self
+            .peers
+            .peer_session_is_current_sync(peer_id, peer_session_generation)
+        {
+            return Some("peer_session_changed");
+        }
+        if self
+            .peers
+            .current_remote_candidate_epoch(peer_id)
+            .await
+            .unwrap_or_default()
+            != remote_candidate_epoch
+        {
+            return Some("candidate_epoch_changed");
+        }
+        let profile_current = self
+            .peers
+            .hard_hard_plan_for_peer(peer_id)
+            .await
+            .is_some_and(|plan| {
+                plan.local_profile_generation == profile_fence.0
+                    && plan.remote_profile_generation == profile_fence.1
+            });
+        if !profile_current {
+            return Some("profile_generation_changed");
+        }
+        if !self
+            .peers
+            .hard_hard_session_token_is_current(peer_id, session_token)
+            .await
+        {
+            return Some("session_retired");
+        }
+        if self.peers.direct_commit_seq_sync(peer_id) != direct_commit_seq {
+            return Some("direct_commit_seq_changed");
+        }
+        None
     }
 
     /// Exact-index sweep with an optional Hard↔Hard profile-generation fence.
@@ -2386,6 +2578,7 @@ impl UdpTransport {
         let mut last_budget_reason = None;
         let mut sent_endpoints = HashSet::new();
         let mut first_send_at_ms = None;
+        let mut last_send_at_ms: Option<u64> = None;
         let mut per_socket_sent = 0u32;
         let commit_seq_at_start = self.peers.direct_commit_seq_sync(peer_id);
         let network_generation_at_start = self.peers.current_network_generation_sync();
@@ -2525,6 +2718,10 @@ impl UdpTransport {
                         packets_sent = packets_sent.saturating_add(1);
                         if let Some(sent_at_ms) = sent.first_send_at_ms {
                             first_send_at_ms.get_or_insert(sent_at_ms);
+                            last_send_at_ms = Some(
+                                last_send_at_ms
+                                    .map_or(sent_at_ms, |last| last.max(sent_at_ms)),
+                            );
                         }
                         per_socket_sent =
                             per_socket_sent.saturating_add(u32::from(sent.datagrams_sent));
@@ -2573,6 +2770,9 @@ impl UdpTransport {
             budget_skipped,
             epoch_budget_exhausted: false,
             candidate_iteration_capped: false,
+            sent_target_endpoints: sent_endpoints.into_iter().collect(),
+            last_send_at_ms,
+            ..PunchSendReport::default()
         })
     }
 }
@@ -2696,16 +2896,63 @@ fn hard_hard_birthday_capacity_plan(
     Some((actual_level, actual_socket_count))
 }
 
-fn hard_hard_birthday_assignments(
+fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSendReport) {
+    destination.packets_sent = destination.packets_sent.saturating_add(source.packets_sent);
+    destination.budget_skipped = destination.budget_skipped.saturating_add(source.budget_skipped);
+    destination.epoch_budget_exhausted |= source.epoch_budget_exhausted;
+    destination.candidate_iteration_capped |= source.candidate_iteration_capped;
+    destination.first_send_at_ms = match (destination.first_send_at_ms, source.first_send_at_ms) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (None, right) => right,
+        (left, None) => left,
+    };
+    destination.last_send_at_ms = match (destination.last_send_at_ms, source.last_send_at_ms) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (None, right) => right,
+        (left, None) => left,
+    };
+    for endpoint in source.sent_target_endpoints {
+        if !destination.sent_target_endpoints.contains(&endpoint) {
+            destination.sent_target_endpoints.push(endpoint);
+        }
+    }
+    for (socket_index, sent) in source.per_socket_sent {
+        if let Some((_, existing)) = destination
+            .per_socket_sent
+            .iter_mut()
+            .find(|(index, _)| *index == socket_index)
+        {
+            *existing = existing.saturating_add(sent);
+        } else {
+            destination.per_socket_sent.push((socket_index, sent));
+        }
+    }
+}
+
+fn hard_hard_birthday_wave_count(socket_count: usize) -> usize {
+    match socket_count {
+        0 => 0,
+        1 => 1,
+        _ => HARD_HARD_BIRTHDAY_WAVES,
+    }
+}
+
+fn hard_hard_birthday_packets_planned(socket_count: usize, target_count: usize) -> usize {
+    target_count.saturating_mul(hard_hard_birthday_wave_count(socket_count))
+}
+
+fn hard_hard_birthday_wave_assignments(
     socket_count: usize,
     targets: Vec<SocketAddr>,
+    wave: usize,
 ) -> Vec<Vec<SocketAddr>> {
     if socket_count == 0 {
         return Vec::new();
     }
     let mut assignments = vec![Vec::new(); socket_count];
+    let socket_offset = wave % socket_count;
     for (index, target) in targets.into_iter().enumerate() {
-        assignments[index % socket_count].push(target);
+        assignments[(index + socket_offset) % socket_count].push(target);
     }
     assignments
 }
@@ -3463,11 +3710,12 @@ impl Drop for ProvisionalSocketGuard {
 #[cfg(test)]
 mod birthday_tests {
     use super::{
-        hard_hard_birthday_assignments, hard_hard_birthday_candidates,
-        hard_hard_birthday_capacity_plan,
+        hard_hard_birthday_candidates, hard_hard_birthday_capacity_plan,
+        hard_hard_birthday_packets_planned, hard_hard_birthday_wave_assignments,
+        hard_hard_birthday_wave_count,
     };
     use p2pnet_nat::mapping::AllocationModelKind;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[test]
@@ -3501,18 +3749,41 @@ mod birthday_tests {
     }
 
     #[test]
-    fn birthday_assignments_send_each_target_once_without_socket_cartesian_product() {
+    fn birthday_two_waves_rotate_targets_without_socket_cartesian_product() {
         for (socket_count, level) in [(2, 64), (4, 128), (8, 256)] {
             let targets = (1..=level)
                 .map(|port| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port as u16))
                 .collect::<Vec<_>>();
-            let assignments = hard_hard_birthday_assignments(socket_count, targets.clone());
-            assert_eq!(assignments.len(), socket_count);
-            let flattened = assignments.into_iter().flatten().collect::<Vec<_>>();
-            assert_eq!(flattened.len(), level);
-            assert_eq!(flattened.iter().collect::<HashSet<_>>().len(), level);
-            assert!(flattened.iter().all(|target| targets.contains(target)));
+            assert_eq!(hard_hard_birthday_wave_count(socket_count), 2);
+            let first = hard_hard_birthday_wave_assignments(socket_count, targets.clone(), 0);
+            let second = hard_hard_birthday_wave_assignments(socket_count, targets.clone(), 1);
+            assert_eq!(first.len(), socket_count);
+            assert_eq!(second.len(), socket_count);
+            for assignments in [&first, &second] {
+                let flattened = assignments.iter().flatten().copied().collect::<Vec<_>>();
+                assert_eq!(flattened.len(), level);
+                assert_eq!(flattened.iter().collect::<HashSet<_>>().len(), level);
+                assert!(flattened.iter().all(|target| targets.contains(target)));
+            }
+            let first_socket = first
+                .iter()
+                .enumerate()
+                .flat_map(|(socket, assigned)| assigned.iter().map(move |target| (*target, socket)))
+                .collect::<HashMap<_, _>>();
+            let second_socket = second
+                .iter()
+                .enumerate()
+                .flat_map(|(socket, assigned)| assigned.iter().map(move |target| (*target, socket)))
+                .collect::<HashMap<_, _>>();
+            assert!(targets
+                .iter()
+                .all(|target| first_socket[target] != second_socket[target]));
         }
+        assert_eq!(hard_hard_birthday_wave_count(1), 1);
+        assert_eq!(hard_hard_birthday_wave_count(0), 0);
+        assert_eq!(hard_hard_birthday_packets_planned(2, 64), 128);
+        assert_eq!(hard_hard_birthday_packets_planned(4, 96), 192);
+        assert_eq!(hard_hard_birthday_packets_planned(1, 96), 96);
     }
 
     #[test]

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -2264,6 +2264,7 @@ impl UdpTransport {
             attempts,
             None,
             None,
+            None,
         )
         .await
     }
@@ -2340,6 +2341,11 @@ impl UdpTransport {
         session_token: &str,
         progress: Option<Arc<Mutex<BirthdaySweepProgress>>>,
     ) -> Result<PunchSendReport> {
+        let live = if let Some(progress) = progress.as_ref() {
+            Some(progress.lock().await.live.clone())
+        } else {
+            None
+        };
         let mut effective_targets = Vec::with_capacity(targets.len().min(crate::MAX_SIGNAL_CANDIDATES));
         for target in targets {
             if target.port() == 0 || effective_targets.contains(&target) {
@@ -2460,6 +2466,11 @@ impl UdpTransport {
             birthday.targets_assigned = birthday
                 .targets_assigned
                 .saturating_add(effective_targets.len());
+            update_live_birthday_counters(&live, |counters| {
+                counters.targets_assigned = counters
+                    .targets_assigned
+                    .saturating_add(u32::try_from(wave_assigned_count).unwrap_or(u32::MAX));
+            });
             let mut workers = JoinSet::new();
             for (socket_position, socket_index) in
                 effective_socket_indices.iter().copied().enumerate()
@@ -2471,10 +2482,11 @@ impl UdpTransport {
                 let transport = self.clone();
                 let peer_id = peer_id.to_string();
                 let session_token = session_token.to_string();
+                let live_counters = live.clone();
                 let assigned_count = assigned.len();
                 workers.spawn(async move {
                     let result = transport
-                        .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session(
+                        .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
                             &peer_id,
                             socket_index,
                             assigned,
@@ -2482,6 +2494,7 @@ impl UdpTransport {
                             1,
                             Some(profile_fence),
                             Some(&session_token),
+                            live_counters,
                         )
                         .await;
                     (assigned_count, result)
@@ -2492,14 +2505,15 @@ impl UdpTransport {
 
             let mut wave_report = PunchSendReport::default();
             let mut wave_fully_completed = true;
-            let mut ordinary_worker_failed = false;
-            let mut join_worker_failed = false;
+            let mut failure_kind = None;
             while let Some(joined) = workers.join_next().await {
+                update_live_birthday_counters(&live, |counters| {
+                    counters.workers_completed = counters.workers_completed.saturating_add(1);
+                });
                 record_birthday_worker_result(
                     &mut wave_report,
                     &mut wave_fully_completed,
-                    &mut ordinary_worker_failed,
-                    &mut join_worker_failed,
+                    &mut failure_kind,
                     joined,
                 );
             }
@@ -2513,14 +2527,16 @@ impl UdpTransport {
                     .unwrap_or(u32::MAX)
                     .saturating_sub(wave_report.targets_attempted),
             );
+            update_live_birthday_counters(&live, |counters| {
+                counters.targets_cancelled = counters
+                    .targets_cancelled
+                    .saturating_add(wave_report.targets_cancelled);
+            });
             merge_punch_send_reports(&mut aggregate, wave_report.clone());
-            if ordinary_worker_failed || join_worker_failed {
-                aggregate.worker_failed = true;
-                let stop_reason = if join_worker_failed {
-                    "worker_failed"
-                } else {
-                    "send_error"
-                };
+            if let Some(failure_kind) = failure_kind.or(wave_report.failure_kind) {
+                aggregate.failure_kind = Some(failure_kind);
+                aggregate.worker_failed |= failure_kind == BirthdaySweepFailureKind::WorkerJoin;
+                let stop_reason = failure_kind.stop_reason();
                 birthday.stop_reason = Some(stop_reason.to_string());
                 update_birthday_sweep_counters(&mut birthday, &aggregate);
                 publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
@@ -2706,6 +2722,31 @@ impl UdpTransport {
         profile_fence: Option<(u64, u64)>,
         hard_hard_session_token: Option<&str>,
     ) -> Result<PunchSendReport> {
+        self.punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
+            peer_id,
+            socket_index,
+            candidates,
+            probe_interval,
+            attempts,
+            profile_fence,
+            hard_hard_session_token,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
+        &self,
+        peer_id: &str,
+        socket_index: usize,
+        candidates: Vec<SocketAddr>,
+        probe_interval: Duration,
+        attempts: u32,
+        profile_fence: Option<(u64, u64)>,
+        hard_hard_session_token: Option<&str>,
+        live: Option<Arc<StdMutex<LiveBirthdayCounters>>>,
+    ) -> Result<PunchSendReport> {
         let Some((index, socket, _lease)) = self
             .resolve_dynamic_socket_index_for_send(peer_id, socket_index)
             .await
@@ -2725,6 +2766,7 @@ impl UdpTransport {
             attempts,
             profile_fence,
             hard_hard_session_token,
+            live,
         )
         .await
     }
@@ -2740,9 +2782,14 @@ impl UdpTransport {
         attempts: u32,
         profile_fence: Option<(u64, u64)>,
         hard_hard_session_token: Option<&str>,
+        live: Option<Arc<StdMutex<LiveBirthdayCounters>>>,
     ) -> Result<PunchSendReport> {
         let schedule = build_probe_schedule(&candidates, probe_interval, attempts);
         let mut packets_sent = 0u32;
+        let mut logical_probes_attempted = 0u32;
+        let mut logical_probes_sent = 0u32;
+        let mut physical_datagrams_sent = 0u32;
+        let mut physical_send_errors = 0u32;
         let mut budget_skipped = 0u32;
         let mut last_budget_reason = None;
         let mut sent_endpoints = HashSet::new();
@@ -2750,8 +2797,10 @@ impl UdpTransport {
         let mut last_send_at_ms: Option<u64> = None;
         let mut per_socket_sent = 0u32;
         let targets_assigned = u32::try_from(candidates.len()).unwrap_or(u32::MAX);
+        let mut targets_examined = 0u32;
         let mut targets_attempted = 0u32;
         let mut target_processing_completed = true;
+        let mut failure_kind = None;
         let commit_seq_at_start = self.peers.direct_commit_seq_sync(peer_id);
         let network_generation_at_start = self.peers.current_network_generation_sync();
         let remote_candidate_epoch_at_start = self
@@ -2771,7 +2820,10 @@ impl UdpTransport {
                 sleep(round.delay_before).await;
             }
             for candidate in round.endpoints {
-                targets_attempted = targets_attempted.saturating_add(1);
+                targets_examined = targets_examined.saturating_add(1);
+                update_live_birthday_counters(&live, |counters| {
+                    counters.targets_examined = counters.targets_examined.saturating_add(1);
+                });
                 if let Some(token) = hard_hard_session_token {
                     if self
                         .peers
@@ -2852,6 +2904,14 @@ impl UdpTransport {
                     target_processing_completed = false;
                     break;
                 }
+                // All session, network, profile, winner, Direct and commit
+                // fences passed. A budget rejection below is still an
+                // attempted target: it entered this worker's admission path,
+                // but it is not a logical Probe construction/send attempt.
+                targets_attempted = targets_attempted.saturating_add(1);
+                update_live_birthday_counters(&live, |counters| {
+                    counters.targets_attempted = counters.targets_attempted.saturating_add(1);
+                });
                 if self
                     .peers
                     .direct_probe_endpoint_quarantined(
@@ -2863,6 +2923,9 @@ impl UdpTransport {
                 {
                     budget_skipped = budget_skipped.saturating_add(1);
                     last_budget_reason = Some("direct_slow_relay_retained");
+                    update_live_birthday_counters(&live, |counters| {
+                        counters.budget_skipped = counters.budget_skipped.saturating_add(1);
+                    });
                     trace!(
                         "Skipped dynamic-socket punch for peer {peer_id} candidate {candidate}: recent slow ACK quarantine"
                     );
@@ -2880,11 +2943,19 @@ impl UdpTransport {
                         // credit all apply to fresh-mapping punches.
                         budget_skipped = budget_skipped.saturating_add(1);
                         last_budget_reason = Some(outbound_probe_admission_reason(limited));
+                        update_live_birthday_counters(&live, |counters| {
+                            counters.budget_skipped = counters.budget_skipped.saturating_add(1);
+                        });
                         continue;
                     }
                 }
+                logical_probes_attempted = logical_probes_attempted.saturating_add(1);
+                update_live_birthday_counters(&live, |counters| {
+                    counters.logical_probes_attempted =
+                        counters.logical_probes_attempted.saturating_add(1);
+                });
                 match self
-                    .send_probe_on_socket_result_with_hard_hard_token(
+                    .send_probe_on_socket_result_with_hard_hard_token_classified(
                         index,
                         socket.clone(),
                         Some(peer_id),
@@ -2897,6 +2968,28 @@ impl UdpTransport {
                 {
                     Ok(sent) => {
                         packets_sent = packets_sent.saturating_add(1);
+                        logical_probes_sent = logical_probes_sent.saturating_add(1);
+                        let successful_datagrams = u32::from(sent.datagrams_sent);
+                        let failed_datagrams = u32::from(sent.physical_send_errors);
+                        physical_datagrams_sent =
+                            physical_datagrams_sent.saturating_add(successful_datagrams);
+                        physical_send_errors = physical_send_errors.saturating_add(failed_datagrams);
+                        update_live_birthday_counters(&live, |counters| {
+                            counters.logical_probes_sent =
+                                counters.logical_probes_sent.saturating_add(1);
+                            counters.physical_datagrams_sent = counters
+                                .physical_datagrams_sent
+                                .saturating_add(successful_datagrams);
+                            counters.physical_send_errors = counters
+                                .physical_send_errors
+                                .saturating_add(failed_datagrams);
+                        });
+                        if sent.physical_send_errors > 0 {
+                            failure_kind = combine_birthday_failure_kind(
+                                failure_kind,
+                                Some(BirthdaySweepFailureKind::Send),
+                            );
+                        }
                         if let Some(sent_at_ms) = sent.first_send_at_ms {
                             first_send_at_ms.get_or_insert(sent_at_ms);
                             last_send_at_ms = Some(
@@ -2918,9 +3011,22 @@ impl UdpTransport {
                             sleep(OUTBOUND_CONNECTIVITY_PROBE_SPACING).await;
                         }
                     }
-                    Err(error) => {
+                    Err(failure) => {
+                        physical_send_errors = physical_send_errors.saturating_add(u32::from(
+                            failure.physical_send_errors,
+                        ));
+                        update_live_birthday_counters(&live, |counters| {
+                            counters.physical_send_errors = counters
+                                .physical_send_errors
+                                .saturating_add(u32::from(failure.physical_send_errors));
+                        });
+                        failure_kind = combine_birthday_failure_kind(
+                            failure_kind,
+                            Some(BirthdaySweepFailureKind::Send),
+                        );
                         debug!(
-                            "Dynamic-socket punch to peer {peer_id} candidate {candidate} failed: {error}"
+                            "Dynamic-socket punch to peer {peer_id} candidate {candidate} failed: {}",
+                            failure.error
                         );
                     }
                 }
@@ -2943,6 +3049,10 @@ impl UdpTransport {
         }
         Ok(PunchSendReport {
             packets_sent,
+            logical_probes_attempted,
+            logical_probes_sent,
+            physical_datagrams_sent,
+            physical_send_errors,
             unique_target_endpoints: u32::try_from(sent_endpoints.len()).unwrap_or(u32::MAX),
             first_send_at_ms,
             per_socket_sent: (per_socket_sent > 0)
@@ -2954,9 +3064,11 @@ impl UdpTransport {
             sent_target_endpoints: sent_endpoints.into_iter().collect(),
             last_send_at_ms,
             targets_assigned,
+            targets_examined,
             targets_attempted,
             targets_cancelled: targets_assigned.saturating_sub(targets_attempted),
             target_processing_completed,
+            failure_kind,
             ..PunchSendReport::default()
         })
     }
@@ -3118,35 +3230,88 @@ fn hard_hard_birthday_socket_plan(
 fn record_birthday_worker_result(
     wave_report: &mut PunchSendReport,
     wave_fully_completed: &mut bool,
-    ordinary_worker_failed: &mut bool,
-    join_worker_failed: &mut bool,
+    failure_kind: &mut Option<BirthdaySweepFailureKind>,
     joined: std::result::Result<(usize, Result<PunchSendReport>), tokio::task::JoinError>,
 ) {
     match joined {
         Ok((_assigned_count, Ok(report))) => {
-            *wave_fully_completed &= report.target_processing_completed;
+            *wave_fully_completed &=
+                report.target_processing_completed && report.failure_kind.is_none();
+            *failure_kind = combine_birthday_failure_kind(*failure_kind, report.failure_kind);
             merge_punch_send_reports(wave_report, report);
         }
         Ok((assigned_count, Err(_error))) => {
-            *ordinary_worker_failed = true;
             *wave_fully_completed = false;
+            *failure_kind = combine_birthday_failure_kind(
+                *failure_kind,
+                Some(BirthdaySweepFailureKind::Send),
+            );
             wave_report.targets_cancelled = wave_report
                 .targets_cancelled
                 .saturating_add(u32::try_from(assigned_count).unwrap_or(u32::MAX));
         }
         Err(_join_error) => {
-            *join_worker_failed = true;
             *wave_fully_completed = false;
+            *failure_kind = combine_birthday_failure_kind(
+                *failure_kind,
+                Some(BirthdaySweepFailureKind::WorkerJoin),
+            );
+            wave_report.worker_failed = true;
         }
     }
 }
 
+fn combine_birthday_failure_kind(
+    left: Option<BirthdaySweepFailureKind>,
+    right: Option<BirthdaySweepFailureKind>,
+) -> Option<BirthdaySweepFailureKind> {
+    match (left, right) {
+        (Some(BirthdaySweepFailureKind::WorkerJoin), _)
+        | (_, Some(BirthdaySweepFailureKind::WorkerJoin)) => {
+            Some(BirthdaySweepFailureKind::WorkerJoin)
+        }
+        (Some(BirthdaySweepFailureKind::Send), _) | (_, Some(BirthdaySweepFailureKind::Send)) => {
+            Some(BirthdaySweepFailureKind::Send)
+        }
+        (None, None) => None,
+    }
+}
+
 fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSendReport) {
-    destination.packets_sent = destination.packets_sent.saturating_add(source.packets_sent);
+    let source_logical_sent = source.logical_probes_sent.max(source.packets_sent);
+    let source_logical_attempted = source
+        .logical_probes_attempted
+        .max(source_logical_sent);
+    let source_targets_examined = source.targets_examined.max(source.targets_attempted);
+    let source_physical_datagrams_sent = source.physical_datagrams_sent.max(
+        source
+            .per_socket_sent
+            .iter()
+            .map(|(_, sent)| *sent)
+            .sum(),
+    );
+    destination.packets_sent = destination
+        .packets_sent
+        .saturating_add(source_logical_sent);
+    destination.logical_probes_sent = destination
+        .logical_probes_sent
+        .saturating_add(source_logical_sent);
+    destination.logical_probes_attempted = destination
+        .logical_probes_attempted
+        .saturating_add(source_logical_attempted);
+    destination.physical_datagrams_sent = destination
+        .physical_datagrams_sent
+        .saturating_add(source_physical_datagrams_sent);
+    destination.physical_send_errors = destination
+        .physical_send_errors
+        .saturating_add(source.physical_send_errors);
     destination.budget_skipped = destination.budget_skipped.saturating_add(source.budget_skipped);
     destination.targets_assigned = destination
         .targets_assigned
         .saturating_add(source.targets_assigned);
+    destination.targets_examined = destination
+        .targets_examined
+        .saturating_add(source_targets_examined);
     destination.targets_attempted = destination
         .targets_attempted
         .saturating_add(source.targets_attempted);
@@ -3158,7 +3323,12 @@ fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSend
     } else {
         destination.target_processing_completed &= source.target_processing_completed;
     }
-    destination.worker_failed |= source.worker_failed;
+    destination.worker_failed |= source.worker_failed
+        || source.failure_kind == Some(BirthdaySweepFailureKind::WorkerJoin);
+    destination.failure_kind = combine_birthday_failure_kind(
+        destination.failure_kind,
+        source.failure_kind,
+    );
     destination.epoch_budget_exhausted |= source.epoch_budget_exhausted;
     destination.candidate_iteration_capped |= source.candidate_iteration_capped;
     destination.first_send_at_ms = match (destination.first_send_at_ms, source.first_send_at_ms) {
@@ -3193,15 +3363,65 @@ pub(crate) fn update_birthday_sweep_counters(
     birthday: &mut BirthdaySweepReport,
     aggregate: &PunchSendReport,
 ) {
+    birthday.targets_assigned = birthday
+        .targets_assigned
+        .max(aggregate.targets_assigned as usize);
     birthday.targets_attempted = aggregate.targets_attempted as usize;
-    birthday.logical_probes_sent = aggregate.packets_sent as usize;
-    birthday.physical_datagrams_sent = aggregate
-        .per_socket_sent
-        .iter()
-        .map(|(_, sent)| *sent as usize)
-        .sum();
+    birthday.targets_examined = aggregate
+        .targets_examined
+        .max(aggregate.targets_attempted) as usize;
+    let logical_probes_sent = aggregate.logical_probes_sent.max(aggregate.packets_sent);
+    birthday.logical_probes_attempted = aggregate
+        .logical_probes_attempted
+        .max(logical_probes_sent) as usize;
+    birthday.logical_probes_sent = logical_probes_sent as usize;
+    birthday.physical_datagrams_sent = aggregate.physical_datagrams_sent.max(
+        aggregate
+            .per_socket_sent
+            .iter()
+            .map(|(_, sent)| *sent)
+            .sum(),
+    ) as usize;
+    birthday.physical_send_errors = aggregate.physical_send_errors as usize;
     birthday.targets_budget_skipped = aggregate.budget_skipped as usize;
     birthday.targets_cancelled = aggregate.targets_cancelled as usize;
+}
+
+fn update_live_birthday_counters(
+    live: &Option<Arc<StdMutex<LiveBirthdayCounters>>>,
+    update: impl FnOnce(&mut LiveBirthdayCounters),
+) {
+    let Some(live) = live else {
+        return;
+    };
+    let mut counters = live.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    update(&mut counters);
+}
+
+pub(crate) fn apply_live_birthday_counters(
+    report: &mut PunchSendReport,
+    live: &LiveBirthdayCounters,
+) {
+    report.targets_assigned = report.targets_assigned.max(live.targets_assigned);
+    report.targets_examined = report.targets_examined.max(live.targets_examined);
+    report.targets_attempted = report.targets_attempted.max(live.targets_attempted);
+    report.targets_cancelled = report.targets_cancelled.max(live.targets_cancelled);
+    report.budget_skipped = report.budget_skipped.max(live.budget_skipped);
+    report.logical_probes_sent = report
+        .logical_probes_sent
+        .max(live.logical_probes_sent)
+        .max(report.packets_sent);
+    report.logical_probes_attempted = report
+        .logical_probes_attempted
+        .max(live.logical_probes_attempted)
+        .max(report.logical_probes_sent);
+    report.packets_sent = report.packets_sent.max(report.logical_probes_sent);
+    report.physical_datagrams_sent = report
+        .physical_datagrams_sent
+        .max(live.physical_datagrams_sent);
+    report.physical_send_errors = report
+        .physical_send_errors
+        .max(live.physical_send_errors);
 }
 
 async fn publish_birthday_sweep_progress(
@@ -3212,9 +3432,24 @@ async fn publish_birthday_sweep_progress(
     let Some(progress) = progress else {
         return;
     };
+    let live = {
+        let current = progress.lock().await;
+        current.live.clone()
+    };
+    let live_snapshot = live
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    let mut published_aggregate = aggregate.clone();
+    apply_live_birthday_counters(&mut published_aggregate, &live_snapshot);
+    let mut published_birthday = birthday.clone();
+    published_birthday.targets_assigned = published_birthday
+        .targets_assigned
+        .max(published_aggregate.targets_assigned as usize);
+    update_birthday_sweep_counters(&mut published_birthday, &published_aggregate);
     let mut current = progress.lock().await;
-    current.birthday = birthday.clone();
-    current.aggregate = aggregate.clone();
+    current.birthday = published_birthday;
+    current.aggregate = published_aggregate;
 }
 
 pub(crate) fn hard_hard_birthday_wave_count(socket_count: usize) -> usize {
@@ -4001,7 +4236,8 @@ mod birthday_tests {
         hard_hard_birthday_candidates, hard_hard_birthday_capacity_plan,
         hard_hard_birthday_packets_planned, hard_hard_birthday_socket_plan,
         hard_hard_birthday_wave_assignments, hard_hard_birthday_wave_count,
-        record_birthday_worker_result, HardHardSocketSnapshot, PunchSendReport,
+        record_birthday_worker_result, BirthdaySweepFailureKind, HardHardSocketSnapshot,
+        PunchSendReport,
     };
     use crate::error::DaemonError;
     use p2pnet_nat::mapping::AllocationModelKind;
@@ -4166,13 +4402,11 @@ mod birthday_tests {
     async fn birthday_worker_collection_preserves_partial_stats_and_join_errors() {
         let mut wave_report = PunchSendReport::default();
         let mut wave_fully_completed = true;
-        let mut ordinary_worker_failed = false;
-        let mut join_worker_failed = false;
+        let mut failure_kind = None;
         record_birthday_worker_result(
             &mut wave_report,
             &mut wave_fully_completed,
-            &mut ordinary_worker_failed,
-            &mut join_worker_failed,
+            &mut failure_kind,
             Ok((2, Ok(PunchSendReport {
                 packets_sent: 1,
                 per_socket_sent: vec![(41, 2)],
@@ -4185,21 +4419,19 @@ mod birthday_tests {
         assert_eq!(wave_report.packets_sent, 1);
         assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
         assert!(wave_fully_completed);
-        assert!(!ordinary_worker_failed);
-        assert!(!join_worker_failed);
+        assert_eq!(failure_kind, None);
 
         record_birthday_worker_result(
             &mut wave_report,
             &mut wave_fully_completed,
-            &mut ordinary_worker_failed,
-            &mut join_worker_failed,
+            &mut failure_kind,
             Ok((3, Err(DaemonError::Network("injected worker error".to_string())))),
         );
         assert_eq!(wave_report.packets_sent, 1);
         assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
         assert_eq!(wave_report.targets_cancelled, 3);
         assert!(!wave_fully_completed);
-        assert!(ordinary_worker_failed);
+        assert_eq!(failure_kind, Some(BirthdaySweepFailureKind::Send));
 
         let handle = tokio::spawn(async { std::future::pending::<()>().await });
         handle.abort();
@@ -4207,13 +4439,11 @@ mod birthday_tests {
         record_birthday_worker_result(
             &mut wave_report,
             &mut wave_fully_completed,
-            &mut ordinary_worker_failed,
-            &mut join_worker_failed,
+            &mut failure_kind,
             Err(join_error),
         );
         assert!(!wave_fully_completed);
-        assert!(ordinary_worker_failed);
-        assert!(join_worker_failed);
+        assert_eq!(failure_kind, Some(BirthdaySweepFailureKind::WorkerJoin));
         assert_eq!(wave_report.packets_sent, 1);
         assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
     }

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -496,6 +496,7 @@ impl UdpTransport {
             .and_then(|entry| entry.hard_hard_session_token.clone())
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn hard_hard_socket_indices_for_token(
         &self,
         peer_id: &str,
@@ -512,6 +513,44 @@ impl UdpTransport {
                     && entry.phase.is_usable()
             })
             .map(|(index, _)| *index)
+            .collect()
+    }
+
+    /// Snapshot the exact sockets requested by one Hard↔Hard session without
+    /// following affinity or falling back to the ordinary pool.  The caller
+    /// owns the requested index list from the session ledger; a missing entry
+    /// is represented explicitly as detached/unusable so diagnostics can
+    /// distinguish it from a smaller request.
+    pub(crate) async fn hard_hard_socket_snapshot_for_token(
+        &self,
+        peer_id: &str,
+        token: &str,
+        requested_socket_indices: &[usize],
+    ) -> Vec<HardHardSocketSnapshot> {
+        let state = self.socket_state.lock().await;
+        let mut seen = HashSet::with_capacity(requested_socket_indices.len());
+        requested_socket_indices
+            .iter()
+            .copied()
+            .filter(|socket_index| seen.insert(*socket_index))
+            .map(|socket_index| {
+                let entry = state.dynamic.get(&socket_index);
+                let attached = entry.is_some_and(|entry| {
+                    entry.peer_id == peer_id
+                        && entry.hard_hard_session_token.as_deref() == Some(token)
+                });
+                let usable = attached
+                    && entry.is_some_and(|entry| {
+                        entry.phase.is_usable()
+                            && entry.network_generation
+                                == self.peers.current_network_generation_sync()
+                    });
+                HardHardSocketSnapshot {
+                    socket_index,
+                    attached,
+                    usable,
+                }
+            })
             .collect()
     }
 
@@ -2258,6 +2297,7 @@ impl UdpTransport {
     /// so a target is retried from a different source port without creating a
     /// socket-count Cartesian product.
     #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)]
     pub(crate) async fn punch_hard_hard_birthday_candidates(
         &self,
         peer_id: &str,
@@ -2267,6 +2307,38 @@ impl UdpTransport {
         peer_session_generation: crate::peer::PeerSessionGeneration,
         profile_fence: (u64, u64),
         session_token: &str,
+    ) -> Result<PunchSendReport> {
+        self.punch_hard_hard_birthday_candidates_with_metadata(
+            peer_id,
+            socket_indices,
+            targets.clone(),
+            requested_level,
+            targets.len(),
+            targets.len(),
+            peer_session_generation,
+            profile_fence,
+            session_token,
+            None,
+        )
+        .await
+    }
+
+    /// Scheduler entry used by the Hard↔Hard runtime.  The metadata counts
+    /// come from the local session ledger's pre-cap measurement contract; the
+    /// scheduler never derives them from the remote/effective target list.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn punch_hard_hard_birthday_candidates_with_metadata(
+        &self,
+        peer_id: &str,
+        requested_socket_indices: Vec<usize>,
+        targets: Vec<SocketAddr>,
+        requested_level: usize,
+        generated_candidate_count: usize,
+        signaled_candidate_count: usize,
+        peer_session_generation: crate::peer::PeerSessionGeneration,
+        profile_fence: (u64, u64),
+        session_token: &str,
+        progress: Option<Arc<Mutex<BirthdaySweepProgress>>>,
     ) -> Result<PunchSendReport> {
         let mut effective_targets = Vec::with_capacity(targets.len().min(crate::MAX_SIGNAL_CANDIDATES));
         for target in targets {
@@ -2278,49 +2350,76 @@ impl UdpTransport {
                 break;
             }
         }
-        let mut effective_socket_indices = Vec::with_capacity(socket_indices.len());
-        for socket_index in socket_indices {
-            if !effective_socket_indices.contains(&socket_index) {
-                effective_socket_indices.push(socket_index);
-            }
-        }
-
-        let waves_planned = hard_hard_birthday_wave_count(effective_socket_indices.len());
+        let requested_socket_count = hard_hard_birthday_socket_count(requested_level);
+        // This is the only socket snapshot used for scheduling.  It is exact
+        // and session-token scoped; a detached member becomes unavailable and
+        // can never be replaced by a pool socket.
+        let socket_snapshot = self
+            .hard_hard_socket_snapshot_for_token(
+                peer_id,
+                session_token,
+                &requested_socket_indices,
+            )
+            .await;
+        let socket_plan = hard_hard_birthday_socket_plan(requested_level, socket_snapshot);
+        let attached_socket_count = socket_plan.attached_socket_count;
+        let effective_socket_indices = socket_plan.usable_socket_indices;
+        let usable_socket_count = socket_plan.usable_socket_count;
+        let unavailable_socket_count = socket_plan.unavailable_socket_count;
+        let waves_planned = hard_hard_birthday_wave_count(usable_socket_count);
         let mut birthday = BirthdaySweepReport {
             requested_level,
+            generated_candidate_count,
+            signaled_candidate_count,
             effective_target_count: effective_targets.len(),
+            requested_socket_count,
+            attached_socket_count,
+            usable_socket_count,
+            unavailable_socket_count,
+            socket_count: usable_socket_count,
             waves_planned,
             packets_planned: hard_hard_birthday_packets_planned(
-                effective_socket_indices.len(),
+                usable_socket_count,
                 effective_targets.len(),
             ),
             ..BirthdaySweepReport::default()
         };
+        if usable_socket_count == 1 {
+            birthday.degraded_reason = Some(if requested_socket_count > 1 {
+                "partial_socket_unavailable"
+            } else {
+                "single_socket"
+            }
+            .to_string());
+        } else if usable_socket_count > 0 && usable_socket_count < requested_socket_count {
+            birthday.degraded_reason = Some("partial_socket_unavailable".to_string());
+        }
         let mut aggregate = PunchSendReport::default();
+        publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
         if effective_targets.is_empty() {
             birthday.stop_reason = Some("empty_targets".to_string());
+            update_birthday_sweep_counters(&mut birthday, &aggregate);
             aggregate.birthday = Some(birthday);
+            publish_birthday_sweep_progress(
+                &progress,
+                aggregate.birthday.as_ref().expect("birthday report just set"),
+                &aggregate,
+            )
+            .await;
             return Ok(aggregate);
         }
         if effective_socket_indices.is_empty() {
             birthday.stop_reason = Some("socket_unavailable".to_string());
+            update_birthday_sweep_counters(&mut birthday, &aggregate);
             aggregate.birthday = Some(birthday);
+            publish_birthday_sweep_progress(
+                &progress,
+                aggregate.birthday.as_ref().expect("birthday report just set"),
+                &aggregate,
+            )
+            .await;
             return Ok(aggregate);
         }
-
-        // Keep the first-wave launch timing identical to the existing
-        // one-shot path. Each worker still resolves its exact socket
-        // fail-closed immediately before it can send; a fully detached set is
-        // reported as `socket_unavailable` after that wave.
-        birthday.socket_count = effective_socket_indices.len();
-        if birthday.socket_count == 1 {
-            birthday.degraded_reason = Some("single_socket".to_string());
-        }
-        birthday.waves_planned = hard_hard_birthday_wave_count(effective_socket_indices.len());
-        birthday.packets_planned = hard_hard_birthday_packets_planned(
-            birthday.socket_count,
-            birthday.effective_target_count,
-        );
 
         let network_generation_at_start = self.peers.current_network_generation_sync();
         let remote_candidate_epoch_at_start = self
@@ -2357,6 +2456,10 @@ impl UdpTransport {
                 effective_targets.clone(),
                 wave,
             );
+            let wave_assigned_count = assignments.iter().map(Vec::len).sum::<usize>();
+            birthday.targets_assigned = birthday
+                .targets_assigned
+                .saturating_add(effective_targets.len());
             let mut workers = JoinSet::new();
             for (socket_position, socket_index) in
                 effective_socket_indices.iter().copied().enumerate()
@@ -2368,8 +2471,9 @@ impl UdpTransport {
                 let transport = self.clone();
                 let peer_id = peer_id.to_string();
                 let session_token = session_token.to_string();
+                let assigned_count = assigned.len();
                 workers.spawn(async move {
-                    transport
+                    let result = transport
                         .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session(
                             &peer_id,
                             socket_index,
@@ -2379,26 +2483,75 @@ impl UdpTransport {
                             Some(profile_fence),
                             Some(&session_token),
                         )
-                        .await
+                        .await;
+                    (assigned_count, result)
                 });
             }
+            update_birthday_sweep_counters(&mut birthday, &aggregate);
+            publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
 
             let mut wave_report = PunchSendReport::default();
-            let mut worker_failed = false;
+            let mut wave_fully_completed = true;
+            let mut ordinary_worker_failed = false;
+            let mut join_worker_failed = false;
             while let Some(joined) = workers.join_next().await {
-                let Ok(result) = joined else {
-                    worker_failed = true;
-                    continue;
-                };
-                let report = result?;
-                merge_punch_send_reports(&mut wave_report, report);
+                record_birthday_worker_result(
+                    &mut wave_report,
+                    &mut wave_fully_completed,
+                    &mut ordinary_worker_failed,
+                    &mut join_worker_failed,
+                    joined,
+                );
             }
-            if worker_failed {
-                birthday.stop_reason = Some("send_error".to_string());
+            // A JoinError has no return payload, so normalize the wave's
+            // assigned count from the scheduler plan and retain every target
+            // not reached by a returned worker as cancelled progress.
+            wave_report.targets_assigned =
+                u32::try_from(wave_assigned_count).unwrap_or(u32::MAX);
+            wave_report.targets_cancelled = wave_report.targets_cancelled.max(
+                u32::try_from(wave_assigned_count)
+                    .unwrap_or(u32::MAX)
+                    .saturating_sub(wave_report.targets_attempted),
+            );
+            merge_punch_send_reports(&mut aggregate, wave_report.clone());
+            if ordinary_worker_failed || join_worker_failed {
+                aggregate.worker_failed = true;
+                let stop_reason = if join_worker_failed {
+                    "worker_failed"
+                } else {
+                    "send_error"
+                };
+                birthday.stop_reason = Some(stop_reason.to_string());
+                update_birthday_sweep_counters(&mut birthday, &aggregate);
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
+                return Err(DaemonError::Network(format!(
+                    "hard-hard birthday worker stopped: {stop_reason}"
+                )));
+            }
+            if !wave_fully_completed {
+                birthday.stop_reason = Some(
+                    self
+                    .hard_hard_birthday_stop_reason(
+                        peer_id,
+                        session_token,
+                        profile_fence,
+                        peer_session_generation,
+                        network_generation_at_start,
+                        remote_candidate_epoch_at_start,
+                        direct_commit_seq_at_start,
+                    )
+                    .await
+                    .unwrap_or("socket_unavailable")
+                    .to_string(),
+                );
+                update_birthday_sweep_counters(&mut birthday, &aggregate);
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
-            birthday.waves_completed = birthday.waves_completed.saturating_add(1);
-            merge_punch_send_reports(&mut aggregate, wave_report.clone());
+            birthday.waves_fully_completed = birthday.waves_fully_completed.saturating_add(1);
+            birthday.waves_completed = birthday.waves_fully_completed;
+            update_birthday_sweep_counters(&mut birthday, &aggregate);
+            publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
             if let Some(reason) = self
                 .hard_hard_birthday_stop_reason(
                     peer_id,
@@ -2412,22 +2565,27 @@ impl UdpTransport {
                 .await
             {
                 birthday.stop_reason = Some(reason.to_string());
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
             if wave_report.epoch_budget_exhausted {
                 birthday.stop_reason = Some("epoch_budget_exhausted".to_string());
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
             if wave_report.candidate_iteration_capped {
                 birthday.stop_reason = Some("candidate_iteration_capped".to_string());
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
             if wave_report.packets_sent == 0 && wave_report.budget_skipped > 0 {
                 birthday.stop_reason = Some("budget_exhausted".to_string());
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
             if wave_report.packets_sent == 0 && wave_report.budget_skipped == 0 {
                 birthday.stop_reason = Some("socket_unavailable".to_string());
+                publish_birthday_sweep_progress(&progress, &birthday, &aggregate).await;
                 break;
             }
         }
@@ -2437,7 +2595,14 @@ impl UdpTransport {
         }
         aggregate.unique_target_endpoints =
             u32::try_from(aggregate.sent_target_endpoints.len()).unwrap_or(u32::MAX);
+        update_birthday_sweep_counters(&mut birthday, &aggregate);
         aggregate.birthday = Some(birthday);
+        publish_birthday_sweep_progress(
+            &progress,
+            aggregate.birthday.as_ref().expect("birthday report just set"),
+            &aggregate,
+        )
+        .await;
         Ok(aggregate)
     }
 
@@ -2545,7 +2710,11 @@ impl UdpTransport {
             .resolve_dynamic_socket_index_for_send(peer_id, socket_index)
             .await
         else {
-            return Ok(PunchSendReport::default());
+            return Ok(PunchSendReport {
+                targets_assigned: u32::try_from(candidates.len()).unwrap_or(u32::MAX),
+                targets_cancelled: u32::try_from(candidates.len()).unwrap_or(u32::MAX),
+                ..PunchSendReport::default()
+            });
         };
         self.punch_candidates_from_dynamic_socket_resolved(
             peer_id,
@@ -2580,6 +2749,9 @@ impl UdpTransport {
         let mut first_send_at_ms = None;
         let mut last_send_at_ms: Option<u64> = None;
         let mut per_socket_sent = 0u32;
+        let targets_assigned = u32::try_from(candidates.len()).unwrap_or(u32::MAX);
+        let mut targets_attempted = 0u32;
+        let mut target_processing_completed = true;
         let commit_seq_at_start = self.peers.direct_commit_seq_sync(peer_id);
         let network_generation_at_start = self.peers.current_network_generation_sync();
         let remote_candidate_epoch_at_start = self
@@ -2592,12 +2764,14 @@ impl UdpTransport {
                 trace!(
                     "Aborting dynamic-socket punch for peer {peer_id}: network generation changed mid-session"
                 );
+                target_processing_completed = false;
                 break;
             }
             if !round.delay_before.is_zero() {
                 sleep(round.delay_before).await;
             }
             for candidate in round.endpoints {
+                targets_attempted = targets_attempted.saturating_add(1);
                 if let Some(token) = hard_hard_session_token {
                     if self
                         .peers
@@ -2608,6 +2782,7 @@ impl UdpTransport {
                         trace!(
                             "Aborting dynamic-socket Hard↔Hard scatter for peer {peer_id}: winner already selected"
                         );
+                        target_processing_completed = false;
                         break 'schedule;
                     }
                 }
@@ -2615,6 +2790,7 @@ impl UdpTransport {
                     trace!(
                         "Aborting dynamic-socket punch for peer {peer_id}: network generation changed before candidate send"
                     );
+                    target_processing_completed = false;
                     break;
                 }
                 if self
@@ -2627,6 +2803,7 @@ impl UdpTransport {
                     trace!(
                         "Aborting dynamic-socket punch for peer {peer_id}: remote candidate epoch changed before candidate send"
                     );
+                    target_processing_completed = false;
                     break;
                 }
                 if let Some((local_profile_generation, remote_profile_generation)) = profile_fence {
@@ -2642,6 +2819,7 @@ impl UdpTransport {
                         trace!(
                             "Aborting dynamic-socket punch for peer {peer_id}: Hard↔Hard profile generation changed before candidate send"
                         );
+                        target_processing_completed = false;
                         break;
                     }
                 }
@@ -2654,6 +2832,7 @@ impl UdpTransport {
                         trace!(
                             "Aborting dynamic-socket Hard↔Hard punch for peer {peer_id}: session token was retired"
                         );
+                        target_processing_completed = false;
                         break;
                     }
                 }
@@ -2663,12 +2842,14 @@ impl UdpTransport {
                     trace!(
                         "Aborting dynamic-socket UDP punch for peer {peer_id}: Direct was confirmed mid-session"
                     );
+                    target_processing_completed = false;
                     break;
                 }
                 if self.peers.direct_commit_seq_sync(peer_id) != commit_seq_at_start {
                     trace!(
                         "Aborting dynamic-socket UDP punch for peer {peer_id}: direct_commit_seq advanced past {commit_seq_at_start:?} mid-session"
                     );
+                    target_processing_completed = false;
                     break;
                 }
                 if self
@@ -2772,6 +2953,10 @@ impl UdpTransport {
             candidate_iteration_capped: false,
             sent_target_endpoints: sent_endpoints.into_iter().collect(),
             last_send_at_ms,
+            targets_assigned,
+            targets_attempted,
+            targets_cancelled: targets_assigned.saturating_sub(targets_attempted),
+            target_processing_completed,
             ..PunchSendReport::default()
         })
     }
@@ -2859,7 +3044,7 @@ fn hard_hard_birthday_candidates(
     candidates
 }
 
-fn hard_hard_birthday_socket_count(level: usize) -> usize {
+pub(crate) fn hard_hard_birthday_socket_count(level: usize) -> usize {
     match level {
         0..=64 => 2,
         65..=128 => 4,
@@ -2896,9 +3081,84 @@ fn hard_hard_birthday_capacity_plan(
     Some((actual_level, actual_socket_count))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BirthdaySocketPlan {
+    requested_socket_count: usize,
+    attached_socket_count: usize,
+    usable_socket_count: usize,
+    unavailable_socket_count: usize,
+    usable_socket_indices: Vec<usize>,
+}
+
+/// Convert the exact session socket snapshot into the only socket list the
+/// birthday scheduler is allowed to use.  This deliberately has no pool
+/// lookup or "best effort" substitution: a missing requested member remains
+/// unavailable and lowers the wave plan.
+fn hard_hard_birthday_socket_plan(
+    requested_level: usize,
+    snapshot: Vec<HardHardSocketSnapshot>,
+) -> BirthdaySocketPlan {
+    let requested_socket_count = hard_hard_birthday_socket_count(requested_level);
+    let attached_socket_count = snapshot.iter().filter(|entry| entry.attached).count();
+    let usable_socket_indices = snapshot
+        .into_iter()
+        .filter(|entry| entry.usable)
+        .map(|entry| entry.socket_index)
+        .collect::<Vec<_>>();
+    let usable_socket_count = usable_socket_indices.len();
+    BirthdaySocketPlan {
+        requested_socket_count,
+        attached_socket_count,
+        usable_socket_count,
+        unavailable_socket_count: requested_socket_count.saturating_sub(usable_socket_count),
+        usable_socket_indices,
+    }
+}
+
+fn record_birthday_worker_result(
+    wave_report: &mut PunchSendReport,
+    wave_fully_completed: &mut bool,
+    ordinary_worker_failed: &mut bool,
+    join_worker_failed: &mut bool,
+    joined: std::result::Result<(usize, Result<PunchSendReport>), tokio::task::JoinError>,
+) {
+    match joined {
+        Ok((_assigned_count, Ok(report))) => {
+            *wave_fully_completed &= report.target_processing_completed;
+            merge_punch_send_reports(wave_report, report);
+        }
+        Ok((assigned_count, Err(_error))) => {
+            *ordinary_worker_failed = true;
+            *wave_fully_completed = false;
+            wave_report.targets_cancelled = wave_report
+                .targets_cancelled
+                .saturating_add(u32::try_from(assigned_count).unwrap_or(u32::MAX));
+        }
+        Err(_join_error) => {
+            *join_worker_failed = true;
+            *wave_fully_completed = false;
+        }
+    }
+}
+
 fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSendReport) {
     destination.packets_sent = destination.packets_sent.saturating_add(source.packets_sent);
     destination.budget_skipped = destination.budget_skipped.saturating_add(source.budget_skipped);
+    destination.targets_assigned = destination
+        .targets_assigned
+        .saturating_add(source.targets_assigned);
+    destination.targets_attempted = destination
+        .targets_attempted
+        .saturating_add(source.targets_attempted);
+    destination.targets_cancelled = destination
+        .targets_cancelled
+        .saturating_add(source.targets_cancelled);
+    if destination.targets_assigned == 0 {
+        destination.target_processing_completed = source.target_processing_completed;
+    } else {
+        destination.target_processing_completed &= source.target_processing_completed;
+    }
+    destination.worker_failed |= source.worker_failed;
     destination.epoch_budget_exhausted |= source.epoch_budget_exhausted;
     destination.candidate_iteration_capped |= source.candidate_iteration_capped;
     destination.first_send_at_ms = match (destination.first_send_at_ms, source.first_send_at_ms) {
@@ -2929,7 +3189,35 @@ fn merge_punch_send_reports(destination: &mut PunchSendReport, source: PunchSend
     }
 }
 
-fn hard_hard_birthday_wave_count(socket_count: usize) -> usize {
+pub(crate) fn update_birthday_sweep_counters(
+    birthday: &mut BirthdaySweepReport,
+    aggregate: &PunchSendReport,
+) {
+    birthday.targets_attempted = aggregate.targets_attempted as usize;
+    birthday.logical_probes_sent = aggregate.packets_sent as usize;
+    birthday.physical_datagrams_sent = aggregate
+        .per_socket_sent
+        .iter()
+        .map(|(_, sent)| *sent as usize)
+        .sum();
+    birthday.targets_budget_skipped = aggregate.budget_skipped as usize;
+    birthday.targets_cancelled = aggregate.targets_cancelled as usize;
+}
+
+async fn publish_birthday_sweep_progress(
+    progress: &Option<Arc<Mutex<BirthdaySweepProgress>>>,
+    birthday: &BirthdaySweepReport,
+    aggregate: &PunchSendReport,
+) {
+    let Some(progress) = progress else {
+        return;
+    };
+    let mut current = progress.lock().await;
+    current.birthday = birthday.clone();
+    current.aggregate = aggregate.clone();
+}
+
+pub(crate) fn hard_hard_birthday_wave_count(socket_count: usize) -> usize {
     match socket_count {
         0 => 0,
         1 => 1,
@@ -3711,9 +3999,11 @@ impl Drop for ProvisionalSocketGuard {
 mod birthday_tests {
     use super::{
         hard_hard_birthday_candidates, hard_hard_birthday_capacity_plan,
-        hard_hard_birthday_packets_planned, hard_hard_birthday_wave_assignments,
-        hard_hard_birthday_wave_count,
+        hard_hard_birthday_packets_planned, hard_hard_birthday_socket_plan,
+        hard_hard_birthday_wave_assignments, hard_hard_birthday_wave_count,
+        record_birthday_worker_result, HardHardSocketSnapshot, PunchSendReport,
     };
+    use crate::error::DaemonError;
     use p2pnet_nat::mapping::AllocationModelKind;
     use std::collections::{HashMap, HashSet};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -3793,5 +4083,138 @@ mod birthday_tests {
         assert_eq!(hard_hard_birthday_capacity_plan(256, 7), Some((128, 4)));
         assert_eq!(hard_hard_birthday_capacity_plan(256, 8), Some((256, 8)));
         assert_eq!(hard_hard_birthday_capacity_plan(256, 1), None);
+    }
+
+    #[test]
+    fn birthday_socket_plan_is_exact_and_fails_closed() {
+        let partial = hard_hard_birthday_socket_plan(
+            64,
+            vec![
+                HardHardSocketSnapshot {
+                    socket_index: 41,
+                    attached: true,
+                    usable: true,
+                },
+                HardHardSocketSnapshot {
+                    socket_index: 42,
+                    attached: true,
+                    usable: false,
+                },
+            ],
+        );
+        assert_eq!(partial.requested_socket_count, 2);
+        assert_eq!(partial.attached_socket_count, 2);
+        assert_eq!(partial.usable_socket_count, 1);
+        assert_eq!(partial.unavailable_socket_count, 1);
+        assert_eq!(partial.usable_socket_indices, vec![41]);
+        assert_eq!(hard_hard_birthday_wave_count(partial.usable_socket_count), 1);
+
+        let detached = hard_hard_birthday_socket_plan(
+            64,
+            vec![
+                HardHardSocketSnapshot {
+                    socket_index: 41,
+                    attached: false,
+                    usable: false,
+                },
+                HardHardSocketSnapshot {
+                    socket_index: 42,
+                    attached: false,
+                    usable: false,
+                },
+            ],
+        );
+        assert_eq!(detached.attached_socket_count, 0);
+        assert_eq!(detached.usable_socket_count, 0);
+        assert_eq!(detached.unavailable_socket_count, 2);
+        assert!(detached.usable_socket_indices.is_empty());
+        assert_eq!(hard_hard_birthday_wave_count(detached.usable_socket_count), 0);
+
+        let full = hard_hard_birthday_socket_plan(
+            128,
+            (0..4)
+                .map(|offset| HardHardSocketSnapshot {
+                    socket_index: 100 + offset,
+                    attached: true,
+                    usable: true,
+                })
+                .collect(),
+        );
+        assert_eq!(full.requested_socket_count, 4);
+        assert_eq!(full.attached_socket_count, 4);
+        assert_eq!(full.usable_socket_count, 4);
+        assert_eq!(full.unavailable_socket_count, 0);
+        assert_eq!(hard_hard_birthday_wave_count(full.usable_socket_count), 2);
+
+        let capped = hard_hard_birthday_socket_plan(
+            256,
+            (0..4)
+                .map(|offset| HardHardSocketSnapshot {
+                    socket_index: 200 + offset,
+                    attached: true,
+                    usable: true,
+                })
+                .collect(),
+        );
+        assert_eq!(capped.requested_socket_count, 8);
+        assert_eq!(capped.usable_socket_count, 4);
+        assert_eq!(capped.unavailable_socket_count, 4);
+        assert_eq!(capped.usable_socket_indices, vec![200, 201, 202, 203]);
+    }
+
+    #[tokio::test]
+    async fn birthday_worker_collection_preserves_partial_stats_and_join_errors() {
+        let mut wave_report = PunchSendReport::default();
+        let mut wave_fully_completed = true;
+        let mut ordinary_worker_failed = false;
+        let mut join_worker_failed = false;
+        record_birthday_worker_result(
+            &mut wave_report,
+            &mut wave_fully_completed,
+            &mut ordinary_worker_failed,
+            &mut join_worker_failed,
+            Ok((2, Ok(PunchSendReport {
+                packets_sent: 1,
+                per_socket_sent: vec![(41, 2)],
+                targets_assigned: 2,
+                targets_attempted: 2,
+                target_processing_completed: true,
+                ..PunchSendReport::default()
+            }))),
+        );
+        assert_eq!(wave_report.packets_sent, 1);
+        assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
+        assert!(wave_fully_completed);
+        assert!(!ordinary_worker_failed);
+        assert!(!join_worker_failed);
+
+        record_birthday_worker_result(
+            &mut wave_report,
+            &mut wave_fully_completed,
+            &mut ordinary_worker_failed,
+            &mut join_worker_failed,
+            Ok((3, Err(DaemonError::Network("injected worker error".to_string())))),
+        );
+        assert_eq!(wave_report.packets_sent, 1);
+        assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
+        assert_eq!(wave_report.targets_cancelled, 3);
+        assert!(!wave_fully_completed);
+        assert!(ordinary_worker_failed);
+
+        let handle = tokio::spawn(async { std::future::pending::<()>().await });
+        handle.abort();
+        let join_error = handle.await.expect_err("aborted worker must yield JoinError");
+        record_birthday_worker_result(
+            &mut wave_report,
+            &mut wave_fully_completed,
+            &mut ordinary_worker_failed,
+            &mut join_worker_failed,
+            Err(join_error),
+        );
+        assert!(!wave_fully_completed);
+        assert!(ordinary_worker_failed);
+        assert!(join_worker_failed);
+        assert_eq!(wave_report.packets_sent, 1);
+        assert_eq!(wave_report.per_socket_sent, vec![(41, 2)]);
     }
 }

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -456,6 +456,10 @@ impl UdpTransport {
                     entry.peer_id == identity.peer_id
                         && entry.network_generation == identity.network_generation
                         && entry.punch_generation == identity.punch_generation
+                        && entry
+                            .hard_hard_session_token
+                            .as_deref()
+                            .is_none_or(|token| token == identity.session_token)
                         && entry.phase.is_usable()
                         && entry.socket.local_addr().ok() == Some(identity.socket_local_endpoint)
                 })

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -2868,11 +2868,13 @@ impl UdpTransport {
         let mut first_send_at_ms = None;
         let mut last_send_at_ms: Option<u64> = None;
         let mut per_socket_sent = 0u32;
+        let mut per_socket_sent_index = index;
         let targets_assigned = u32::try_from(candidates.len()).unwrap_or(u32::MAX);
         let mut targets_examined = 0u32;
         let mut targets_attempted = 0u32;
         let mut target_processing_completed = true;
         let mut failure_kind = None;
+        let live_recorder = live.clone().map(BirthdayLiveRecorder::new);
         let commit_seq_at_start = self.peers.direct_commit_seq_sync(peer_id);
         let network_generation_at_start = self.peers.current_network_generation_sync();
         let remote_candidate_epoch_at_start = self
@@ -3066,6 +3068,7 @@ impl UdpTransport {
                         PendingProbePurpose::ConnectivityCheck,
                         hard_hard_session_token,
                         true,
+                        live_recorder.clone(),
                     )
                     .await
                 {
@@ -3074,8 +3077,7 @@ impl UdpTransport {
                         logical_probes_sent = logical_probes_sent.saturating_add(1);
                         let successful_datagrams = u32::from(sent.datagrams_sent);
                         let failed_datagrams = u32::from(sent.physical_send_errors);
-                        let actual_socket_index = sent.socket_index;
-                        let successful_send_at_ms = sent.first_send_at_ms;
+                        per_socket_sent_index = sent.socket_index;
                         physical_datagrams_sent =
                             physical_datagrams_sent.saturating_add(successful_datagrams);
                         physical_send_errors =
@@ -3084,40 +3086,6 @@ impl UdpTransport {
                             partial_physical_send_errors =
                                 partial_physical_send_errors.saturating_add(failed_datagrams);
                         }
-                        update_live_birthday_progress(&live, |progress| {
-                            let counters = &mut progress.counters;
-                            counters.logical_probes_sent =
-                                counters.logical_probes_sent.saturating_add(1);
-                            counters.physical_datagrams_sent = counters
-                                .physical_datagrams_sent
-                                .saturating_add(successful_datagrams);
-                            counters.physical_send_errors = counters
-                                .physical_send_errors
-                                .saturating_add(failed_datagrams);
-                            counters.partial_physical_send_errors = counters
-                                .partial_physical_send_errors
-                                .saturating_add(failed_datagrams);
-                            if successful_datagrams > 0 {
-                                progress.sent_target_endpoints.insert(candidate);
-                                let sent = progress
-                                    .per_socket_sent
-                                    .entry(actual_socket_index)
-                                    .or_default();
-                                *sent = sent.saturating_add(successful_datagrams);
-                                if let Some(sent_at_ms) = successful_send_at_ms {
-                                    progress.first_send_at_ms = Some(
-                                        progress
-                                            .first_send_at_ms
-                                            .map_or(sent_at_ms, |first| first.min(sent_at_ms)),
-                                    );
-                                    progress.last_send_at_ms = Some(
-                                        progress
-                                            .last_send_at_ms
-                                            .map_or(sent_at_ms, |last| last.max(sent_at_ms)),
-                                    );
-                                }
-                            }
-                        });
                         if let Some(sent_at_ms) = sent.first_send_at_ms {
                             first_send_at_ms.get_or_insert(sent_at_ms);
                             last_send_at_ms = Some(
@@ -3149,13 +3117,6 @@ impl UdpTransport {
                                 physical_send_errors.saturating_add(failed_datagrams);
                             logical_probe_send_failures =
                                 logical_probe_send_failures.saturating_add(1);
-                            update_live_birthday_counters(&live, |counters| {
-                                counters.logical_probe_send_failures =
-                                    counters.logical_probe_send_failures.saturating_add(1);
-                                counters.physical_send_errors = counters
-                                    .physical_send_errors
-                                    .saturating_add(failed_datagrams);
-                            });
                         } else {
                             probe_path_errors = probe_path_errors.saturating_add(1);
                             update_live_birthday_counters(&live, |counters| {
@@ -3208,7 +3169,7 @@ impl UdpTransport {
             unique_target_endpoints: u32::try_from(sent_endpoints.len()).unwrap_or(u32::MAX),
             first_send_at_ms,
             per_socket_sent: (per_socket_sent > 0)
-                .then_some(vec![(index, per_socket_sent)])
+                .then_some(vec![(per_socket_sent_index, per_socket_sent)])
                 .unwrap_or_default(),
             budget_skipped,
             epoch_budget_exhausted: false,

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -639,21 +639,6 @@ impl UdpTransport {
         else {
             return false;
         };
-        self.peers
-            .record_direct_event_for_generation_with_socket(
-                peer_id,
-                network_generation,
-                "hard_hard_peer_reflexive_learned",
-                None,
-                Some(identity.socket_index),
-                None,
-                None,
-                format!(
-                    "authenticated peer-reflexive evidence socket_index={} punch_generation={} local_endpoint={}",
-                    identity.socket_index, identity.punch_generation, identity.socket_local_endpoint
-                ),
-            )
-            .await;
         let losers = {
             let mut state = self.socket_state.lock().await;
             let Some(entry) = state.dynamic.get(&socket_index) else {
@@ -674,11 +659,12 @@ impl UdpTransport {
                     epoch,
                 },
             );
-            state
+            let winner = state
                 .dynamic
                 .get_mut(&socket_index)
-                .expect("winner entry verified above")
-                .phase = DynamicSocketPhase::Finalized;
+                .expect("winner entry verified above");
+            winner.authenticated_evidence = winner.authenticated_evidence.saturating_add(1);
+            winner.phase = DynamicSocketPhase::Finalized;
             let loser_indices = state
                 .dynamic
                 .iter()
@@ -695,6 +681,27 @@ impl UdpTransport {
                 .filter_map(|index| state.dynamic.remove(&index))
                 .collect::<Vec<_>>()
         };
+        // The authenticated packet, affinity pin and Finalized phase are one
+        // socket-state commit.  In particular, no durable diagnostics await
+        // may sit between manager winner selection and this local evidence:
+        // timeout cleanup is allowed to inspect the winner concurrently and
+        // must never retire the exact socket merely because the event ring is
+        // contended.
+        self.peers
+            .record_direct_event_for_generation_with_socket(
+                peer_id,
+                network_generation,
+                "hard_hard_peer_reflexive_learned",
+                None,
+                Some(identity.socket_index),
+                None,
+                None,
+                format!(
+                    "authenticated peer-reflexive evidence socket_index={} punch_generation={} local_endpoint={}",
+                    identity.socket_index, identity.punch_generation, identity.socket_local_endpoint
+                ),
+            )
+            .await;
         for entry in losers {
             self.detach_dynamic_entry(entry, "hard_hard_loser_socket")
                 .await;
@@ -715,6 +722,53 @@ impl UdpTransport {
             )
             .await;
         true
+    }
+
+    /// Exact token-tagged socket behind a manager-selected Hard↔Hard winner.
+    ///
+    /// This deliberately does not require affinity or the UDP evidence
+    /// counter: manager selection itself is only reachable from an
+    /// authenticated Probe v2 admission, and there is one cancellation point
+    /// between that manager commit and the socket-state commit above.  The
+    /// predicate is used only to keep that exact socket alive for the
+    /// remainder of the already-bounded session; it is never Direct proof.
+    pub(crate) async fn hard_hard_socket_identity_is_exact_session_socket(
+        &self,
+        identity: &crate::peer::HardHardFreshSocketIdentity,
+    ) -> bool {
+        let state = self.socket_state.lock().await;
+        state
+            .dynamic
+            .get(&identity.socket_index)
+            .is_some_and(|entry| {
+                entry.peer_id == identity.peer_id
+                    && entry.hard_hard_session_token.as_deref()
+                        == Some(identity.session_token.as_str())
+                    && entry.network_generation == identity.network_generation
+                    && entry.punch_generation == identity.punch_generation
+                    && entry.phase.is_usable()
+                    && entry.socket.local_addr().ok() == Some(identity.socket_local_endpoint)
+                    && self.peers.current_network_generation_sync() == identity.network_generation
+            })
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn promote_hard_hard_winner_for_test(
+        &self,
+        peer_id: &str,
+        token: &str,
+        socket_index: usize,
+        network_generation: u64,
+    ) -> bool {
+        let epoch_guard = self.network_epoch_gate.lock().await;
+        self.promote_hard_hard_winner_in_epoch(
+            &epoch_guard,
+            peer_id,
+            token,
+            socket_index,
+            network_generation,
+        )
+        .await
     }
 
     pub(crate) async fn hard_hard_socket_identity_is_current(
@@ -779,6 +833,13 @@ impl UdpTransport {
             .get(&socket_index)
             .map(|entry| entry.authenticated_evidence)
             .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn clear_authenticated_evidence_for_test(&self, socket_index: usize) {
+        if let Some(entry) = self.socket_state.lock().await.dynamic.get_mut(&socket_index) {
+            entry.authenticated_evidence = 0;
+        }
     }
 
     #[cfg(test)]

--- a/client/daemon/src/udp/dynamic_punch.rs
+++ b/client/daemon/src/udp/dynamic_punch.rs
@@ -608,8 +608,15 @@ impl UdpTransport {
         socket_index: usize,
         network_generation: u64,
     ) -> bool {
-        let (punch_generation, local_endpoint) = {
-            let state = self.socket_state.lock().await;
+        let (identity, losers) = {
+            // Keep the exact socket entry locked across manager selection.
+            // `hard_hard_select_winner` commits its session record and sticky
+            // winner without any later await; once it returns, this same poll
+            // writes authenticated evidence, affinity and Finalized phase.
+            // Cancellation therefore observes either no winner transaction or
+            // the complete manager + UDP transaction, never a preservable
+            // manager-only half state.
+            let mut state = self.socket_state.lock().await;
             let Some(entry) = state.dynamic.get(&socket_index) else {
                 return false;
             };
@@ -623,34 +630,21 @@ impl UdpTransport {
             let Some(local_endpoint) = entry.socket.local_addr().ok() else {
                 return false;
             };
-            (entry.punch_generation, local_endpoint)
-        };
-        let Some(identity) = self
-            .peers
-            .hard_hard_select_winner(
-                peer_id,
-                token,
-                socket_index,
-                network_generation,
-                punch_generation,
-                local_endpoint,
-            )
-            .await
-        else {
-            return false;
-        };
-        let losers = {
-            let mut state = self.socket_state.lock().await;
-            let Some(entry) = state.dynamic.get(&socket_index) else {
+            let punch_generation = entry.punch_generation;
+            let Some(identity) = self
+                .peers
+                .hard_hard_select_winner(
+                    peer_id,
+                    token,
+                    socket_index,
+                    network_generation,
+                    punch_generation,
+                    local_endpoint,
+                )
+                .await
+            else {
                 return false;
             };
-            if entry.peer_id != peer_id
-                || entry.network_generation != network_generation
-                || entry.punch_generation != punch_generation
-                || entry.hard_hard_session_token.as_deref() != Some(token)
-            {
-                return false;
-            }
             let epoch = state.next_epoch();
             state.affinity.insert(
                 peer_id.to_string(),
@@ -676,10 +670,11 @@ impl UdpTransport {
                 })
                 .map(|(index, _)| *index)
                 .collect::<Vec<_>>();
-            loser_indices
+            let losers = loser_indices
                 .into_iter()
                 .filter_map(|index| state.dynamic.remove(&index))
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            (identity, losers)
         };
         // The authenticated packet, affinity pin and Finalized phase are one
         // socket-state commit.  In particular, no durable diagnostics await
@@ -722,34 +717,6 @@ impl UdpTransport {
             )
             .await;
         true
-    }
-
-    /// Exact token-tagged socket behind a manager-selected Hard↔Hard winner.
-    ///
-    /// This deliberately does not require affinity or the UDP evidence
-    /// counter: manager selection itself is only reachable from an
-    /// authenticated Probe v2 admission, and there is one cancellation point
-    /// between that manager commit and the socket-state commit above.  The
-    /// predicate is used only to keep that exact socket alive for the
-    /// remainder of the already-bounded session; it is never Direct proof.
-    pub(crate) async fn hard_hard_socket_identity_is_exact_session_socket(
-        &self,
-        identity: &crate::peer::HardHardFreshSocketIdentity,
-    ) -> bool {
-        let state = self.socket_state.lock().await;
-        state
-            .dynamic
-            .get(&identity.socket_index)
-            .is_some_and(|entry| {
-                entry.peer_id == identity.peer_id
-                    && entry.hard_hard_session_token.as_deref()
-                        == Some(identity.session_token.as_str())
-                    && entry.network_generation == identity.network_generation
-                    && entry.punch_generation == identity.punch_generation
-                    && entry.phase.is_usable()
-                    && entry.socket.local_addr().ok() == Some(identity.socket_local_endpoint)
-                    && self.peers.current_network_generation_sync() == identity.network_generation
-            })
     }
 
     #[cfg(test)]
@@ -853,6 +820,11 @@ impl UdpTransport {
             .dynamic
             .get(&socket_index)
             .map(|entry| entry.phase)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hard_hard_socket_state_is_locked_for_test(&self) -> bool {
+        self.socket_state.try_lock().is_err()
     }
 
     /// Detach a superseded generation's predecessor socket, unless the

--- a/client/daemon/src/udp/inbound.rs
+++ b/client/daemon/src/udp/inbound.rs
@@ -667,15 +667,17 @@ impl UdpTransport {
                                 )
                                 .await;
                         }
-                        let _ = self
-                            .remember_peer_socket_for_generation_in_epoch(
-                                &epoch_guard,
-                                &identity.source_node_id,
-                                socket_index,
-                                generation,
-                                SocketEvidence::Fresh,
-                            )
-                            .await;
+                        if !hard_hard_winner_promoted {
+                            let _ = self
+                                .remember_peer_socket_for_generation_in_epoch(
+                                    &epoch_guard,
+                                    &identity.source_node_id,
+                                    socket_index,
+                                    generation,
+                                    SocketEvidence::Fresh,
+                                )
+                                .await;
+                        }
                         self.notify_peer_reflexive_observation(&identity.source_node_id, source)
                             .await;
 
@@ -935,8 +937,9 @@ impl UdpTransport {
                             let local_endpoint = pending.local_endpoint;
                             let purpose = pending.purpose;
                             let socket_epoch = pending.socket_epoch;
-                            if let Some(token) = hard_hard_token.as_deref() {
-                                let _ = self
+                            let hard_hard_winner_promoted =
+                                if let Some(token) = hard_hard_token.as_deref() {
+                                    self
                                     .promote_hard_hard_winner_in_epoch(
                                         &epoch_guard,
                                         &identity.source_node_id,
@@ -944,8 +947,10 @@ impl UdpTransport {
                                         socket_index,
                                         generation,
                                     )
-                                    .await;
-                            }
+                                    .await
+                                } else {
+                                    false
+                                };
                             self.update_socket_diagnostics(socket_index, |metrics| {
                                 metrics.probe_acks_received += 1
                             })
@@ -971,15 +976,17 @@ impl UdpTransport {
                                 },
                             )
                             .await;
-                            let _ = self
-                                .remember_peer_socket_for_generation_in_epoch(
-                                    &epoch_guard,
-                                    &identity.source_node_id,
-                                    socket_index,
-                                    generation,
-                                    SocketEvidence::Stamped(socket_epoch),
-                                )
-                                .await;
+                            if !hard_hard_winner_promoted {
+                                let _ = self
+                                    .remember_peer_socket_for_generation_in_epoch(
+                                        &epoch_guard,
+                                        &identity.source_node_id,
+                                        socket_index,
+                                        generation,
+                                        SocketEvidence::Stamped(socket_epoch),
+                                    )
+                                    .await;
+                            }
                             self.peers
                                 .learn_authenticated_endpoint_in_epoch(
                                     &epoch_guard,

--- a/client/daemon/src/udp/outbound.rs
+++ b/client/daemon/src/udp/outbound.rs
@@ -1105,6 +1105,8 @@ impl UdpTransport {
             budget_skipped,
             epoch_budget_exhausted,
             candidate_iteration_capped,
+            sent_target_endpoints: sent_endpoints.into_iter().collect(),
+            ..PunchSendReport::default()
         })
     }
 

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -1372,21 +1372,67 @@ pub(crate) struct BirthdaySweepReport {
     pub waves_completed: usize,
     pub packets_planned: usize,
     pub targets_assigned: usize,
+    pub targets_examined: usize,
     pub targets_attempted: usize,
+    pub logical_probes_attempted: usize,
     pub logical_probes_sent: usize,
     pub physical_datagrams_sent: usize,
+    pub physical_send_errors: usize,
     pub targets_budget_skipped: usize,
     pub targets_cancelled: usize,
     pub stop_reason: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BirthdaySweepFailureKind {
+    Send,
+    WorkerJoin,
+}
+
+impl BirthdaySweepFailureKind {
+    pub(crate) const fn stop_reason(self) -> &'static str {
+        match self {
+            Self::Send => "send_error",
+            Self::WorkerJoin => "worker_failed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LiveBirthdayCounters {
+    pub targets_assigned: u32,
+    pub targets_examined: u32,
+    pub targets_attempted: u32,
+    pub targets_cancelled: u32,
+    pub budget_skipped: u32,
+    pub logical_probes_attempted: u32,
+    pub logical_probes_sent: u32,
+    pub physical_datagrams_sent: u32,
+    pub physical_send_errors: u32,
+    pub workers_completed: u32,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct BirthdaySweepProgress {
     pub birthday: BirthdaySweepReport,
     /// Partial logical/physical send counters published after every worker
     /// wave.  This lets the caller emit a terminal summary when its deadline
     /// or cancellation drops the scheduler future before it returns.
     pub aggregate: PunchSendReport,
+    /// Session-scoped counters updated at each target/send event. This lock
+    /// is independent of the peer connection map and is never held across a
+    /// UDP send or another await.
+    pub live: Arc<StdMutex<LiveBirthdayCounters>>,
+}
+
+impl Default for BirthdaySweepProgress {
+    fn default() -> Self {
+        Self {
+            birthday: BirthdaySweepReport::default(),
+            aggregate: PunchSendReport::default(),
+            live: Arc::new(StdMutex::new(LiveBirthdayCounters::default())),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1399,6 +1445,16 @@ pub(crate) struct HardHardSocketSnapshot {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PunchSendReport {
     pub packets_sent: u32,
+    /// Logical probes that passed admission and entered Probe construction or
+    /// the physical send path.
+    pub logical_probes_attempted: u32,
+    /// Logical probes with at least one successful physical datagram send.
+    pub logical_probes_sent: u32,
+    /// Successful physical UDP datagrams, including compatibility copies.
+    pub physical_datagrams_sent: u32,
+    /// Physical UDP sends that returned an error, including compatibility
+    /// copies after a successful primary send.
+    pub physical_send_errors: u32,
     pub unique_target_endpoints: u32,
     /// Wall-clock UNIX milliseconds captured immediately after the first
     /// successful kernel UDP send in this punch session.  `None` means the
@@ -1434,13 +1490,20 @@ pub(crate) struct PunchSendReport {
     /// worker progressed through them.  A worker that exits on a fence is not
     /// complete even if its task joins successfully.
     pub targets_assigned: u32,
+    /// Targets dequeued by this worker.
+    pub targets_examined: u32,
     pub targets_attempted: u32,
     pub targets_cancelled: u32,
     pub target_processing_completed: bool,
-    /// Set when the scheduler observed a normal worker error or JoinError.
+    /// Set when the scheduler observed a worker JoinError or panic. Normal
+    /// worker/business failures are carried by `failure_kind=Send` instead.
     /// The caller still receives the partial report so it can emit one final
     /// summary before returning the Hard↔Hard sweep as failed.
     pub worker_failed: bool,
+    /// Typed failure retained through scheduler aggregation. `Send` covers
+    /// ordinary worker/business errors and actual UDP send failures;
+    /// `WorkerJoin` covers a JoinError or panic.
+    pub failure_kind: Option<BirthdaySweepFailureKind>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -121,6 +121,65 @@ impl HeartbeatSendGate {
     }
 }
 
+/// Deterministic seam for production-entry terminal-progress tests. A real
+/// Birthday worker can publish its first sends and then pause before returning
+/// to the scheduler, allowing deadline/cancellation code to snapshot live
+/// progress without waiting for a real multi-second deadline.
+#[cfg(test)]
+pub(crate) struct BirthdayWorkerCompletionGate {
+    pub(crate) reached: tokio::sync::Notify,
+    pub(crate) release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+pub(crate) struct BirthdayWorkerCompletionGateGuard {
+    _gate: Arc<BirthdayWorkerCompletionGate>,
+}
+
+#[cfg(test)]
+static BIRTHDAY_WORKER_COMPLETION_GATE: std::sync::LazyLock<
+    std::sync::Mutex<Option<Arc<BirthdayWorkerCompletionGate>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+impl Drop for BirthdayWorkerCompletionGateGuard {
+    fn drop(&mut self) {
+        *BIRTHDAY_WORKER_COMPLETION_GATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_birthday_worker_completion_gate_for_test() -> (
+    Arc<BirthdayWorkerCompletionGate>,
+    BirthdayWorkerCompletionGateGuard,
+) {
+    let gate = Arc::new(BirthdayWorkerCompletionGate {
+        reached: tokio::sync::Notify::new(),
+        release: tokio::sync::Notify::new(),
+    });
+    *BIRTHDAY_WORKER_COMPLETION_GATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(gate.clone());
+    (
+        gate.clone(),
+        BirthdayWorkerCompletionGateGuard { _gate: gate },
+    )
+}
+
+#[cfg(test)]
+pub(crate) async fn wait_for_birthday_worker_completion_gate_for_test() {
+    let gate = BIRTHDAY_WORKER_COMPLETION_GATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(gate) = gate {
+        gate.reached.notify_waiters();
+        gate.release.notified().await;
+    }
+}
+
 /// Deterministic one-shot seam after UDP lifecycle cleanup but before the
 /// remote-incarnation reset is published. The transaction still owns the
 /// peer adoption lock while parked here.
@@ -1376,17 +1435,53 @@ pub(crate) struct BirthdaySweepReport {
     pub targets_attempted: usize,
     pub logical_probes_attempted: usize,
     pub logical_probes_sent: usize,
+    /// Logical probes for which every protocol-required physical datagram
+    /// failed.  A transient failure is recorded here but does not stop the
+    /// bounded sweep; the scheduler decides at the end whether all probes
+    /// failed and only then exposes `send_error`.
+    pub logical_probe_send_failures: usize,
     pub physical_datagrams_sent: usize,
     pub physical_send_errors: usize,
+    /// Physical errors belonging to a logical probe that still had at least
+    /// one successful datagram.  Compatibility-copy failures are the usual
+    /// example and never become a session failure by themselves.
+    pub partial_physical_send_errors: usize,
     pub targets_budget_skipped: usize,
     pub targets_cancelled: usize,
     pub stop_reason: Option<String>,
+}
+
+/// Classification of a failed Probe send path.  The physical-send variant is
+/// deliberately distinct from generation/session fences: a fence can return
+/// `Err` without any datagram having failed at the kernel boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeSendFailureKind {
+    PhysicalSend,
+    NetworkGenerationChanged,
+    CandidateEpochChanged,
+    LocalProfileGenerationChanged,
+    RemoteProfileGenerationChanged,
+    PeerSessionChanged,
+    SessionRetired,
+    SocketUnavailable,
+    SocketRevoked,
+    ProbeRegistrationFailed,
+    ProbeEncodingFailed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BirthdaySweepFailureKind {
     Send,
     WorkerJoin,
+    NetworkGenerationChanged,
+    CandidateEpochChanged,
+    ProfileGenerationChanged,
+    PeerSessionChanged,
+    SessionRetired,
+    SocketUnavailable,
+    SocketRevoked,
+    ProbeRegistrationFailed,
+    ProbeEncodingFailed,
 }
 
 impl BirthdaySweepFailureKind {
@@ -1394,6 +1489,48 @@ impl BirthdaySweepFailureKind {
         match self {
             Self::Send => "send_error",
             Self::WorkerJoin => "worker_failed",
+            Self::NetworkGenerationChanged => "network_generation_changed",
+            Self::CandidateEpochChanged => "candidate_epoch_changed",
+            Self::ProfileGenerationChanged => "profile_generation_changed",
+            Self::PeerSessionChanged => "peer_session_changed",
+            Self::SessionRetired => "session_retired",
+            Self::SocketUnavailable => "socket_unavailable",
+            Self::SocketRevoked => "socket_revoked",
+            Self::ProbeRegistrationFailed => "probe_registration_failed",
+            Self::ProbeEncodingFailed => "probe_encoding_failed",
+        }
+    }
+
+    pub(crate) const fn from_probe_failure(kind: ProbeSendFailureKind) -> Self {
+        match kind {
+            ProbeSendFailureKind::PhysicalSend => Self::Send,
+            ProbeSendFailureKind::NetworkGenerationChanged => Self::NetworkGenerationChanged,
+            ProbeSendFailureKind::CandidateEpochChanged => Self::CandidateEpochChanged,
+            ProbeSendFailureKind::LocalProfileGenerationChanged
+            | ProbeSendFailureKind::RemoteProfileGenerationChanged => Self::ProfileGenerationChanged,
+            ProbeSendFailureKind::PeerSessionChanged => Self::PeerSessionChanged,
+            ProbeSendFailureKind::SessionRetired => Self::SessionRetired,
+            ProbeSendFailureKind::SocketUnavailable => Self::SocketUnavailable,
+            ProbeSendFailureKind::SocketRevoked => Self::SocketRevoked,
+            ProbeSendFailureKind::ProbeRegistrationFailed => Self::ProbeRegistrationFailed,
+            ProbeSendFailureKind::ProbeEncodingFailed => Self::ProbeEncodingFailed,
+        }
+    }
+
+    pub(crate) fn from_stop_reason(reason: &str) -> Option<Self> {
+        match reason {
+            "send_error" => Some(Self::Send),
+            "worker_failed" => Some(Self::WorkerJoin),
+            "network_generation_changed" => Some(Self::NetworkGenerationChanged),
+            "candidate_epoch_changed" => Some(Self::CandidateEpochChanged),
+            "profile_generation_changed" => Some(Self::ProfileGenerationChanged),
+            "peer_session_changed" => Some(Self::PeerSessionChanged),
+            "session_retired" => Some(Self::SessionRetired),
+            "socket_unavailable" => Some(Self::SocketUnavailable),
+            "socket_revoked" => Some(Self::SocketRevoked),
+            "probe_registration_failed" => Some(Self::ProbeRegistrationFailed),
+            "probe_encoding_failed" => Some(Self::ProbeEncodingFailed),
+            _ => None,
         }
     }
 }
@@ -1407,9 +1544,24 @@ pub(crate) struct LiveBirthdayCounters {
     pub budget_skipped: u32,
     pub logical_probes_attempted: u32,
     pub logical_probes_sent: u32,
+    pub logical_probe_send_failures: u32,
     pub physical_datagrams_sent: u32,
     pub physical_send_errors: u32,
+    pub partial_physical_send_errors: u32,
+    pub probe_path_errors: u32,
     pub workers_completed: u32,
+}
+
+/// Complete session-level live progress.  The counter values alone cannot
+/// explain which target/socket emitted a partial sweep, so the endpoint set,
+/// socket histogram and physical-send timestamps are kept beside them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LiveBirthdayProgress {
+    pub counters: LiveBirthdayCounters,
+    pub sent_target_endpoints: HashSet<SocketAddr>,
+    pub per_socket_sent: BTreeMap<usize, u32>,
+    pub first_send_at_ms: Option<u64>,
+    pub last_send_at_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -1422,7 +1574,7 @@ pub(crate) struct BirthdaySweepProgress {
     /// Session-scoped counters updated at each target/send event. This lock
     /// is independent of the peer connection map and is never held across a
     /// UDP send or another await.
-    pub live: Arc<StdMutex<LiveBirthdayCounters>>,
+    pub live: Arc<StdMutex<LiveBirthdayProgress>>,
 }
 
 impl Default for BirthdaySweepProgress {
@@ -1430,7 +1582,7 @@ impl Default for BirthdaySweepProgress {
         Self {
             birthday: BirthdaySweepReport::default(),
             aggregate: PunchSendReport::default(),
-            live: Arc::new(StdMutex::new(LiveBirthdayCounters::default())),
+            live: Arc::new(StdMutex::new(LiveBirthdayProgress::default())),
         }
     }
 }
@@ -1450,11 +1602,19 @@ pub(crate) struct PunchSendReport {
     pub logical_probes_attempted: u32,
     /// Logical probes with at least one successful physical datagram send.
     pub logical_probes_sent: u32,
+    /// Logical probes whose every required physical send failed.
+    pub logical_probe_send_failures: u32,
     /// Successful physical UDP datagrams, including compatibility copies.
     pub physical_datagrams_sent: u32,
     /// Physical UDP sends that returned an error, including compatibility
     /// copies after a successful primary send.
     pub physical_send_errors: u32,
+    /// Errors from a logical probe that still had at least one successful
+    /// physical datagram.  These are degraded sends, not session failures.
+    pub partial_physical_send_errors: u32,
+    /// Non-physical errors in the Probe build/registration path.  This keeps
+    /// a `send_error` classification explainable when no kernel send failed.
+    pub probe_path_errors: u32,
     pub unique_target_endpoints: u32,
     /// Wall-clock UNIX milliseconds captured immediately after the first
     /// successful kernel UDP send in this punch session.  `None` means the

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -1353,14 +1353,47 @@ impl PunchSocketPolicy {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct BirthdaySweepReport {
     pub requested_level: usize,
+    pub generated_candidate_count: usize,
+    pub signaled_candidate_count: usize,
     pub effective_target_count: usize,
+    pub requested_socket_count: usize,
+    pub attached_socket_count: usize,
+    pub usable_socket_count: usize,
+    pub unavailable_socket_count: usize,
+    /// Kept as a compatibility alias for existing diagnostics consumers; it
+    /// is always the exact usable socket count for this sweep.
     pub socket_count: usize,
     pub degraded_reason: Option<String>,
     pub waves_planned: usize,
     pub waves_started: usize,
+    pub waves_fully_completed: usize,
+    /// Compatibility alias retained for existing event parsers.  It has the
+    /// same value as `waves_fully_completed` and is never a worker-join count.
     pub waves_completed: usize,
     pub packets_planned: usize,
+    pub targets_assigned: usize,
+    pub targets_attempted: usize,
+    pub logical_probes_sent: usize,
+    pub physical_datagrams_sent: usize,
+    pub targets_budget_skipped: usize,
+    pub targets_cancelled: usize,
     pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BirthdaySweepProgress {
+    pub birthday: BirthdaySweepReport,
+    /// Partial logical/physical send counters published after every worker
+    /// wave.  This lets the caller emit a terminal summary when its deadline
+    /// or cancellation drops the scheduler future before it returns.
+    pub aggregate: PunchSendReport,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct HardHardSocketSnapshot {
+    pub socket_index: usize,
+    pub attached: bool,
+    pub usable: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1397,6 +1430,17 @@ pub(crate) struct PunchSendReport {
     pub last_send_at_ms: Option<u64>,
     /// Present only for the bounded Hard↔Hard Birthday scheduler.
     pub birthday: Option<BirthdaySweepReport>,
+    /// Number of exact targets assigned to this worker and how far the
+    /// worker progressed through them.  A worker that exits on a fence is not
+    /// complete even if its task joins successfully.
+    pub targets_assigned: u32,
+    pub targets_attempted: u32,
+    pub targets_cancelled: u32,
+    pub target_processing_completed: bool,
+    /// Set when the scheduler observed a normal worker error or JoinError.
+    /// The caller still receives the partial report so it can emit one final
+    /// summary before returning the Hard↔Hard sweep as failed.
+    pub worker_failed: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -965,6 +965,46 @@ pub(crate) enum DynamicSocketPhase {
     Finalized,
 }
 
+#[cfg(test)]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct HardHardDynamicSocketLifecycleSnapshot {
+    pub(crate) socket_index: usize,
+    pub(crate) phase: DynamicSocketPhase,
+    pub(crate) network_generation: u64,
+    pub(crate) punch_generation: u64,
+    pub(crate) token_present: bool,
+    pub(crate) token_matches_expected: bool,
+    pub(crate) token_digest: Option<String>,
+    pub(crate) authenticated_evidence: u64,
+    pub(crate) outstanding_send_leases: usize,
+    pub(crate) pending_probe_count: usize,
+    pub(crate) reader_finished: bool,
+    pub(crate) affinity_selected: bool,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct HardHardPendingProbeLifecycleSnapshot {
+    pub(crate) socket_index: usize,
+    pub(crate) token_matches_expected: bool,
+    pub(crate) peer_matches: bool,
+    pub(crate) expired: bool,
+    pub(crate) binding_present: bool,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct HardHardUdpLifecycleSnapshot {
+    pub(crate) peer_id: String,
+    pub(crate) expected_token_present: bool,
+    pub(crate) dynamic_sockets: Vec<HardHardDynamicSocketLifecycleSnapshot>,
+    pub(crate) pending_probes: Vec<HardHardPendingProbeLifecycleSnapshot>,
+    pub(crate) orphan_probe_bindings: usize,
+}
+
 impl DynamicSocketPhase {
     /// Whether a dynamic socket may be handed out as the peer's traffic path.
     ///

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -1351,6 +1351,19 @@ impl PunchSocketPolicy {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BirthdaySweepReport {
+    pub requested_level: usize,
+    pub effective_target_count: usize,
+    pub socket_count: usize,
+    pub degraded_reason: Option<String>,
+    pub waves_planned: usize,
+    pub waves_started: usize,
+    pub waves_completed: usize,
+    pub packets_planned: usize,
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PunchSendReport {
     pub packets_sent: u32,
     pub unique_target_endpoints: u32,
@@ -1375,6 +1388,15 @@ pub(crate) struct PunchSendReport {
     /// The session stopped enumerating candidates because the epoch's hard
     /// candidate-iteration budget was reached.
     pub candidate_iteration_capped: bool,
+    /// Exact endpoints that accepted at least one logical probe. This is an
+    /// internal aggregation aid for multi-wave Hard↔Hard diagnostics; callers
+    /// must use `unique_target_endpoints` for the bounded count.
+    pub sent_target_endpoints: Vec<SocketAddr>,
+    /// Wall-clock UNIX milliseconds captured after the last successful
+    /// kernel UDP send in this punch session.
+    pub last_send_at_ms: Option<u64>,
+    /// Present only for the bounded Hard↔Hard Birthday scheduler.
+    pub birthday: Option<BirthdaySweepReport>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/client/daemon/src/udp/state.rs
+++ b/client/daemon/src/udp/state.rs
@@ -180,6 +180,66 @@ pub(crate) async fn wait_for_birthday_worker_completion_gate_for_test() {
     }
 }
 
+/// Deterministic seam immediately after the production main `send_to` returns
+/// and after its session-local live recorder commit, but before the first
+/// post-send diagnostics/cleanup await.  The guard restores the hook and
+/// releases a parked sender when a test exits through an assertion failure.
+#[cfg(test)]
+pub(crate) struct ProbePostSendGate {
+    pub(crate) reached: tokio::sync::Notify,
+    pub(crate) release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+pub(crate) struct ProbePostSendGateGuard {
+    gate: Arc<ProbePostSendGate>,
+}
+
+#[cfg(test)]
+static PROBE_POST_SEND_GATE: std::sync::LazyLock<
+    std::sync::Mutex<Option<Arc<ProbePostSendGate>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+impl Drop for ProbePostSendGateGuard {
+    fn drop(&mut self) {
+        *PROBE_POST_SEND_GATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        self.gate.release.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_probe_post_send_gate_for_test() -> (
+    Arc<ProbePostSendGate>,
+    ProbePostSendGateGuard,
+) {
+    let gate = Arc::new(ProbePostSendGate {
+        reached: tokio::sync::Notify::new(),
+        release: tokio::sync::Notify::new(),
+    });
+    *PROBE_POST_SEND_GATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(gate.clone());
+    (
+        gate.clone(),
+        ProbePostSendGateGuard { gate },
+    )
+}
+
+#[cfg(test)]
+pub(crate) async fn wait_for_probe_post_send_gate_for_test() {
+    let gate = PROBE_POST_SEND_GATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(gate) = gate {
+        gate.reached.notify_waiters();
+        gate.release.notified().await;
+    }
+}
+
 /// Deterministic one-shot seam after UDP lifecycle cleanup but before the
 /// remote-incarnation reset is published. The transaction still owns the
 /// peer adoption lock while parked here.
@@ -1562,6 +1622,116 @@ pub(crate) struct LiveBirthdayProgress {
     pub per_socket_sent: BTreeMap<usize, u32>,
     pub first_send_at_ms: Option<u64>,
     pub last_send_at_ms: Option<u64>,
+}
+
+/// Synchronous session-local telemetry for a bounded Birthday sweep.
+///
+/// Admission owns the physical `send_to` boundary, so this recorder is called
+/// immediately after each send future resolves and before diagnostics,
+/// pending-probe cleanup, or any other follow-up await.  It contains no
+/// connection-manager state and never awaits while holding its short-lived
+/// standard mutex.
+#[derive(Clone)]
+pub(crate) struct BirthdayLiveRecorder {
+    progress: Arc<StdMutex<LiveBirthdayProgress>>,
+}
+
+impl BirthdayLiveRecorder {
+    pub(crate) fn new(progress: Arc<StdMutex<LiveBirthdayProgress>>) -> Self {
+        Self { progress }
+    }
+
+    fn update(&self, update: impl FnOnce(&mut LiveBirthdayProgress)) {
+        let mut progress = self
+            .progress
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        update(&mut progress);
+    }
+
+    fn record_success_timestamp(progress: &mut LiveBirthdayProgress, sent_at_ms: u64) {
+        progress.first_send_at_ms = Some(
+            progress
+                .first_send_at_ms
+                .map_or(sent_at_ms, |first| first.min(sent_at_ms)),
+        );
+        progress.last_send_at_ms = Some(
+            progress
+                .last_send_at_ms
+                .map_or(sent_at_ms, |last| last.max(sent_at_ms)),
+        );
+    }
+
+    /// Commit the authenticated/main datagram. This is the one logical Probe
+    /// contribution and the first physical datagram contribution.
+    pub(crate) fn record_primary_success(
+        &self,
+        socket_index: usize,
+        target: SocketAddr,
+        sent_at_ms: u64,
+    ) {
+        self.update(|progress| {
+            progress.counters.logical_probes_sent = progress
+                .counters
+                .logical_probes_sent
+                .saturating_add(1);
+            progress.counters.physical_datagrams_sent = progress
+                .counters
+                .physical_datagrams_sent
+                .saturating_add(1);
+            progress.sent_target_endpoints.insert(target);
+            let sent = progress.per_socket_sent.entry(socket_index).or_default();
+            *sent = sent.saturating_add(1);
+            Self::record_success_timestamp(progress, sent_at_ms);
+        });
+    }
+
+    /// Commit a compatibility datagram. It is physical-only: the logical
+    /// Probe and unique target were already committed with the main packet.
+    pub(crate) fn record_compatibility_success(
+        &self,
+        socket_index: usize,
+        sent_at_ms: u64,
+    ) {
+        self.update(|progress| {
+            progress.counters.physical_datagrams_sent = progress
+                .counters
+                .physical_datagrams_sent
+                .saturating_add(1);
+            let sent = progress.per_socket_sent.entry(socket_index).or_default();
+            *sent = sent.saturating_add(1);
+            Self::record_success_timestamp(progress, sent_at_ms);
+        });
+    }
+
+    /// Commit a failed main physical send before pending-probe cleanup.
+    pub(crate) fn record_primary_error(&self) {
+        self.update(|progress| {
+            progress.counters.logical_probe_send_failures = progress
+                .counters
+                .logical_probe_send_failures
+                .saturating_add(1);
+            progress.counters.physical_send_errors = progress
+                .counters
+                .physical_send_errors
+                .saturating_add(1);
+        });
+    }
+
+    /// Commit a failed compatibility copy as a partial physical error. The
+    /// logical Probe remains successful because its main datagram succeeded.
+    pub(crate) fn record_compatibility_error(&self) {
+        self.update(|progress| {
+            progress.counters.physical_send_errors = progress
+                .counters
+                .physical_send_errors
+                .saturating_add(1);
+            progress.counters.partial_physical_send_errors = progress
+                .counters
+                .partial_physical_send_errors
+                .saturating_add(1);
+        });
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/client/daemon/src/udp/tests/part04.rs
+++ b/client/daemon/src/udp/tests/part04.rs
@@ -878,6 +878,52 @@ async fn exact_dynamic_socket_send_error_is_reported_as_send_error() {
 }
 
 #[tokio::test]
+async fn probe_send_blackhole_is_successful_and_raii_scoped() {
+    let (_peers, transport, _nat) = generation_env().await;
+    let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let receiver_endpoint = receiver.local_addr().unwrap();
+    let payload = b"probe-send-blackhole";
+    let mut received = [0u8; 64];
+
+    let blackhole = transport.blackhole_probe_sends_for_test();
+    assert_eq!(
+        transport
+            .send_probe_datagram(&sender, payload, receiver_endpoint)
+            .await
+            .unwrap(),
+        payload.len()
+    );
+    assert!(
+        timeout(
+            Duration::from_millis(50),
+            receiver.recv_from(&mut received)
+        )
+        .await
+        .is_err(),
+        "a blackholed test datagram must not enter the kernel"
+    );
+
+    drop(blackhole);
+    assert_eq!(
+        transport
+            .send_probe_datagram(&sender, payload, receiver_endpoint)
+            .await
+            .unwrap(),
+        payload.len()
+    );
+    let (received_len, source) = timeout(
+        Duration::from_secs(1),
+        receiver.recv_from(&mut received),
+    )
+    .await
+    .expect("dropping the guard must restore the real UDP send")
+    .unwrap();
+    assert_eq!(&received[..received_len], payload);
+    assert_eq!(source, sender.local_addr().unwrap());
+}
+
+#[tokio::test]
 async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_counts() {
     let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
     // The authenticated primary is physical attempt 1; the compatibility

--- a/client/daemon/src/udp/tests/part04.rs
+++ b/client/daemon/src/udp/tests/part04.rs
@@ -14,8 +14,8 @@ const NAT_IP: [u8; 4] = [127, 0, 0, 1];
 
 /// A simulated linear-symmetric NAT middlebox on the loopback address.
 /// (127.0.0.2 is not bound on every macOS build, so the public side shares
-/// 127.0.0.1 with the client; ports never overlap because the allocator
-/// starts at 45390 while ephemeral sockets use 49152+.)
+/// 127.0.0.1 with the client; every public and observer endpoint is still
+/// kernel-assigned.
 ///
 /// One fresh public port is allocated per (local socket, destination) pair,
 /// walking a configurable step sequence. STUN observer sockets double as the
@@ -25,11 +25,6 @@ const NAT_IP: [u8; 4] = [127, 0, 0, 1];
 /// forwarded back through the peer's public endpoint so the punching side
 /// sees the peer's stable public address.
 ///
-/// Every instance starts its allocator at a unique base port so parallel
-/// tests never fight over the same public forwarder bindings.
-static NAT_INSTANCE_BASE_PORTS: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(45390);
-
 struct SimulatedNat {
     /// STUN observer endpoints (127.0.0.2:X) the client measures against.
     observers: Vec<SocketAddr>,
@@ -53,11 +48,72 @@ struct SimulatedNat {
     /// Per-public-port outbound forwarder sockets.
     forwarders: Arc<Mutex<HashMap<u16, Arc<UdpSocket>>>>,
     nat_ip: IpAddr,
+    /// Own every background router/observer task so a test releases its
+    /// synthetic NAT resources as soon as the fixture is dropped.
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+/// Reserve a short arithmetic run from a kernel-selected base. The simulator
+/// needs deterministic port deltas for the production learner, but it must
+/// not claim a process-global fixed range: a :0 seed plus an explicit
+/// reservation makes each test instance independent across test binaries.
+async fn reserve_linear_forwarders(
+    nat_ip: IpAddr,
+    step: i16,
+) -> (u16, HashMap<u16, Arc<UdpSocket>>) {
+    const RESERVED_MAPPING_PORTS: usize = 16;
+    const RESERVATION_RETRIES: usize = 64;
+
+    for _ in 0..RESERVATION_RETRIES {
+        let seed = UdpSocket::bind(SocketAddr::new(nat_ip, 0))
+            .await
+            .unwrap_or_else(|error| panic!("bind simulated NAT :0 seed: {error}"));
+        let base_port = seed
+            .local_addr()
+            .expect("simulated NAT seed must have a local address")
+            .port();
+        let mut reserved = HashMap::with_capacity(RESERVED_MAPPING_PORTS);
+        reserved.insert(base_port, Arc::new(seed));
+        if step == 0 {
+            return (base_port, reserved);
+        }
+        let mut port = base_port;
+        let mut available = true;
+        for _ in 1..RESERVED_MAPPING_PORTS {
+            port = port.wrapping_add(step as u16);
+            if port == 0 {
+                available = false;
+                break;
+            }
+            match UdpSocket::bind(SocketAddr::new(nat_ip, port)).await {
+                Ok(socket) => {
+                    reserved.insert(port, Arc::new(socket));
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied
+                    ) =>
+                {
+                    available = false;
+                    break;
+                }
+                Err(error) => panic!("bind simulated NAT reserved forwarder: {error}"),
+            }
+        }
+        if available {
+            return (base_port, reserved);
+        }
+        // Dropping the reservation closes every candidate socket before the
+        // next :0 seed is selected.
+    }
+    panic!("could not reserve a kernel-selected simulated NAT port run");
 }
 
 impl SimulatedNat {
     async fn start(step: i16, consume_before_punch: bool) -> Self {
         let nat_ip = IpAddr::V4(Ipv4Addr::from(NAT_IP));
+        let (base_port, reserved_forwarders) = reserve_linear_forwarders(nat_ip, step).await;
         let mut observer_holders = Vec::new();
         let mut observers = Vec::new();
         for _ in 0..3 {
@@ -73,13 +129,8 @@ impl SimulatedNat {
                 .await
                 .unwrap();
         let peer_private = peer_private_socket.local_addr().unwrap();
-        drop(observer_holders);
 
-        let base_port = NAT_INSTANCE_BASE_PORTS
-            .fetch_add(256, std::sync::atomic::Ordering::Relaxed)
-            .min(u16::MAX as u32 - 4_096) as u16;
-
-        let nat = Self {
+        let mut nat = Self {
             observers,
             peer_public,
             peer_private,
@@ -90,9 +141,11 @@ impl SimulatedNat {
             next_port: Arc::new(Mutex::new(base_port)),
             step,
             consume_before_punch,
-            forwarders: Arc::new(Mutex::new(HashMap::new())),
+            forwarders: Arc::new(Mutex::new(reserved_forwarders)),
             nat_ip,
+            tasks: Vec::new(),
         };
+        let mut tasks = Vec::new();
 
         // Outbound/inbound router on the peer's public endpoint.
         {
@@ -105,7 +158,7 @@ impl SimulatedNat {
             let nat_ip = nat.nat_ip;
             let step = nat.step;
             let consume_before_punch = nat.consume_before_punch;
-            tokio::spawn(async move {
+            tasks.push(tokio::spawn(async move {
                 let mut buf = vec![0u8; 2048];
                 while let Ok((len, client_src)) = peer_public_socket.recv_from(&mut buf).await {
                     let data = buf[..len].to_vec();
@@ -182,7 +235,7 @@ impl SimulatedNat {
                     // mapping's public source port.
                     let _ = forwarder.send_to(&data, peer_private).await;
                 }
-            });
+            }));
         }
 
         // Per-mapping forwarder loops: inbound peer ACKs are forwarded back
@@ -193,7 +246,7 @@ impl SimulatedNat {
             let forwarders = nat.forwarders.clone();
             let mapping_sources = nat.mapping_sources.clone();
             let peer_public_socket = peer_public_socket.clone();
-            tokio::spawn(async move {
+            tasks.push(tokio::spawn(async move {
                 let mut buf = vec![0u8; 2048];
                 loop {
                     let sockets = {
@@ -225,7 +278,7 @@ impl SimulatedNat {
                         sleep(Duration::from_millis(2)).await;
                     }
                 }
-            });
+            }));
         }
 
         // STUN observer loops.
@@ -234,11 +287,10 @@ impl SimulatedNat {
             let next_port = nat.next_port.clone();
             let step = nat.step;
             let nat_ip = nat.nat_ip;
-            for observer in nat.observers.iter().copied() {
-                let socket = UdpSocket::bind(observer).await.unwrap();
+            for (observer, socket) in nat.observers.iter().copied().zip(observer_holders) {
                 let mappings = mappings.clone();
                 let next_port = next_port.clone();
-                tokio::spawn(async move {
+                tasks.push(tokio::spawn(async move {
                     let mut buf = vec![0u8; 2048];
                     while let Ok((len, client_src)) = socket.recv_from(&mut buf).await {
                         let data = buf[..len].to_vec();
@@ -268,10 +320,11 @@ impl SimulatedNat {
                             }
                         }
                     }
-                });
+                }));
             }
         }
 
+        nat.tasks = tasks;
         nat
     }
 
@@ -289,6 +342,14 @@ impl SimulatedNat {
             .await
             .get(&(client_src, self.peer_public))
             .expect("punch mapping assigned")
+    }
+}
+
+impl Drop for SimulatedNat {
+    fn drop(&mut self) {
+        for task in self.tasks.drain(..) {
+            task.abort();
+        }
     }
 }
 
@@ -781,7 +842,7 @@ async fn hard_hard_measurement_sweeps_from_the_same_exact_socket() {
 #[tokio::test]
 async fn exact_dynamic_socket_send_error_is_reported_as_send_error() {
     let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
-    transport.set_probe_send_failures_for_test([1]);
+    let _send_failures = transport.set_probe_send_failures_for_test([1]);
 
     let report = transport
         .punch_candidates_from_dynamic_socket_index(
@@ -822,7 +883,7 @@ async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_c
     // The authenticated primary is physical attempt 1; the compatibility
     // copy is attempt 2. Fail only that copy so one logical Probe still has a
     // successful physical send and one physical error.
-    transport.set_probe_send_failures_for_test([2]);
+    let _send_failures = transport.set_probe_send_failures_for_test([2]);
 
     let report = transport
         .punch_candidates_from_dynamic_socket_index(
@@ -840,17 +901,46 @@ async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_c
     assert_eq!(report.packets_sent, 1);
     assert_eq!(report.physical_datagrams_sent, 1);
     assert_eq!(report.physical_send_errors, 1);
+    assert_eq!(report.partial_physical_send_errors, 1);
     assert_eq!(report.per_socket_sent, vec![(socket_index, 1)]);
-    assert_eq!(
-        report.failure_kind,
-        Some(crate::udp::BirthdaySweepFailureKind::Send)
-    );
+    assert_eq!(report.failure_kind, None);
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_transient_primary_failure_continues_to_later_target() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    // Fail only the first target's authenticated primary. The next target
+    // must still enter the same bounded exact-socket sweep and send.
+    let _send_failures = transport.set_probe_send_failures_for_test([1]);
+
+    let later_target: SocketAddr = "127.0.0.1:41001".parse().unwrap();
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public, later_target],
+            Duration::ZERO,
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.logical_probes_attempted, 2);
+    assert_eq!(report.logical_probes_sent, 1);
+    assert_eq!(report.logical_probe_send_failures, 1);
+    assert_eq!(report.physical_datagrams_sent, 2);
+    assert_eq!(report.physical_send_errors, 1);
+    assert_eq!(report.failure_kind, None);
+    assert_eq!(report.targets_attempted, 2);
+    assert_eq!(report.targets_cancelled, 0);
+    assert_eq!(report.unique_target_endpoints, 1);
+    assert_eq!(report.sent_target_endpoints, vec![later_target]);
 }
 
 #[tokio::test]
 async fn exact_dynamic_socket_all_physical_failures_keep_target_progress() {
     let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
-    transport.set_probe_send_failures_for_test([1, 2]);
+    let _send_failures = transport.set_probe_send_failures_for_test([1, 2]);
 
     let report = transport
         .punch_candidates_from_dynamic_socket_index(
@@ -908,11 +998,41 @@ async fn hard_hard_detached_exact_socket_sweep_fails_closed_without_pool_sends()
         .unwrap();
     assert_eq!(report.packets_sent, 0);
     assert_eq!(report.unique_target_endpoints, 0);
+    assert_eq!(report.probe_path_errors, 1);
+    assert_eq!(
+        report.failure_kind,
+        Some(crate::udp::BirthdaySweepFailureKind::SocketUnavailable)
+    );
     assert!(!peers.is_direct("peer-b").await);
     assert_eq!(
         peers.select_path_for_data("peer-b", true, true).await.path,
         Some(NetworkPath::Relay),
         "a detached exact Hard↔Hard socket must leave Relay as the data path"
+    );
+}
+
+#[tokio::test]
+async fn hard_hard_wrong_owner_exact_socket_is_revoked_not_unavailable() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index(
+            "peer-c",
+            socket_index,
+            vec![nat.peer_public],
+            Duration::ZERO,
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.packets_sent, 0);
+    assert_eq!(report.targets_assigned, 1);
+    assert_eq!(report.targets_cancelled, 1);
+    assert_eq!(report.probe_path_errors, 1);
+    assert_eq!(
+        report.failure_kind,
+        Some(crate::udp::BirthdaySweepFailureKind::SocketRevoked)
     );
 }
 

--- a/client/daemon/src/udp/tests/part04.rs
+++ b/client/daemon/src/udp/tests/part04.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 
 use crate::peer::NetworkPath;
 use p2pnet_nat::{
@@ -904,6 +904,85 @@ async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_c
     assert_eq!(report.partial_physical_send_errors, 1);
     assert_eq!(report.per_socket_sent, vec![(socket_index, 1)]);
     assert_eq!(report.failure_kind, None);
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_live_recorder_counts_compatibility_success_once() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    let live = Arc::new(StdMutex::new(crate::udp::LiveBirthdayProgress::default()));
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public],
+            Duration::ZERO,
+            1,
+            None,
+            None,
+            Some(live.clone()),
+        )
+        .await
+        .unwrap();
+
+    let live = live.lock().unwrap();
+    assert_eq!(live.counters.logical_probes_sent, 1);
+    assert_eq!(live.counters.physical_datagrams_sent, 2);
+    assert_eq!(live.counters.physical_send_errors, 0);
+    assert_eq!(live.counters.partial_physical_send_errors, 0);
+    assert_eq!(live.sent_target_endpoints.len(), 1);
+    assert_eq!(live.per_socket_sent.get(&socket_index), Some(&2));
+    assert!(live.first_send_at_ms.is_some());
+    assert!(live.last_send_at_ms.is_some());
+    assert_eq!(
+        live.counters.physical_datagrams_sent,
+        live.per_socket_sent.values().sum::<u32>()
+    );
+    assert_eq!(report.logical_probes_sent, 1);
+    assert_eq!(report.physical_datagrams_sent, 2);
+    assert_eq!(report.per_socket_sent, vec![(socket_index, 2)]);
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_live_recorder_counts_compatibility_failure_as_partial() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    // The authenticated primary is physical attempt 1; fail only the
+    // compatibility copy at attempt 2.
+    let _send_failures = transport.set_probe_send_failures_for_test([2]);
+    let live = Arc::new(StdMutex::new(crate::udp::LiveBirthdayProgress::default()));
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index_with_profile_fence_and_session_and_live(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public],
+            Duration::ZERO,
+            1,
+            None,
+            None,
+            Some(live.clone()),
+        )
+        .await
+        .unwrap();
+
+    let live = live.lock().unwrap();
+    assert_eq!(live.counters.logical_probes_sent, 1);
+    assert_eq!(live.counters.physical_datagrams_sent, 1);
+    assert_eq!(live.counters.physical_send_errors, 1);
+    assert_eq!(live.counters.partial_physical_send_errors, 1);
+    assert_eq!(live.sent_target_endpoints.len(), 1);
+    assert_eq!(live.per_socket_sent.get(&socket_index), Some(&1));
+    assert!(live.first_send_at_ms.is_some());
+    assert!(live.last_send_at_ms.is_some());
+    assert_eq!(
+        live.counters.physical_datagrams_sent,
+        live.per_socket_sent.values().sum::<u32>()
+    );
+    assert_eq!(report.logical_probes_sent, 1);
+    assert_eq!(report.physical_datagrams_sent, 1);
+    assert_eq!(report.physical_send_errors, 1);
+    assert_eq!(report.partial_physical_send_errors, 1);
+    assert_eq!(report.per_socket_sent, vec![(socket_index, 1)]);
 }
 
 #[tokio::test]

--- a/client/daemon/src/udp/tests/part04.rs
+++ b/client/daemon/src/udp/tests/part04.rs
@@ -878,52 +878,6 @@ async fn exact_dynamic_socket_send_error_is_reported_as_send_error() {
 }
 
 #[tokio::test]
-async fn probe_send_blackhole_is_successful_and_raii_scoped() {
-    let (_peers, transport, _nat) = generation_env().await;
-    let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let receiver_endpoint = receiver.local_addr().unwrap();
-    let payload = b"probe-send-blackhole";
-    let mut received = [0u8; 64];
-
-    let blackhole = transport.blackhole_probe_sends_for_test();
-    assert_eq!(
-        transport
-            .send_probe_datagram(&sender, payload, receiver_endpoint)
-            .await
-            .unwrap(),
-        payload.len()
-    );
-    assert!(
-        timeout(
-            Duration::from_millis(50),
-            receiver.recv_from(&mut received)
-        )
-        .await
-        .is_err(),
-        "a blackholed test datagram must not enter the kernel"
-    );
-
-    drop(blackhole);
-    assert_eq!(
-        transport
-            .send_probe_datagram(&sender, payload, receiver_endpoint)
-            .await
-            .unwrap(),
-        payload.len()
-    );
-    let (received_len, source) = timeout(
-        Duration::from_secs(1),
-        receiver.recv_from(&mut received),
-    )
-    .await
-    .expect("dropping the guard must restore the real UDP send")
-    .unwrap();
-    assert_eq!(&received[..received_len], payload);
-    assert_eq!(source, sender.local_addr().unwrap());
-}
-
-#[tokio::test]
 async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_counts() {
     let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
     // The authenticated primary is physical attempt 1; the compatibility

--- a/client/daemon/src/udp/tests/part04.rs
+++ b/client/daemon/src/udp/tests/part04.rs
@@ -373,6 +373,39 @@ async fn generation_env() -> (Arc<PeerManager>, Arc<UdpTransport>, SimulatedNat)
     (peers, Arc::new(transport), nat)
 }
 
+async fn committed_dynamic_socket_for_send_test(
+    peers: &Arc<PeerManager>,
+    transport: &Arc<UdpTransport>,
+    peer_id: &str,
+) -> usize {
+    let (socket_index, socket) = transport.bind_fresh_punch_socket().await.unwrap();
+    let handoff = transport
+        .attach_dynamic_punch_socket(peer_id, socket_index, socket, 0, 1, None)
+        .await
+        .unwrap();
+    assert!(
+        handoff
+            .commit_and_pin(transport, peer_id, socket_index, 0, 1)
+            .await
+            .committed
+    );
+    assert!(handoff.finalize().await);
+    assert!(
+        transport
+            .resolve_dynamic_socket_index_for_send(peer_id, socket_index)
+            .await
+            .is_some()
+    );
+    let _ = peers;
+    socket_index
+}
+
+async fn exact_send_report_fixture() -> (Arc<PeerManager>, Arc<UdpTransport>, SimulatedNat, usize) {
+    let (peers, transport, nat) = generation_env().await;
+    let socket_index = committed_dynamic_socket_for_send_test(&peers, &transport, "peer-b").await;
+    (peers, transport, nat, socket_index)
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn dynamic_attach_waits_for_first_reader_poll_before_immediate_stun() {
     let (_peers, transport, nat) = generation_env().await;
@@ -743,6 +776,105 @@ async fn hard_hard_measurement_sweeps_from_the_same_exact_socket() {
     );
 
     listener.abort();
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_send_error_is_reported_as_send_error() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    transport.set_probe_send_failures_for_test([1]);
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public],
+            Duration::ZERO,
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.logical_probes_attempted, 1);
+    assert_eq!(report.logical_probes_sent, 0);
+    assert_eq!(report.physical_datagrams_sent, 0);
+    assert_eq!(report.physical_send_errors, 1);
+    assert_eq!(report.targets_assigned, 1);
+    assert_eq!(report.targets_examined, 1);
+    assert_eq!(report.targets_attempted, 1);
+    assert_eq!(report.targets_cancelled, 0);
+    assert_eq!(report.budget_skipped, 0);
+    assert_eq!(
+        report.failure_kind,
+        Some(crate::udp::BirthdaySweepFailureKind::Send)
+    );
+    assert_ne!(
+        report
+            .birthday
+            .as_ref()
+            .and_then(|birthday| birthday.stop_reason.as_deref()),
+        Some("socket_unavailable")
+    );
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_partial_physical_failure_keeps_success_and_error_counts() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    // The authenticated primary is physical attempt 1; the compatibility
+    // copy is attempt 2. Fail only that copy so one logical Probe still has a
+    // successful physical send and one physical error.
+    transport.set_probe_send_failures_for_test([2]);
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public],
+            Duration::ZERO,
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.logical_probes_attempted, 1);
+    assert_eq!(report.logical_probes_sent, 1);
+    assert_eq!(report.packets_sent, 1);
+    assert_eq!(report.physical_datagrams_sent, 1);
+    assert_eq!(report.physical_send_errors, 1);
+    assert_eq!(report.per_socket_sent, vec![(socket_index, 1)]);
+    assert_eq!(
+        report.failure_kind,
+        Some(crate::udp::BirthdaySweepFailureKind::Send)
+    );
+}
+
+#[tokio::test]
+async fn exact_dynamic_socket_all_physical_failures_keep_target_progress() {
+    let (_peers, transport, nat, socket_index) = exact_send_report_fixture().await;
+    transport.set_probe_send_failures_for_test([1, 2]);
+
+    let report = transport
+        .punch_candidates_from_dynamic_socket_index(
+            "peer-b",
+            socket_index,
+            vec![nat.peer_public, "127.0.0.1:41001".parse().unwrap()],
+            Duration::ZERO,
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(report.logical_probes_attempted, 2);
+    assert_eq!(report.logical_probes_sent, 0);
+    assert_eq!(report.physical_datagrams_sent, 0);
+    assert_eq!(report.physical_send_errors, 2);
+    assert_eq!(report.targets_assigned, 2);
+    assert_eq!(report.targets_examined, 2);
+    assert_eq!(report.targets_attempted, 2);
+    assert_eq!(report.targets_cancelled, 0);
+    assert_eq!(
+        report.failure_kind,
+        Some(crate::udp::BirthdaySweepFailureKind::Send)
+    );
 }
 
 #[tokio::test]

--- a/contracts/fixtures/signal_candidate_cap.json
+++ b/contracts/fixtures/signal_candidate_cap.json
@@ -1,0 +1,3 @@
+{
+  "max_signal_candidates": 96
+}

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,6 +20,22 @@ import (
 	"github.com/yhan-sun/p2wlan/server/database"
 	"github.com/yhan-sun/p2wlan/server/signaling"
 )
+
+func TestSignalCandidateCapMatchesSharedFixture(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "contracts", "fixtures", "signal_candidate_cap.json"))
+	if err != nil {
+		t.Fatalf("read shared signal candidate cap fixture: %v", err)
+	}
+	var fixture struct {
+		MaxSignalCandidates int `json:"max_signal_candidates"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode shared signal candidate cap fixture: %v", err)
+	}
+	if fixture.MaxSignalCandidates != maxSignalCandidates {
+		t.Fatalf("candidate cap drifted: Go=%d fixture=%d", maxSignalCandidates, fixture.MaxSignalCandidates)
+	}
+}
 
 func TestCreateSignalWakesAuthenticatedWebSocketAndRemainsDurable(t *testing.T) {
 	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))


### PR DESCRIPTION
## 变更摘要

集成已验收的 Hard NAT traversal 可靠性修复，包括：

- 统一 Hard candidate 信令上限与 requested/generated/signaled/effective 诊断；
- 保留原始 Birthday requested level；
- exact dynamic socket snapshot 与 socket 降级统计；
- 有界两波 Birthday 探测，不进行完整 socket-target 笛卡尔积；
- Hard↔Stable/Fresh 有界两次尝试；
- 类型化 Probe 发送和 session/fence 失败原因；
- 主包成功、compatibility 部分失败的正确发送语义；
- logical probe、physical datagram 和发送错误分离统计；
- send_to 返回后的同步 Birthday telemetry 提交点；
- deadline/cancel 完整 live summary；
- Probe session ID 提前捕获；
- Direct validation diagnostics 非阻塞；
- authenticated Probe、matched ACK、exact socket winner 和旧 session/ACK fence。

## 已完成的集成验收

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- 非 Hard workspace suite 通过；
- 动态发现 Hard exact tests：57 项；
- Hard exact：57/57 × 3；
- Parallel workspace：1120/1120 × 3；
- Single-thread workspace：1120/1120；
- Go tests：6 packages；
- `go vet ./...`；
- `git diff --check`；
- `cargo fmt --all --check`。

## 能力边界

- 本次修复提高复杂 NAT 下的探测可靠性和诊断准确性；
- 不承诺真正高熵双 APDM/APDF NAT 必然直连；
- Relay 仍是必要兜底；
- 尚未部署到真实 Android/Air/mini；
- 不包含 Phase 6。
