### PR TITLE
ci: establish stable required gate and package PR coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           fi
           echo "build identity gate PASS (commit=$HEAD_SHA sha=$BIN_SHA)"
 
-  rust-windows:
+  rust_windows:
     name: Rust Check (Windows)
     runs-on: windows-latest
     steps:
@@ -147,7 +147,7 @@ jobs:
         working-directory: server
         run: go test ./... -count=1
 
-  repository-policy:
+  repository_policy:
     name: React absence and security scan
     runs-on: ubuntu-latest
     steps:
@@ -179,7 +179,7 @@ jobs:
   required:
     name: CI Required
     if: always()
-    needs: [rust, rust-windows, go, repository-policy]
+    needs: [rust, rust_windows, go, repository_policy]
     runs-on: ubuntu-latest
     steps:
       - name: Enforce required job results
@@ -187,7 +187,7 @@ jobs:
         run: |
           set -euo pipefail
           test "${{ needs.rust.result }}" = "success"
-          test "${{ needs['rust-windows'].result }}" = "success"
+          test "${{ needs.rust_windows.result }}" = "success"
           test "${{ needs.go.result }}" = "success"
-          test "${{ needs['repository-policy'].result }}" = "success"
+          test "${{ needs.repository_policy.result }}" = "success"
           echo "all required CI jobs succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           set -euo pipefail
           test "${{ needs.rust.result }}" = "success"
-          test "${{ needs.rust-windows.result }}" = "success"
+          test "${{ needs['rust-windows'].result }}" = "success"
           test "${{ needs.go.result }}" = "success"
-          test "${{ needs.repository-policy.result }}" = "success"
+          test "${{ needs['repository-policy'].result }}" = "success"
           echo "all required CI jobs succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             "$hard_hard_binary" "$test_name" --exact --test-threads=1
           done <<< "$hard_hard_tests"
       - name: Linux route gate tests
-        run: cargo test -p p2wlan-daemon --lib route::tests::
+        run: "cargo test -p p2wlan-daemon --lib route::tests::"
       - name: Rust Linux Target Cross-Compile Check
         run: |
           rustup target add x86_64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rust:
@@ -54,15 +62,15 @@ jobs:
             "$hard_hard_binary" "$test_name" --exact --test-threads=1
           done <<< "$hard_hard_tests"
       - name: Linux route gate tests
-        run: "cargo test -p p2wlan-daemon --lib route::tests::"
+        run: cargo test -p p2wlan-daemon --lib route::tests::
       - name: Rust Linux Target Cross-Compile Check
         run: |
           rustup target add x86_64-unknown-linux-gnu
           cargo check --target x86_64-unknown-linux-gnu
       - name: Build Identity Gate
         # The built daemon must report the exact commit CI checked out, and
-        # --version must carry that commit too.  A drift here means /status.version
-        # could no longer prove which build is running.
+        # --version must carry that commit too. A drift here means
+        # /status.version could no longer prove which build is running.
         run: |
           cargo build -p p2wlan-daemon
           HEAD_SHA="$(git rev-parse HEAD)"
@@ -133,13 +141,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Go Vet
-        run: |
-          cd server
-          go vet ./...
+        working-directory: server
+        run: go vet ./...
       - name: Go Test
-        run: |
-          cd server
-          go test ./... -count=1
+        working-directory: server
+        run: go test ./... -count=1
 
   repository-policy:
     name: React absence and security scan
@@ -169,3 +175,34 @@ jobs:
             echo "unsafe production credential transport found" >&2
             exit 1
           fi
+
+  required:
+    name: CI Required
+    if: ${{ always() }}
+    needs:
+      - rust
+      - rust-windows
+      - go
+      - repository-policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce required job results
+        env:
+          REQUIRED_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          jobs = json.loads(os.environ["REQUIRED_RESULTS"])
+          failed = {
+              name: data.get("result", "missing")
+              for name, data in jobs.items()
+              if data.get("result") != "success"
+          }
+          if failed:
+              print("required CI jobs did not succeed:", failed, file=sys.stderr)
+              raise SystemExit(1)
+          print("all required CI jobs succeeded:", sorted(jobs))
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -178,31 +178,16 @@ jobs:
 
   required:
     name: CI Required
-    if: ${{ always() }}
-    needs:
-      - rust
-      - rust-windows
-      - go
-      - repository-policy
+    if: always()
+    needs: [rust, rust-windows, go, repository-policy]
     runs-on: ubuntu-latest
     steps:
       - name: Enforce required job results
-        env:
-          REQUIRED_RESULTS: ${{ toJSON(needs) }}
+        shell: bash
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          jobs = json.loads(os.environ["REQUIRED_RESULTS"])
-          failed = {
-              name: data.get("result", "missing")
-              for name, data in jobs.items()
-              if data.get("result") != "success"
-          }
-          if failed:
-              print("required CI jobs did not succeed:", failed, file=sys.stderr)
-              raise SystemExit(1)
-          print("all required CI jobs succeeded:", sorted(jobs))
-          PY
+          set -euo pipefail
+          test "${{ needs.rust.result }}" = "success"
+          test "${{ needs.rust-windows.result }}" = "success"
+          test "${{ needs.go.result }}" = "success"
+          test "${{ needs.repository-policy.result }}" = "success"
+          echo "all required CI jobs succeeded"

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -3,14 +3,25 @@ name: Package Test Builds
 on:
   workflow_dispatch:
   push:
-    branches:
-      - fix/hard-hard-birthday-validation
+    branches: [main]
     paths:
       - ".github/workflows/package-test.yml"
       - "apps/flutter_client/**"
       - "client/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "contracts/**"
+      - "scripts/build_android_native.sh"
+      - "scripts/release/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/package-test.yml"
+      - "apps/flutter_client/**"
+      - "client/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "contracts/**"
       - "scripts/build_android_native.sh"
       - "scripts/release/**"
 
@@ -18,7 +29,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: package-test-${{ github.ref }}
+  group: package-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -95,8 +106,8 @@ jobs:
             --app-info "$app/Contents/Info.plist" \
             --expected-commit "$EXPECTED_COMMIT"
 
-          # Ad-hoc signing is sufficient for a local test DMG. It is not a
-          # notarized distribution build and may require Finder/Open Anyway.
+          # Ad-hoc signing is sufficient for CI packaging. Distribution
+          # notarization remains deliberately outside this task.
           codesign --force --deep --sign - "$app"
           codesign --verify --deep --strict --verbose=2 "$app"
           ln -s /Applications "$work/Applications"
@@ -163,7 +174,8 @@ jobs:
       - name: Restore Flutter-managed source files
         run: bash scripts/release/hermetic_build.sh restore
 
-      - name: Configure Android release signing
+      - name: Configure stable Android release signing
+        if: github.event_name != 'pull_request'
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -186,10 +198,14 @@ jobs:
           EOF
           chmod 600 apps/flutter_client/android/key.properties
 
-      - name: Build arm64 signed APK
+      - name: Build arm64 APK
         working-directory: apps/flutter_client
         env:
           P2WLAN_ANDROID_ABIS: arm64-v8a
+          # Fork and same-repository PRs intentionally receive no release
+          # signing material. A debug-signed release-mode APK is sufficient to
+          # prove packaging; tagged releases retain stable signing.
+          P2WLAN_ALLOW_DEBUG_RELEASE_SIGNING: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: |
           bash ../../scripts/release/build_flutter_client.sh apk \
             --release \
@@ -200,7 +216,7 @@ jobs:
       - name: Restore Flutter-managed source files after build
         run: bash scripts/release/hermetic_build.sh restore
 
-      - name: Verify and stage arm64 signed APK
+      - name: Verify and stage arm64 APK
         working-directory: apps/flutter_client
         run: |
           set -euo pipefail
@@ -220,10 +236,10 @@ jobs:
           sha256sum ../../dist-test/p2wlan-android-arm64-release.apk \
             > ../../dist-test/p2wlan-android-arm64-release.apk.sha256
 
-      - name: Upload Android signed test package
+      - name: Upload Android test package
         uses: actions/upload-artifact@v4
         with:
-          name: p2wlan-android-arm64-signed-test
+          name: p2wlan-android-arm64-test
           path: dist-test/
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
## 目标

收口 CI 门禁配置，使普通 PR/main 修改能够稳定触发核心校验与打包验证，并提供一个适合分支保护绑定的稳定聚合状态。

## 变更

- 为 `ci.yml` 增加 `workflow_dispatch`、最小权限和并发取消；
- 增加稳定聚合状态 `CI Required`，任何 Rust/Windows/Go/仓库策略任务非成功均失败；
- 将 Go job 改为明确 `working-directory`；
- 将 `package-test.yml` 从临时修复分支迁移到 `main` push 和 `main` PR；
- 扩充 package-test 路径覆盖 `contracts/**`；
- PR Android 包使用允许的 debug release signing，不读取发布签名 secrets；
- main/tag 侧仍保留稳定 Android signing；
- 签名/公证产品化不在本任务范围。

## 验收

- `CI Required` 必须成功；
- Package Test Builds 的 macOS arm64 与 Android arm64 必须成功；
- PR head SHA 必须与被验收 SHA 一致。

## 仓库设置后续

代码合并后，分支保护应只绑定稳定 context `CI Required`；GitHub connector 当前不提供分支保护写接口，因此设置层变更需要在仓库设置中完成。