### PR TITLE
test(nat): add stable pull-request topology gate

### DIFF
--- a/.github/workflows/nat-topology-gate.yml
+++ b/.github/workflows/nat-topology-gate.yml
@@ -1,0 +1,170 @@
+name: NAT Topology Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology-gate.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology-gate.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  schedule:
+    - cron: "23 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nat-topology-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit:
+    name: NAT simulator unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Run simulator parser and unit tests
+        run: bash scripts/nat-sim/run-ci-topology.sh unit
+      - name: Upload unit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-unit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/p2wlan-nat-topology-*.log
+          if-no-files-found: error
+          retention-days: 14
+
+  direct:
+    name: Direct cold-start topology
+    needs: unit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Run deterministic Direct topology
+        run: bash scripts/nat-sim/run-ci-topology.sh direct
+      - name: Upload Direct evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-direct-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  relay:
+    name: Relay blackhole topology
+    needs: direct
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Run deterministic Relay topology
+        run: bash scripts/nat-sim/run-ci-topology.sh relay
+      - name: Upload Relay evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  fail_closed:
+    name: Observability fail-closed injection
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: relay
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Prove missing status evidence fails closed
+        run: bash scripts/nat-sim/run-ci-topology.sh fail-closed
+      - name: Upload failure-injection evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-fail-closed-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  required:
+    name: NAT Topology Required
+    if: always()
+    needs: [unit, direct, relay]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce required topology results
+        run: |
+          test "${{ needs.unit.result }}" = "success"
+          test "${{ needs.direct.result }}" = "success"
+          test "${{ needs.relay.result }}" = "success"
+          echo "all required NAT topology profiles succeeded"

--- a/scripts/nat-sim/run-ci-topology.sh
+++ b/scripts/nat-sim/run-ci-topology.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Stable CI entry point for the deterministic NAT simulator.
+#
+# The simulator and acceptance logic live in nat-sim-smoke.sh.  This wrapper
+# deliberately keeps the required PR profiles conservative and reproducible:
+# one cold-start round, deterministic seeds, no injected loss/reordering, and
+# bounded but generous convergence windows.  More aggressive fault profiles
+# remain available through the smoke harness and scheduled/manual runs.
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SMOKE="$ROOT_DIR/scripts/nat-sim/nat-sim-smoke.sh"
+PROFILE=${1:-unit}
+RUN_ID=${GITHUB_RUN_ID:-local-$$}
+RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
+ARTIFACT_PARENT=${NAT_TOPOLOGY_ARTIFACT_ROOT:-${RUNNER_TEMP:-/tmp}}
+ARTIFACT_DIR="$ARTIFACT_PARENT/p2wlan-nat-topology-${RUN_ID}-${RUN_ATTEMPT}-${PROFILE}"
+LOG_FILE="${ARTIFACT_DIR}.log"
+RUN_NAME="nat-ci-${PROFILE}-${RUN_ID}-${RUN_ATTEMPT}"
+
+mkdir -p "$ARTIFACT_PARENT"
+if [[ -e "$ARTIFACT_DIR" || -e "$LOG_FILE" ]]; then
+  echo "[nat-ci] refusing to reuse artifact path: $ARTIFACT_DIR" >&2
+  exit 2
+fi
+
+run_smoke() {
+  local expected=$1
+  shift
+  local status
+
+  set +e
+  timeout --signal=TERM --kill-after=30s 20m \
+    env \
+      NETWORK_ID=default \
+      ROUNDS=1 \
+      NAT_SEED_BASE=20260828 \
+      NAT_SIM_RUN_ID="$RUN_NAME" \
+      NAT_SIM_ARTIFACT_DIR="$ARTIFACT_DIR" \
+      NAT_SIM_RUST_LOG=info \
+      "$@" \
+      bash "$SMOKE" 2>&1 | tee "$LOG_FILE"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$expected" == success ]]; then
+    if [[ "$status" -ne 0 ]]; then
+      echo "[nat-ci] profile=$PROFILE failed status=$status log=$LOG_FILE artifacts=$ARTIFACT_DIR" >&2
+      return "$status"
+    fi
+    echo "[nat-ci] profile=$PROFILE PASS log=$LOG_FILE artifacts=$ARTIFACT_DIR"
+    return 0
+  fi
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "[nat-ci] profile=$PROFILE unexpectedly succeeded" >&2
+    return 1
+  fi
+  if ! grep -Eq 'reason_code=status_(http_500_injected|unavailable|schema_invalid)' "$LOG_FILE"; then
+    echo "[nat-ci] profile=$PROFILE failed without the expected fail-closed reason" >&2
+    return 1
+  fi
+  echo "[nat-ci] profile=$PROFILE PASS expected_failure_status=$status"
+}
+
+case "$PROFILE" in
+  unit)
+    bash -n "$SMOKE"
+    python3 -m unittest discover \
+      -s "$ROOT_DIR/scripts/nat-sim" \
+      -p 'test_nat_sim.py' \
+      -v 2>&1 | tee "$LOG_FILE"
+    ;;
+  direct)
+    run_smoke success \
+      MODE=direct \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=90 \
+      OVERLAY_TIMEOUT_S=60 \
+      OVERLAY_BURST=32
+    ;;
+  relay)
+    run_smoke success \
+      MODE=relay-only \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=60 \
+      OVERLAY_TIMEOUT_S=90 \
+      OVERLAY_BURST=64 \
+      RELAY_COUNT=1
+    ;;
+  fail-closed)
+    run_smoke failure \
+      MODE=relay-only \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=60 \
+      OVERLAY_TIMEOUT_S=90 \
+      OVERLAY_BURST=16 \
+      RELAY_COUNT=1 \
+      STATUS_FAILURE_INJECTION=1
+    ;;
+  *)
+    echo "usage: $0 {unit|direct|relay|fail-closed}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 目标

用现有成熟 NAT simulator 建立真正阻断 PR 的稳定拓扑门禁，不重复实现模拟器内部。

## 变更

- 新增 `scripts/nat-sim/run-ci-topology.sh`，提供 `unit/direct/relay/fail-closed` 固定 profile；
- Direct 使用默认可复现双 NAT、无丢包/乱序、单轮冷启动和更长收敛窗口；
- Relay 使用确定性 UDP blackhole，要求加密 Relay overlay 和连续 burst 成功；
- PR 依次执行 unit → Direct → Relay，避免并发冷启动相互放大资源抖动；
- 增加稳定聚合状态 `NAT Topology Required`；
- scheduled/manual 额外验证 status 证据缺失必须 fail closed；
- 每个 profile 无论成功失败都上传日志、status、timeline 和 NAT trace artifact。

## 验收

- `NAT simulator unit tests` 成功；
- `Direct cold-start topology` 成功；
- `Relay blackhole topology` 成功；
- `NAT Topology Required` 成功；
- head SHA 与被验收 Actions SHA 一致。

## 取代方案

该 PR 是 #16/#19 首轮方案失败后的重派版本：去掉过于激进的 PR 基线参数，同时把完整拓扑保留在 PR 门禁中。