### PR TITLE
test(windows): close lifecycle regressions with WER evidence

### DIFF
--- a/.github/workflows/windows-lifecycle.yml
+++ b/.github/workflows/windows-lifecycle.yml
@@ -1,0 +1,125 @@
+name: Windows Lifecycle
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/windows-lifecycle.yml"
+      - "client/daemon/**"
+      - "client/tray/**"
+      - "client/desktop-host/**"
+      - "apps/flutter_client/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/windows-lifecycle.yml"
+      - "client/daemon/**"
+      - "client/tray/**"
+      - "client/desktop-host/**"
+      - "apps/flutter_client/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-lifecycle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lifecycle:
+    name: Windows Lifecycle Required
+    runs-on: windows-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Capture Windows Error Reporting baseline
+        shell: pwsh
+        run: |
+          $baseline = [DateTime]::UtcNow.ToString('o')
+          "P2WLAN_WER_BASELINE=$baseline" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "WER baseline: $baseline"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter dependencies
+        working-directory: apps/flutter_client
+        run: flutter pub get
+
+      - name: Restore Flutter-managed source files
+        shell: bash
+        run: bash scripts/release/hermetic_build.sh restore
+
+      - name: Formatting gates
+        shell: bash
+        run: |
+          cargo fmt --all --check
+          cd apps/flutter_client
+          dart format --output=none --set-exit-if-changed test/windows_daemon_lifecycle_integration_test.dart
+
+      - name: Build release daemon
+        run: cargo build -p p2wlan-daemon --release
+
+      - name: Run Rust lifecycle regression
+        env:
+          P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
+        run: cargo test -p p2wlan-daemon --test windows_lifecycle --release -- --test-threads=1
+
+      - name: Run Flutter process lifecycle regression
+        working-directory: apps/flutter_client
+        env:
+          P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
+        run: flutter test test/windows_daemon_lifecycle_integration_test.dart
+
+      - name: Assert no daemon process leaked
+        if: always()
+        shell: pwsh
+        run: |
+          $leaked = @(Get-Process -Name 'p2wlan-daemon' -ErrorAction SilentlyContinue)
+          if ($leaked.Count -gt 0) {
+            $leaked | Format-Table Id, ProcessName, StartTime -AutoSize
+            Stop-Process -Id ($leaked | Select-Object -ExpandProperty Id) -Force -ErrorAction SilentlyContinue
+            throw "p2wlan-daemon process leaked after lifecycle tests"
+          }
+          Write-Host 'No p2wlan-daemon process leaked.'
+
+      - name: Assert no new Windows crash or BEX event
+        if: always()
+        shell: pwsh
+        run: |
+          $start = [DateTime]::Parse($env:P2WLAN_WER_BASELINE).ToLocalTime()
+          $events = @(Get-WinEvent -FilterHashtable @{ LogName = 'Application'; StartTime = $start } -ErrorAction SilentlyContinue |
+            Where-Object {
+              $_.Id -in @(1000, 1001) -and
+              ($_.Message -match '(?i)p2wlan-(daemon|desktop|flutter_client).*\.exe|(?i)BEX64')
+            } |
+            Select-Object TimeCreated, Id, ProviderName, LevelDisplayName, Message)
+          $events | ConvertTo-Json -Depth 4 | Set-Content -Path windows-lifecycle-events.json -Encoding utf8
+          if ($events.Count -gt 0) {
+            $events | Format-List
+            throw "Windows recorded a P2WLAN crash/BEX event during lifecycle tests"
+          }
+          Write-Host 'No P2WLAN crash or BEX event was recorded.'
+
+      - name: Upload lifecycle evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-lifecycle-evidence
+          path: windows-lifecycle-events.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/apps/flutter_client/test/windows_daemon_lifecycle_integration_test.dart
+++ b/apps/flutter_client/test/windows_daemon_lifecycle_integration_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String? _daemonPath() {
+  final configured = Platform.environment['P2WLAN_DAEMON_BIN'];
+  if (configured != null && configured.trim().isNotEmpty) {
+    return configured;
+  }
+  const fallback = '../../target/release/p2wlan-daemon.exe';
+  return File(fallback).existsSync() ? fallback : null;
+}
+
+Future<ProcessResult> _runDaemon(String daemon, List<String> arguments) async {
+  final result = await Process.run(
+    daemon,
+    arguments,
+    stdoutEncoding: utf8,
+    stderrEncoding: utf8,
+  ).timeout(const Duration(seconds: 20));
+  expect(
+    result.exitCode,
+    0,
+    reason: 'daemon lifecycle command failed\n'
+        'args=$arguments\nstdout=${result.stdout}\nstderr=${result.stderr}',
+  );
+  return result;
+}
+
+void main() {
+  test(
+    'release daemon survives repeated probe startup and clean exit',
+    () async {
+      final daemon = _daemonPath();
+      expect(daemon, isNotNull, reason: 'P2WLAN_DAEMON_BIN was not provided');
+
+      final seenPids = <int>{};
+      for (var cycle = 0; cycle < 12; cycle++) {
+        final result = await _runDaemon(daemon!, const ['--binary-probe']);
+        final payload = jsonDecode(result.stdout as String) as Map<String, dynamic>;
+        expect(payload['status'], 'ok', reason: 'cycle=$cycle payload=$payload');
+        expect(payload['protocol_version'], 1);
+        final pid = payload['pid'] as int?;
+        expect(pid, isNotNull);
+        expect(pid, greaterThan(0));
+        expect(seenPids.add(pid!), isTrue, reason: 'cycle=$cycle reused pid=$pid');
+      }
+    },
+    skip: !Platform.isWindows,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'release daemon tray source drains and exits cleanly across cycles',
+    () async {
+      final daemon = _daemonPath();
+      expect(daemon, isNotNull, reason: 'P2WLAN_DAEMON_BIN was not provided');
+
+      for (var cycle = 0; cycle < 8; cycle++) {
+        final event = jsonEncode({
+          'event_type': 'status',
+          'sequence': cycle + 1,
+          'emitted_at_ms': 1700000000000 + cycle,
+          'connection_generation': cycle + 100,
+          'payload': {'state': 'stopping', 'cycle': cycle},
+        });
+        final result = await _runDaemon(daemon!, [
+          '--test-tray-event-source',
+          '--test-tray-event',
+          event,
+          '--test-tray-event-count',
+          '3',
+          '--test-tray-event-delay-ms',
+          '2',
+        ]);
+        final lines = const LineSplitter()
+            .convert(result.stdout as String)
+            .where((line) => line.trim().isNotEmpty)
+            .toList(growable: false);
+        expect(lines, hasLength(3), reason: 'cycle=$cycle lines=$lines');
+        for (var index = 0; index < lines.length; index++) {
+          final envelope = jsonDecode(lines[index]) as Map<String, dynamic>;
+          final emitted = envelope['event'] as Map<String, dynamic>;
+          expect(emitted['sequence'], cycle + index + 1);
+          expect(emitted['connection_generation'], cycle + 100);
+        }
+      }
+    },
+    skip: !Platform.isWindows,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}

--- a/client/daemon/tests/windows_lifecycle.rs
+++ b/client/daemon/tests/windows_lifecycle.rs
@@ -1,0 +1,124 @@
+#![cfg(target_os = "windows")]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+const PROBE_CYCLES: u64 = 20;
+const TRAY_SOURCE_CYCLES: u64 = 12;
+
+fn daemon_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("P2WLAN_DAEMON_BIN") {
+        return PathBuf::from(path);
+    }
+    if let Some(path) = option_env!("CARGO_BIN_EXE_p2wlan-daemon") {
+        return PathBuf::from(path);
+    }
+    panic!("P2WLAN_DAEMON_BIN or CARGO_BIN_EXE_p2wlan-daemon is required");
+}
+
+fn run_daemon(args: &[String]) -> Output {
+    let output = Command::new(daemon_path())
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to start p2wlan-daemon: {error}"));
+    assert!(
+        output.status.success(),
+        "daemon lifecycle probe failed: status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+#[test]
+fn windows_binary_probe_repeated_start_exit_is_clean() {
+    for cycle in 0..PROBE_CYCLES {
+        let output = run_daemon(&["--binary-probe".to_string()]);
+        let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "cycle {cycle} returned invalid probe JSON: {error}; stdout={}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        });
+        assert_eq!(value["status"], "ok", "cycle {cycle}: {value}");
+        assert_eq!(value["protocol_version"], 1, "cycle {cycle}: {value}");
+        assert!(
+            value["pid"].as_u64().is_some_and(|pid| pid > 0),
+            "cycle {cycle} did not report a process id: {value}"
+        );
+    }
+}
+
+#[test]
+fn windows_tray_event_source_repeated_start_exit_is_clean() {
+    for cycle in 0..TRAY_SOURCE_CYCLES {
+        let event = json!({
+            "event_type": "status",
+            "sequence": cycle + 1,
+            "emitted_at_ms": 1_700_000_000_000u64 + cycle,
+            "connection_generation": cycle + 10,
+            "payload": {
+                "cycle": cycle,
+                "state": "stopping"
+            }
+        });
+        let args = vec![
+            "--test-tray-event-source".to_string(),
+            "--test-tray-event".to_string(),
+            event.to_string(),
+            "--test-tray-event-count".to_string(),
+            "1".to_string(),
+            "--test-tray-event-delay-ms".to_string(),
+            "1".to_string(),
+        ];
+        let output = run_daemon(&args);
+        let lines = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1, "cycle {cycle}: {lines:?}");
+        let envelope: Value = serde_json::from_str(&lines[0])
+            .unwrap_or_else(|error| panic!("cycle {cycle} returned invalid event JSON: {error}"));
+        assert_eq!(
+            envelope["event"]["sequence"],
+            cycle + 1,
+            "cycle {cycle}: {envelope}"
+        );
+    }
+}
+
+#[test]
+fn windows_tray_event_source_drains_bounded_sequence_before_exit() {
+    let event = json!({
+        "event_type": "status",
+        "sequence": 77,
+        "emitted_at_ms": 1_700_000_000_077u64,
+        "connection_generation": 7,
+        "payload": {"state": "running"}
+    });
+    let count = 8u64;
+    let args = vec![
+        "--test-tray-event-source".to_string(),
+        "--test-tray-event".to_string(),
+        event.to_string(),
+        "--test-tray-event-count".to_string(),
+        count.to_string(),
+        "--test-tray-event-delay-ms".to_string(),
+        Duration::from_millis(2).as_millis().to_string(),
+    ];
+    let output = run_daemon(&args);
+    let envelopes = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("tray source must emit JSON lines"))
+        .collect::<Vec<_>>();
+    assert_eq!(envelopes.len(), count as usize);
+    for (index, envelope) in envelopes.iter().enumerate() {
+        assert_eq!(envelope["event"]["sequence"], 77 + index as u64);
+    }
+}


### PR DESCRIPTION
## 目标

收口 Windows 启动/退出链路，避免旧版本曾出现的退出期 BEX64/WER 崩溃重新进入发布包。

## 变更

- Rust integration test：release daemon `--binary-probe` 20 轮启动退出；
- Rust integration test：托盘事件源重复启动、有限序列 drain 后退出；
- Flutter integration test：通过真实 Windows release daemon 做多轮进程生命周期回归；
- 新增独立 `Windows Lifecycle Required` workflow；
- Action 记录测试起始时间，完成后检查残留 `p2wlan-daemon.exe`；
- Action 检查 Application Event Log 中新增的 Event 1000/1001、P2WLAN crash 或 BEX64；
- 始终上传生命周期事件证据。

## 验收

- Rust 与 Flutter 生命周期测试全部成功；
- 不存在遗留 daemon 进程；
- 测试窗口内没有 P2WLAN WER/BEX 事件；
- 原 CI、Flutter、Package Test Builds 不回归；
- 合并 main 后 `Windows Lifecycle Required` 再次成功，随后给 issue #1 补证据并关闭。
