### PR TITLE
test(nat): add deterministic topology matrix and CI evidence

### DIFF
--- a/.github/workflows/nat-topology.yml
+++ b/.github/workflows/nat-topology.yml
@@ -1,0 +1,119 @@
+name: NAT Topology
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "scripts/relay_keygen.go"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "scripts/relay_keygen.go"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  schedule:
+    - cron: "19 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nat-topology-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  simulator_unit:
+    name: NAT Topology Required
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate harness shell syntax
+        run: |
+          bash -n scripts/nat-sim/nat-sim-smoke.sh
+          bash -n scripts/nat-sim/run-topology-scenario.sh
+
+      - name: Validate registered scenarios
+        run: |
+          scenarios="$(bash scripts/nat-sim/run-topology-scenario.sh --list)"
+          test "$(printf '%s\n' "$scenarios" | sed '/^$/d' | sort -u | wc -l)" -eq 6
+          printf '%s\n' "$scenarios"
+
+      - name: Run deterministic simulator tests
+        run: bash scripts/nat-sim/run-topology-scenario.sh simulator-unit
+
+  topology_smoke:
+    name: NAT smoke (${{ matrix.scenario }})
+    if: github.event_name != 'pull_request'
+    needs: simulator_unit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        scenario:
+          - direct-baseline
+          - hard-hard-strict
+          - relay-blackhole
+          - relay-failover
+          - observability-fail-closed
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            libxdo-dev \
+            librsvg2-dev \
+            xdotool \
+            patchelf
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache-dependency-path: server/go.sum
+
+      - name: Run topology scenario
+        run: bash scripts/nat-sim/run-topology-scenario.sh "${{ matrix.scenario }}"
+
+      - name: Upload topology evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-${{ matrix.scenario }}
+          path: ${{ runner.temp }}/p2wlan-nat-${{ matrix.scenario }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/nat-sim/README.md
+++ b/scripts/nat-sim/README.md
@@ -1,0 +1,54 @@
+# Deterministic NAT topology framework
+
+This directory contains the local, deterministic network-topology regression
+used by P2WLAN. It is intentionally separate from real Mini/Air device
+acceptance: loopback simulation is repeatable CI evidence, not proof that every
+carrier or campus NAT behaves the same way.
+
+## Entry points
+
+```bash
+# List registered scenarios.
+bash scripts/nat-sim/run-topology-scenario.sh --list
+
+# Fast simulator and observability unit tests.
+bash scripts/nat-sim/run-topology-scenario.sh simulator-unit
+
+# One complete end-to-end topology.
+bash scripts/nat-sim/run-topology-scenario.sh direct-baseline
+```
+
+The scenario runner is the only CI-facing entry point. It pins seeds, round
+counts, port-stride behavior and time budgets so a named scenario does not
+silently change meaning between runs.
+
+## Scenario contract
+
+| Scenario | Required behavior |
+| --- | --- |
+| `simulator-unit` | STUN encoding, APDM mappings, filtering, loss/reordering and observability parsers remain deterministic. |
+| `direct-baseline` | Two fresh daemons establish and prove bidirectional encrypted Direct traffic through independent NATs. |
+| `hard-hard-strict` | Both endpoint-dependent NATs use non-unit port strides and consumed mappings; fresh mapping, prediction and bounded Birthday probing must still produce a proven Direct path. |
+| `relay-blackhole` | Inter-NAT UDP is impossible while STUN works; Relay is the only usable encrypted path and the business-packet burst is lossless. |
+| `relay-failover` | Killing the confirmed active Relay causes selection, confirmation and business traffic to recover on a second Relay. |
+| `observability-fail-closed` | Missing required status evidence is rejected; the harness must not manufacture an empty success document. |
+
+## CI policy
+
+Pull requests run shell validation and the deterministic Python suite as the
+stable `NAT Topology Required` check. Main-branch changes, the weekly schedule
+and manual dispatch additionally execute every end-to-end scenario. Each smoke
+job writes to a unique artifact directory and uploads its complete evidence,
+including daemon logs, status snapshots, relay metrics and the NAT trace.
+
+The workflow deliberately runs end-to-end jobs only for changes that can affect
+NAT traversal, the daemon, Relay, the control plane or the evidence contract.
+This keeps unrelated UI/documentation pull requests from paying the full
+network-simulation cost.
+
+## Failure handling
+
+A scenario failure is a product or harness failure until its artifact proves
+otherwise. Do not rerun to obtain a green result without first classifying the
+reason code. The failure-injection scenario protects this rule by verifying
+that unavailable or malformed required evidence remains a hard failure.

--- a/scripts/nat-sim/run-topology-scenario.sh
+++ b/scripts/nat-sim/run-topology-scenario.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SMOKE="$ROOT_DIR/scripts/nat-sim/nat-sim-smoke.sh"
+SCENARIO=${1:-}
+
+list_scenarios() {
+  cat <<'EOF'
+simulator-unit
+direct-baseline
+hard-hard-strict
+relay-blackhole
+relay-failover
+observability-fail-closed
+EOF
+}
+
+if [[ "$SCENARIO" == "--list" ]]; then
+  list_scenarios
+  exit 0
+fi
+
+if [[ -z "$SCENARIO" ]]; then
+  echo "usage: bash scripts/nat-sim/run-topology-scenario.sh <scenario>" >&2
+  echo "available scenarios:" >&2
+  list_scenarios >&2
+  exit 2
+fi
+
+artifact_dir() {
+  if [[ -n "${NAT_SIM_ARTIFACT_DIR:-}" ]]; then
+    printf '%s\n' "$NAT_SIM_ARTIFACT_DIR"
+    return
+  fi
+  local run_id=${GITHUB_RUN_ID:-local}
+  local attempt=${GITHUB_RUN_ATTEMPT:-1}
+  printf '%s/p2wlan-nat-%s-%s-%s\n' "${RUNNER_TEMP:-/tmp}" "$SCENARIO" "$run_id" "$attempt"
+}
+
+run_smoke() {
+  local output
+  output=$(artifact_dir)
+  NAT_SIM_ARTIFACT_DIR="$output" \
+    NAT_SIM_RUN_ID="topology-${SCENARIO}-${GITHUB_RUN_ID:-local}" \
+    bash "$SMOKE"
+}
+
+case "$SCENARIO" in
+  simulator-unit)
+    python3 -m unittest -v "$ROOT_DIR/scripts/nat-sim/test_nat_sim.py"
+    ;;
+
+  direct-baseline)
+    MODE=direct \
+    ROUNDS=1 \
+    NAT_SEED_BASE=2026082801 \
+    STEP_A=1 STEP_B=1 \
+    CONSUME_A=0 CONSUME_B=0 \
+    LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+    DIRECT_TIMEOUT_S=60 OVERLAY_TIMEOUT_S=30 \
+    run_smoke
+    ;;
+
+  hard-hard-strict)
+    # Both sides use endpoint-dependent mapping/filtering, deterministic
+    # non-unit port strides and pre-punch allocation consumption. This forces
+    # fresh mapping, prediction and bounded Birthday probing to participate.
+    MODE=direct \
+    ROUNDS=1 \
+    NAT_SEED_BASE=2026082811 \
+    STEP_A=3 STEP_B=5 \
+    CONSUME_A=8 CONSUME_B=11 \
+    LOSS=0 REORDER=0 STRICT_FILTERING=1 \
+    FRESH_MAPPING_PUNCH=1 PREDICTED_CANDIDATES=1 BIRTHDAY_PROBING=1 \
+    SOCKET_POOL=64 \
+    DIRECT_TIMEOUT_S=90 OVERLAY_TIMEOUT_S=30 \
+    run_smoke
+    ;;
+
+  relay-blackhole)
+    # STUN still works, while all inter-NAT UDP is blackholed. Relay must be
+    # the only usable encrypted data path and the burst must be lossless.
+    MODE=relay-only \
+    ROUNDS=1 \
+    NAT_SEED_BASE=2026082821 \
+    OVERLAY_BURST=64 \
+    DIRECT_TIMEOUT_S=30 OVERLAY_TIMEOUT_S=45 \
+    run_smoke
+    ;;
+
+  relay-failover)
+    # Start with two relay candidates, kill the active one after first usable
+    # evidence and require a newly confirmed relay plus recovered overlay.
+    MODE=relay-only \
+    ROUNDS=1 \
+    NAT_SEED_BASE=2026082831 \
+    OVERLAY_BURST=32 \
+    RELAY_COUNT=2 RELAY_FAILOVER=1 \
+    DIRECT_TIMEOUT_S=30 OVERLAY_TIMEOUT_S=60 \
+    run_smoke
+    ;;
+
+  observability-fail-closed)
+    # An unavailable required status endpoint must make the harness fail. A
+    # zero exit here would mean missing evidence was silently accepted.
+    set +e
+    MODE=relay-only \
+    ROUNDS=1 \
+    NAT_SEED_BASE=2026082841 \
+    OVERLAY_BURST=8 \
+    STATUS_FAILURE_INJECTION=1 \
+    DIRECT_TIMEOUT_S=20 OVERLAY_TIMEOUT_S=30 \
+    run_smoke
+    status=$?
+    set -e
+    if [[ "$status" -eq 0 ]]; then
+      echo "observability fail-closed scenario unexpectedly passed" >&2
+      exit 1
+    fi
+    echo "observability fail-closed scenario rejected missing status evidence as expected"
+    ;;
+
+  *)
+    echo "unknown NAT topology scenario: $SCENARIO" >&2
+    echo "available scenarios:" >&2
+    list_scenarios >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 目标

把现有 NAT simulator 从散落的手工入口收敛为可命名、可重复、可产出证据的拓扑回归框架。

## 变更

- 新增 `run-topology-scenario.sh` 作为唯一 CI 场景入口；
- 固定六个场景：simulator unit、Direct baseline、严格 Hard↔Hard、UDP 黑洞 Relay、Relay failover、observability fail-closed；
- 新增 `NAT Topology` workflow；
- PR 跑 shell 校验和确定性 simulator 单测，稳定检查名为 `NAT Topology Required`；
- main、每周定时和手动触发执行完整端到端矩阵；
- 每个端到端场景使用唯一 artifact 目录并始终上传证据；
- 新增框架说明、场景不变量和失败处理规则。

## 验收

- PR `NAT Topology Required` 成功；
- shell 场景注册无重复且数量固定；
- 合并到 main 后五个端到端场景全部成功；
- 失败注入场景必须以“底层 smoke 失败、包装场景成功确认 fail-closed”的方式通过；
- 所有端到端场景均生成证据 artifact。
