### PR TITLE
fix(peer): close path state machine acceptance gaps

### DIFF
--- a/.github/workflows/path-state-machine-required.yml
+++ b/.github/workflows/path-state-machine-required.yml
@@ -1,6 +1,8 @@
 name: Path State Machine
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     paths:

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -93,6 +93,11 @@ pub struct Daemon {
     /// outbound path can wait event-driven for a relay to come up instead of
     /// polling at a fixed interval.
     relay_available_tx: watch::Sender<bool>,
+    /// Shared event edge for forced Relay probing and encrypted-session
+    /// maintenance. A bounded initiator connection-writer timeout bumps this
+    /// edge after cancelling its reservation, so the failed setup is retried
+    /// by the normal maintenance owner instead of remaining silently lost.
+    path_setup_kick_tx: watch::Sender<u64>,
     /// Android's VpnService establishes the TUN before the Rust daemon starts.
     #[cfg(target_os = "android")]
     android_tun_fd: Option<std::os::fd::RawFd>,
@@ -171,6 +176,7 @@ impl Daemon {
 
         let udp_transport = Arc::new(RwLock::new(None));
         let (relay_available_tx, _relay_available_rx) = tokio::sync::watch::channel(false);
+        let (path_setup_kick_tx, _path_setup_kick_rx) = tokio::sync::watch::channel(0u64);
 
         // Register the punch-session canceller on the peer manager so a
         // stale/404 quarantined peer's in-flight recovery session is
@@ -239,6 +245,7 @@ impl Daemon {
             timeline,
             status_events,
             relay_available_tx,
+            path_setup_kick_tx,
             #[cfg(target_os = "android")]
             android_tun_fd: None,
             #[cfg(target_os = "android")]

--- a/client/daemon/src/lib/daemon/handshake.rs
+++ b/client/daemon/src/lib/daemon/handshake.rs
@@ -41,6 +41,13 @@ impl HandshakeArbiter {
 const RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: Duration = Duration::from_millis(750);
 const REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: &str =
     "responder_handshake_arbiter_timeout";
+/// A transient connection snapshot may make the initiator's atomic Probe
+/// binding stage contend. This bound is deliberately shorter than the normal
+/// handshake retry cadence: its purpose is to remove the queued writer and
+/// reschedule, not to hide a wedged connection map behind a longer timeout.
+const INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT: Duration = Duration::from_millis(250);
+const REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT: &str =
+    "initiator_probe_binding_writer_timeout";
 
 /// Correlate one control-plane session without writing the raw session token
 /// to logs. This uses the existing local diagnostic fingerprint only; it is

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -442,7 +442,19 @@ impl Daemon {
                     drop(epoch_guard);
                     drop(emit_guard);
 
-                    tokio::select! {
+                    let writer_wait_started = Instant::now();
+                    self.timeline.emit(
+                        "initiator_publish_probe_binding_writer_wait",
+                        None,
+                        Some("connection_writer_contended"),
+                        Some(format!(
+                            "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} timeout_ms={}",
+                            reservation.owner,
+                            INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+                        )),
+                    );
+
+                    let writer_available = tokio::select! {
                         biased;
                         changed = reservation.cancellation.changed() => {
                             if changed.is_err() || *reservation.cancellation.borrow() {
@@ -452,9 +464,54 @@ impl Daemon {
                                     .cancel_reservation_if_current(&peer_id, reservation.owner);
                                 return Ok(None);
                             }
+                            continue;
                         }
-                        () = self.peers.wait_for_probe_session_binding_writer() => {}
+                        available = self.peers.wait_for_probe_session_binding_writer(
+                            INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT,
+                        ) => available
+                    };
+                    if !writer_available {
+                        let wait_ms = writer_wait_started.elapsed().as_millis();
+                        self.pending_handshakes
+                            .lock()
+                            .await
+                            .cancel_reservation_if_current(&peer_id, reservation.owner);
+                        let next_kick = (*self.path_setup_kick_tx.borrow()).wrapping_add(1);
+                        self.path_setup_kick_tx.send_replace(next_kick);
+                        self.timeline.emit(
+                            "initiator_publish_probe_binding_writer_timeout",
+                            None,
+                            Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT),
+                            Some(format!(
+                                "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={wait_ms} timeout_ms={} reschedule_kick={next_kick}",
+                                reservation.owner,
+                                INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+                            )),
+                        );
+                        warn!(
+                            event = "initiator_publish_probe_binding_writer_timeout",
+                            reason_code = REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT,
+                            peer_id = %peer_id,
+                            owner = reservation.owner,
+                            network_generation = handshake_generation,
+                            retry = binding_contentions,
+                            wait_ms,
+                            timeout_ms = INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis(),
+                            reschedule_kick = next_kick,
+                            "Probe binding connection writer remained contended; reservation cancelled and path setup rescheduled"
+                        );
+                        return Ok(None);
                     }
+                    self.timeline.emit(
+                        "initiator_publish_probe_binding_writer_available",
+                        None,
+                        None,
+                        Some(format!(
+                            "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={}",
+                            reservation.owner,
+                            writer_wait_started.elapsed().as_millis()
+                        )),
+                    );
                 }
                 Some(ProbeBindingStage::Staged) => {
                     let inserted = {

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -84,6 +84,136 @@ impl Daemon {
         Some(reservation)
     }
 
+    /// Transfer a contended Probe-binding publication out of the cooperative
+    /// control-event work set. The control loop contains branches that await
+    /// connection-map readers and writers; keeping the first fair writer
+    /// waiter inside that same loop can therefore prevent both the waiter and
+    /// its timeout from ever being polled. This independently scheduled task
+    /// owns no emit, network-epoch, handshake-arbiter, or connection guard.
+    fn defer_initiator_probe_binding_writer_retry(
+        &self,
+        peer_id: String,
+        owner: u64,
+        network_generation: u64,
+        retry: u32,
+        mut cancellation: tokio::sync::watch::Receiver<bool>,
+    ) {
+        let peers = self.peers.clone();
+        let pending_handshakes = self.pending_handshakes.clone();
+        let path_setup_kick_tx = self.path_setup_kick_tx.clone();
+        let timeline = self.timeline.clone();
+
+        timeline.emit(
+            "initiator_publish_probe_binding_writer_wait",
+            None,
+            Some("connection_writer_contended"),
+            Some(format!(
+                "peer={peer_id} owner={owner} generation={network_generation} retry={retry} timeout_ms={}",
+                INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+            )),
+        );
+
+        // The task is intrinsically bounded by the writer timeout. Dropping
+        // the JoinHandle deliberately detaches it from the serial control
+        // loop whose cooperative polling is the condition being avoided.
+        tokio::spawn(async move {
+            if *cancellation.borrow() || cancellation.has_changed().is_err() {
+                return;
+            }
+
+            let writer_wait_started = Instant::now();
+            timeline.emit(
+                "initiator_publish_probe_binding_writer_wait_started",
+                None,
+                Some("connection_writer_contended"),
+                Some(format!(
+                    "peer={peer_id} owner={owner} generation={network_generation} retry={retry} timeout_ms={}",
+                    INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+                )),
+            );
+            let writer_available = tokio::select! {
+                biased;
+                changed = cancellation.changed() => {
+                    let _ = changed;
+                    timeline.emit(
+                        "initiator_publish_probe_binding_writer_wait_cancelled",
+                        None,
+                        Some("initiator_reservation_cancelled"),
+                        Some(format!(
+                            "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={}",
+                            writer_wait_started.elapsed().as_millis()
+                        )),
+                    );
+                    return;
+                }
+                available = peers.wait_for_probe_session_binding_writer(
+                    INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT,
+                ) => available
+            };
+            let wait_ms = writer_wait_started.elapsed().as_millis();
+
+            // Re-check cancellation while obtaining the short reservation
+            // mutex. PeerLeft/network-generation cleanup wins over this old
+            // retry and therefore cannot be followed by a stale kick.
+            let cancelled_current = tokio::select! {
+                biased;
+                changed = cancellation.changed() => {
+                    let _ = changed;
+                    false
+                }
+                mut state = pending_handshakes.lock() => {
+                    state.cancel_reservation_if_current(&peer_id, owner)
+                }
+            };
+            if !cancelled_current {
+                timeline.emit(
+                    "initiator_publish_probe_binding_writer_wait_stale",
+                    None,
+                    Some("initiator_reservation_replaced"),
+                    Some(format!(
+                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} writer_available={writer_available}"
+                    )),
+                );
+                return;
+            }
+
+            let next_kick = (*path_setup_kick_tx.borrow()).wrapping_add(1);
+            path_setup_kick_tx.send_replace(next_kick);
+            if writer_available {
+                timeline.emit(
+                    "initiator_publish_probe_binding_writer_available",
+                    None,
+                    None,
+                    Some(format!(
+                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} reschedule_kick={next_kick}"
+                    )),
+                );
+            } else {
+                timeline.emit(
+                    "initiator_publish_probe_binding_writer_timeout",
+                    None,
+                    Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT),
+                    Some(format!(
+                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} timeout_ms={} reschedule_kick={next_kick}",
+                        INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+                    )),
+                );
+                warn!(
+                    event = "initiator_publish_probe_binding_writer_timeout",
+                    reason_code = REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT,
+                    peer_id = %peer_id,
+                    owner,
+                    network_generation,
+                    retry,
+                    wait_ms,
+                    timeout_ms = INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis(),
+                    reschedule_kick = next_kick,
+                    "Probe binding connection writer remained contended; reservation cancelled and path setup rescheduled"
+                );
+            }
+        });
+    }
+
     /// Complete an initiator handshake after the control event loop has
     /// atomically admitted a reservation for this peer.
     ///
@@ -334,13 +464,14 @@ impl Daemon {
         let peer_id = peer_info.node_id.clone();
         let session_id = new_probe_session_id();
         let (probe_ephemeral, probe_ephemeral_public_key) = new_probe_ephemeral_keypair();
-        let mut binding_contentions = 0u32;
-        let (attempt_no, pending_id) = loop {
+        let binding_contentions = 0u32;
+        let (attempt_no, pending_id) = {
             // The outbound worker establishes the canonical lifecycle order
             // `emit -> generation -> session/connection`. The connection
             // mutation itself is non-blocking while these outer guards are
-            // held; on contention we release both, queue for writer
-            // availability, and revalidate this entire transaction.
+            // held; on contention we release both and transfer a bounded
+            // writer wait to an independent task. Normal maintenance starts a
+            // fresh transaction after that task publishes its retry edge.
             let emit_wait_started = Instant::now();
             self.timeline.emit(
                 "initiator_publish_emit_lock_wait",
@@ -429,7 +560,7 @@ impl Daemon {
             );
             match stage {
                 None => {
-                    binding_contentions = binding_contentions.saturating_add(1);
+                    let binding_contentions = binding_contentions.saturating_add(1);
                     self.timeline.emit(
                         "initiator_publish_probe_binding_contended",
                         None,
@@ -441,77 +572,16 @@ impl Daemon {
                     );
                     drop(epoch_guard);
                     drop(emit_guard);
-
-                    let writer_wait_started = Instant::now();
-                    self.timeline.emit(
-                        "initiator_publish_probe_binding_writer_wait",
-                        None,
-                        Some("connection_writer_contended"),
-                        Some(format!(
-                            "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} timeout_ms={}",
-                            reservation.owner,
-                            INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
-                        )),
+                    reservation.disposition =
+                        HandshakeStartDisposition::ProbeBindingRetryDeferred;
+                    self.defer_initiator_probe_binding_writer_retry(
+                        peer_id.clone(),
+                        reservation.owner,
+                        handshake_generation,
+                        binding_contentions,
+                        reservation.cancellation.clone(),
                     );
-
-                    let writer_available = tokio::select! {
-                        biased;
-                        changed = reservation.cancellation.changed() => {
-                            if changed.is_err() || *reservation.cancellation.borrow() {
-                                self.pending_handshakes
-                                    .lock()
-                                    .await
-                                    .cancel_reservation_if_current(&peer_id, reservation.owner);
-                                return Ok(None);
-                            }
-                            continue;
-                        }
-                        available = self.peers.wait_for_probe_session_binding_writer(
-                            INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT,
-                        ) => available
-                    };
-                    if !writer_available {
-                        let wait_ms = writer_wait_started.elapsed().as_millis();
-                        self.pending_handshakes
-                            .lock()
-                            .await
-                            .cancel_reservation_if_current(&peer_id, reservation.owner);
-                        let next_kick = (*self.path_setup_kick_tx.borrow()).wrapping_add(1);
-                        self.path_setup_kick_tx.send_replace(next_kick);
-                        self.timeline.emit(
-                            "initiator_publish_probe_binding_writer_timeout",
-                            None,
-                            Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT),
-                            Some(format!(
-                                "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={wait_ms} timeout_ms={} reschedule_kick={next_kick}",
-                                reservation.owner,
-                                INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
-                            )),
-                        );
-                        warn!(
-                            event = "initiator_publish_probe_binding_writer_timeout",
-                            reason_code = REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT,
-                            peer_id = %peer_id,
-                            owner = reservation.owner,
-                            network_generation = handshake_generation,
-                            retry = binding_contentions,
-                            wait_ms,
-                            timeout_ms = INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis(),
-                            reschedule_kick = next_kick,
-                            "Probe binding connection writer remained contended; reservation cancelled and path setup rescheduled"
-                        );
-                        return Ok(None);
-                    }
-                    self.timeline.emit(
-                        "initiator_publish_probe_binding_writer_available",
-                        None,
-                        None,
-                        Some(format!(
-                            "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={}",
-                            reservation.owner,
-                            writer_wait_started.elapsed().as_millis()
-                        )),
-                    );
+                    return Ok(None);
                 }
                 Some(ProbeBindingStage::Staged) => {
                     let inserted = {
@@ -570,7 +640,7 @@ impl Daemon {
                     );
                     drop(epoch_guard);
                     drop(emit_guard);
-                    break (attempt_no, pending_id);
+                    (attempt_no, pending_id)
                 }
                 Some(stage) => {
                     drop(epoch_guard);
@@ -749,6 +819,9 @@ impl Daemon {
                 self.start_hole_punch_at(&peer_id, Some(punch_at_ms), None, None)
                     .await;
             }
+            Ok(None)
+                if reservation.disposition
+                    == HandshakeStartDisposition::ProbeBindingRetryDeferred => {}
             Ok(None) if !*reservation.cancellation.borrow() => {
                 self.publish_current_candidates_to_peer(&peer_id, "peer event")
                     .await;

--- a/client/daemon/src/lib/daemon/run.rs
+++ b/client/daemon/src/lib/daemon/run.rs
@@ -339,7 +339,8 @@ impl Daemon {
         // actor when a first business packet starts waiting (or a relay comes
         // up), so the probe fires immediately instead of waiting for the next
         // poll tick.
-        let (relay_probe_kick_tx, relay_probe_kick_rx) = tokio::sync::watch::channel(0u64);
+        let relay_probe_kick_tx = self.path_setup_kick_tx.clone();
+        let relay_probe_kick_rx = relay_probe_kick_tx.subscribe();
         // The probe loop and handshake maintenance each keep their own watch
         // cursor. A first business packet therefore wakes both paths without
         // making either consumer steal the other's notification.

--- a/client/daemon/src/lib/pending_handshake.rs
+++ b/client/daemon/src/lib/pending_handshake.rs
@@ -89,11 +89,18 @@ impl PendingPeerReflexive {
 /// incarnation could then clear a newer reservation after `PeerLeft`/rejoin.
 /// The token and cancellation receiver make the reservation linearizable with
 /// lifecycle cleanup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HandshakeStartDisposition {
+    Active,
+    ProbeBindingRetryDeferred,
+}
+
 struct HandshakeStartReservation {
     owner: u64,
     network_generation: u64,
     peer_session_generation: PeerSessionGeneration,
     cancellation: tokio::sync::watch::Receiver<bool>,
+    disposition: HandshakeStartDisposition,
 }
 
 /// Owner token for the one responder worker admitted for a peer.
@@ -262,6 +269,7 @@ impl PendingHandshakeState {
             network_generation,
             peer_session_generation,
             cancellation,
+            disposition: HandshakeStartDisposition::Active,
         })
     }
 

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -1994,6 +1994,202 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedules_initiator() {
+    let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
+    let daemon = Arc::new(Daemon::new(config));
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let peer_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "peer-relay-snapshot-contention".to_string(),
+        device_name: String::new(),
+        app_version: String::new(),
+        public_key: hex::encode(peer_identity.public_key()),
+        endpoint: String::new(),
+        nat_type: "Unknown".to_string(),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.relay_available_tx.send_replace(true);
+
+    // Reproduce the production startup actor, not a synthetic lock owner: the
+    // forced-Relay target scan has acquired its real connection snapshot when
+    // the initiator reaches atomic Probe-binding publication.
+    let relay_snapshot_gate = Arc::new(crate::peer::RelayProbeSnapshotTestGate::new());
+    daemon.peers.install_relay_probe_snapshot_gate_for_test(
+        &peer_info.node_id,
+        relay_snapshot_gate.clone(),
+    );
+    let relay_peers = daemon.peers.clone();
+    let relay_targets = tokio::spawn(async move { relay_peers.relay_probe_targets().await });
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        relay_snapshot_gate.reached.notified(),
+    )
+    .await
+    .expect("the real relay target snapshot must own the connection reader");
+
+    let mut reschedule_rx = daemon.path_setup_kick_tx.subscribe();
+    let mut reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .await
+        .expect("event initiator reservation must be admitted");
+    let worker_daemon = daemon.clone();
+    let worker_peer = peer_info.clone();
+    let mut worker = tokio::spawn(async move {
+        worker_daemon
+            .run_reserved_initiator_handshake(&worker_peer, &mut reservation)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if daemon
+                .timeline
+                .snapshot()
+                .events
+                .iter()
+                .any(|event| event.event == "initiator_publish_probe_binding_writer_wait")
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("initiator must enter the bounded connection-writer wait");
+
+    // The writer barrier must own no upper guard while queued.
+    let epoch_gate = daemon.peers.network_epoch_gate();
+    let epoch_guard = tokio::time::timeout(Duration::from_millis(100), epoch_gate.lock())
+        .await
+        .expect("writer wait must not retain the network epoch guard");
+    drop(epoch_guard);
+    let emit_guard = tokio::time::timeout(
+        Duration::from_millis(100),
+        daemon
+            .transport
+            .acquire_outbound_emit_guard(&peer_info.node_id),
+    )
+        .await
+        .expect("writer wait must not retain the outbound emit guard");
+    drop(emit_guard);
+
+    // Tokio queues this real status read behind the waiting writer. The old
+    // unbounded barrier left it there until /status returned 503.
+    let status_peers = daemon.peers.clone();
+    let status_peer_id = peer_info.node_id.clone();
+    let mut status_read = tokio::spawn(async move {
+        status_peers.get_connection(&status_peer_id).await
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut status_read)
+            .await
+            .is_err(),
+        "the status reader should initially queue behind the connection writer"
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), reschedule_rx.changed())
+        .await
+        .expect("bounded writer timeout must publish a maintenance reschedule edge")
+        .expect("path-setup reschedule sender must stay live");
+    let first_result = tokio::time::timeout(Duration::from_secs(1), &mut worker)
+        .await
+        .expect("contended initiator must fail within the writer bound")
+        .expect("initiator task must not panic")
+        .expect("bounded contention is a non-fatal initiator outcome");
+    assert_eq!(first_result, None);
+
+    // Cancellation of the timed-out writer removes it from the fair queue;
+    // readers can progress even while the original Relay snapshot is still
+    // deliberately alive.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut status_read)
+            .await
+            .expect("status read must resume when the timed-out writer is removed")
+            .expect("status task must not panic")
+            .is_some()
+    );
+    assert!(
+        !daemon
+            .pending_handshakes
+            .lock()
+            .await
+            .pending
+            .contains_key(&peer_info.node_id),
+        "timed-out publication must cancel its reservation atomically"
+    );
+    let timeout_event = daemon
+        .timeline
+        .snapshot()
+        .events
+        .into_iter()
+        .find(|event| event.event == "initiator_publish_probe_binding_writer_timeout")
+        .expect("timeout must have a structured timeline diagnostic");
+    assert_eq!(
+        timeout_event.reason_code.as_deref(),
+        Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT)
+    );
+    assert!(timeout_event
+        .detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("timeout_ms=250")
+            && detail.contains("reschedule_kick=")));
+
+    relay_snapshot_gate.release.notify_one();
+    let targets = tokio::time::timeout(Duration::from_secs(1), relay_targets)
+        .await
+        .expect("relay target scan must resume")
+        .expect("relay target task must not panic");
+    assert!(targets
+        .iter()
+        .any(|(peer_id, _, _)| peer_id == &peer_info.node_id));
+
+    // Consume the reschedule edge the same way maintenance does: a fresh
+    // reservation succeeds once the real Relay reader has left the map.
+    let mut retry_reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .await
+        .expect("rescheduled initiator must obtain a fresh reservation");
+    let _retry_result = tokio::time::timeout(
+        Duration::from_secs(2),
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut retry_reservation),
+    )
+    .await
+    .expect("rescheduled initiator must not stall");
+    assert!(daemon.timeline.snapshot().events.iter().any(|event| {
+        event.event == "initiator_publish_probe_binding_staged"
+            && event
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains(&peer_info.node_id))
+    }));
+
+    let session_id = {
+        let mut state = daemon.pending_handshakes.lock().await;
+        let session_id = state
+            .pending_session_ids
+            .get(&peer_info.node_id)
+            .cloned();
+        state.remove(&peer_info.node_id);
+        session_id
+    };
+    if let Some(session_id) = session_id {
+        daemon
+            .peers
+            .discard_pending_probe_session_binding(&peer_info.node_id, &session_id)
+            .await;
+    }
+}
+
 #[tokio::test]
 async fn committed_initiator_offer_wait_is_cancelled_when_pending_is_removed() {
     let peer_id = "peer-cancelled-initiator-offer";

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -1920,6 +1920,7 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
     let pending = daemon.pending_handshakes.clone();
     let timeline = daemon.timeline.clone();
     let peer_id = peer_info.node_id.clone();
+    let mut reschedule_rx = daemon.path_setup_kick_tx.subscribe();
 
     // A candidate/connection reader is sufficient to make Probe-binding
     // staging need the connection writer. The old publish path inserted its
@@ -1959,43 +1960,36 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
         .expect("connection contention must not retain the network-epoch guard");
     drop(epoch_guard);
 
-    drop(connection_guard);
-    let _result = tokio::time::timeout(Duration::from_secs(2), worker)
+    let result = tokio::time::timeout(Duration::from_secs(1), worker)
         .await
-        .expect("initiator must retry after the connection writer becomes available")
-        .expect("initiator task must not panic");
+        .expect("contended initiator must leave the cooperative owner immediately")
+        .expect("initiator task must not panic")
+        .expect("connection contention is a non-fatal initiator outcome");
+    assert_eq!(result, None);
 
-    let snapshot = timeline.snapshot();
-    let staged = snapshot
-        .events
-        .iter()
-        .position(|event| event.event == "initiator_publish_probe_binding_staged")
-        .expect("retry must stage the Probe binding");
-    let inserted = snapshot
-        .events
-        .iter()
-        .position(|event| event.event == "initiator_publish_pending_inserted")
-        .expect("retry must commit the pending initiator");
-    assert!(
-        staged < inserted,
-        "Probe binding staging must precede pending-initiator publication"
-    );
-
-    let session_id = {
-        let mut state = pending.lock().await;
-        let session_id = state.pending_session_ids.get(&peer_id).cloned();
-        state.remove(&peer_id);
-        session_id
-    };
-    if let Some(session_id) = session_id {
-        peers
-            .discard_pending_probe_session_binding(&peer_id, &session_id)
-            .await;
-    }
+    drop(connection_guard);
+    tokio::time::timeout(Duration::from_secs(1), reschedule_rx.changed())
+        .await
+        .expect("writer availability must publish a maintenance reschedule edge")
+        .expect("path-setup reschedule sender must stay live");
+    assert!(timeline.snapshot().events.iter().any(|event| {
+        event.event == "initiator_publish_probe_binding_writer_available"
+            && event
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("reschedule_kick="))
+    }));
+    let state = pending.lock().await;
+    assert!(!state.pending.contains_key(&peer_id));
+    assert!(!state.starting.contains(&peer_id));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedules_initiator() {
+async fn relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_and_reschedules_initiator(
+) {
+    use std::future::Future;
+    use std::task::Poll;
+
     let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
     let daemon = Arc::new(Daemon::new(config));
     let local_public = daemon.local_identity().unwrap().public_key();
@@ -2042,30 +2036,67 @@ async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedu
         .reserve_event_initiator_handshake(&peer_info.node_id)
         .await
         .expect("event initiator reservation must be admitted");
-    let worker_daemon = daemon.clone();
-    let worker_peer = peer_info.clone();
-    let mut worker = tokio::spawn(async move {
-        worker_daemon
-            .run_reserved_initiator_handshake(&worker_peer, &mut reservation)
-            .await
-    });
+    let mut worker = Box::pin(
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut reservation),
+    );
 
-    tokio::time::timeout(Duration::from_secs(1), async {
+    // Poll the cooperative slow-work future only until it queues the writer.
+    // The production failure kept the writer and its timeout inside this
+    // future, so its first Pending at this point let a later control-loop
+    // branch wait behind that same writer forever. The fixed future transfers
+    // ownership to an independently scheduled bounded task and is Ready in
+    // the very poll that records contention.
+    let first_result = tokio::time::timeout(Duration::from_secs(1), async {
         loop {
-            if daemon
+            let polled = std::future::poll_fn(|context| {
+                Poll::Ready(worker.as_mut().poll(context))
+            })
+            .await;
+            let writer_scheduled = daemon
                 .timeline
                 .snapshot()
                 .events
                 .iter()
-                .any(|event| event.event == "initiator_publish_probe_binding_writer_wait")
-            {
+                .any(|event| event.event == "initiator_publish_probe_binding_writer_wait");
+            match polled {
+                Poll::Ready(result) => {
+                    assert!(
+                        writer_scheduled,
+                        "initiator completed before exercising writer contention"
+                    );
+                    break result;
+                }
+                Poll::Pending if writer_scheduled => {
+                    panic!(
+                        "cooperative initiator retained the queued writer waiter and its timeout"
+                    );
+                }
+                Poll::Pending => tokio::task::yield_now().await,
+            }
+        }
+    })
+    .await
+    .expect("initiator must reach writer contention")
+    .expect("connection contention is a non-fatal initiator outcome");
+    assert_eq!(first_result, None);
+    drop(worker);
+    assert_eq!(
+        reservation.disposition,
+        HandshakeStartDisposition::ProbeBindingRetryDeferred
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if daemon.timeline.snapshot().events.iter().any(|event| {
+                event.event == "initiator_publish_probe_binding_writer_wait_started"
+            }) {
                 break;
             }
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("initiator must enter the bounded connection-writer wait");
+    .expect("detached writer waiter must start independently");
 
     // The writer barrier must own no upper guard while queued.
     let epoch_gate = daemon.peers.network_epoch_gate();
@@ -2085,29 +2116,32 @@ async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedu
 
     // Tokio queues this real status read behind the waiting writer. The old
     // unbounded barrier left it there until /status returned 503.
-    let status_peers = daemon.peers.clone();
-    let status_peer_id = peer_info.node_id.clone();
-    let mut status_read = tokio::spawn(async move {
-        status_peers.get_connection(&status_peer_id).await
-    });
-    assert!(
-        tokio::time::timeout(Duration::from_millis(50), &mut status_read)
-            .await
-            .is_err(),
-        "the status reader should initially queue behind the connection writer"
-    );
+    let mut status_read = {
+        let queue_deadline = Instant::now() + Duration::from_millis(100);
+        loop {
+            let status_peers = daemon.peers.clone();
+            let status_peer_id = peer_info.node_id.clone();
+            let mut candidate = tokio::spawn(async move {
+                status_peers.get_connection(&status_peer_id).await
+            });
+            if tokio::time::timeout(Duration::from_millis(10), &mut candidate)
+                .await
+                .is_err()
+            {
+                break candidate;
+            }
+            assert!(
+                Instant::now() < queue_deadline,
+                "the detached connection writer never entered Tokio's fair queue"
+            );
+            tokio::task::yield_now().await;
+        }
+    };
 
     tokio::time::timeout(Duration::from_secs(1), reschedule_rx.changed())
         .await
         .expect("bounded writer timeout must publish a maintenance reschedule edge")
         .expect("path-setup reschedule sender must stay live");
-    let first_result = tokio::time::timeout(Duration::from_secs(1), &mut worker)
-        .await
-        .expect("contended initiator must fail within the writer bound")
-        .expect("initiator task must not panic")
-        .expect("bounded contention is a non-fatal initiator outcome");
-    assert_eq!(first_result, None);
-
     // Cancellation of the timed-out writer removes it from the fair queue;
     // readers can progress even while the original Relay snapshot is still
     // deliberately alive.
@@ -2118,15 +2152,16 @@ async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedu
             .expect("status task must not panic")
             .is_some()
     );
+    let state = daemon.pending_handshakes.lock().await;
     assert!(
-        !daemon
-            .pending_handshakes
-            .lock()
-            .await
-            .pending
-            .contains_key(&peer_info.node_id),
+        !state.pending.contains_key(&peer_info.node_id),
+        "timed-out publication must not publish a pending initiator"
+    );
+    assert!(
+        !state.starting.contains(&peer_info.node_id),
         "timed-out publication must cancel its reservation atomically"
     );
+    drop(state);
     let timeout_event = daemon
         .timeline
         .snapshot()
@@ -2188,6 +2223,110 @@ async fn relay_probe_snapshot_contention_times_out_unblocks_readers_and_reschedu
             .discard_pending_probe_session_binding(&peer_info.node_id, &session_id)
             .await;
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn detached_probe_binding_writer_wait_cancels_without_stale_reschedule() {
+    let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
+    let daemon = Arc::new(Daemon::new(config));
+    let peer_identity = NodeIdentity::generate();
+    let peer_info = control::PeerInfo {
+        node_id: "peer-cancelled-detached-writer".to_string(),
+        device_name: String::new(),
+        app_version: String::new(),
+        public_key: hex::encode(peer_identity.public_key()),
+        endpoint: String::new(),
+        nat_type: "Unknown".to_string(),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    daemon.peers.add_peer(&peer_info).await;
+
+    let reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .await
+        .expect("event initiator reservation must be admitted");
+    let connection_guard = daemon
+        .peers
+        .connection_map_for_test()
+        .read_owned()
+        .await;
+    let reschedule_rx = daemon.path_setup_kick_tx.subscribe();
+    daemon.defer_initiator_probe_binding_writer_retry(
+        peer_info.node_id.clone(),
+        reservation.owner,
+        reservation.network_generation,
+        1,
+        reservation.cancellation.clone(),
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if daemon.timeline.snapshot().events.iter().any(|event| {
+                event.event == "initiator_publish_probe_binding_writer_wait_started"
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached writer waiter must start");
+
+    let mut status_read = {
+        let queue_deadline = Instant::now() + Duration::from_millis(100);
+        loop {
+            let status_peers = daemon.peers.clone();
+            let status_peer_id = peer_info.node_id.clone();
+            let mut candidate = tokio::spawn(async move {
+                status_peers.get_connection(&status_peer_id).await
+            });
+            if tokio::time::timeout(Duration::from_millis(10), &mut candidate)
+                .await
+                .is_err()
+            {
+                break candidate;
+            }
+            assert!(
+                Instant::now() < queue_deadline,
+                "the detached connection writer never entered Tokio's fair queue"
+            );
+            tokio::task::yield_now().await;
+        }
+    };
+
+    daemon
+        .pending_handshakes
+        .lock()
+        .await
+        .clear_peer(&peer_info.node_id);
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if daemon.timeline.snapshot().events.iter().any(|event| {
+                event.event == "initiator_publish_probe_binding_writer_wait_cancelled"
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reservation cancellation must wake the detached writer waiter");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut status_read)
+            .await
+            .expect("status read must resume after cancellation removes the writer")
+            .expect("status task must not panic")
+            .is_some()
+    );
+    assert!(
+        matches!(reschedule_rx.has_changed(), Ok(false)),
+        "a cancelled old owner must not publish a path-setup retry"
+    );
+    drop(connection_guard);
 }
 
 #[tokio::test]

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -288,6 +288,27 @@ impl AuthenticatedProbeVerifyGate {
     }
 }
 
+/// Deterministic one-shot pause inside the real Relay target snapshot.  This
+/// is test-only instrumentation for reproducing the startup ordering in which
+/// Relay probing owns a connection reader while initiator publication needs
+/// the writer; production builds contain neither the field nor the branch.
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct RelayProbeSnapshotTestGate {
+    pub(crate) reached: tokio::sync::Notify,
+    pub(crate) release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl RelayProbeSnapshotTestGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            reached: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProbeBindingStage {
     Staged,
@@ -518,7 +539,8 @@ mod path_state_machine;
 pub(crate) use path_state_machine::{
     ActiveBusinessPath, DirectAttemptNumber, DirectCandidateContinuity, DirectValidationIdentity,
     PathEpoch, PathEvent, PathRetention, PathStateMachine, PathStateMachineSnapshot,
-    PathTransitionOutcome, PeerPathLifecycle, RelayConnectionIdentity,
+    PathTransitionOutcome, PeerPathLifecycle, RelayBusinessObservation, RelayConnectionIdentity,
+    RelayHealthObservationIdentity,
 };
 
 include!("peer/connection/core.rs");

--- a/client/daemon/src/peer/connection/core.rs
+++ b/client/daemon/src/peer/connection/core.rs
@@ -560,6 +560,18 @@ impl PeerConnection {
             );
             return outcome;
         }
+        if !outcome.applies_side_effects() {
+            debug!(
+                target: "p2pnet_daemon::peer::path_state_machine",
+                event = "path_transition_duplicate",
+                peer_id = %self.node_id,
+                epoch = ?event_epoch,
+                decision = ?outcome.decision,
+                revision = outcome.snapshot.revision,
+                "ignored duplicate path event without executing side effects"
+            );
+            return outcome;
+        }
 
         // Publish the compatibility projection before the closure so legacy
         // selector helpers observe the newly committed path; the connection

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -34,6 +34,8 @@ impl PeerManager {
             #[cfg(test)]
             authenticated_probe_verify_gate: Arc::new(std::sync::Mutex::new(None)),
             #[cfg(test)]
+            relay_probe_snapshot_test_gate: Arc::new(std::sync::Mutex::new(None)),
+            #[cfg(test)]
             hard_hard_cleanup_gate: Arc::new(std::sync::Mutex::new(None)),
             diagnostics_cache: Arc::new(std::sync::Mutex::new(None)),
             committed_business_paths: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/client/daemon/src/peer/manager/direct_success.rs
+++ b/client/daemon/src/peer/manager/direct_success.rs
@@ -424,6 +424,9 @@ impl PeerManager {
             if !outcome.accepted() {
                 return false;
             }
+            if !outcome.applies_side_effects() {
+                return true;
+            }
             pair_success
         };
         // Direct validation is a background upgrade, not permission to tear

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -1340,9 +1340,18 @@ impl PeerManager {
     /// Queue once for connection-writer availability without retaining the
     /// writer. The initiator calls this only after releasing emit/epoch, then
     /// re-enters and revalidates the full generation transaction before
-    /// retrying the non-blocking stage.
-    pub(crate) async fn wait_for_probe_session_binding_writer(&self) {
-        drop(self.connections.write().await);
+    /// retrying the non-blocking stage. Dropping this future on cancellation
+    /// removes its waiter from Tokio's writer-preferred queue; the explicit
+    /// bound prevents this availability barrier from starving later readers.
+    pub(crate) async fn wait_for_probe_session_binding_writer(
+        &self,
+        max_wait: Duration,
+    ) -> bool {
+        tokio::time::timeout(max_wait, async {
+            drop(self.connections.write().await);
+        })
+        .await
+        .is_ok()
     }
 
     /// Extend a staged responder binding after the control-plane answer

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -1338,11 +1338,11 @@ impl PeerManager {
     }
 
     /// Queue once for connection-writer availability without retaining the
-    /// writer. The initiator calls this only after releasing emit/epoch, then
-    /// re-enters and revalidates the full generation transaction before
-    /// retrying the non-blocking stage. Dropping this future on cancellation
-    /// removes its waiter from Tokio's writer-preferred queue; the explicit
-    /// bound prevents this availability barrier from starving later readers.
+    /// writer. The independently scheduled initiator retry task calls this
+    /// only after the cooperative control-loop future has released every
+    /// upper guard and returned. Dropping this future on cancellation removes
+    /// its waiter from Tokio's writer-preferred queue; the explicit bound
+    /// prevents this availability barrier from starving later readers.
     pub(crate) async fn wait_for_probe_session_binding_writer(
         &self,
         max_wait: Duration,

--- a/client/daemon/src/peer/manager/relay.rs
+++ b/client/daemon/src/peer/manager/relay.rs
@@ -1,4 +1,42 @@
 impl PeerManager {
+    #[cfg(test)]
+    pub(crate) fn install_relay_probe_snapshot_gate_for_test(
+        &self,
+        node_id: &str,
+        gate: Arc<RelayProbeSnapshotTestGate>,
+    ) {
+        *self
+            .relay_probe_snapshot_test_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some((node_id.to_string(), gate));
+    }
+
+    #[cfg(test)]
+    async fn pause_relay_probe_snapshot_for_test(
+        &self,
+        connections: &HashMap<String, PeerConnection>,
+    ) {
+        let gate = {
+            let mut installed = self
+                .relay_probe_snapshot_test_gate
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if installed
+                .as_ref()
+                .is_some_and(|(peer_id, _)| connections.contains_key(peer_id))
+            {
+                installed.take().map(|(_, gate)| gate)
+            } else {
+                None
+            }
+        };
+        if let Some(gate) = gate {
+            gate.reached.notify_one();
+            gate.release.notified().await;
+        }
+    }
+
     /// Whether the peer is direct in a specific generation.
     pub async fn is_direct_for_generation(&self, node_id: &str, generation: u64) -> bool {
         generation == self.current_network_generation().await && self.is_direct(node_id).await
@@ -1344,6 +1382,10 @@ impl PeerManager {
                 generation,
                 ack_connection_id,
                 Some(expectation.peer_session_generation),
+                RelayHealthObservationIdentity {
+                    owner_token: expectation.owner_token,
+                    request_id: expectation.request_id,
+                },
                 relay_rtt,
             )
             .await;
@@ -1362,6 +1404,7 @@ impl PeerManager {
         confirmation_changed || accepted
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn accept_relay_probe_ack_for_current_lifecycle(
         &self,
         node_id: &str,
@@ -1369,6 +1412,7 @@ impl PeerManager {
         generation: u64,
         relay_connection_id: Option<u64>,
         peer_session_generation: Option<PeerSessionGeneration>,
+        observation: RelayHealthObservationIdentity,
         relay_rtt: Option<Duration>,
     ) -> bool {
         let epoch_gate = self.network_epoch_gate();
@@ -1395,10 +1439,23 @@ impl PeerManager {
         if !current {
             return false;
         }
-        if let Some(relay_rtt) = relay_rtt {
-            conn.relay_health.record_success_with_latency(relay_rtt);
-        }
-        true
+        let Some(relay_rtt) = relay_rtt else {
+            return true;
+        };
+        let relay = RelayConnectionIdentity::new(
+            PathEpoch::new(
+                generation,
+                expected_lifecycle,
+                conn.remote_candidate_epoch(),
+            ),
+            relay_endpoint,
+            relay_connection_id,
+        );
+        conn.commit_path_transition(
+            PathEvent::RelayHealthObserved { relay, observation },
+            |conn| conn.relay_health.record_success_with_latency(relay_rtt),
+        )
+        .accepted()
     }
 
     /// Peers that still need a forced-relay probe: online and not yet relay
@@ -1410,10 +1467,10 @@ impl PeerManager {
     /// quarantined/offline.
     pub async fn relay_probe_targets(&self) -> Vec<(String, String, u64)> {
         let generation = self.current_network_generation().await;
-        let candidates: Vec<_> = self
-            .connections
-            .read()
-            .await
+        let connections = self.connections.read().await;
+        #[cfg(test)]
+        self.pause_relay_probe_snapshot_for_test(&connections).await;
+        let candidates: Vec<_> = connections
             .values()
             .filter(|conn| {
                 conn.online
@@ -1422,6 +1479,7 @@ impl PeerManager {
             })
             .map(|conn| (conn.node_id.clone(), conn.virtual_ip.clone(), generation))
             .collect();
+        drop(connections);
         let mut targets = Vec::with_capacity(candidates.len());
         for candidate in candidates {
             if !self.peer_quarantined(&candidate.0).await {
@@ -1635,6 +1693,7 @@ impl PeerManager {
             let outcome = conn.commit_path_transition(
                 PathEvent::RelayBusinessUsable {
                     relay: relay_identity,
+                    observation: RelayBusinessObservation::Sent,
                 },
                 |conn| {
                     conn.relay_first.business_sent_generation = Some(generation);
@@ -1788,6 +1847,7 @@ impl PeerManager {
                 let outcome = conn.commit_path_transition(
                     PathEvent::RelayBusinessUsable {
                         relay: relay_identity,
+                        observation: RelayBusinessObservation::Received,
                     },
                     |conn| {
                         let first_receive =

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -286,6 +286,10 @@ impl RemoteIdentityLedger {
 type AuthenticatedProbeVerifyGateSlot =
     Arc<std::sync::Mutex<Option<(String, Arc<AuthenticatedProbeVerifyGate>)>>>;
 
+#[cfg(test)]
+type RelayProbeSnapshotTestGateSlot =
+    Arc<std::sync::Mutex<Option<(String, Arc<RelayProbeSnapshotTestGate>)>>>;
+
 /// Manages all peer connections.
 pub struct PeerManager {
     /// Active peer connections, indexed by node ID.
@@ -303,6 +307,8 @@ pub struct PeerManager {
     peer_membership: Arc<std::sync::Mutex<PeerMembershipState>>,
     #[cfg(test)]
     authenticated_probe_verify_gate: AuthenticatedProbeVerifyGateSlot,
+    #[cfg(test)]
+    relay_probe_snapshot_test_gate: RelayProbeSnapshotTestGateSlot,
     #[cfg(test)]
     hard_hard_cleanup_gate:
         Arc<std::sync::Mutex<Option<HardHardCleanupGateRegistration>>>,

--- a/client/daemon/src/peer/path_state_machine.rs
+++ b/client/daemon/src/peer/path_state_machine.rs
@@ -6,7 +6,10 @@
 //! with enums instead of another collection of independently mutable flags.
 
 use super::{ConnectionState, NetworkPath, PeerSessionGeneration};
+use std::collections::VecDeque;
 use std::net::SocketAddr;
+
+const MAX_ACCEPTED_HEALTH_OBSERVATIONS: usize = 64;
 
 /// The three independent generations that fence every path event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -185,6 +188,85 @@ pub(crate) struct RelayConnectionIdentity {
     pub(crate) incarnation: RelayConnectionIncarnation,
 }
 
+/// A business packet is an observation in one concrete direction.  Keeping
+/// the direction in the typed event lets a send followed by a receive execute
+/// two distinct side effects even though the first observation already made
+/// Relay the usable path; replaying either direction remains a duplicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayBusinessObservation {
+    Sent,
+    Received,
+}
+
+/// Identity of one periodic Relay health sample.  The token is allocated at
+/// the relay writer boundary and echoed by the ACK, so retries of the same
+/// encrypted observation retain this identity while a later sample gets a
+/// distinct one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RelayHealthObservationIdentity {
+    pub(crate) owner_token: u64,
+    pub(crate) request_id: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathEventReceipt {
+    PeerOnline(PathEpoch),
+    NetworkGenerationAdvanced {
+        epoch: PathEpoch,
+        retained: PathRetention,
+    },
+    RelayPeerConfirmed(RelayConnectionIdentity),
+    RelayBusiness {
+        relay: RelayConnectionIdentity,
+        observation: RelayBusinessObservation,
+    },
+    DirectCommitted(DirectValidationIdentity),
+}
+
+impl PathEventReceipt {
+    fn epoch(&self) -> PathEpoch {
+        match self {
+            Self::PeerOnline(epoch) | Self::NetworkGenerationAdvanced { epoch, .. } => *epoch,
+            Self::RelayPeerConfirmed(relay) | Self::RelayBusiness { relay, .. } => relay.epoch,
+            Self::DirectCommitted(validation) => validation.epoch,
+        }
+    }
+
+    fn is_relay(&self) -> bool {
+        matches!(
+            self,
+            Self::RelayPeerConfirmed(_) | Self::RelayBusiness { .. }
+        )
+    }
+
+    fn remains_current(&self, state: &PathState) -> bool {
+        if state.epoch != Some(self.epoch()) {
+            return false;
+        }
+        match self {
+            Self::PeerOnline(_) | Self::NetworkGenerationAdvanced { .. } => true,
+            Self::RelayPeerConfirmed(receipt) => state
+                .relay
+                .confirmed_identity()
+                .is_some_and(|current| current.same_transport(receipt)),
+            Self::RelayBusiness { relay, .. } => {
+                matches!(&state.relay, RelayPathState::Usable(current) if current.same_transport(relay))
+            }
+            Self::DirectCommitted(receipt) => {
+                matches!(state.direct, DirectPathState::Committed(current) if current == *receipt)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathObservationIdentity {
+    RelayHealth {
+        relay: RelayConnectionIdentity,
+        observation: RelayHealthObservationIdentity,
+    },
+}
+
 impl RelayConnectionIdentity {
     pub(crate) fn new(
         epoch: PathEpoch,
@@ -232,8 +314,7 @@ impl RelayConnectionIdentity {
     }
 }
 
-/// Monotonic retry identity.  Reusing an attempt number is harmless because
-/// duplicate events reduce to a no-op.
+/// Monotonic retry identity used to order one Direct probing/retry cycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DirectAttemptNumber(pub(crate) u64);
 
@@ -293,6 +374,11 @@ pub(crate) enum PathEvent {
     },
     RelayBusinessUsable {
         relay: RelayConnectionIdentity,
+        observation: RelayBusinessObservation,
+    },
+    RelayHealthObserved {
+        relay: RelayConnectionIdentity,
+        observation: RelayHealthObservationIdentity,
     },
     RelayTransportLost {
         relay: RelayConnectionIdentity,
@@ -350,13 +436,51 @@ impl PathEvent {
             | Self::CompatibilityStateRequested { epoch, .. } => Some(*epoch),
             Self::RelayTransportReady { relay }
             | Self::RelayPeerConfirmed { relay }
-            | Self::RelayBusinessUsable { relay }
+            | Self::RelayBusinessUsable { relay, .. }
+            | Self::RelayHealthObserved { relay, .. }
             | Self::RelayTransportLost { relay }
             | Self::RelayPathFailed { relay } => Some(relay.epoch),
             Self::DirectValidationStarted { validation } | Self::DirectCommitted { validation } => {
                 Some(validation.epoch)
             }
             Self::IdentityReset => None,
+        }
+    }
+
+    fn idempotency_receipt(&self) -> Option<PathEventReceipt> {
+        match self {
+            Self::PeerOnline { epoch } => Some(PathEventReceipt::PeerOnline(*epoch)),
+            Self::NetworkGenerationAdvanced { epoch, retained } => {
+                Some(PathEventReceipt::NetworkGenerationAdvanced {
+                    epoch: *epoch,
+                    retained: *retained,
+                })
+            }
+            Self::RelayPeerConfirmed { relay } => {
+                Some(PathEventReceipt::RelayPeerConfirmed(relay.clone()))
+            }
+            Self::RelayBusinessUsable { relay, observation } => {
+                Some(PathEventReceipt::RelayBusiness {
+                    relay: relay.clone(),
+                    observation: *observation,
+                })
+            }
+            Self::DirectCommitted { validation } => {
+                Some(PathEventReceipt::DirectCommitted(*validation))
+            }
+            _ => None,
+        }
+    }
+
+    fn observation_identity(&self) -> Option<PathObservationIdentity> {
+        match self {
+            Self::RelayHealthObserved { relay, observation } => {
+                Some(PathObservationIdentity::RelayHealth {
+                    relay: relay.clone(),
+                    observation: *observation,
+                })
+            }
+            _ => None,
         }
     }
 }
@@ -478,7 +602,8 @@ pub(crate) struct PathState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PathTransitionDecision {
     Applied,
-    Noop,
+    AcceptedObservation,
+    Duplicate,
     RejectedNetworkGeneration,
     RejectedPeerSessionGeneration,
     RejectedRemoteCandidateEpoch,
@@ -491,7 +616,14 @@ pub(crate) enum PathTransitionDecision {
 
 impl PathTransitionDecision {
     pub(crate) fn accepted(self) -> bool {
-        matches!(self, Self::Applied | Self::Noop)
+        matches!(
+            self,
+            Self::Applied | Self::AcceptedObservation | Self::Duplicate
+        )
+    }
+
+    pub(crate) fn applies_side_effects(self) -> bool {
+        matches!(self, Self::Applied | Self::AcceptedObservation)
     }
 }
 
@@ -519,6 +651,9 @@ pub(crate) struct PathTransition {
     decision: PathTransitionDecision,
     next: PathState,
     actions: Vec<PathAction>,
+    receipt: Option<PathEventReceipt>,
+    observation: Option<PathObservationIdentity>,
+    clear_relay_receipts: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -540,6 +675,10 @@ impl PathTransitionOutcome {
     pub(crate) fn accepted(&self) -> bool {
         self.decision.accepted()
     }
+
+    pub(crate) fn applies_side_effects(&self) -> bool {
+        self.decision.applies_side_effects()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -547,6 +686,8 @@ pub(crate) struct PathStateMachine {
     state: PathState,
     revision: u64,
     rejected_transitions: u64,
+    accepted_event_receipts: Vec<PathEventReceipt>,
+    accepted_observations: VecDeque<PathObservationIdentity>,
 }
 
 impl PathStateMachine {
@@ -563,6 +704,8 @@ impl PathStateMachine {
             },
             revision: 0,
             rejected_transitions: 0,
+            accepted_event_receipts: Vec::new(),
+            accepted_observations: VecDeque::new(),
         }
     }
 
@@ -587,6 +730,9 @@ impl PathStateMachine {
     pub(crate) fn reduce(&self, event: PathEvent) -> PathTransition {
         let previous = &self.state;
         let mut next = previous.clone();
+        let receipt = event.idempotency_receipt();
+        let observation = event.observation_identity();
+        let clear_relay_receipts = matches!(&event, PathEvent::RelayPathFailed { .. });
 
         let result: Result<(), PathTransitionDecision> = (|| match event {
             PathEvent::IdentityReset => {
@@ -634,9 +780,13 @@ impl PathStateMachine {
                 self.validate_exact_epoch(relay.epoch)?;
                 self.reduce_relay_confirmed(&mut next, relay)
             }
-            PathEvent::RelayBusinessUsable { relay } => {
+            PathEvent::RelayBusinessUsable { relay, .. } => {
                 self.validate_exact_epoch(relay.epoch)?;
                 self.reduce_relay_usable(&mut next, relay)
+            }
+            PathEvent::RelayHealthObserved { relay, .. } => {
+                self.validate_exact_epoch(relay.epoch)?;
+                self.reduce_relay_health_observed(&relay)
             }
             PathEvent::RelayTransportLost { relay } => {
                 self.validate_bound_epoch(relay.epoch)?;
@@ -696,6 +846,9 @@ impl PathStateMachine {
                 decision,
                 next: previous.clone(),
                 actions: Vec::new(),
+                receipt: None,
+                observation: None,
+                clear_relay_receipts: false,
             };
         }
         if !Self::state_is_valid(&next) {
@@ -704,6 +857,27 @@ impl PathStateMachine {
                 decision: PathTransitionDecision::RejectedIllegalTransition,
                 next: previous.clone(),
                 actions: Vec::new(),
+                receipt: None,
+                observation: None,
+                clear_relay_receipts: false,
+            };
+        }
+
+        if receipt
+            .as_ref()
+            .is_some_and(|identity| self.accepted_event_receipts.contains(identity))
+            || observation
+                .as_ref()
+                .is_some_and(|identity| self.accepted_observations.contains(identity))
+        {
+            return PathTransition {
+                base_revision: self.revision,
+                decision: PathTransitionDecision::Duplicate,
+                next: previous.clone(),
+                actions: Vec::new(),
+                receipt: None,
+                observation: None,
+                clear_relay_receipts: false,
             };
         }
 
@@ -711,12 +885,15 @@ impl PathStateMachine {
         PathTransition {
             base_revision: self.revision,
             decision: if next == *previous {
-                PathTransitionDecision::Noop
+                PathTransitionDecision::AcceptedObservation
             } else {
                 PathTransitionDecision::Applied
             },
             next,
             actions,
+            receipt,
+            observation,
+            clear_relay_receipts,
         }
     }
 
@@ -733,13 +910,30 @@ impl PathStateMachine {
         } else {
             Vec::new()
         };
-        if decision.accepted() {
+        if decision.applies_side_effects() {
+            if transition.clear_relay_receipts {
+                self.accepted_event_receipts
+                    .retain(|receipt| !receipt.is_relay());
+            }
             if decision == PathTransitionDecision::Applied {
                 self.state = transition.next;
-                self.revision = self.revision.wrapping_add(1);
+                self.accepted_event_receipts
+                    .retain(|receipt| receipt.remains_current(&self.state));
             }
+            if let Some(receipt) = transition.receipt {
+                self.accepted_event_receipts.push(receipt);
+            }
+            if let Some(observation) = transition.observation {
+                self.accepted_observations.push_back(observation);
+                while self.accepted_observations.len() > MAX_ACCEPTED_HEALTH_OBSERVATIONS {
+                    self.accepted_observations.pop_front();
+                }
+            }
+            self.revision = self.revision.wrapping_add(1);
         } else {
-            self.rejected_transitions = self.rejected_transitions.wrapping_add(1);
+            if !decision.accepted() {
+                self.rejected_transitions = self.rejected_transitions.wrapping_add(1);
+            }
         }
         PathTransitionOutcome {
             decision,
@@ -831,6 +1025,10 @@ impl PathStateMachine {
             (ActiveBusinessPath::Direct(_), DirectPathState::Committed(identity), _) => {
                 ActiveBusinessPath::Direct(*identity)
             }
+            (ActiveBusinessPath::Direct(_), _, relay) => relay
+                .confirmed_identity()
+                .cloned()
+                .map_or(ActiveBusinessPath::Unavailable, ActiveBusinessPath::Relay),
             (ActiveBusinessPath::Relay(_), _, relay) => relay
                 .confirmed_identity()
                 .cloned()
@@ -838,6 +1036,15 @@ impl PathStateMachine {
             _ => ActiveBusinessPath::Unavailable,
         };
         Self::set_projection_after_epoch_change(next, previous_active, epoch);
+        if previous_active == Some(NetworkPath::Direct)
+            && next.active.network_path() == Some(NetworkPath::Relay)
+        {
+            next.recovery = PathRecoveryState::Degraded {
+                epoch,
+                from: NetworkPath::Direct,
+                fallback: Some(NetworkPath::Relay),
+            };
+        }
         Ok(())
     }
 
@@ -974,6 +1181,19 @@ impl PathStateMachine {
         if !matches!(next.active, ActiveBusinessPath::Direct(_)) {
             next.active = ActiveBusinessPath::Relay(relay);
             next.compatibility_state = ConnectionState::Relay;
+        }
+        Ok(())
+    }
+
+    fn reduce_relay_health_observed(
+        &self,
+        relay: &RelayConnectionIdentity,
+    ) -> Result<(), PathTransitionDecision> {
+        let Some(current) = self.state.relay.confirmed_identity() else {
+            return Err(PathTransitionDecision::RejectedIllegalTransition);
+        };
+        if !current.same_transport(relay) {
+            return Err(PathTransitionDecision::RejectedRelayConnectionIdentity);
         }
         Ok(())
     }
@@ -1637,7 +1857,7 @@ mod tests {
         ));
 
         let duplicate = commit(&mut machine, PathEvent::DirectCommitted { validation: ack });
-        assert_eq!(duplicate.decision, PathTransitionDecision::Noop);
+        assert_eq!(duplicate.decision, PathTransitionDecision::Duplicate);
         assert_eq!(duplicate.snapshot.revision, committed.snapshot.revision);
 
         let wrong_request_endpoint = DirectValidationIdentity::authenticated_ack(
@@ -1772,6 +1992,56 @@ mod tests {
             retained.snapshot.state.direct,
             DirectPathState::Committed(identity) if identity.epoch == after
         ));
+    }
+
+    #[test]
+    fn network_generation_relay_only_retention_falls_back_from_direct_to_relay() {
+        let before = epoch(4, 2, 10);
+        let after = epoch(5, 2, 10);
+        let mut machine = online_machine(before);
+        let confirmed_relay = relay(before, "relay.test:443", 51);
+        assert!(commit(
+            &mut machine,
+            PathEvent::RelayPeerConfirmed {
+                relay: confirmed_relay,
+            },
+        )
+        .accepted());
+        commit_direct(&mut machine, validation(before, 8, 4));
+
+        let retained = commit(
+            &mut machine,
+            PathEvent::NetworkGenerationAdvanced {
+                epoch: after,
+                retained: PathRetention::Relay,
+            },
+        );
+
+        assert_eq!(retained.decision, PathTransitionDecision::Applied);
+        assert!(matches!(
+            retained.snapshot.state.active,
+            ActiveBusinessPath::Relay(ref identity) if identity.epoch == after
+        ));
+        assert!(matches!(
+            retained.snapshot.state.relay,
+            RelayPathState::Confirmed(ref identity) if identity.epoch == after
+        ));
+        assert!(matches!(
+            retained.snapshot.state.direct,
+            DirectPathState::Idle
+        ));
+        assert_eq!(
+            retained.snapshot.state.recovery,
+            PathRecoveryState::Degraded {
+                epoch: after,
+                from: NetworkPath::Direct,
+                fallback: Some(NetworkPath::Relay),
+            }
+        );
+        assert_eq!(
+            retained.snapshot.state.compatibility_state,
+            ConnectionState::Relay
+        );
     }
 
     #[test]
@@ -1957,8 +2227,118 @@ mod tests {
             },
         );
         let duplicate = commit(&mut machine, PathEvent::RelayPeerConfirmed { relay });
-        assert_eq!(duplicate.decision, PathTransitionDecision::Noop);
+        assert_eq!(duplicate.decision, PathTransitionDecision::Duplicate);
         assert_eq!(duplicate.snapshot.revision, first.snapshot.revision);
+    }
+
+    #[test]
+    fn observations_are_accepted_once_per_typed_identity_without_state_churn() {
+        let current = epoch(1, 1, 1);
+        let mut machine = online_machine(current);
+        let relay = relay(current, "relay.test:443", 4);
+        assert!(commit(
+            &mut machine,
+            PathEvent::RelayPeerConfirmed {
+                relay: relay.clone(),
+            },
+        )
+        .accepted());
+
+        let sent = commit(
+            &mut machine,
+            PathEvent::RelayBusinessUsable {
+                relay: relay.clone(),
+                observation: RelayBusinessObservation::Sent,
+            },
+        );
+        assert_eq!(sent.decision, PathTransitionDecision::Applied);
+        let sent_revision = sent.snapshot.revision;
+        let duplicate_sent = commit(
+            &mut machine,
+            PathEvent::RelayBusinessUsable {
+                relay: relay.clone(),
+                observation: RelayBusinessObservation::Sent,
+            },
+        );
+        assert_eq!(duplicate_sent.decision, PathTransitionDecision::Duplicate);
+        assert_eq!(duplicate_sent.snapshot.revision, sent_revision);
+
+        let received = commit(
+            &mut machine,
+            PathEvent::RelayBusinessUsable {
+                relay: relay.clone(),
+                observation: RelayBusinessObservation::Received,
+            },
+        );
+        assert_eq!(
+            received.decision,
+            PathTransitionDecision::AcceptedObservation
+        );
+        assert_eq!(received.snapshot.state, sent.snapshot.state);
+        assert_eq!(received.snapshot.revision, sent_revision + 1);
+        let duplicate_received = commit(
+            &mut machine,
+            PathEvent::RelayBusinessUsable {
+                relay: relay.clone(),
+                observation: RelayBusinessObservation::Received,
+            },
+        );
+        assert_eq!(
+            duplicate_received.decision,
+            PathTransitionDecision::Duplicate
+        );
+        assert_eq!(
+            duplicate_received.snapshot.revision,
+            received.snapshot.revision
+        );
+
+        let first_health = RelayHealthObservationIdentity {
+            owner_token: 70,
+            request_id: 8,
+        };
+        let first_sample = commit(
+            &mut machine,
+            PathEvent::RelayHealthObserved {
+                relay: relay.clone(),
+                observation: first_health,
+            },
+        );
+        assert_eq!(
+            first_sample.decision,
+            PathTransitionDecision::AcceptedObservation
+        );
+        assert_eq!(first_sample.snapshot.state, received.snapshot.state);
+        let duplicate_sample = commit(
+            &mut machine,
+            PathEvent::RelayHealthObserved {
+                relay: relay.clone(),
+                observation: first_health,
+            },
+        );
+        assert_eq!(duplicate_sample.decision, PathTransitionDecision::Duplicate);
+        assert_eq!(
+            duplicate_sample.snapshot.revision,
+            first_sample.snapshot.revision
+        );
+
+        let independent_sample = commit(
+            &mut machine,
+            PathEvent::RelayHealthObserved {
+                relay,
+                observation: RelayHealthObservationIdentity {
+                    owner_token: 71,
+                    request_id: 9,
+                },
+            },
+        );
+        assert_eq!(
+            independent_sample.decision,
+            PathTransitionDecision::AcceptedObservation
+        );
+        assert_eq!(
+            independent_sample.snapshot.revision,
+            first_sample.snapshot.revision + 1
+        );
     }
 
     #[test]

--- a/client/daemon/src/peer/tests.rs
+++ b/client/daemon/src/peer/tests.rs
@@ -21,3 +21,4 @@ include!("tests/part14.rs");
 include!("tests/part15.rs");
 include!("tests/part16.rs");
 include!("tests/part17.rs");
+include!("tests/part18.rs");

--- a/client/daemon/src/peer/tests/part18.rs
+++ b/client/daemon/src/peer/tests/part18.rs
@@ -1,0 +1,438 @@
+use super::path_state_machine::{PathRecoveryState, PathTransitionDecision};
+
+#[tokio::test]
+async fn candidate_refresh_relay_only_retention_commits_relay_fallback_mirror() {
+    let manager = PeerManager::new(test_config());
+    let direct_endpoint: SocketAddr = "198.51.100.90:51831".parse().unwrap();
+    let relay_endpoint = "tcp://relay.test:18081";
+    manager
+        .add_peer(&test_peer("peer-relay-retention", direct_endpoint))
+        .await;
+    let generation = manager.current_network_generation().await;
+    assert!(manager
+        .confirm_relay_peer("peer-relay-retention", relay_endpoint, generation)
+        .await);
+    manager
+        .record_direct_probe_success_with_latency(
+            "peer-relay-retention",
+            direct_endpoint,
+            Some(Duration::from_millis(8)),
+        )
+        .await;
+    manager
+        .record_direct_success("peer-relay-retention", Some(direct_endpoint))
+        .await;
+    assert_eq!(
+        manager
+            .get_connection("peer-relay-retention")
+            .await
+            .unwrap()
+            .active_path(),
+        Some(NetworkPath::Direct)
+    );
+
+    {
+        let mut connections = manager.connections.write().await;
+        let connection = connections.get_mut("peer-relay-retention").unwrap();
+        let pair = connection
+            .candidate_pairs
+            .iter_mut()
+            .find(|pair| pair.remote_endpoint == direct_endpoint)
+            .unwrap();
+        pair.consecutive_failures = 1;
+    }
+
+    let next_generation = manager
+        .advance_candidate_refresh_generation("relay-only retention acceptance")
+        .await;
+    let connection = manager
+        .get_connection("peer-relay-retention")
+        .await
+        .unwrap();
+    let state = connection.path_state_snapshot().state;
+    assert_eq!(connection.state, ConnectionState::Relay);
+    assert_eq!(connection.active_path(), Some(NetworkPath::Relay));
+    assert_eq!(connection.relay_confirmed_generation, Some(next_generation));
+    assert_eq!(
+        state.recovery,
+        PathRecoveryState::Degraded {
+            epoch: PathEpoch::new(
+                next_generation,
+                manager
+                    .peer_session_generation_sync("peer-relay-retention")
+                    .unwrap(),
+                connection.remote_candidate_epoch(),
+            ),
+            from: NetworkPath::Direct,
+            fallback: Some(NetworkPath::Relay),
+        }
+    );
+
+    let committed = manager
+        .committed_business_path_snapshots_sync()
+        .into_iter()
+        .find(|snapshot| snapshot.peer_id == "peer-relay-retention")
+        .expect("committed path mirror must contain the peer");
+    assert!(matches!(
+        committed.active,
+        ActiveBusinessPath::Relay(ref relay) if relay.epoch.network_generation == next_generation
+    ));
+}
+
+#[tokio::test]
+async fn duplicate_path_events_preserve_revision_counters_timestamps_and_markers() {
+    let manager = PeerManager::new(test_config());
+    let peer_id = "peer-idempotent-path-events";
+    let direct_endpoint: SocketAddr = "198.51.100.91:51831".parse().unwrap();
+    let relay_endpoint = "tcp://relay.test:18082";
+    let relay_connection_id = 91;
+    manager.add_peer(&test_peer(peer_id, direct_endpoint)).await;
+    let generation = manager.current_network_generation().await;
+    manager
+        .mark_relay_transport_ready_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await;
+    assert!(manager
+        .confirm_relay_peer_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await);
+
+    let before_relay_duplicate = manager.get_connection(peer_id).await.unwrap();
+    assert!(!manager
+        .confirm_relay_peer_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await);
+    let after_relay_duplicate = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(
+        after_relay_duplicate.path_state_snapshot(),
+        before_relay_duplicate.path_state_snapshot()
+    );
+    assert_eq!(
+        after_relay_duplicate.relay_confirm_seq,
+        before_relay_duplicate.relay_confirm_seq
+    );
+    assert_eq!(
+        after_relay_duplicate.relay_confirmed_at,
+        before_relay_duplicate.relay_confirmed_at
+    );
+    assert_eq!(
+        after_relay_duplicate.relay_health.success_count,
+        before_relay_duplicate.relay_health.success_count
+    );
+    assert_eq!(
+        after_relay_duplicate.relay_health.last_success_at,
+        before_relay_duplicate.relay_health.last_success_at
+    );
+
+    assert!(manager
+        .mark_relay_first_business_sent_for_generation_with_transport(
+            peer_id,
+            generation,
+            relay_endpoint,
+            Some(relay_connection_id),
+        )
+        .await);
+    let after_first_sent = manager.get_connection(peer_id).await.unwrap();
+    assert!(!manager
+        .mark_relay_first_business_sent_for_generation_with_transport(
+            peer_id,
+            generation,
+            relay_endpoint,
+            Some(relay_connection_id),
+        )
+        .await);
+    let after_duplicate_sent = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(
+        after_duplicate_sent.path_state_snapshot(),
+        after_first_sent.path_state_snapshot()
+    );
+    assert_eq!(
+        after_duplicate_sent.relay_first.business_sent_generation,
+        after_first_sent.relay_first.business_sent_generation
+    );
+    assert_eq!(
+        after_duplicate_sent.relay_first.business_exchange_generation,
+        after_first_sent.relay_first.business_exchange_generation
+    );
+
+    assert!(manager
+        .mark_relay_first_business_received_for_generation_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await);
+    let after_first_received = manager.get_connection(peer_id).await.unwrap();
+    assert!(!manager
+        .mark_relay_first_business_received_for_generation_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await);
+    let after_duplicate_received = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(
+        after_duplicate_received.path_state_snapshot(),
+        after_first_received.path_state_snapshot()
+    );
+    assert_eq!(
+        after_duplicate_received
+            .relay_first
+            .business_received_generation,
+        after_first_received
+            .relay_first
+            .business_received_generation
+    );
+    assert_eq!(
+        after_duplicate_received
+            .relay_first
+            .business_exchange_generation,
+        after_first_received
+            .relay_first
+            .business_exchange_generation
+    );
+    assert_eq!(
+        after_duplicate_received
+            .relay_first
+            .business_gate_completed_generation,
+        after_first_received
+            .relay_first
+            .business_gate_completed_generation
+    );
+
+    manager
+        .record_direct_probe_success_with_latency(
+            peer_id,
+            direct_endpoint,
+            Some(Duration::from_millis(8)),
+        )
+        .await;
+    manager
+        .record_direct_success(peer_id, Some(direct_endpoint))
+        .await;
+    let before_direct_duplicate = manager.get_connection(peer_id).await.unwrap();
+    let before_pair = before_direct_duplicate
+        .candidate_pairs
+        .iter()
+        .find(|pair| pair.remote_endpoint == direct_endpoint)
+        .unwrap()
+        .clone();
+    let before_committed_mirror = manager.committed_business_path_snapshots_sync();
+
+    manager
+        .record_direct_success(peer_id, Some(direct_endpoint))
+        .await;
+    let after_direct_duplicate = manager.get_connection(peer_id).await.unwrap();
+    let after_pair = after_direct_duplicate
+        .candidate_pairs
+        .iter()
+        .find(|pair| pair.remote_endpoint == direct_endpoint)
+        .unwrap();
+    assert_eq!(
+        after_direct_duplicate.path_state_snapshot(),
+        before_direct_duplicate.path_state_snapshot()
+    );
+    assert_eq!(
+        after_direct_duplicate.direct_health.success_count,
+        before_direct_duplicate.direct_health.success_count
+    );
+    assert_eq!(
+        after_direct_duplicate.direct_health.last_success_at,
+        before_direct_duplicate.direct_health.last_success_at
+    );
+    assert_eq!(
+        after_direct_duplicate.direct_commit_seq,
+        before_direct_duplicate.direct_commit_seq
+    );
+    assert_eq!(after_pair.success_count, before_pair.success_count);
+    assert_eq!(after_pair.last_success_at, before_pair.last_success_at);
+    assert_eq!(after_pair.selected_at, before_pair.selected_at);
+    assert_eq!(
+        after_direct_duplicate.direct_events.len(),
+        before_direct_duplicate.direct_events.len()
+    );
+    assert_eq!(
+        after_direct_duplicate.path_events.len(),
+        before_direct_duplicate.path_events.len()
+    );
+    assert_eq!(
+        after_direct_duplicate.connected_at,
+        before_direct_duplicate.connected_at
+    );
+    assert_eq!(
+        manager.committed_business_path_snapshots_sync(),
+        before_committed_mirror
+    );
+
+    let epoch = after_direct_duplicate
+        .path_state_snapshot()
+        .state
+        .epoch
+        .unwrap();
+    let mut connections = manager.connections.write().await;
+    let connection = connections.get_mut(peer_id).unwrap();
+    let revision = connection.path_state_snapshot().revision;
+    let bytes_sent = connection.bytes_sent;
+    let direct_success_count = connection.direct_health.success_count;
+    let direct_event_count = connection.direct_events.len();
+    let peer_online_duplicate = connection.commit_path_transition(
+        PathEvent::PeerOnline { epoch },
+        |connection| {
+            connection.bytes_sent = connection.bytes_sent.saturating_add(1);
+            connection.direct_health.record_success();
+            connection.record_direct_event(
+                generation,
+                "duplicate_peer_online_side_effect",
+                None,
+                None,
+                None,
+                "must not execute",
+            );
+        },
+    );
+    assert_eq!(peer_online_duplicate.decision, PathTransitionDecision::Duplicate);
+    assert_eq!(connection.path_state_snapshot().revision, revision);
+    assert_eq!(connection.bytes_sent, bytes_sent);
+    assert_eq!(connection.direct_health.success_count, direct_success_count);
+    assert_eq!(connection.direct_events.len(), direct_event_count);
+
+    let first_generation_observation = connection.commit_path_transition(
+        PathEvent::NetworkGenerationAdvanced {
+            epoch,
+            retained: PathRetention::DirectAndRelay,
+        },
+        |_| {},
+    );
+    assert_eq!(
+        first_generation_observation.decision,
+        PathTransitionDecision::AcceptedObservation
+    );
+    let generation_revision = connection.path_state_snapshot().revision;
+    let generation_duplicate = connection.commit_path_transition(
+        PathEvent::NetworkGenerationAdvanced {
+            epoch,
+            retained: PathRetention::DirectAndRelay,
+        },
+        |connection| {
+            connection.bytes_sent = connection.bytes_sent.saturating_add(1);
+            connection.direct_health.record_success();
+        },
+    );
+    assert_eq!(generation_duplicate.decision, PathTransitionDecision::Duplicate);
+    assert_eq!(
+        connection.path_state_snapshot().revision,
+        generation_revision
+    );
+    assert_eq!(connection.bytes_sent, bytes_sent);
+    assert_eq!(connection.direct_health.success_count, direct_success_count);
+}
+
+#[tokio::test]
+async fn independent_relay_health_observations_apply_once_each() {
+    let manager = PeerManager::new(test_config());
+    let peer_id = "peer-independent-relay-health";
+    let direct_endpoint: SocketAddr = "198.51.100.92:51831".parse().unwrap();
+    let relay_endpoint = "tcp://relay.test:18083";
+    let relay_connection_id = 92;
+    manager.add_peer(&test_peer(peer_id, direct_endpoint)).await;
+    let generation = manager.current_network_generation().await;
+    manager
+        .mark_relay_transport_ready_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await;
+    assert!(manager
+        .confirm_relay_peer_with_transport(
+            peer_id,
+            relay_endpoint,
+            generation,
+            Some(relay_connection_id),
+        )
+        .await);
+    let peer_session_generation = manager.peer_session_generation_sync(peer_id).unwrap();
+
+    let observe = |request_id, owner_token| crate::relay_probe::RelayProbeToken {
+        kind: crate::relay_probe::RelayProbeKind::Ack,
+        generation,
+        request_id,
+        owner_token,
+    };
+    assert!(manager.register_relay_validation_expectation_at_write_boundary(
+        peer_id,
+        generation,
+        1,
+        101,
+        relay_endpoint,
+        relay_connection_id,
+        peer_session_generation,
+        Instant::now(),
+    ));
+    assert!(manager
+        .consume_relay_probe_ack_with_transport(
+            peer_id,
+            observe(1, 101),
+            relay_endpoint,
+            Some(relay_connection_id),
+        )
+        .await);
+    let first = manager.get_connection(peer_id).await.unwrap();
+    let first_revision = first.path_state_snapshot().revision;
+    let first_success_count = first.relay_health.success_count;
+    let first_success_at = first.relay_health.last_success_at;
+
+    assert!(!manager
+        .consume_relay_probe_ack_with_transport(
+            peer_id,
+            observe(1, 101),
+            relay_endpoint,
+            Some(relay_connection_id),
+        )
+        .await);
+    let duplicate = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(duplicate.path_state_snapshot().revision, first_revision);
+    assert_eq!(duplicate.relay_health.success_count, first_success_count);
+    assert_eq!(duplicate.relay_health.last_success_at, first_success_at);
+
+    assert!(manager.register_relay_validation_expectation_at_write_boundary(
+        peer_id,
+        generation,
+        2,
+        102,
+        relay_endpoint,
+        relay_connection_id,
+        peer_session_generation,
+        Instant::now(),
+    ));
+    assert!(manager
+        .consume_relay_probe_ack_with_transport(
+            peer_id,
+            observe(2, 102),
+            relay_endpoint,
+            Some(relay_connection_id),
+        )
+        .await);
+    let independent = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(independent.path_state_snapshot().revision, first_revision + 1);
+    assert_eq!(
+        independent.relay_health.success_count,
+        first_success_count + 1
+    );
+    assert!(independent.relay_health.last_success_at >= first_success_at);
+}


### PR DESCRIPTION
## Scope and revisions

This PR fixes only the first-stage Path State Machine acceptance gaps. It does not add DPLPMTUD runtime integration, metrics infrastructure, NAT strategies, UI changes, version changes, tags, signing, or release changes.

- Base: `6c618e2fa5b5ddec855d56856dbc1c4074158bf3`
- Head: `2638b0594e108ff26e2e61f2ce16222efe1a892c`
- Branch: `fix/path-state-machine-acceptance-20260830`

## Exact Relay blackhole root cause

Primary artifact: [Actions run 33264591658](https://github.com/yhan-sun/p2wlan/actions/runs/33264591658). A first bounded-wait implementation exposed the final missing piece in [superseded-SHA attempt 2](https://github.com/yhan-sun/p2wlan/actions/runs/33270318539/attempts/2): after `initiator_publish_probe_binding_writer_wait timeout_ms=250`, neither `writer_available` nor `writer_timeout` was ever emitted.

The long-lived blocker was not a reader guard held for three minutes. It was a fair `PeerManager.connections` writer waiter whose future and timeout were owned by the cooperatively-polled control-loop `slow_work` set.

The exact cycle was:

1. `run_relay_peer_probe_loop -> relay_probe_targets -> PeerManager.connections.read()` held the production Relay target snapshot when initiator publication ran.
2. `run_reserved_initiator_handshake -> try_stage_probe_session_binding` observed contention, then the old implementation queued `PeerManager.connections.write().await` inside a `FuturesUnordered<ControlEventWork>` future and yielded.
3. Tokio's writer-fair `RwLock` placed that writer ahead of all later readers.
4. The artifact had already queued a roster update (`poll_peers: 1 updated` at `19:28:57.031`, before daemon event processing at `19:28:57.924`). The serial loop selected `ControlEvent::PeerUpdated`, acquired the per-peer handshake arbiter, then entered `PeerManager.get_connection -> connections.read().await` behind the first queued writer.
5. The serial loop was now awaiting the later reader and could no longer poll the earlier `slow_work` writer future or its 250 ms timer. This is the cooperative polling inversion.
6. `/status` readers queued behind the same fair writer and eventually returned 503. Relay TCP keepalive stayed healthy because it does not need this map; no WireGuard session was published, so both `RelayPeerConfirmed` counts stayed zero.

Thus the call chain that initially held the read lock was the real Relay target scan; the call chain that made the wait permanent was `run_control_event_loop(PeerUpdated) -> get_connection -> connections.read().await` waiting behind the initiator's unpolled writer barrier.

## Lock order before and after

Before:

1. initiator acquired per-peer emit guard;
2. initiator acquired network epoch guard;
3. initiator tried the `connections` writer;
4. on contention it released epoch and emit, but retained the writer wait and timeout inside control-loop `slow_work`;
5. a later `PeerUpdated` control branch acquired the handshake arbiter and waited for a `connections` reader behind that writer;
6. the serial owner could no longer poll the earlier writer/timeout, starving setup and diagnostics indefinitely.

After:

1. canonical publication still acquires emit, then epoch, and performs only a nonblocking `connections` writer attempt;
2. on contention it releases epoch and emit immediately and marks the reservation `ProbeBindingRetryDeferred`, so `run_event_initiator_handshake` does not start an unrelated candidate-publication fallback;
3. the cooperative initiator future returns in the same poll that records contention;
4. an independently scheduled task, holding no emit, epoch, handshake-arbiter, connection, or other upper guard, races reservation cancellation against a 250 ms writer-availability bound;
5. writer availability or timeout removes the fair writer barrier, cancels only the exact current reservation owner, emits structured diagnostics, and bumps the shared path-setup watch edge; normal maintenance then starts a fresh transaction and revalidates generation/session state;
6. PeerLeft, generation cleanup, or owner replacement wins through the reservation watch/owner check: the old waiter exits without publishing a stale retry edge.

No unconditional sleep, topology timeout increase, ignored 503, or weakened NAT assertion was added.

## Relay-only retention

For a generation advance where old active is Direct, Direct is not retainable, and a confirmed Relay has `PathRetention::Relay`, the reducer atomically commits:

- active path: Relay;
- compatibility projection: `ConnectionState::Relay`;
- recovery: `Degraded { from: Direct, fallback: Some(Relay) }`;
- committed business-path mirror: the retained Relay identity stamped with the new generation.

It no longer projects `Unavailable`.

## Event-wide idempotency

`PathTransitionDecision` distinguishes `Applied`, `AcceptedObservation`, `Duplicate`, and typed rejection outcomes.

Durable typed receipts cover `PeerOnline`, `NetworkGenerationAdvanced`, `RelayPeerConfirmed`, directional `RelayBusinessUsable`, and `DirectCommitted`. Relay health uses a separate bounded identity `(owner_token, request_id)`.

- `Duplicate` returns before compatibility projection, side-effect closure, caches, health/candidate counters, timestamps, event rings, commit sequence, or business markers.
- A new typed health/business observation may be `AcceptedObservation` and execute once even when the path-state enum itself is unchanged.
- Exact replay becomes `Duplicate`; receipts are pruned when their generation/path identity is no longer current.

## New and changed regression tests

Relay liveness and cancellation:

- `relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_and_reschedules_initiator`
- `detached_probe_binding_writer_wait_cancels_without_stale_reschedule`
- `initiator_publish_releases_epoch_while_connection_writer_is_contended`

The main concurrency test pauses the actual production `relay_probe_targets()` snapshot, directly polls the same cooperative initiator future, and fails if that future returns `Pending` after queuing the writer. It then queues a real status read behind the detached writer, proves emit/epoch guards are free, proves the 250 ms bound unblocks the status read while the Relay snapshot is still held, consumes the maintenance edge, and verifies a fresh reservation stages the Probe binding. This is not only a manually-held read-lock/release test.

Relay-only retention:

- `network_generation_relay_only_retention_falls_back_from_direct_to_relay`
- `candidate_refresh_relay_only_retention_commits_relay_fallback_mirror`

Idempotency and side effects:

- `observations_are_accepted_once_per_typed_identity_without_state_churn`
- `duplicate_path_events_preserve_revision_counters_timestamps_and_markers`
- `independent_relay_health_observations_apply_once_each`

These assert reducer state/revision plus health counters, candidate-pair counters, commit sequence, event ring, timestamps, and business markers.

## Commands executed and results

Final local Head verification:

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — PASS
- `cargo test --workspace` — PASS; daemon lib 1164/1164, all workspace and doc tests passed
- targeted Relay liveness/cancellation, retention, reducer idempotency, PeerConnection mirror, and health-observation tests — PASS
- `git diff --check` — PASS
- `bash scripts/nat-sim/run-ci-topology.sh relay` — local macOS prerequisite failure before topology execution because GNU `timeout` is unavailable (exit 127); no test result was claimed from this invocation
- the same underlying Relay-only topology command used by the wrapper (`ROUNDS=1 MODE=relay-only LOSS=0 REORDER=0 STRICT_FILTERING=0 DIRECT_TIMEOUT_S=60 OVERLAY_TIMEOUT_S=90 OVERLAY_BURST=64 RELAY_COUNT=1`) — PASS; RelayConfirmed A/B 1/1, Direct A/B 0/0, overlay A/B 132/132, zero drop/replay/invalid, ready-to-usable 39 ms/1 ms

Development diagnostics retained for audit:

- the first daemon-wide idempotency run exposed 20 legacy failures from classifying untyped observations too broadly; implementation was narrowed to typed receipts and the final suite is clean;
- after removing the in-future retry loop, clippy correctly reported `never_loop`; the loop was removed and final clippy passed;
- superseded Head `35c35c047606f75e218ea039e290a76946a751cc` passed initial local/remote checks but Relay attempt 2 reproduced the blackhole and invalidated its earlier count; it is not acceptance evidence;
- final-SHA regular CI attempt 1 reached an unrelated, untouched Hard↔Hard Windows test and hit its existing `diagnostics()[0]` timing race; the isolated same-SHA Windows job was rerun without changing or weakening that test. Final result is listed below.

## Same-Head Relay blackhole evidence: 5 consecutive passes

All five attempts use exact Head `2638b0594e108ff26e2e61f2ce16222efe1a892c`, seed/profile from `run-ci-topology.sh relay`, RelayConfirmed A/B 1/1, Direct A/B 0/0, relay ingress on both ends, and zero drop/replay/invalid.

| Attempt | Relay job | Overlay A/B | ready→usable A/B | Required aggregate |
|---|---|---:|---:|---|
| 1 | [99152380962](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99152380962) | 132/132 | 2/34 ms | [99152679690](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99152679690) |
| 2 | [99152729741](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99152729741) | 133/133 | 7/22 ms | [99153009442](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153009442) |
| 3 | [99153051575](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153051575) | 132/132 | 8/9 ms | [99153357934](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153357934) |
| 4 | [99153416104](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153416104) | 132/132 | 3/78 ms | [99153718398](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153718398) |
| 5 | [99153776342](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99153776342) | 132/132 | 207/5 ms | [99154090347](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/job/99154090347) |

Attempt pages: [1](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/1), [2](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/2), [3](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/3), [4](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/4), [5](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/5).

## Final-SHA Actions

- [Path State Machine](https://github.com/yhan-sun/p2wlan/actions/runs/33272112217) — PASS (`Path State Machine Required` PASS)
- [NAT Topology Gate](https://github.com/yhan-sun/p2wlan/actions/runs/33272112203/attempts/5) — PASS (`NAT Topology Required` PASS)
- [Windows Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33272112234) — PASS (`Windows Lifecycle Required` PASS)
- [Mobile Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33272112204) — PASS
- [CI attempt 1](https://github.com/yhan-sun/p2wlan/actions/runs/33272112205/attempts/1) / [Windows-only attempt 2](https://github.com/yhan-sun/p2wlan/actions/runs/33272112205/attempts/2) — PASS on attempt 2 (`CI Required` PASS); attempt 1 hit the unrelated, untouched Hard↔Hard diagnostics timing race recorded above
- [Flutter Client](https://github.com/yhan-sun/p2wlan/actions/runs/33272112209) — PASS
- [Package Test Builds](https://github.com/yhan-sun/p2wlan/actions/runs/33272112220) — PASS

`Path State Machine Required` is configured for both `pull_request` and pushes to `main`. On pull requests its aggregate requires same-Head-SHA NAT, Windows, and Mobile gates.

<details>
<summary>Superseded-SHA Actions used during diagnosis (not acceptance evidence)</summary>

- [Path State Machine](https://github.com/yhan-sun/p2wlan/actions/runs/33270318519)
- [NAT initial run, including reproduced failure on attempt 2](https://github.com/yhan-sun/p2wlan/actions/runs/33270318539/attempts/2)
- [NAT diagnostic dispatch 1](https://github.com/yhan-sun/p2wlan/actions/runs/33270469193)
- [NAT diagnostic dispatch 2](https://github.com/yhan-sun/p2wlan/actions/runs/33270619327)
- [Windows Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33270318514)
- [Mobile Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33270318544)
- [CI](https://github.com/yhan-sun/p2wlan/actions/runs/33270318577)
- [Flutter Client](https://github.com/yhan-sun/p2wlan/actions/runs/33270318553)
- [Package Test Builds](https://github.com/yhan-sun/p2wlan/actions/runs/33270318492)

</details>

## Compatibility and behavior

No control-plane, Probe, Relay, status, or wire protocol changed. No public state interface changed. New receipts, observation identities, and handshake disposition are internal only.

Intended behavior changes are limited to independently bounded/rescheduled initiator lock contention, correct retained-Relay fallback during generation advancement, and suppression of exact duplicate internal side effects. Normal Direct/Relay selection and wire compatibility are unchanged.

This PR is open for human acceptance only. It must not be merged by automation.
