### PR TITLE
test(nat): preserve topology evidence in required CI gate

### DIFF
--- a/.github/workflows/nat-topology-gate.yml
+++ b/.github/workflows/nat-topology-gate.yml
@@ -1,0 +1,170 @@
+name: NAT Topology Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology-gate.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nat-topology-gate.yml"
+      - "scripts/nat-sim/**"
+      - "scripts/diagnostics-auth.sh"
+      - "client/nat/**"
+      - "client/daemon/**"
+      - "client/relay/**"
+      - "server/**"
+      - "contracts/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  schedule:
+    - cron: "23 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nat-topology-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit:
+    name: NAT simulator unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Run simulator parser and unit tests
+        run: bash scripts/nat-sim/run-ci-topology.sh unit
+      - name: Upload unit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-unit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/p2wlan-nat-topology-*.log
+          if-no-files-found: error
+          retention-days: 14
+
+  direct:
+    name: Direct cold-start topology
+    needs: unit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Run deterministic Direct topology
+        run: bash scripts/nat-sim/run-ci-topology.sh direct
+      - name: Upload Direct evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-direct-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  relay:
+    name: Relay blackhole topology
+    needs: direct
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Run deterministic Relay topology
+        run: bash scripts/nat-sim/run-ci-topology.sh relay
+      - name: Upload Relay evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  fail_closed:
+    name: Observability fail-closed injection
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: relay
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Prove missing status evidence fails closed
+        run: bash scripts/nat-sim/run-ci-topology.sh fail-closed
+      - name: Upload failure-injection evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nat-topology-fail-closed-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/p2wlan-nat-topology-*.log
+            ${{ runner.temp }}/p2wlan-nat-topology-*/**
+          if-no-files-found: error
+          retention-days: 14
+
+  required:
+    name: NAT Topology Required
+    if: always()
+    needs: [unit, direct, relay]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce required topology results
+        run: |
+          test "${{ needs.unit.result }}" = "success"
+          test "${{ needs.direct.result }}" = "success"
+          test "${{ needs.relay.result }}" = "success"
+          echo "all required NAT topology profiles succeeded"

--- a/.github/workflows/task-acceptance-nat-v3.yml
+++ b/.github/workflows/task-acceptance-nat-v3.yml
@@ -1,0 +1,91 @@
+name: Task Acceptance - NAT v3
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  actions: read
+
+concurrency:
+  group: task-acceptance-nat-v3-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  accept:
+    name: NAT v3 acceptance and merge
+    if: github.head_ref == 'test/nat-topology-gate-v3-20260828'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Wait for the complete acceptance set
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(
+            "CI Required"
+            "NAT Topology Required"
+            "Analyze and Test"
+            "Android arm64 Release APK"
+            "Linux x64 Release Bundle"
+            "macOS Release Apps"
+            "Windows x64 Release Bundle"
+            "iOS Compile"
+            "macOS arm64 test DMG"
+            "Android arm64 test APK"
+          )
+
+          for attempt in $(seq 1 120); do
+            checks="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+              --jq '.check_runs | map({name, status, conclusion})')"
+
+            failed=0
+            pending=0
+            for name in "${required[@]}"; do
+              state="$(jq -r --arg name "$name" '
+                [.[] | select(.name == $name)]
+                | if length == 0 then "missing"
+                  elif any(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "stale") then "failed"
+                  elif any(.status != "completed") then "pending"
+                  elif any(.conclusion == "success") then "success"
+                  else "pending" end
+              ' <<<"$checks")"
+              printf '%-36s %s\n' "$name" "$state"
+              case "$state" in
+                failed) failed=1 ;;
+                missing|pending) pending=1 ;;
+              esac
+            done
+
+            if [[ "$failed" -ne 0 ]]; then
+              echo "acceptance failed for $HEAD_SHA" >&2
+              exit 1
+            fi
+            if [[ "$pending" -eq 0 ]]; then
+              echo "complete acceptance set passed for $HEAD_SHA"
+              exit 0
+            fi
+            sleep 30
+          done
+
+          echo "acceptance checks did not converge for $HEAD_SHA" >&2
+          exit 1
+
+      - name: Verify PR still points at the accepted SHA
+        run: |
+          set -euo pipefail
+          current="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"
+          test "$current" = "$HEAD_SHA"
+
+      - name: Merge accepted NAT topology task
+        run: gh pr merge "$PR" --repo "$REPO" --merge --match-head-commit "$HEAD_SHA"

--- a/client/daemon/NAT_TOPOLOGY_CI.md
+++ b/client/daemon/NAT_TOPOLOGY_CI.md
@@ -1,0 +1,20 @@
+# NAT topology CI contract
+
+`NAT Topology Required` reuses `scripts/nat-sim/nat-sim-smoke.sh` and adds a
+stable pull-request entry point in `scripts/nat-sim/run-ci-topology.sh`.
+
+Required pull-request profiles execute serially:
+
+1. simulator/parser unit tests;
+2. one deterministic cold-start Direct topology;
+3. one deterministic UDP-blackhole topology that must carry encrypted overlay
+   traffic through Relay.
+
+The wrapper preserves the smoke harness' module-level DEBUG evidence filters.
+Those records are part of the acceptance contract: hiding them with a global
+`info` override can make a real path indistinguishable from missing evidence.
+Every profile writes a unique log/artifact directory and the aggregate gate
+rejects failed, cancelled or skipped required profiles.
+
+Scheduled/manual runs additionally inject an unavailable status surface and
+must fail closed instead of treating absent diagnostics as success.

--- a/scripts/nat-sim/run-ci-topology.sh
+++ b/scripts/nat-sim/run-ci-topology.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Stable CI entry point for the deterministic NAT simulator.
+#
+# The simulator and acceptance logic live in nat-sim-smoke.sh. This wrapper
+# keeps required PR profiles conservative and reproducible while preserving
+# the smoke harness' default module-level DEBUG filters: its acceptance gate
+# intentionally consumes those structured timeline/overlay evidence records.
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SMOKE="$ROOT_DIR/scripts/nat-sim/nat-sim-smoke.sh"
+PROFILE=${1:-unit}
+RUN_ID=${GITHUB_RUN_ID:-local-$$}
+RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
+ARTIFACT_PARENT=${NAT_TOPOLOGY_ARTIFACT_ROOT:-${RUNNER_TEMP:-/tmp}}
+ARTIFACT_DIR="$ARTIFACT_PARENT/p2wlan-nat-topology-${RUN_ID}-${RUN_ATTEMPT}-${PROFILE}"
+LOG_FILE="${ARTIFACT_DIR}.log"
+RUN_NAME="nat-ci-${PROFILE}-${RUN_ID}-${RUN_ATTEMPT}"
+
+mkdir -p "$ARTIFACT_PARENT"
+if [[ -e "$ARTIFACT_DIR" || -e "$LOG_FILE" ]]; then
+  echo "[nat-ci] refusing to reuse artifact path: $ARTIFACT_DIR" >&2
+  exit 2
+fi
+
+run_smoke() {
+  local expected=$1
+  shift
+  local status
+
+  set +e
+  timeout --signal=TERM --kill-after=30s 20m \
+    env \
+      NETWORK_ID=default \
+      ROUNDS=1 \
+      NAT_SEED_BASE=20260828 \
+      NAT_SIM_RUN_ID="$RUN_NAME" \
+      NAT_SIM_ARTIFACT_DIR="$ARTIFACT_DIR" \
+      "$@" \
+      bash "$SMOKE" 2>&1 | tee "$LOG_FILE"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$expected" == success ]]; then
+    if [[ "$status" -ne 0 ]]; then
+      echo "[nat-ci] profile=$PROFILE failed status=$status log=$LOG_FILE artifacts=$ARTIFACT_DIR" >&2
+      return "$status"
+    fi
+    echo "[nat-ci] profile=$PROFILE PASS log=$LOG_FILE artifacts=$ARTIFACT_DIR"
+    return 0
+  fi
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "[nat-ci] profile=$PROFILE unexpectedly succeeded" >&2
+    return 1
+  fi
+  if ! grep -Eq 'reason_code=status_(http_500_injected|unavailable|schema_invalid)' "$LOG_FILE"; then
+    echo "[nat-ci] profile=$PROFILE failed without the expected fail-closed reason" >&2
+    return 1
+  fi
+  echo "[nat-ci] profile=$PROFILE PASS expected_failure_status=$status"
+}
+
+case "$PROFILE" in
+  unit)
+    bash -n "$SMOKE"
+    python3 -m unittest discover \
+      -s "$ROOT_DIR/scripts/nat-sim" \
+      -p 'test_nat_sim.py' \
+      -v 2>&1 | tee "$LOG_FILE"
+    ;;
+  direct)
+    run_smoke success \
+      MODE=direct \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=90 \
+      OVERLAY_TIMEOUT_S=60 \
+      OVERLAY_BURST=32
+    ;;
+  relay)
+    run_smoke success \
+      MODE=relay-only \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=60 \
+      OVERLAY_TIMEOUT_S=90 \
+      OVERLAY_BURST=64 \
+      RELAY_COUNT=1
+    ;;
+  fail-closed)
+    run_smoke failure \
+      MODE=relay-only \
+      STEP_A=1 STEP_B=1 \
+      CONSUME_A=0 CONSUME_B=0 \
+      LOSS=0 REORDER=0 STRICT_FILTERING=0 \
+      DIRECT_TIMEOUT_S=60 \
+      OVERLAY_TIMEOUT_S=90 \
+      OVERLAY_BURST=16 \
+      RELAY_COUNT=1 \
+      STATUS_FAILURE_INJECTION=1
+    ;;
+  *)
+    echo "usage: $0 {unit|direct|relay|fail-closed}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 重派原因

#21 的 wrapper 将 `NAT_SIM_RUST_LOG` 覆盖为纯 `info`，而既有 NAT smoke 的通过条件会读取模块级 DEBUG timeline/overlay 证据；路径可能真实建立但验收证据被 wrapper 自己过滤。该分支从当前 `main` 重新创建，不叠加失败分支历史。

## 变更

- 保留现有 `nat-sim-smoke.sh` 的默认证据级别；
- PR 串行执行 unit → Direct → Relay；
- Direct 使用默认线性 NAT、单轮冷启动和 90 秒收敛窗；
- Relay 使用确定性 UDP blackhole 和 64 包加密 overlay burst；
- 统一上传完整 artifact；
- 聚合状态固定为 `NAT Topology Required`；
- scheduled/manual 额外执行 fail-closed 注入。

## 验收

四个 PR 必需 job 全部成功且 Actions SHA 与 head SHA 一致后才允许合并。