### PR TITLE
feat(peer): add Direct UDP DPLPMTUD runtime foundation

### DIFF
--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 55
     steps:
-      - name: Require same-Head Path State Machine and CI gates
+      - name: Require same-Head existing, Flutter, and Package jobs
         uses: actions/github-script@v7
         with:
           script: |
@@ -171,8 +171,17 @@ jobs:
               'Windows Lifecycle Required',
               'Mobile Lifecycle Required',
               'CI Required',
-              'Flutter Client',
-              'Package Test Builds',
+              // Flutter Client publishes one check-run per job rather than a
+              // workflow-level check with the workflow name.
+              'Analyze and Test',
+              'Android arm64 Release APK',
+              'Linux x64 Release Bundle',
+              'macOS Release Apps',
+              'Windows x64 Release Bundle',
+              'iOS Compile',
+              // Package Test Builds likewise publishes its concrete jobs.
+              'macOS arm64 test DMG',
+              'Android arm64 test APK',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
             const deadline = Date.now() + 50 * 60 * 1000;

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -1,0 +1,261 @@
+name: DPLPMTUD
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/dplpmtud-required.yml"
+      - ".github/workflows/path-state-machine-required.yml"
+      - "client/daemon/**"
+      - "docs/dplpmtud-runtime-foundation.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dplpmtud-required.yml"
+      - ".github/workflows/path-state-machine-required.yml"
+      - "client/daemon/**"
+      - "docs/dplpmtud-runtime-foundation.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: read
+
+concurrency:
+  group: dplpmtud-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  VALIDATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  dplpmtud_linux:
+    name: DPLPMTUD Linux checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VALIDATION_SHA }}
+          fetch-depth: 0
+
+      - name: Verify exact validation SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          echo "DPLPMTUD validation SHA: $actual"
+          test "$actual" = "$VALIDATION_SHA"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Linux workspace dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            libxdo-dev \
+            librsvg2-dev \
+            xdotool \
+            patchelf
+
+      - name: Cargo format
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: DPLPMTUD reducer, lifecycle, compatibility, and codec tests
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests -- --test-threads=1
+
+      - name: Encrypted UDP blackhole test with evidence
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak -- --exact --nocapture --test-threads=1
+
+      - name: Cargo workspace tests
+        run: cargo test --workspace
+
+      - name: Diff whitespace check
+        run: git diff --check
+
+  dplpmtud_blackhole:
+    name: DPLPMTUD blackhole run ${{ matrix.iteration }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        iteration: [1, 2, 3, 4, 5]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VALIDATION_SHA }}
+          fetch-depth: 0
+
+      - name: Verify exact validation SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          echo "DPLPMTUD_BLACKHOLE_RUN iteration=${{ matrix.iteration }} expected_head=$VALIDATION_SHA actual_head=$actual"
+          test "$actual" = "$VALIDATION_SHA"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run deterministic encrypted UDP blackhole chain
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak -- --exact --nocapture --test-threads=1
+
+  dplpmtud_windows:
+    name: DPLPMTUD Windows checks
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VALIDATION_SHA }}
+          fetch-depth: 0
+
+      - name: Verify exact validation SHA
+        shell: pwsh
+        run: |
+          $actual = git rev-parse HEAD
+          Write-Host "DPLPMTUD validation SHA: $actual"
+          if ($actual -ne $env:VALIDATION_SHA) { throw "checked out $actual instead of $env:VALIDATION_SHA" }
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Compile daemon on Windows
+        run: cargo check -p p2wlan-daemon --all-targets --all-features
+
+      - name: Reducer search and timeout lifecycle
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::timeout_retries_then_only_narrows_search_bounds -- --exact --test-threads=1
+
+      - name: Owner and path replacement cancellation
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::worker_owner_token_closes_same_identity_exit_aba -- --exact --test-threads=1
+
+      - name: PeerLeft and shutdown cleanup
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::close_and_peer_left_remove_all_worker_ownership -- --exact --test-threads=1
+
+      - name: Capability compatibility
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::capability_extension_is_additive_and_legacy_packets_remain_decodable -- --exact --test-threads=1
+
+      - name: Packet codec and exact datagram budget
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::codec_round_trip_uses_exact_udp_datagram_budget_and_compact_ack -- --exact --test-threads=1
+
+      - name: IPv4 and IPv6 budget separation
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::ipv4_and_ipv6_budget_layers_are_never_mixed -- --exact --test-threads=1
+
+  existing_required_gates:
+    name: Existing required gates on PR Head
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    steps:
+      - name: Require same-Head Path State Machine and CI gates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredNames = [
+              'Path State Machine Required',
+              'CI Required',
+            ];
+            const targetSha = context.payload.pull_request?.head?.sha || context.sha;
+            const deadline = Date.now() + 50 * 60 * 1000;
+            let lastSummary = '';
+
+            core.info(`Waiting for required checks on exact PR Head ${targetSha}`);
+            while (Date.now() < deadline) {
+              const response = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: targetSha,
+                per_page: 100,
+                filter: 'latest',
+              });
+              const latestByName = new Map();
+              for (const run of response.data.check_runs) {
+                if (!requiredNames.includes(run.name)) continue;
+                const prior = latestByName.get(run.name);
+                if (!prior || new Date(run.started_at || 0) > new Date(prior.started_at || 0)) {
+                  latestByName.set(run.name, run);
+                }
+              }
+
+              const summary = requiredNames.map((name) => {
+                const run = latestByName.get(name);
+                return `${name}=${run ? `${run.status}/${run.conclusion || 'pending'}@${run.head_sha}` : 'missing'}`;
+              }).join(', ');
+              if (summary !== lastSummary) {
+                core.info(`same-Head gate status: ${summary}`);
+                lastSummary = summary;
+              }
+
+              const wrongSha = requiredNames.filter((name) => {
+                const run = latestByName.get(name);
+                return run && run.head_sha !== targetSha;
+              });
+              if (wrongSha.length > 0) {
+                core.setFailed(`Required gate resolved to a non-Head SHA for ${targetSha}: ${wrongSha.join(', ')}`);
+                return;
+              }
+
+              const failed = requiredNames.filter((name) => {
+                const run = latestByName.get(name);
+                return run && run.status === 'completed' && run.conclusion !== 'success';
+              });
+              if (failed.length > 0) {
+                core.setFailed(`Required gate failed for ${targetSha}: ${failed.join(', ')}`);
+                return;
+              }
+
+              const complete = requiredNames.every((name) => {
+                const run = latestByName.get(name);
+                return run && run.head_sha === targetSha &&
+                  run.status === 'completed' && run.conclusion === 'success';
+              });
+              if (complete) {
+                core.info(`All existing required gates passed on exact PR Head ${targetSha}.`);
+                return;
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+            }
+
+            core.setFailed(`Timed out waiting for required gates on ${targetSha}: ${lastSummary}`);
+
+  required:
+    name: DPLPMTUD Required
+    if: always()
+    needs:
+      - dplpmtud_linux
+      - dplpmtud_blackhole
+      - dplpmtud_windows
+      - existing_required_gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce aggregate results
+        env:
+          LINUX_RESULT: ${{ needs.dplpmtud_linux.result }}
+          BLACKHOLE_RESULT: ${{ needs.dplpmtud_blackhole.result }}
+          WINDOWS_RESULT: ${{ needs.dplpmtud_windows.result }}
+          EXTERNAL_RESULT: ${{ needs.existing_required_gates.result }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          test "$LINUX_RESULT" = "success"
+          test "$BLACKHOLE_RESULT" = "success"
+          test "$WINDOWS_RESULT" = "success"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            test "$EXTERNAL_RESULT" = "success"
+          else
+            test "$EXTERNAL_RESULT" = "skipped"
+          fi

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -1,4 +1,4 @@
-name: DPLPMTUD
+name: DPLPMTUD Required
 
 on:
   push:
@@ -167,7 +167,12 @@ jobs:
           script: |
             const requiredNames = [
               'Path State Machine Required',
+              'NAT Topology Required',
+              'Windows Lifecycle Required',
+              'Mobile Lifecycle Required',
               'CI Required',
+              'Flutter Client',
+              'Package Test Builds',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
             const deadline = Date.now() + 50 * 60 * 1000;

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -1528,8 +1528,9 @@ impl DplpmtudRuntime {
     }
 
     /// Linearization point immediately before a worker attempts the kernel
-    /// send. Cancellation that wins first prevents the send.
-    pub(crate) fn begin_probe_send(&self, plan: &DplpmtudProbePlan) -> bool {
+    /// send. Marking the probe sent here, before socket I/O, prevents a fast
+    /// authenticated ACK from racing ahead of the send bookkeeping.
+    pub(crate) fn begin_probe_send(&self, plan: &DplpmtudProbePlan, now: Instant) -> bool {
         let mut registry = self
             .registry
             .lock()
@@ -1545,11 +1546,20 @@ impl DplpmtudRuntime {
             || entry.machine.identity() != Some(&plan.path_identity)
             || entry.machine.outstanding_identity() != Some(plan.probe_identity)
             || entry.send_in_progress
-            || Instant::now() >= plan.deadline
+            || now >= plan.deadline
+        {
+            return false;
+        }
+        if entry.machine.apply(DplpmtudEvent::ProbeSent {
+            probe: plan.probe_identity,
+            now,
+        }) != DplpmtudTransitionDecision::Applied
         {
             return false;
         }
         entry.send_in_progress = true;
+        entry.notify.notify_waiters();
+        self.publish_snapshot_locked(&plan.peer_id, entry, now);
         true
     }
 
@@ -1573,12 +1583,7 @@ impl DplpmtudRuntime {
         }
         entry.send_in_progress = false;
         match result {
-            Ok(()) => {
-                let _ = entry.machine.apply(DplpmtudEvent::ProbeSent {
-                    probe: plan.probe_identity,
-                    now,
-                });
-            }
+            Ok(()) => {}
             Err(()) => {
                 let _ = entry.machine.apply(DplpmtudEvent::ProbeSendFailed {
                     probe: plan.probe_identity,
@@ -1629,6 +1634,9 @@ impl DplpmtudRuntime {
         let Ok(mut registry) = self.registry.try_lock() else {
             return DplpmtudTransitionDecision::Busy;
         };
+        if registry.closed {
+            return DplpmtudTransitionDecision::Stale;
+        }
         let Some(entry) = registry.entries.get_mut(peer_id) else {
             return DplpmtudTransitionDecision::Stale;
         };
@@ -1641,7 +1649,9 @@ impl DplpmtudRuntime {
         let exact_ingress = ingress.remote_endpoint == current_path.authenticated_remote_endpoint
             && ingress.local_endpoint == current_path.local_endpoint
             && ingress.socket == current_path.socket;
-        let decision = if entry.machine.identity() != Some(current_path)
+        let worker_is_current = entry.worker_running && entry.worker_owner_token.is_some();
+        let decision = if !worker_is_current
+            || entry.machine.identity() != Some(current_path)
             || !exact_wire_identity
             || !exact_ingress
         {
@@ -1780,11 +1790,16 @@ pub(crate) struct DplpmtudAckIngress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use crate::control::PeerInfo;
     use crate::dataplane::OutboundPacket;
-    use crate::peer::PeerSessionGeneration;
+    use crate::peer::{PeerManager, PeerSessionGeneration};
     use crate::transport::{DirectValidationKind, WireGuardTransport};
+    use crate::udp::UdpTransport;
     use p2pnet_crypto::NodeIdentity;
     use p2pnet_wireguard::{HandshakeInitiator, HandshakeResponder, TransportSession};
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use tokio::sync::{mpsc, watch};
     use tokio::time::timeout;
 
     fn test_identity(peer_id: &str) -> DplpmtudPathIdentity {
@@ -2023,7 +2038,7 @@ mod tests {
         let plan = runtime
             .schedule_probe("peer", &identity, lease.worker_owner_token, now)
             .expect("probe must schedule");
-        assert!(runtime.begin_probe_send(&plan));
+        assert!(runtime.begin_probe_send(&plan, now));
         runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
         let exact_ingress = DplpmtudAckIngress {
             remote_endpoint: identity.authenticated_remote_endpoint,
@@ -2145,7 +2160,7 @@ mod tests {
         let plan = runtime
             .schedule_probe("peer", &identity, lease.worker_owner_token, now)
             .unwrap();
-        assert!(runtime.begin_probe_send(&plan));
+        assert!(runtime.begin_probe_send(&plan, now));
         runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
         assert_eq!(
             runtime.try_accept_ack(
@@ -2165,6 +2180,54 @@ mod tests {
         assert_eq!(
             runtime.timeout_probe(&plan, plan.deadline + Duration::from_millis(1)),
             DplpmtudTransitionDecision::Applied
+        );
+    }
+
+    #[test]
+    fn ack_after_worker_cancellation_is_stale() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        let plan = runtime
+            .schedule_probe("peer", &identity, lease.worker_owner_token, now)
+            .unwrap();
+        assert!(runtime.begin_probe_send(&plan, now));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        runtime.cancel_peer("peer", "peer_left", now + Duration::from_millis(2));
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &identity,
+                plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: identity.authenticated_remote_endpoint,
+                    local_endpoint: identity.local_endpoint,
+                    socket: identity.socket,
+                },
+                now + Duration::from_millis(3),
+            ),
+            DplpmtudTransitionDecision::Stale
+        );
+        assert_eq!(runtime.snapshots().remove("peer").unwrap().success_count, 0);
+
+        runtime.close("shutdown", now + Duration::from_millis(4));
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &identity,
+                plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: identity.authenticated_remote_endpoint,
+                    local_endpoint: identity.local_endpoint,
+                    socket: identity.socket,
+                },
+                now + Duration::from_millis(5),
+            ),
+            DplpmtudTransitionDecision::Stale
         );
     }
 
@@ -2225,7 +2288,7 @@ mod tests {
         let old_plan = runtime
             .schedule_probe("peer", &first_identity, first.worker_owner_token, now)
             .unwrap();
-        assert!(runtime.begin_probe_send(&old_plan));
+        assert!(runtime.begin_probe_send(&old_plan, now));
         runtime.finish_probe_send(&old_plan, Ok(()), now + Duration::from_millis(1));
         assert_eq!(
             runtime.try_accept_ack(
@@ -2252,7 +2315,7 @@ mod tests {
             DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
         );
         assert_eq!(snapshot.state, DplpmtudState::Base);
-        assert!(!runtime.begin_probe_send(&old_plan));
+        assert!(!runtime.begin_probe_send(&old_plan, now + Duration::from_millis(4)));
         runtime.finish_worker("peer", &first_identity, first.worker_owner_token);
         assert_eq!(runtime.active_worker_count(), 1);
         assert!(runtime
@@ -2484,8 +2547,354 @@ mod tests {
         (buffer, source)
     }
 
-    #[tokio::test]
+    async fn yield_until(mut predicate: impl FnMut() -> bool, message: &str) {
+        for _ in 0..100_000 {
+            if predicate() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("{message}");
+    }
+
+    fn peer_info(node_id: &str, virtual_ip: &str, endpoint: SocketAddr) -> PeerInfo {
+        PeerInfo {
+            node_id: node_id.to_string(),
+            virtual_ip: virtual_ip.to_string(),
+            endpoint: endpoint.to_string(),
+            online: true,
+            ..PeerInfo::default()
+        }
+    }
+
+    async fn commit_test_direct_path(
+        peers: &Arc<PeerManager>,
+        udp: &UdpTransport,
+        peer_id: &str,
+        remote_endpoint: SocketAddr,
+        local_endpoint: SocketAddr,
+        owner_token: u64,
+        request_id: u16,
+    ) -> DplpmtudPathIdentity {
+        let generation = peers.current_network_generation_sync();
+        let peer_session_generation = peers
+            .peer_session_generation_sync(peer_id)
+            .expect("test peer must be online");
+        let remote_candidate_epoch = peers
+            .current_remote_candidate_epoch(peer_id)
+            .await
+            .expect("test peer must have a candidate epoch");
+        let epoch = PathEpoch::new(generation, peer_session_generation, remote_candidate_epoch);
+        assert!(
+            peers
+                .mark_direct_validation_started(
+                    peer_id,
+                    crate::peer::DirectValidationIdentity::owned(
+                        epoch,
+                        owner_token,
+                        Some(request_id),
+                        Some(remote_endpoint),
+                    ),
+                )
+                .await
+        );
+        let committed = crate::peer::DirectValidationIdentity::authenticated_ack(
+            epoch,
+            owner_token,
+            request_id,
+            Some(remote_endpoint),
+            remote_endpoint,
+        );
+        let epoch_gate = peers.network_epoch_gate();
+        let epoch_guard = epoch_gate.lock().await;
+        assert!(peers
+            .record_direct_success_for_generation_with_local_endpoint_and_latency_in_epoch_for_remote_epoch(
+                &epoch_guard,
+                peer_id,
+                Some(remote_endpoint),
+                generation,
+                Some(local_endpoint),
+                None,
+                Some(remote_candidate_epoch),
+                Some(committed),
+            )
+            .await);
+        drop(epoch_guard);
+        let identity = DplpmtudPathIdentity::from_committed_validation(
+            peer_id,
+            committed,
+            remote_endpoint,
+            local_endpoint,
+            udp.transport_instance_id(),
+            0,
+        )
+        .expect("test Direct identity must contain owner, request and matching IP family");
+        assert!(peers.dplpmtud_path_is_current_sync(&identity));
+        identity
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak() {
+        const BLACKHOLE_THRESHOLD: usize = 1397;
+        let peers_a = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        let peers_b = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        let udp_a = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers_a.clone())
+            .await
+            .unwrap();
+        let udp_b = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers_b.clone())
+            .await
+            .unwrap();
+        let endpoint_a = udp_a.local_addr().unwrap();
+        let endpoint_b = udp_b.local_addr().unwrap();
+        let router = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let router_endpoint = router.local_addr().unwrap();
+        peers_a
+            .add_peer(&peer_info("peer-b", "10.20.0.2", router_endpoint))
+            .await;
+        peers_b
+            .add_peer(&peer_info("peer-a", "10.20.0.1", endpoint_a))
+            .await;
+
+        // DPLPMTUD is deliberately background measurement for an already
+        // authoritative Direct path. This fixture commits that prerequisite
+        // through the same PeerManager state-machine path used by production;
+        // only Probe delivery, ACK authentication, bounds changes and the
+        // blackhole outcome are exercised by the assertions below.
+        let identity = commit_test_direct_path(
+            &peers_a,
+            &udp_a,
+            "peer-b",
+            router_endpoint,
+            endpoint_a,
+            17,
+            19,
+        )
+        .await;
+        let runtime = udp_a.dplpmtud_runtime();
+        let peer_session_generation = identity.epoch.peer_session_generation.value();
+        assert!(runtime.mark_supported("peer-b", peer_session_generation));
+
+        let (session_a, session_b) = establish_sessions();
+        let (wireguard_a, _) = WireGuardTransport::new();
+        let (wireguard_b, _) = WireGuardTransport::new();
+        let _ = wireguard_a.add_session("peer-b", session_a).await;
+        let _ = wireguard_b.add_session("peer-a", session_b).await;
+
+        let (a_encrypted_tx, a_encrypted_rx) = mpsc::channel(64);
+        let (b_encrypted_tx, b_encrypted_rx) = mpsc::channel(64);
+        let a_reader_tx = a_encrypted_tx.clone();
+        let b_reader_tx = b_encrypted_tx.clone();
+        let udp_a = udp_a
+            .with_dplpmtud_local_virtual_ip(Ipv4Addr::new(10, 20, 0, 1))
+            .with_inbound_channel(a_encrypted_tx);
+        let udp_b = udp_b.with_inbound_channel(b_encrypted_tx);
+        // The live daemon uses a publication watch, rather than a static
+        // transport option.  Keep the same owner check in this E2E test so a
+        // queued datagram from a withdrawn UDP publication cannot become
+        // DPLPMTUD evidence.
+        udp_a.set_inbound_publication_owner(101);
+        udp_b.set_inbound_publication_owner(202);
+        let (udp_a_watch_tx, udp_a_watch_rx) = watch::channel(Some(udp_a.clone()));
+        let (udp_b_watch_tx, udp_b_watch_rx) = watch::channel(Some(udp_b.clone()));
+        let (a_overlay_tx, mut a_overlay_rx) = mpsc::channel(8);
+        let (b_overlay_tx, mut b_overlay_rx) = mpsc::channel(8);
+
+        let a_reader = tokio::spawn({
+            let udp = udp_a.clone();
+            async move { udp.run_inbound(a_reader_tx).await }
+        });
+        let b_reader = tokio::spawn({
+            let udp = udp_b.clone();
+            async move { udp.run_inbound(b_reader_tx).await }
+        });
+        let a_transport = tokio::spawn({
+            let wireguard = wireguard_a.clone();
+            let peers = peers_a.clone();
+            async move {
+                wireguard
+                    .run_inbound_with_peers_live_udp(
+                        a_encrypted_rx,
+                        a_overlay_tx,
+                        Some(peers),
+                        udp_a_watch_rx,
+                    )
+                    .await
+            }
+        });
+        let b_transport = tokio::spawn({
+            let wireguard = wireguard_b.clone();
+            let peers = peers_b.clone();
+            async move {
+                wireguard
+                    .run_inbound_with_peers_live_udp(
+                        b_encrypted_rx,
+                        b_overlay_tx,
+                        Some(peers),
+                        udp_b_watch_rx,
+                    )
+                    .await
+            }
+        });
+
+        let dropped_probe_count = Arc::new(AtomicUsize::new(0));
+        let router_task = tokio::spawn({
+            let dropped_probe_count = dropped_probe_count.clone();
+            async move {
+                let mut buffer = vec![0u8; 65_535];
+                loop {
+                    let (size, source) = router.recv_from(&mut buffer).await.unwrap();
+                    if source == endpoint_a {
+                        if size <= BLACKHOLE_THRESHOLD {
+                            router.send_to(&buffer[..size], endpoint_b).await.unwrap();
+                        } else {
+                            dropped_probe_count.fetch_add(1, AtomicOrdering::Relaxed);
+                        }
+                    } else if source == endpoint_b {
+                        router.send_to(&buffer[..size], endpoint_a).await.unwrap();
+                    }
+                }
+            }
+        });
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let scheduler = tokio::spawn(crate::run_dplpmtud_scheduler_until_cancelled(
+            udp_a.clone(),
+            peers_a.clone(),
+            wireguard_a.clone(),
+            shutdown_rx,
+        ));
+
+        yield_until(
+            || {
+                runtime
+                    .snapshots()
+                    .get("peer-b")
+                    .is_some_and(|snapshot| snapshot.outstanding_probe.is_some())
+            },
+            "DPLPMTUD scheduler must submit its first production probe",
+        )
+        .await;
+
+        let mut observed_probe_sizes = Vec::new();
+        let mut observed_blackhole_drops = 0;
+        let mut observed_timeouts = 0;
+        let mut observed_successes = 0;
+        loop {
+            let snapshot = runtime
+                .snapshots()
+                .remove("peer-b")
+                .expect("DPLPMTUD path snapshot must remain published");
+            if snapshot.state == DplpmtudState::SearchComplete {
+                break;
+            }
+            let Some(outstanding) = snapshot.outstanding_probe else {
+                tokio::task::yield_now().await;
+                continue;
+            };
+            if outstanding.sent_age_ms.is_none() {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            let candidate = outstanding.candidate_udp_datagram_size as usize;
+            observed_probe_sizes.push(candidate);
+            if candidate <= BLACKHOLE_THRESHOLD {
+                let expected_successes = observed_successes + 1;
+                yield_until(
+                    || {
+                        runtime
+                            .snapshots()
+                            .get("peer-b")
+                            .is_some_and(|value| value.success_count >= expected_successes)
+                    },
+                    "an allowed encrypted Probe must return through the production ACK path",
+                )
+                .await;
+                observed_successes = expected_successes;
+            } else {
+                let expected_drops = observed_blackhole_drops + 1;
+                yield_until(
+                    || dropped_probe_count.load(AtomicOrdering::Relaxed) >= expected_drops,
+                    "the controllable blackhole must receive every disallowed Probe",
+                )
+                .await;
+                observed_blackhole_drops = expected_drops;
+                let expected_timeouts = observed_timeouts + 1;
+                tokio::time::advance(DPLPMTUD_PROBE_TIMEOUT + Duration::from_millis(1)).await;
+                yield_until(
+                    || {
+                        runtime
+                            .snapshots()
+                            .get("peer-b")
+                            .is_some_and(|value| value.timeout_count >= expected_timeouts)
+                    },
+                    "a blackholed Probe must be retired by the bounded timeout path",
+                )
+                .await;
+                observed_timeouts = expected_timeouts;
+            }
+        }
+
+        let result = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(result.state, DplpmtudState::SearchComplete);
+        assert!(result.confirmed_udp_datagram_size as usize <= BLACKHOLE_THRESHOLD);
+        assert!(
+            BLACKHOLE_THRESHOLD - result.confirmed_udp_datagram_size as usize
+                <= DPLPMTUD_SEARCH_GRANULARITY as usize
+        );
+        assert!(observed_probe_sizes
+            .iter()
+            .any(|size| *size <= BLACKHOLE_THRESHOLD));
+        assert!(observed_probe_sizes
+            .iter()
+            .any(|size| *size > BLACKHOLE_THRESHOLD));
+        let connection = peers_a.get_connection("peer-b").await.unwrap();
+        assert_eq!(
+            connection.active_path(),
+            Some(crate::peer::NetworkPath::Direct)
+        );
+        assert_eq!(connection.direct_health.failure_count, 0);
+        assert_eq!(connection.relay_health.failure_count, 0);
+        assert!(a_overlay_rx.try_recv().is_err());
+        assert!(b_overlay_rx.try_recv().is_err());
+
+        shutdown_tx.send(true).unwrap();
+        scheduler.await.unwrap();
+        assert_eq!(runtime.active_worker_count(), 0);
+        drop(udp_a_watch_tx);
+        drop(udp_b_watch_tx);
+        a_reader.abort();
+        b_reader.abort();
+        a_transport.abort();
+        b_transport.abort();
+        router_task.abort();
+        let _ = a_reader.await;
+        let _ = b_reader.await;
+        let _ = a_transport.await;
+        let _ = b_transport.await;
+        let _ = router_task.await;
+        println!(
+            "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} success_count={} dropped_probe_count={} direct_active=true direct_health_failure_count={} relay_fallback_count=0 task_leak={}",
+            BLACKHOLE_THRESHOLD,
+            result.confirmed_udp_datagram_size,
+            result.search_upper_udp_datagram_size,
+            result.probe_count,
+            result.timeout_count,
+            result.success_count,
+            dropped_probe_count.load(AtomicOrdering::Relaxed),
+            connection.direct_health.failure_count,
+            runtime.active_worker_count() != 0,
+        );
+    }
+
+    #[tokio::test]
+    // Keep the reducer-only blackhole model as a narrow state-machine
+    // regression. The acceptance test above is the production-path test used
+    // by CI; this supplemental test intentionally does not stand in for it.
+    async fn reducer_blackhole_state_machine_regression() {
         const BLACKHOLE_THRESHOLD: usize = 1397;
         let socket_a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let socket_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -2564,7 +2973,7 @@ mod tests {
             generation_probe_size,
             generation_plan.probe_identity.candidate_udp_datagram_size.0 as usize
         );
-        assert!(runtime.begin_probe_send(&generation_plan));
+        assert!(runtime.begin_probe_send(&generation_plan, logical_now));
         socket_a
             .send_to(&generation_encrypted.wire_bytes, endpoint_b)
             .await
@@ -2694,7 +3103,7 @@ mod tests {
                 probe_size,
                 plan.probe_identity.candidate_udp_datagram_size.0 as usize
             );
-            assert!(runtime.begin_probe_send(&plan));
+            assert!(runtime.begin_probe_send(&plan, logical_now));
             let allowed = probe_size <= BLACKHOLE_THRESHOLD;
             let target = if allowed { endpoint_b } else { sink_endpoint };
             assert_eq!(
@@ -2903,7 +3312,7 @@ mod tests {
             logical_now + Duration::from_millis(1),
         );
         assert!(*peer_left_lease.cancel_rx.borrow());
-        assert!(!runtime.begin_probe_send(&peer_left_plan));
+        assert!(!runtime.begin_probe_send(&peer_left_plan, logical_now + Duration::from_millis(1),));
         assert_eq!(
             runtime.timeout_probe(&peer_left_plan, peer_left_plan.deadline),
             DplpmtudTransitionDecision::Noop

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -1,176 +1,1656 @@
-//! Path MTU discovery — bounded probing / fallback decision logic (audit §16).
+//! Authenticated Direct UDP Datagram Packetization Layer Path MTU Discovery.
 //!
-//! The live probe (an authenticated padded datagram plus a timeout over the
-//! selected path) must be driven by something that decides *which* size to try
-//! next and *how far* to fall back when a probe fails.  That decision is pure
-//! state — it takes the set of sizes tried so far and their success/failure and
-//! returns the next size — so it is unit-tested here without any network.
+//! This phase deliberately keeps three layers distinct:
+//! - [`OuterIpPacketSize`]: complete outer IP packet (IP + UDP + datagram);
+//! - [`UdpDatagramSize`]: bytes passed to `UdpSocket::send_to`;
+//! - [`OverlayPayloadBudget`]: decrypted WireGuard plaintext budget.
 //!
-//! Strategy (mirrors audit §16.3):
-//!   - Start at a conservative floor (1200).
-//!   - Probe upward through a ladder of candidate sizes.
-//!   - A failed probe does NOT mean the path is dead: it means the current size
-//!     is too big, so collapse to the largest size that already succeeded (fast
-//!     fallback).  This is O(1) — no re-probing from scratch — which keeps the
-//!     cost bounded and the convergence quick.
-//!
-//! The path is intentionally split per (peer, path_type, generation) by the
-//! caller ([`MtuState`]); this module owns no path identity.
+//! The reducer below never selects an active path and never mutates Direct
+//! health. A probe timeout only narrows one exact Direct path's size search.
 
-/// The minimum probe size we always start from.
-pub const MTU_FLOOR: u32 = 1200;
-/// IPv6-safe minimum (RFC 8200): the largest size guaranteed to pass if any
-/// IPv6 size passes.
-pub const IPV6_SAFE_MIN_MTU: u32 = 1280;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
+use std::time::Duration;
 
-/// Candidate sizes probed in ascending order (audit §16.3 ladder).
-pub const MTU_LADDER: &[u32] = &[1280, 1360, 1380, 1420];
+use p2pnet_tun::{Ipv4Packet, Protocol};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use tokio::net::UdpSocket;
+use tokio::sync::{watch, Notify};
+use tokio::time::Instant;
 
-/// A per-path MTU decision state.
-///
-/// The caller resets this whenever the `(peer, path_type, generation)` changes
-/// (audit §16.2), so this struct is intentionally stateless across those axes.
+use crate::peer::{ActiveBusinessPath, DirectValidationIdentity, PathEpoch, PeerPathLifecycle};
+
+/// WireGuard transport header (16 bytes) plus ChaCha20-Poly1305 tag (16 bytes).
+pub(crate) const WIREGUARD_UDP_DATAGRAM_OVERHEAD: u32 = 32;
+/// Outer IPv4 + UDP framing, excluded from [`UdpDatagramSize`].
+pub(crate) const IPV4_OUTER_IP_UDP_OVERHEAD: u32 = 20 + 8;
+/// Outer IPv6 + UDP framing, excluded from [`UdpDatagramSize`].
+pub(crate) const IPV6_OUTER_IP_UDP_OVERHEAD: u32 = 40 + 8;
+/// Conservative UDP datagram baseline for an authenticated Direct path.
+pub(crate) const DPLPMTUD_BASE_UDP_DATAGRAM_SIZE: u32 = 1200;
+/// Ethernet-sized IPv4 UDP datagram ceiling: 1500 - IPv4(20) - UDP(8).
+pub(crate) const DPLPMTUD_IPV4_UDP_DATAGRAM_CEILING: u32 = 1472;
+/// Ethernet-sized IPv6 UDP datagram ceiling: 1500 - IPv6(40) - UDP(8).
+pub(crate) const DPLPMTUD_IPV6_UDP_DATAGRAM_CEILING: u32 = 1452;
+pub(crate) const DPLPMTUD_SEARCH_GRANULARITY: u32 = 8;
+pub(crate) const DPLPMTUD_MAX_RETRIES: u8 = 2;
+pub(crate) const DPLPMTUD_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const DPLPMTUD_RAISE_INTERVAL: Duration = Duration::from_secs(10 * 60);
+pub(crate) const DPLPMTUD_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+pub(crate) const DPLPMTUD_WORKER_MAX_LIFETIME: Duration = Duration::from_secs(60 * 60);
+pub(crate) const MAX_TRACKED_DPLPMTUD_PEERS: usize = 256;
+const MAX_CONSUMED_PROBE_RECEIPTS: usize = 32;
+
+const DIRECT_VALIDATION_TOKEN_BYTES: usize = 8 + 2 + 1 + 8;
+const DIRECT_VALIDATION_CAPABILITY_EXTENSION: [u8; 6] = [b'D', b'P', b'M', b'1', 1, 1];
+const DPLPMTUD_PROBE_PREFIX: &[u8] = b"p2wlan-dplpmtud-probe-v1";
+const DPLPMTUD_ACK_PREFIX: &[u8] = b"p2wlan-dplpmtud-ack-v1";
+const DPLPMTUD_TOKEN_BYTES: usize = 8 + 16 + 16 + 8 + 8 + 8 + 8 + 2 + 4 + 1;
+const INNER_IPV4_ICMP_OVERHEAD: usize = 20 + 8;
+
+/// Additive capability bytes inserted before the existing fixed Direct-
+/// validation tail token. Old peers locate that token from the end and safely
+/// ignore these bytes.
+pub(crate) const fn direct_validation_capability_extension() -> [u8; 6] {
+    DIRECT_VALIDATION_CAPABILITY_EXTENSION
+}
+
+/// Capability negotiation is fail-closed: legacy or malformed extensions are
+/// treated as unsupported and therefore never receive a size Probe.
+pub(crate) fn direct_validation_supports_dplpmtud(packet: &[u8]) -> bool {
+    let Ok(ip) = Ipv4Packet::new(packet) else {
+        return false;
+    };
+    if ip.protocol() != Protocol::Icmp {
+        return false;
+    }
+    let Some(payload) = ip.payload().get(8..) else {
+        return false;
+    };
+    let prefix_len = if payload.starts_with(crate::DIRECT_VALIDATION_REQUEST_PAYLOAD) {
+        crate::DIRECT_VALIDATION_REQUEST_PAYLOAD.len()
+    } else if payload.starts_with(crate::DIRECT_VALIDATION_ACK_PAYLOAD) {
+        crate::DIRECT_VALIDATION_ACK_PAYLOAD.len()
+    } else {
+        return false;
+    };
+    let Some(token_start) = payload.len().checked_sub(DIRECT_VALIDATION_TOKEN_BYTES) else {
+        return false;
+    };
+    token_start >= prefix_len
+        && payload[prefix_len..token_start] == DIRECT_VALIDATION_CAPABILITY_EXTENSION
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct OuterIpPacketSize(pub(crate) u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct UdpDatagramSize(pub(crate) u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct OverlayPayloadBudget(pub(crate) u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OuterIpFamily {
+    Ipv4,
+    Ipv6,
+}
+
+impl OuterIpFamily {
+    pub(crate) const fn from_ip(ip: IpAddr) -> Self {
+        match ip {
+            IpAddr::V4(_) => Self::Ipv4,
+            IpAddr::V6(_) => Self::Ipv6,
+        }
+    }
+
+    pub(crate) const fn outer_ip_udp_overhead(self) -> u32 {
+        match self {
+            Self::Ipv4 => IPV4_OUTER_IP_UDP_OVERHEAD,
+            Self::Ipv6 => IPV6_OUTER_IP_UDP_OVERHEAD,
+        }
+    }
+
+    pub(crate) const fn ceiling_udp_datagram_size(self) -> UdpDatagramSize {
+        match self {
+            Self::Ipv4 => UdpDatagramSize(DPLPMTUD_IPV4_UDP_DATAGRAM_CEILING),
+            Self::Ipv6 => UdpDatagramSize(DPLPMTUD_IPV6_UDP_DATAGRAM_CEILING),
+        }
+    }
+}
+
+impl UdpDatagramSize {
+    pub(crate) const fn outer_ip_packet_size(self, family: OuterIpFamily) -> OuterIpPacketSize {
+        OuterIpPacketSize(self.0 + family.outer_ip_udp_overhead())
+    }
+
+    pub(crate) const fn overlay_payload_budget(self) -> Option<OverlayPayloadBudget> {
+        match self.0.checked_sub(WIREGUARD_UDP_DATAGRAM_OVERHEAD) {
+            Some(value) => Some(OverlayPayloadBudget(value)),
+            None => None,
+        }
+    }
+}
+
+/// Stable identity of the concrete local socket in one UDP publication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct DplpmtudSocketIdentity {
+    pub(crate) transport_instance_id: u64,
+    pub(crate) socket_index: usize,
+}
+
+/// Exact local identity of one already-authenticated Direct UDP path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DplpmtudPathIdentity {
+    pub(crate) peer_id: String,
+    pub(crate) epoch: PathEpoch,
+    pub(crate) direct_validation_owner_token: u64,
+    pub(crate) direct_validation_request_id: u16,
+    pub(crate) authenticated_remote_endpoint: SocketAddr,
+    pub(crate) local_endpoint: SocketAddr,
+    pub(crate) socket: DplpmtudSocketIdentity,
+    pub(crate) outer_ip_family: OuterIpFamily,
+}
+
+impl DplpmtudPathIdentity {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_committed_validation(
+        peer_id: impl Into<String>,
+        validation: DirectValidationIdentity,
+        authenticated_remote_endpoint: SocketAddr,
+        local_endpoint: SocketAddr,
+        transport_instance_id: u64,
+        socket_index: usize,
+    ) -> Option<Self> {
+        Some(Self {
+            peer_id: peer_id.into(),
+            epoch: validation.epoch,
+            direct_validation_owner_token: validation.owner_token?,
+            direct_validation_request_id: validation.request_id?,
+            authenticated_remote_endpoint,
+            local_endpoint,
+            socket: DplpmtudSocketIdentity {
+                transport_instance_id,
+                socket_index,
+            },
+            outer_ip_family: OuterIpFamily::from_ip(authenticated_remote_endpoint.ip()),
+        })
+    }
+
+    pub(crate) fn matches_committed_path(
+        &self,
+        lifecycle: PeerPathLifecycle,
+        epoch: Option<PathEpoch>,
+        active: &ActiveBusinessPath,
+    ) -> bool {
+        lifecycle == PeerPathLifecycle::Online
+            && epoch == Some(self.epoch)
+            && matches!(
+                active,
+                ActiveBusinessPath::Direct(validation)
+                    if validation.epoch == self.epoch
+                        && validation.owner_token == Some(self.direct_validation_owner_token)
+                        && validation.request_id == Some(self.direct_validation_request_id)
+                        && validation.commit_endpoint()
+                            == Some(self.authenticated_remote_endpoint)
+            )
+    }
+
+    pub(crate) fn summary(&self) -> DplpmtudPathIdentitySnapshot {
+        DplpmtudPathIdentitySnapshot {
+            peer_id: self.peer_id.clone(),
+            network_generation: self.epoch.network_generation,
+            peer_session_generation: self.epoch.peer_session_generation.value(),
+            remote_candidate_epoch: self.epoch.remote_candidate_epoch,
+            direct_validation_owner_token: self.direct_validation_owner_token,
+            direct_validation_request_id: self.direct_validation_request_id,
+            authenticated_remote_endpoint: self.authenticated_remote_endpoint.to_string(),
+            local_endpoint: self.local_endpoint.to_string(),
+            transport_instance_id: self.socket.transport_instance_id,
+            socket_index: self.socket.socket_index,
+            outer_ip_family: self.outer_ip_family,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DplpmtudPathIdentitySnapshot {
+    pub(crate) peer_id: String,
+    pub(crate) network_generation: u64,
+    pub(crate) peer_session_generation: u64,
+    pub(crate) remote_candidate_epoch: u64,
+    pub(crate) direct_validation_owner_token: u64,
+    pub(crate) direct_validation_request_id: u16,
+    pub(crate) authenticated_remote_endpoint: String,
+    pub(crate) local_endpoint: String,
+    pub(crate) transport_instance_id: u64,
+    pub(crate) socket_index: usize,
+    pub(crate) outer_ip_family: OuterIpFamily,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DplpmtudState {
+    Disabled,
+    Unsupported,
+    Base,
+    Searching,
+    SearchComplete,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct DplpmtudProbeIdentity {
+    pub(crate) sequence: u64,
+    pub(crate) nonce: [u8; 16],
+    pub(crate) path_cookie: [u8; 16],
+    pub(crate) candidate_udp_datagram_size: UdpDatagramSize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MtuState {
-    /// The largest size that has succeeded so far.  Always `>= MTU_FLOOR`.
-    confirmed: u32,
-    /// The largest size probed so far.  Never exceeds the ladder top.
-    probed: u32,
-    /// Index of the next ladder entry to try; `None` when the ladder is
-    /// exhausted (we have climbed to the largest that succeeded).
-    next_index: Option<usize>,
+struct OutstandingProbe {
+    identity: DplpmtudProbeIdentity,
+    scheduled_at: Instant,
+    sent_at: Option<Instant>,
+    deadline: Instant,
+    retry: u8,
 }
 
-impl Default for MtuState {
-    fn default() -> Self {
-        Self::new()
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DplpmtudEvent {
+    StartSearch {
+        now: Instant,
+    },
+    ProbeScheduled {
+        probe: DplpmtudProbeIdentity,
+        retry: u8,
+        now: Instant,
+        deadline: Instant,
+    },
+    ProbeSent {
+        probe: DplpmtudProbeIdentity,
+        now: Instant,
+    },
+    ProbeAcked {
+        probe: DplpmtudProbeIdentity,
+        now: Instant,
+    },
+    ProbeTimedOut {
+        probe: DplpmtudProbeIdentity,
+        now: Instant,
+    },
+    ProbeSendFailed {
+        probe: DplpmtudProbeIdentity,
+        now: Instant,
+    },
+    RaiseTimerExpired {
+        now: Instant,
+    },
+    StaleAck {
+        now: Instant,
+    },
+    Cancelled {
+        reason: String,
+        now: Instant,
+    },
 }
 
-impl MtuState {
-    /// A fresh state: floor confirmed, nothing probed above it.
-    pub fn new() -> Self {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DplpmtudTransitionDecision {
+    Applied,
+    Duplicate,
+    Stale,
+    Noop,
+    Rejected,
+    Busy,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DplpmtudTransition {
+    decision: DplpmtudTransitionDecision,
+    next: DplpmtudStateMachine,
+}
+
+/// Pure bounded reducer for one exact Direct path.
+#[derive(Debug, Clone)]
+pub(crate) struct DplpmtudStateMachine {
+    identity: Option<DplpmtudPathIdentity>,
+    state: DplpmtudState,
+    supported: bool,
+    base_udp_datagram_size: UdpDatagramSize,
+    confirmed_udp_datagram_size: UdpDatagramSize,
+    search_upper_udp_datagram_size: UdpDatagramSize,
+    pending_candidate_udp_datagram_size: Option<UdpDatagramSize>,
+    outstanding: Option<OutstandingProbe>,
+    retry_count: u8,
+    next_sequence: u64,
+    revision: u64,
+    probe_count: u64,
+    success_count: u64,
+    timeout_count: u64,
+    send_failure_count: u64,
+    stale_ack_count: u64,
+    duplicate_ack_count: u64,
+    last_success_at: Option<Instant>,
+    last_timeout_at: Option<Instant>,
+    last_failure_at: Option<Instant>,
+    raise_at: Option<Instant>,
+    last_reset_reason: Option<String>,
+    reset_count: u64,
+    consumed_receipts: VecDeque<DplpmtudProbeIdentity>,
+}
+
+impl DplpmtudStateMachine {
+    pub(crate) fn for_path(identity: DplpmtudPathIdentity, supported: bool, _now: Instant) -> Self {
+        let base = UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE);
+        let upper = identity.outer_ip_family.ceiling_udp_datagram_size();
+        let pending = supported
+            .then(|| next_search_candidate(base, upper))
+            .flatten();
         Self {
-            confirmed: MTU_FLOOR,
-            probed: MTU_FLOOR,
-            next_index: Some(0),
+            identity: Some(identity),
+            state: if supported {
+                DplpmtudState::Base
+            } else {
+                DplpmtudState::Unsupported
+            },
+            supported,
+            base_udp_datagram_size: base,
+            confirmed_udp_datagram_size: base,
+            search_upper_udp_datagram_size: upper,
+            pending_candidate_udp_datagram_size: pending,
+            outstanding: None,
+            retry_count: 0,
+            next_sequence: 1,
+            revision: 1,
+            probe_count: 0,
+            success_count: 0,
+            timeout_count: 0,
+            send_failure_count: 0,
+            stale_ack_count: 0,
+            duplicate_ack_count: 0,
+            last_success_at: None,
+            last_timeout_at: None,
+            last_failure_at: None,
+            raise_at: None,
+            last_reset_reason: Some(
+                if supported {
+                    "direct_committed"
+                } else {
+                    "dplpmtud_capability_not_negotiated"
+                }
+                .to_string(),
+            ),
+            reset_count: 1,
+            consumed_receipts: VecDeque::new(),
         }
     }
 
-    /// The next size the caller should probe, or `None` when probing is done
-    /// (the largest ladder size that succeeded is the effective MTU).
-    pub fn next_probe(&self) -> Option<u32> {
-        self.next_index.and_then(|i| MTU_LADDER.get(i).copied())
+    pub(crate) fn identity(&self) -> Option<&DplpmtudPathIdentity> {
+        self.identity.as_ref()
     }
 
-    /// The effective path MTU: the largest size confirmed possible.  For a
-    /// path that never probed above the floor this is `MTU_FLOOR`.
-    pub fn effective_mtu(&self) -> u32 {
-        self.confirmed
+    pub(crate) const fn state(&self) -> DplpmtudState {
+        self.state
     }
 
-    /// Fold one probe result.
-    ///
-    /// - `Ok(size)`: the given size carried traffic successfully; it becomes
-    ///   the confirmed size and probing continues upward.
-    /// - `Err(_)`: the given size was too large; probing stops immediately and
-    ///   the effective MTU collapses to the last confirmed size (fast fallback,
-    ///   no re-probing from scratch).
-    pub fn record(&mut self, size: u32, succeeded: bool) {
-        if succeeded {
-            if size > self.confirmed {
-                self.confirmed = size;
-            }
-            self.probed = size;
-            match self.next_index {
-                Some(i) if MTU_LADDER.get(i).copied() == Some(size) => {
-                    self.next_index = Some(i + 1);
+    pub(crate) fn outstanding_identity(&self) -> Option<DplpmtudProbeIdentity> {
+        self.outstanding.map(|outstanding| outstanding.identity)
+    }
+
+    pub(crate) fn next_wakeup(&self) -> Option<Instant> {
+        self.outstanding
+            .map(|outstanding| outstanding.deadline)
+            .or(self.raise_at)
+    }
+
+    pub(crate) fn next_probe_components(&self) -> Option<(u64, UdpDatagramSize, u8)> {
+        if !self.supported
+            || !matches!(self.state, DplpmtudState::Base | DplpmtudState::Searching)
+            || self.outstanding.is_some()
+        {
+            return None;
+        }
+        self.pending_candidate_udp_datagram_size
+            .map(|candidate| (self.next_sequence, candidate, self.retry_count))
+    }
+
+    pub(crate) fn reduce(&self, event: DplpmtudEvent) -> DplpmtudTransition {
+        let mut next = self.clone();
+        let decision = match event {
+            DplpmtudEvent::StartSearch { now } => {
+                if self.state != DplpmtudState::Base {
+                    DplpmtudTransitionDecision::Noop
+                } else if self.pending_candidate_udp_datagram_size.is_none() {
+                    next.state = DplpmtudState::SearchComplete;
+                    next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                    DplpmtudTransitionDecision::Applied
+                } else {
+                    next.state = DplpmtudState::Searching;
+                    DplpmtudTransitionDecision::Applied
                 }
-                _ => {
-                    // A size outside the ladder (e.g. a fallback floor) was
-                    // confirmed; keep probing the next unconfirmed ladder entry.
-                    if let Some(next) = MTU_LADDER.iter().position(|s| *s > size) {
-                        self.next_index = Some(next);
+            }
+            DplpmtudEvent::ProbeScheduled {
+                probe,
+                retry,
+                now,
+                deadline,
+            } => {
+                if !matches!(self.state, DplpmtudState::Base | DplpmtudState::Searching)
+                    || self.outstanding.is_some()
+                    || self.pending_candidate_udp_datagram_size
+                        != Some(probe.candidate_udp_datagram_size)
+                    || retry != self.retry_count
+                    || probe.sequence != self.next_sequence
+                    || deadline <= now
+                {
+                    DplpmtudTransitionDecision::Rejected
+                } else {
+                    next.state = DplpmtudState::Searching;
+                    next.outstanding = Some(OutstandingProbe {
+                        identity: probe,
+                        scheduled_at: now,
+                        sent_at: None,
+                        deadline,
+                        retry,
+                    });
+                    next.next_sequence = next.next_sequence.wrapping_add(1).max(1);
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+            DplpmtudEvent::ProbeSent { probe, now } => {
+                if let Some(outstanding) = next.outstanding.as_mut() {
+                    if outstanding.identity == probe && outstanding.sent_at.is_none() {
+                        outstanding.sent_at = Some(now);
+                        next.probe_count = next.probe_count.saturating_add(1);
+                        DplpmtudTransitionDecision::Applied
                     } else {
-                        self.next_index = None;
+                        DplpmtudTransitionDecision::Noop
                     }
+                } else {
+                    DplpmtudTransitionDecision::Noop
                 }
             }
-        } else {
-            // Failure: collapse immediately and stop climbing.  The confirmed
-            // size is already the largest that succeeded.
-            self.probed = size;
-            self.next_index = None;
+            DplpmtudEvent::ProbeAcked { probe, now } => {
+                if self.consumed_receipts.contains(&probe) {
+                    DplpmtudTransitionDecision::Duplicate
+                } else if let Some(outstanding) = self.outstanding {
+                    if outstanding.identity != probe
+                        || outstanding.sent_at.is_none()
+                        || now > outstanding.deadline
+                    {
+                        next.stale_ack_count = next.stale_ack_count.saturating_add(1);
+                        DplpmtudTransitionDecision::Stale
+                    } else {
+                        next.outstanding = None;
+                        next.retry_count = 0;
+                        next.confirmed_udp_datagram_size = next
+                            .confirmed_udp_datagram_size
+                            .max(probe.candidate_udp_datagram_size);
+                        next.success_count = next.success_count.saturating_add(1);
+                        next.last_success_at = Some(now);
+                        push_consumed_receipt(&mut next.consumed_receipts, probe);
+                        next.pending_candidate_udp_datagram_size = next_search_candidate(
+                            next.confirmed_udp_datagram_size,
+                            next.search_upper_udp_datagram_size,
+                        );
+                        if next.pending_candidate_udp_datagram_size.is_none() {
+                            next.state = DplpmtudState::SearchComplete;
+                            next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                        } else {
+                            next.state = DplpmtudState::Searching;
+                            next.raise_at = None;
+                        }
+                        DplpmtudTransitionDecision::Applied
+                    }
+                } else {
+                    next.stale_ack_count = next.stale_ack_count.saturating_add(1);
+                    DplpmtudTransitionDecision::Stale
+                }
+            }
+            DplpmtudEvent::ProbeTimedOut { probe, now } => {
+                let Some(outstanding) = self.outstanding else {
+                    return DplpmtudTransition {
+                        decision: DplpmtudTransitionDecision::Noop,
+                        next,
+                    };
+                };
+                if outstanding.identity != probe
+                    || outstanding.sent_at.is_none()
+                    || now < outstanding.deadline
+                {
+                    DplpmtudTransitionDecision::Rejected
+                } else {
+                    next.outstanding = None;
+                    next.timeout_count = next.timeout_count.saturating_add(1);
+                    next.last_timeout_at = Some(now);
+                    if outstanding.retry < DPLPMTUD_MAX_RETRIES {
+                        next.retry_count = outstanding.retry.saturating_add(1);
+                        next.pending_candidate_udp_datagram_size =
+                            Some(probe.candidate_udp_datagram_size);
+                        next.state = DplpmtudState::Searching;
+                    } else {
+                        next.retry_count = 0;
+                        let failed_upper = probe
+                            .candidate_udp_datagram_size
+                            .0
+                            .saturating_sub(DPLPMTUD_SEARCH_GRANULARITY)
+                            .max(next.confirmed_udp_datagram_size.0);
+                        next.search_upper_udp_datagram_size = UdpDatagramSize(
+                            next.search_upper_udp_datagram_size.0.min(failed_upper),
+                        );
+                        next.pending_candidate_udp_datagram_size = next_search_candidate(
+                            next.confirmed_udp_datagram_size,
+                            next.search_upper_udp_datagram_size,
+                        );
+                        if next.pending_candidate_udp_datagram_size.is_none() {
+                            next.state = DplpmtudState::SearchComplete;
+                            next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                        } else {
+                            next.state = DplpmtudState::Searching;
+                        }
+                    }
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+            DplpmtudEvent::ProbeSendFailed { probe, now } => {
+                if self.outstanding.map(|value| value.identity) != Some(probe) {
+                    DplpmtudTransitionDecision::Noop
+                } else {
+                    next.outstanding = None;
+                    next.send_failure_count = next.send_failure_count.saturating_add(1);
+                    next.last_failure_at = Some(now);
+                    next.state = DplpmtudState::Error;
+                    next.raise_at = Some(now + DPLPMTUD_ERROR_RETRY_INTERVAL);
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+            DplpmtudEvent::RaiseTimerExpired { now } => {
+                if !matches!(
+                    self.state,
+                    DplpmtudState::SearchComplete | DplpmtudState::Error
+                ) || self.raise_at.is_none_or(|deadline| now < deadline)
+                {
+                    DplpmtudTransitionDecision::Noop
+                } else {
+                    next.search_upper_udp_datagram_size = next
+                        .identity
+                        .as_ref()
+                        .map(|identity| identity.outer_ip_family.ceiling_udp_datagram_size())
+                        .unwrap_or(next.search_upper_udp_datagram_size);
+                    next.pending_candidate_udp_datagram_size = next_search_candidate(
+                        next.confirmed_udp_datagram_size,
+                        next.search_upper_udp_datagram_size,
+                    );
+                    next.retry_count = 0;
+                    next.raise_at = None;
+                    next.state = if next.pending_candidate_udp_datagram_size.is_some() {
+                        DplpmtudState::Searching
+                    } else {
+                        next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                        DplpmtudState::SearchComplete
+                    };
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+            DplpmtudEvent::StaleAck { now: _ } => {
+                next.stale_ack_count = next.stale_ack_count.saturating_add(1);
+                DplpmtudTransitionDecision::Stale
+            }
+            DplpmtudEvent::Cancelled { reason, now: _ } => {
+                if self.state == DplpmtudState::Disabled
+                    && self.last_reset_reason.as_deref() == Some(reason.as_str())
+                {
+                    DplpmtudTransitionDecision::Noop
+                } else {
+                    next.state = DplpmtudState::Disabled;
+                    next.supported = false;
+                    next.outstanding = None;
+                    next.pending_candidate_udp_datagram_size = None;
+                    next.raise_at = None;
+                    next.last_reset_reason = Some(reason);
+                    next.reset_count = next.reset_count.saturating_add(1);
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+        };
+        DplpmtudTransition { decision, next }
+    }
+
+    pub(crate) fn commit(&mut self, transition: DplpmtudTransition) -> DplpmtudTransitionDecision {
+        match transition.decision {
+            DplpmtudTransitionDecision::Applied | DplpmtudTransitionDecision::Stale => {
+                *self = transition.next;
+                self.revision = self.revision.saturating_add(1);
+            }
+            DplpmtudTransitionDecision::Duplicate => {
+                // Duplicate ACKs do not alter revision, timestamps, bounds or
+                // success accounting. Only the dedicated diagnostic counter changes.
+                self.duplicate_ack_count = self.duplicate_ack_count.saturating_add(1);
+            }
+            DplpmtudTransitionDecision::Noop
+            | DplpmtudTransitionDecision::Rejected
+            | DplpmtudTransitionDecision::Busy => {}
+        }
+        transition.decision
+    }
+
+    pub(crate) fn apply(&mut self, event: DplpmtudEvent) -> DplpmtudTransitionDecision {
+        let transition = self.reduce(event);
+        self.commit(transition)
+    }
+
+    pub(crate) fn snapshot(&self, now: Instant, live_worker: bool) -> DplpmtudSnapshot {
+        let outstanding_probe = self
+            .outstanding
+            .map(|outstanding| DplpmtudOutstandingSnapshot {
+                sequence: outstanding.identity.sequence,
+                candidate_udp_datagram_size: outstanding.identity.candidate_udp_datagram_size.0,
+                retry: outstanding.retry,
+                scheduled_age_ms: duration_ms(
+                    now.saturating_duration_since(outstanding.scheduled_at),
+                ),
+                sent_age_ms: outstanding
+                    .sent_at
+                    .map(|sent_at| duration_ms(now.saturating_duration_since(sent_at))),
+                deadline_remaining_ms: duration_ms(
+                    outstanding.deadline.saturating_duration_since(now),
+                ),
+            });
+        let family = self
+            .identity
+            .as_ref()
+            .map(|identity| identity.outer_ip_family);
+        DplpmtudSnapshot {
+            state: self.state,
+            supported: self.supported,
+            path_identity: self.identity.as_ref().map(DplpmtudPathIdentity::summary),
+            base_udp_datagram_size: self.base_udp_datagram_size.0,
+            confirmed_udp_datagram_size: self.confirmed_udp_datagram_size.0,
+            search_upper_udp_datagram_size: self.search_upper_udp_datagram_size.0,
+            confirmed_outer_ip_packet_size: family.map(|family| {
+                self.confirmed_udp_datagram_size
+                    .outer_ip_packet_size(family)
+                    .0
+            }),
+            overlay_payload_budget: self
+                .confirmed_udp_datagram_size
+                .overlay_payload_budget()
+                .map(|value| value.0),
+            outstanding_probe,
+            last_success_age_ms: self
+                .last_success_at
+                .map(|at| duration_ms(now.saturating_duration_since(at))),
+            last_timeout_age_ms: self
+                .last_timeout_at
+                .map(|at| duration_ms(now.saturating_duration_since(at))),
+            last_failure_age_ms: self
+                .last_failure_at
+                .map(|at| duration_ms(now.saturating_duration_since(at))),
+            reset_reason: self.last_reset_reason.clone(),
+            reset_count: self.reset_count,
+            revision: self.revision,
+            probe_count: self.probe_count,
+            success_count: self.success_count,
+            timeout_count: self.timeout_count,
+            send_failure_count: self.send_failure_count,
+            stale_ack_count: self.stale_ack_count,
+            duplicate_ack_count: self.duplicate_ack_count,
+            live_worker,
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
 
-    #[test]
-    fn starts_at_floor_and_climbs_ladder() {
-        let mut s = MtuState::new();
-        assert_eq!(s.effective_mtu(), MTU_FLOOR);
-        assert_eq!(s.next_probe(), Some(1280));
+fn push_consumed_receipt(
+    receipts: &mut VecDeque<DplpmtudProbeIdentity>,
+    receipt: DplpmtudProbeIdentity,
+) {
+    if receipts.contains(&receipt) {
+        return;
+    }
+    while receipts.len() >= MAX_CONSUMED_PROBE_RECEIPTS {
+        receipts.pop_front();
+    }
+    receipts.push_back(receipt);
+}
 
-        // Climb the whole ladder successfully.
-        for size in MTU_LADDER {
-            s.record(*size, true);
+fn next_search_candidate(
+    confirmed: UdpDatagramSize,
+    upper: UdpDatagramSize,
+) -> Option<UdpDatagramSize> {
+    if upper.0 <= confirmed.0.saturating_add(DPLPMTUD_SEARCH_GRANULARITY) {
+        return None;
+    }
+    let distance = upper.0 - confirmed.0;
+    let midpoint = confirmed.0 + distance / 2;
+    let aligned = confirmed.0
+        + ((midpoint - confirmed.0) / DPLPMTUD_SEARCH_GRANULARITY) * DPLPMTUD_SEARCH_GRANULARITY;
+    let candidate = aligned
+        .max(confirmed.0.saturating_add(DPLPMTUD_SEARCH_GRANULARITY))
+        .min(upper.0);
+    (candidate > confirmed.0).then_some(UdpDatagramSize(candidate))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DplpmtudOutstandingSnapshot {
+    pub(crate) sequence: u64,
+    pub(crate) candidate_udp_datagram_size: u32,
+    pub(crate) retry: u8,
+    pub(crate) scheduled_age_ms: u64,
+    pub(crate) sent_age_ms: Option<u64>,
+    pub(crate) deadline_remaining_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DplpmtudSnapshot {
+    pub(crate) state: DplpmtudState,
+    pub(crate) supported: bool,
+    pub(crate) path_identity: Option<DplpmtudPathIdentitySnapshot>,
+    pub(crate) base_udp_datagram_size: u32,
+    pub(crate) confirmed_udp_datagram_size: u32,
+    pub(crate) search_upper_udp_datagram_size: u32,
+    pub(crate) confirmed_outer_ip_packet_size: Option<u32>,
+    pub(crate) overlay_payload_budget: Option<u32>,
+    pub(crate) outstanding_probe: Option<DplpmtudOutstandingSnapshot>,
+    pub(crate) last_success_age_ms: Option<u64>,
+    pub(crate) last_timeout_age_ms: Option<u64>,
+    pub(crate) last_failure_age_ms: Option<u64>,
+    pub(crate) reset_reason: Option<String>,
+    pub(crate) reset_count: u64,
+    pub(crate) revision: u64,
+    pub(crate) probe_count: u64,
+    pub(crate) success_count: u64,
+    pub(crate) timeout_count: u64,
+    pub(crate) send_failure_count: u64,
+    pub(crate) stale_ack_count: u64,
+    pub(crate) duplicate_ack_count: u64,
+    pub(crate) live_worker: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DplpmtudWireToken {
+    pub(crate) sequence: u64,
+    pub(crate) nonce: [u8; 16],
+    pub(crate) path_cookie: [u8; 16],
+    pub(crate) network_generation: u64,
+    pub(crate) peer_session_generation: u64,
+    pub(crate) remote_candidate_epoch: u64,
+    pub(crate) direct_validation_owner_token: u64,
+    pub(crate) direct_validation_request_id: u16,
+    pub(crate) candidate_udp_datagram_size: UdpDatagramSize,
+    pub(crate) outer_ip_family: OuterIpFamily,
+}
+
+impl DplpmtudWireToken {
+    pub(crate) fn probe_identity(self) -> DplpmtudProbeIdentity {
+        DplpmtudProbeIdentity {
+            sequence: self.sequence,
+            nonce: self.nonce,
+            path_cookie: self.path_cookie,
+            candidate_udp_datagram_size: self.candidate_udp_datagram_size,
         }
-        assert_eq!(s.effective_mtu(), 1420);
-        assert_eq!(s.next_probe(), None, "ladder exhausted -> probing done");
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DplpmtudControlKind {
+    Probe,
+    Ack,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DplpmtudControlPacket {
+    pub(crate) kind: DplpmtudControlKind,
+    pub(crate) token: DplpmtudWireToken,
+}
+
+pub(crate) fn build_probe_inner_packet(
+    local_virtual_ip: Ipv4Addr,
+    peer_virtual_ip: Ipv4Addr,
+    token: DplpmtudWireToken,
+) -> Result<Vec<u8>, String> {
+    let target_plaintext = usize::try_from(token.candidate_udp_datagram_size.0)
+        .ok()
+        .and_then(|target| target.checked_sub(WIREGUARD_UDP_DATAGRAM_OVERHEAD as usize))
+        .ok_or_else(|| "candidate UDP datagram is smaller than WireGuard overhead".to_string())?;
+    let target_payload = target_plaintext
+        .checked_sub(INNER_IPV4_ICMP_OVERHEAD)
+        .ok_or_else(|| "candidate UDP datagram cannot carry IPv4/ICMP framing".to_string())?;
+    let fixed_payload = DPLPMTUD_PROBE_PREFIX.len() + DPLPMTUD_TOKEN_BYTES;
+    if target_payload < fixed_payload {
+        return Err(format!(
+            "candidate UDP datagram {} is smaller than DPLPMTUD fixed framing {}",
+            token.candidate_udp_datagram_size.0,
+            fixed_payload + INNER_IPV4_ICMP_OVERHEAD + WIREGUARD_UDP_DATAGRAM_OVERHEAD as usize,
+        ));
+    }
+    let mut payload = Vec::with_capacity(target_payload);
+    payload.extend_from_slice(DPLPMTUD_PROBE_PREFIX);
+    encode_wire_token(&mut payload, token);
+    payload.resize(target_payload, 0);
+    let packet = Ipv4Packet::build_icmp_echo_request(
+        local_virtual_ip,
+        peer_virtual_ip,
+        (token.sequence as u16).max(1),
+        (token.sequence as u16).wrapping_add(1),
+        &payload,
+    );
+    if packet.len() != target_plaintext {
+        return Err(format!(
+            "DPLPMTUD plaintext size mismatch: built={} expected={target_plaintext}",
+            packet.len(),
+        ));
+    }
+    Ok(packet)
+}
+
+pub(crate) fn build_ack_inner_packet(
+    local_virtual_ip: Ipv4Addr,
+    peer_virtual_ip: Ipv4Addr,
+    token: DplpmtudWireToken,
+) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(DPLPMTUD_ACK_PREFIX.len() + DPLPMTUD_TOKEN_BYTES);
+    payload.extend_from_slice(DPLPMTUD_ACK_PREFIX);
+    encode_wire_token(&mut payload, token);
+    Ipv4Packet::build_icmp_echo_request(
+        local_virtual_ip,
+        peer_virtual_ip,
+        (token.sequence as u16).max(1),
+        (token.sequence as u16).wrapping_add(1),
+        &payload,
+    )
+}
+
+pub(crate) fn parse_control_packet(packet: &[u8]) -> Option<DplpmtudControlPacket> {
+    let ip = Ipv4Packet::new(packet).ok()?;
+    if ip.protocol() != Protocol::Icmp {
+        return None;
+    }
+    let icmp = ip.payload();
+    if icmp.len() < 8 || icmp[0] != 8 || icmp[1] != 0 {
+        return None;
+    }
+    let payload = &icmp[8..];
+    let (kind, token_bytes) = if let Some(bytes) = payload.strip_prefix(DPLPMTUD_PROBE_PREFIX) {
+        (DplpmtudControlKind::Probe, bytes)
+    } else if let Some(bytes) = payload.strip_prefix(DPLPMTUD_ACK_PREFIX) {
+        (DplpmtudControlKind::Ack, bytes)
+    } else {
+        return None;
+    };
+    let token = decode_wire_token(token_bytes)?;
+    let ceiling = token.outer_ip_family.ceiling_udp_datagram_size().0;
+    if token.candidate_udp_datagram_size.0 < DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+        || token.candidate_udp_datagram_size.0 > ceiling
+    {
+        return None;
+    }
+    Some(DplpmtudControlPacket { kind, token })
+}
+
+fn encode_wire_token(output: &mut Vec<u8>, token: DplpmtudWireToken) {
+    output.extend_from_slice(&token.sequence.to_be_bytes());
+    output.extend_from_slice(&token.nonce);
+    output.extend_from_slice(&token.path_cookie);
+    output.extend_from_slice(&token.network_generation.to_be_bytes());
+    output.extend_from_slice(&token.peer_session_generation.to_be_bytes());
+    output.extend_from_slice(&token.remote_candidate_epoch.to_be_bytes());
+    output.extend_from_slice(&token.direct_validation_owner_token.to_be_bytes());
+    output.extend_from_slice(&token.direct_validation_request_id.to_be_bytes());
+    output.extend_from_slice(&token.candidate_udp_datagram_size.0.to_be_bytes());
+    output.push(match token.outer_ip_family {
+        OuterIpFamily::Ipv4 => 4,
+        OuterIpFamily::Ipv6 => 6,
+    });
+}
+
+fn decode_wire_token(bytes: &[u8]) -> Option<DplpmtudWireToken> {
+    if bytes.len() < DPLPMTUD_TOKEN_BYTES {
+        return None;
+    }
+    let mut cursor = 0usize;
+    let sequence = take_u64(bytes, &mut cursor)?;
+    let nonce = take_array::<16>(bytes, &mut cursor)?;
+    let path_cookie = take_array::<16>(bytes, &mut cursor)?;
+    let network_generation = take_u64(bytes, &mut cursor)?;
+    let peer_session_generation = take_u64(bytes, &mut cursor)?;
+    let remote_candidate_epoch = take_u64(bytes, &mut cursor)?;
+    let direct_validation_owner_token = take_u64(bytes, &mut cursor)?;
+    let direct_validation_request_id = take_u16(bytes, &mut cursor)?;
+    let candidate_udp_datagram_size = UdpDatagramSize(take_u32(bytes, &mut cursor)?);
+    let outer_ip_family = match *bytes.get(cursor)? {
+        4 => OuterIpFamily::Ipv4,
+        6 => OuterIpFamily::Ipv6,
+        _ => return None,
+    };
+    Some(DplpmtudWireToken {
+        sequence,
+        nonce,
+        path_cookie,
+        network_generation,
+        peer_session_generation,
+        remote_candidate_epoch,
+        direct_validation_owner_token,
+        direct_validation_request_id,
+        candidate_udp_datagram_size,
+        outer_ip_family,
+    })
+}
+
+fn take_array<const N: usize>(bytes: &[u8], cursor: &mut usize) -> Option<[u8; N]> {
+    let end = cursor.checked_add(N)?;
+    let value = bytes.get(*cursor..end)?.try_into().ok()?;
+    *cursor = end;
+    Some(value)
+}
+
+fn take_u64(bytes: &[u8], cursor: &mut usize) -> Option<u64> {
+    Some(u64::from_be_bytes(take_array(bytes, cursor)?))
+}
+
+fn take_u32(bytes: &[u8], cursor: &mut usize) -> Option<u32> {
+    Some(u32::from_be_bytes(take_array(bytes, cursor)?))
+}
+
+fn take_u16(bytes: &[u8], cursor: &mut usize) -> Option<u16> {
+    Some(u16::from_be_bytes(take_array(bytes, cursor)?))
+}
+
+/// Build a compatibility-shaped Direct-validation packet carrying a DPLPMTUD
+/// Probe. The fixed Direct-validation tail remains at the end for old decoders.
+pub(crate) fn build_encrypted_probe_plaintext(
+    local_virtual_ip: Ipv4Addr,
+    peer_virtual_ip: Ipv4Addr,
+    identity: &DplpmtudPathIdentity,
+    plan: &DplpmtudProbePlan,
+) -> Result<Vec<u8>, String> {
+    let dplpmtud = build_probe_inner_packet(local_virtual_ip, peer_virtual_ip, plan.wire_token)?;
+    // The DPLPMTUD inner packet itself is the authenticated WireGuard
+    // plaintext. It is parsed before ordinary Direct-validation handling.
+    debug_assert_eq!(identity.peer_id, plan.peer_id);
+    Ok(dplpmtud)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DplpmtudProbePlan {
+    pub(crate) peer_id: String,
+    pub(crate) path_identity: DplpmtudPathIdentity,
+    pub(crate) probe_identity: DplpmtudProbeIdentity,
+    pub(crate) wire_token: DplpmtudWireToken,
+    pub(crate) deadline: Instant,
+}
+
+#[derive(Debug)]
+pub(crate) struct DplpmtudWorkerLease {
+    pub(crate) peer_id: String,
+    pub(crate) identity: DplpmtudPathIdentity,
+    pub(crate) cancel_rx: watch::Receiver<bool>,
+    pub(crate) notify: Arc<Notify>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DplpmtudWorkerStart {
+    pub(crate) lease: DplpmtudWorkerLease,
+    pub(crate) socket: Arc<UdpSocket>,
+    pub(crate) local_virtual_ip: Ipv4Addr,
+    pub(crate) peer_virtual_ip: Ipv4Addr,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct DplpmtudWorkerIngress {
+    state: Arc<StdMutex<VecDeque<DplpmtudWorkerStart>>>,
+    notify: Arc<Notify>,
+}
+
+impl DplpmtudWorkerIngress {
+    pub(crate) fn submit(&self, start: DplpmtudWorkerStart) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.len() >= MAX_TRACKED_DPLPMTUD_PEERS {
+            return false;
+        }
+        state.push_back(start);
+        drop(state);
+        self.notify.notify_one();
+        true
     }
 
-    #[test]
-    fn failure_collapses_to_last_confirmed_and_stops() {
-        let mut s = MtuState::new();
-        s.record(1280, true); // confirmed 1280
-        assert_eq!(s.effective_mtu(), 1280);
-        assert_eq!(s.next_probe(), Some(1360));
-
-        s.record(1360, false); // 1360 too big
-        assert_eq!(
-            s.effective_mtu(),
-            1280,
-            "must fall back to the last confirmed size, not the floor"
-        );
-        assert_eq!(s.next_probe(), None, "no further probing after a failure");
-    }
-
-    #[test]
-    fn floor_failure_keeps_floor_as_effective() {
-        let mut s = MtuState::new();
-        s.record(1280, false);
-        assert_eq!(
-            s.effective_mtu(),
-            MTU_FLOOR,
-            "a floor-adjacent failure still yields a usable conservative floor"
-        );
-        assert_eq!(s.next_probe(), None);
-    }
-
-    #[test]
-    fn partial_climb_stops_at_max_confirmed() {
-        let mut s = MtuState::new();
-        s.record(1280, true);
-        s.record(1360, false);
-        assert_eq!(s.effective_mtu(), 1280);
-        assert_eq!(s.next_probe(), None);
-
-        let mut s2 = MtuState::new();
-        s2.record(1280, true);
-        s2.record(1360, true);
-        s2.record(1380, false);
-        assert_eq!(s2.effective_mtu(), 1360);
-        assert_eq!(s2.next_probe(), None);
-    }
-
-    #[test]
-    fn ipv6_safe_min_is_at_least_floor() {
-        const {
-            assert!(IPV6_SAFE_MIN_MTU >= MTU_FLOOR);
+    pub(crate) async fn next(&self) -> DplpmtudWorkerStart {
+        loop {
+            let notified = self.notify.notified();
+            if let Some(start) = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop_front()
+            {
+                return start;
+            }
+            notified.await;
         }
     }
+
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DplpmtudInstallDecision {
+    Spawned,
+    Unchanged,
+    Unsupported,
+    Closed,
+    CapacityExceeded,
+}
+
+#[derive(Debug)]
+pub(crate) struct DplpmtudInstallResult {
+    pub(crate) decision: DplpmtudInstallDecision,
+    pub(crate) worker: Option<DplpmtudWorkerLease>,
+}
+
+struct RuntimeEntry {
+    machine: DplpmtudStateMachine,
+    path_cookie: [u8; 16],
+    cancel_tx: Option<watch::Sender<bool>>,
+    notify: Arc<Notify>,
+    worker_running: bool,
+    send_in_progress: bool,
+}
+
+#[derive(Default)]
+struct RuntimeRegistry {
+    entries: HashMap<String, RuntimeEntry>,
+    supported_sessions: HashMap<String, u64>,
+    closed: bool,
+}
+
+/// Bounded, cloneable registry shared by one UDP publication, its scheduler,
+/// receive path and diagnostics. No network I/O occurs while the mutex is held.
+#[derive(Clone, Default)]
+pub(crate) struct DplpmtudRuntime {
+    registry: Arc<StdMutex<RuntimeRegistry>>,
+    snapshots: Arc<StdRwLock<HashMap<String, DplpmtudSnapshot>>>,
+}
+
+impl DplpmtudRuntime {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn mark_supported(&self, peer_id: &str, peer_session_generation: u64) -> bool {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return false;
+        }
+        if !registry.supported_sessions.contains_key(peer_id)
+            && registry.supported_sessions.len() >= MAX_TRACKED_DPLPMTUD_PEERS
+        {
+            return false;
+        }
+        registry
+            .supported_sessions
+            .insert(peer_id.to_string(), peer_session_generation)
+            != Some(peer_session_generation)
+    }
+
+    pub(crate) fn is_supported(&self, peer_id: &str, peer_session_generation: u64) -> bool {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .supported_sessions
+            .get(peer_id)
+            .is_some_and(|generation| *generation == peer_session_generation)
+    }
+
+    pub(crate) fn install_path(
+        &self,
+        identity: DplpmtudPathIdentity,
+        supported: bool,
+        now: Instant,
+    ) -> DplpmtudInstallResult {
+        let peer_id = identity.peer_id.clone();
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return DplpmtudInstallResult {
+                decision: DplpmtudInstallDecision::Closed,
+                worker: None,
+            };
+        }
+        if !registry.entries.contains_key(&peer_id)
+            && registry.entries.len() >= MAX_TRACKED_DPLPMTUD_PEERS
+        {
+            return DplpmtudInstallResult {
+                decision: DplpmtudInstallDecision::CapacityExceeded,
+                worker: None,
+            };
+        }
+
+        if let Some(existing) = registry.entries.get_mut(&peer_id) {
+            if existing.machine.identity() == Some(&identity) {
+                if supported && existing.worker_running {
+                    return DplpmtudInstallResult {
+                        decision: DplpmtudInstallDecision::Unchanged,
+                        worker: None,
+                    };
+                }
+                if supported {
+                    let (cancel_tx, cancel_rx) = watch::channel(false);
+                    existing.cancel_tx = Some(cancel_tx);
+                    existing.worker_running = true;
+                    existing.send_in_progress = false;
+                    let notify = existing.notify.clone();
+                    self.publish_snapshot_locked(&peer_id, existing, now);
+                    return DplpmtudInstallResult {
+                        decision: DplpmtudInstallDecision::Spawned,
+                        worker: Some(DplpmtudWorkerLease {
+                            peer_id,
+                            identity,
+                            cancel_rx,
+                            notify,
+                        }),
+                    };
+                }
+                if let Some(cancel_tx) = existing.cancel_tx.take() {
+                    let _ = cancel_tx.send(true);
+                }
+                existing.worker_running = false;
+                existing.send_in_progress = false;
+                existing.machine = DplpmtudStateMachine::for_path(identity, false, now);
+                self.publish_snapshot_locked(&peer_id, existing, now);
+                return DplpmtudInstallResult {
+                    decision: DplpmtudInstallDecision::Unsupported,
+                    worker: None,
+                };
+            } else if let Some(cancel_tx) = existing.cancel_tx.take() {
+                let _ = cancel_tx.send(true);
+            }
+        }
+
+        let mut path_cookie = [0u8; 16];
+        rand::thread_rng().fill_bytes(&mut path_cookie);
+        let notify = Arc::new(Notify::new());
+        if !supported {
+            let entry = RuntimeEntry {
+                machine: DplpmtudStateMachine::for_path(identity, false, now),
+                path_cookie,
+                cancel_tx: None,
+                notify,
+                worker_running: false,
+                send_in_progress: false,
+            };
+            registry.entries.insert(peer_id.clone(), entry);
+            let entry = registry
+                .entries
+                .get(&peer_id)
+                .expect("entry inserted above");
+            self.publish_snapshot_locked(&peer_id, entry, now);
+            return DplpmtudInstallResult {
+                decision: DplpmtudInstallDecision::Unsupported,
+                worker: None,
+            };
+        }
+
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let entry = RuntimeEntry {
+            machine: DplpmtudStateMachine::for_path(identity.clone(), true, now),
+            path_cookie,
+            cancel_tx: Some(cancel_tx),
+            notify: notify.clone(),
+            worker_running: true,
+            send_in_progress: false,
+        };
+        registry.entries.insert(peer_id.clone(), entry);
+        let entry = registry
+            .entries
+            .get(&peer_id)
+            .expect("entry inserted above");
+        self.publish_snapshot_locked(&peer_id, entry, now);
+        DplpmtudInstallResult {
+            decision: DplpmtudInstallDecision::Spawned,
+            worker: Some(DplpmtudWorkerLease {
+                peer_id,
+                identity,
+                cancel_rx,
+                notify,
+            }),
+        }
+    }
+
+    pub(crate) fn retain_known_peers(&self, peers: &HashSet<String>, now: Instant) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let removed = registry
+            .entries
+            .keys()
+            .filter(|peer_id| !peers.contains(*peer_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        for peer_id in removed {
+            if let Some(mut entry) = registry.entries.remove(&peer_id) {
+                if let Some(cancel_tx) = entry.cancel_tx.take() {
+                    let _ = cancel_tx.send(true);
+                }
+                let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
+                    reason: "peer_left".to_string(),
+                    now,
+                });
+            }
+            registry.supported_sessions.remove(&peer_id);
+            self.snapshots
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(&peer_id);
+        }
+    }
+
+    pub(crate) fn cancel_before_network_generation(
+        &self,
+        generation: u64,
+        reason: &str,
+        now: Instant,
+    ) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let peer_ids = registry
+            .entries
+            .iter()
+            .filter_map(|(peer_id, entry)| {
+                entry
+                    .machine
+                    .identity()
+                    .filter(|identity| identity.epoch.network_generation != generation)
+                    .map(|_| peer_id.clone())
+            })
+            .collect::<Vec<_>>();
+        for peer_id in peer_ids {
+            let Some(entry) = registry.entries.get_mut(&peer_id) else {
+                continue;
+            };
+            if let Some(cancel_tx) = entry.cancel_tx.take() {
+                let _ = cancel_tx.send(true);
+            }
+            entry.worker_running = false;
+            entry.send_in_progress = false;
+            let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
+                reason: reason.to_string(),
+                now,
+            });
+            entry.notify.notify_waiters();
+            self.publish_snapshot_locked(&peer_id, entry, now);
+        }
+    }
+
+    pub(crate) fn cancel_peer(&self, peer_id: &str, reason: &str, now: Instant) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(entry) = registry.entries.get_mut(peer_id) else {
+            return;
+        };
+        if let Some(cancel_tx) = entry.cancel_tx.take() {
+            let _ = cancel_tx.send(true);
+        }
+        entry.worker_running = false;
+        entry.send_in_progress = false;
+        let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
+            reason: reason.to_string(),
+            now,
+        });
+        entry.notify.notify_waiters();
+        self.publish_snapshot_locked(peer_id, entry, now);
+    }
+
+    pub(crate) fn close(&self, reason: &str, now: Instant) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        registry.closed = true;
+        for (peer_id, entry) in &mut registry.entries {
+            if let Some(cancel_tx) = entry.cancel_tx.take() {
+                let _ = cancel_tx.send(true);
+            }
+            entry.worker_running = false;
+            entry.send_in_progress = false;
+            let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
+                reason: reason.to_string(),
+                now,
+            });
+            entry.notify.notify_waiters();
+            self.publish_snapshot_locked(peer_id, entry, now);
+        }
+        registry.supported_sessions.clear();
+    }
+
+    pub(crate) fn schedule_probe(
+        &self,
+        peer_id: &str,
+        identity: &DplpmtudPathIdentity,
+        now: Instant,
+    ) -> Option<DplpmtudProbePlan> {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return None;
+        }
+        let entry = registry.entries.get_mut(peer_id)?;
+        if !entry.worker_running || entry.machine.identity() != Some(identity) {
+            return None;
+        }
+        if entry.machine.state() == DplpmtudState::Base {
+            let _ = entry.machine.apply(DplpmtudEvent::StartSearch { now });
+        }
+        if matches!(
+            entry.machine.state(),
+            DplpmtudState::SearchComplete | DplpmtudState::Error
+        ) && entry
+            .machine
+            .next_wakeup()
+            .is_some_and(|deadline| now >= deadline)
+        {
+            let _ = entry
+                .machine
+                .apply(DplpmtudEvent::RaiseTimerExpired { now });
+        }
+        let (sequence, candidate, retry) = entry.machine.next_probe_components()?;
+        let mut nonce = [0u8; 16];
+        rand::thread_rng().fill_bytes(&mut nonce);
+        let probe_identity = DplpmtudProbeIdentity {
+            sequence,
+            nonce,
+            path_cookie: entry.path_cookie,
+            candidate_udp_datagram_size: candidate,
+        };
+        let deadline = now + DPLPMTUD_PROBE_TIMEOUT;
+        if entry.machine.apply(DplpmtudEvent::ProbeScheduled {
+            probe: probe_identity,
+            retry,
+            now,
+            deadline,
+        }) != DplpmtudTransitionDecision::Applied
+        {
+            return None;
+        }
+        let wire_token = DplpmtudWireToken {
+            sequence,
+            nonce,
+            path_cookie: entry.path_cookie,
+            network_generation: identity.epoch.network_generation,
+            peer_session_generation: identity.epoch.peer_session_generation.value(),
+            remote_candidate_epoch: identity.epoch.remote_candidate_epoch,
+            direct_validation_owner_token: identity.direct_validation_owner_token,
+            direct_validation_request_id: identity.direct_validation_request_id,
+            candidate_udp_datagram_size: candidate,
+            outer_ip_family: identity.outer_ip_family,
+        };
+        self.publish_snapshot_locked(peer_id, entry, now);
+        Some(DplpmtudProbePlan {
+            peer_id: peer_id.to_string(),
+            path_identity: identity.clone(),
+            probe_identity,
+            wire_token,
+            deadline,
+        })
+    }
+
+    /// Linearization point immediately before a worker attempts the kernel
+    /// send. Cancellation that wins first prevents the send.
+    pub(crate) fn begin_probe_send(&self, plan: &DplpmtudProbePlan) -> bool {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return false;
+        }
+        let Some(entry) = registry.entries.get_mut(&plan.peer_id) else {
+            return false;
+        };
+        if !entry.worker_running
+            || entry.machine.identity() != Some(&plan.path_identity)
+            || entry.machine.outstanding_identity() != Some(plan.probe_identity)
+            || entry.send_in_progress
+        {
+            return false;
+        }
+        entry.send_in_progress = true;
+        true
+    }
+
+    pub(crate) fn finish_probe_send(
+        &self,
+        plan: &DplpmtudProbePlan,
+        result: Result<(), ()>,
+        now: Instant,
+    ) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(entry) = registry.entries.get_mut(&plan.peer_id) else {
+            return;
+        };
+        entry.send_in_progress = false;
+        if entry.machine.identity() != Some(&plan.path_identity) {
+            return;
+        }
+        match result {
+            Ok(()) => {
+                let _ = entry.machine.apply(DplpmtudEvent::ProbeSent {
+                    probe: plan.probe_identity,
+                    now,
+                });
+            }
+            Err(()) => {
+                let _ = entry.machine.apply(DplpmtudEvent::ProbeSendFailed {
+                    probe: plan.probe_identity,
+                    now,
+                });
+            }
+        }
+        entry.notify.notify_waiters();
+        self.publish_snapshot_locked(&plan.peer_id, entry, now);
+    }
+
+    pub(crate) fn timeout_probe(
+        &self,
+        plan: &DplpmtudProbePlan,
+        now: Instant,
+    ) -> DplpmtudTransitionDecision {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(entry) = registry.entries.get_mut(&plan.peer_id) else {
+            return DplpmtudTransitionDecision::Noop;
+        };
+        if entry.machine.identity() != Some(&plan.path_identity) {
+            return DplpmtudTransitionDecision::Noop;
+        }
+        let decision = entry.machine.apply(DplpmtudEvent::ProbeTimedOut {
+            probe: plan.probe_identity,
+            now,
+        });
+        entry.notify.notify_waiters();
+        self.publish_snapshot_locked(&plan.peer_id, entry, now);
+        decision
+    }
+
+    /// Consume an ACK while the caller holds the upper lifecycle/epoch fence.
+    /// Contention fails closed instead of awaiting a lower registry lock.
+    pub(crate) fn try_accept_ack(
+        &self,
+        peer_id: &str,
+        current_path: &DplpmtudPathIdentity,
+        token: DplpmtudWireToken,
+        ingress: DplpmtudAckIngress,
+        now: Instant,
+    ) -> DplpmtudTransitionDecision {
+        let Ok(mut registry) = self.registry.try_lock() else {
+            return DplpmtudTransitionDecision::Busy;
+        };
+        let Some(entry) = registry.entries.get_mut(peer_id) else {
+            return DplpmtudTransitionDecision::Stale;
+        };
+        let exact_wire_identity = token.network_generation == current_path.epoch.network_generation
+            && token.peer_session_generation == current_path.epoch.peer_session_generation.value()
+            && token.remote_candidate_epoch == current_path.epoch.remote_candidate_epoch
+            && token.direct_validation_owner_token == current_path.direct_validation_owner_token
+            && token.direct_validation_request_id == current_path.direct_validation_request_id
+            && token.outer_ip_family == current_path.outer_ip_family;
+        let exact_ingress = ingress.remote_endpoint == current_path.authenticated_remote_endpoint
+            && ingress.local_endpoint == current_path.local_endpoint
+            && ingress.socket == current_path.socket;
+        let decision = if entry.machine.identity() != Some(current_path)
+            || !exact_wire_identity
+            || !exact_ingress
+        {
+            entry.machine.apply(DplpmtudEvent::StaleAck { now })
+        } else {
+            entry.machine.apply(DplpmtudEvent::ProbeAcked {
+                probe: token.probe_identity(),
+                now,
+            })
+        };
+        entry.notify.notify_waiters();
+        self.publish_snapshot_locked(peer_id, entry, now);
+        decision
+    }
+
+    pub(crate) fn outstanding_is_current(&self, plan: &DplpmtudProbePlan) -> bool {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .get(&plan.peer_id)
+            .is_some_and(|entry| {
+                entry.worker_running
+                    && entry.machine.identity() == Some(&plan.path_identity)
+                    && entry.machine.outstanding_identity() == Some(plan.probe_identity)
+            })
+    }
+
+    pub(crate) fn worker_state(
+        &self,
+        peer_id: &str,
+        identity: &DplpmtudPathIdentity,
+    ) -> Option<(
+        DplpmtudState,
+        Option<Instant>,
+        Option<DplpmtudProbeIdentity>,
+    )> {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .get(peer_id)
+            .filter(|entry| entry.machine.identity() == Some(identity))
+            .map(|entry| {
+                (
+                    entry.machine.state(),
+                    entry.machine.next_wakeup(),
+                    entry.machine.outstanding_identity(),
+                )
+            })
+    }
+
+    pub(crate) fn finish_worker(&self, peer_id: &str, identity: &DplpmtudPathIdentity) {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(entry) = registry.entries.get_mut(peer_id) else {
+            return;
+        };
+        if entry.machine.identity() == Some(identity) {
+            entry.worker_running = false;
+            entry.send_in_progress = false;
+            entry.cancel_tx = None;
+            self.publish_snapshot_locked(peer_id, entry, Instant::now());
+        }
+    }
+
+    pub(crate) fn path_identity(&self, peer_id: &str) -> Option<DplpmtudPathIdentity> {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .get(peer_id)
+            .and_then(|entry| entry.machine.identity().cloned())
+    }
+
+    pub(crate) fn snapshots(&self) -> HashMap<String, DplpmtudSnapshot> {
+        self.snapshots
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tracked_peer_count(&self) -> usize {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_worker_count(&self) -> usize {
+        self.registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .values()
+            .filter(|entry| entry.worker_running)
+            .count()
+    }
+
+    fn publish_snapshot_locked(&self, peer_id: &str, entry: &RuntimeEntry, now: Instant) {
+        self.snapshots
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(
+                peer_id.to_string(),
+                entry.machine.snapshot(now, entry.worker_running),
+            );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DplpmtudAckIngress {
+    pub(crate) remote_endpoint: SocketAddr,
+    pub(crate) local_endpoint: SocketAddr,
+    pub(crate) socket: DplpmtudSocketIdentity,
 }

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -1253,6 +1253,16 @@ impl DplpmtudRuntime {
                         }),
                     };
                 }
+                if existing.machine.state() == DplpmtudState::Unsupported
+                    && !existing.worker_running
+                    && existing.worker_owner_token.is_none()
+                    && existing.cancel_tx.is_none()
+                {
+                    return DplpmtudInstallResult {
+                        decision: DplpmtudInstallDecision::Unsupported,
+                        worker: None,
+                    };
+                }
                 if let Some(cancel_tx) = existing.cancel_tx.take() {
                     let _ = cancel_tx.send(true);
                 }
@@ -1891,6 +1901,34 @@ mod tests {
         let snapshot = machine.snapshot(now, false);
         assert!(!snapshot.supported);
         assert!(snapshot.outstanding_probe.is_none());
+    }
+
+    #[test]
+    fn unsupported_same_identity_replay_is_idempotent() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        assert_eq!(
+            runtime.install_path(identity.clone(), false, now).decision,
+            DplpmtudInstallDecision::Unsupported
+        );
+        let first = runtime.snapshots().remove("peer").unwrap();
+
+        assert_eq!(
+            runtime
+                .install_path(identity, false, now + Duration::from_secs(1))
+                .decision,
+            DplpmtudInstallDecision::Unsupported
+        );
+        let second = runtime.snapshots().remove("peer").unwrap();
+        assert_eq!(second.state, DplpmtudState::Unsupported);
+        assert!(!second.live_worker);
+        assert_eq!(second.revision, first.revision);
+        assert_eq!(second.reset_count, first.reset_count);
+        assert_eq!(second.probe_count, first.probe_count);
+        assert_eq!(second.success_count, first.success_count);
+        assert_eq!(second.timeout_count, first.timeout_count);
+        assert_eq!(second.stale_ack_count, first.stale_ack_count);
     }
 
     #[test]

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -10,7 +10,10 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex as StdMutex, RwLock as StdRwLock,
+};
 use std::time::Duration;
 
 use p2pnet_tun::{Ipv4Packet, Protocol};
@@ -41,6 +44,8 @@ pub(crate) const DPLPMTUD_RAISE_INTERVAL: Duration = Duration::from_secs(10 * 60
 pub(crate) const DPLPMTUD_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) const DPLPMTUD_WORKER_MAX_LIFETIME: Duration = Duration::from_secs(60 * 60);
 pub(crate) const MAX_TRACKED_DPLPMTUD_PEERS: usize = 256;
+pub(crate) const DPLPMTUD_ACK_RATE_LIMIT_PER_PEER: usize = 8;
+pub(crate) const DPLPMTUD_ACK_RATE_WINDOW: Duration = Duration::from_secs(1);
 const MAX_CONSUMED_PROBE_RECEIPTS: usize = 32;
 
 const DIRECT_VALIDATION_TOKEN_BYTES: usize = 8 + 2 + 1 + 8;
@@ -168,6 +173,9 @@ impl DplpmtudPathIdentity {
         transport_instance_id: u64,
         socket_index: usize,
     ) -> Option<Self> {
+        if local_endpoint.is_ipv4() != authenticated_remote_endpoint.is_ipv4() {
+            return None;
+        }
         Some(Self {
             peer_id: peer_id.into(),
             epoch: validation.epoch,
@@ -728,7 +736,7 @@ fn next_search_candidate(
     confirmed: UdpDatagramSize,
     upper: UdpDatagramSize,
 ) -> Option<UdpDatagramSize> {
-    if upper.0 <= confirmed.0.saturating_add(DPLPMTUD_SEARCH_GRANULARITY) {
+    if upper.0 <= confirmed.0 {
         return None;
     }
     let distance = upper.0 - confirmed.0;
@@ -883,10 +891,9 @@ pub(crate) fn parse_control_packet(packet: &[u8]) -> Option<DplpmtudControlPacke
     let payload = &icmp[8..];
     let (kind, token_bytes) = if let Some(bytes) = payload.strip_prefix(DPLPMTUD_PROBE_PREFIX) {
         (DplpmtudControlKind::Probe, bytes)
-    } else if let Some(bytes) = payload.strip_prefix(DPLPMTUD_ACK_PREFIX) {
-        (DplpmtudControlKind::Ack, bytes)
     } else {
-        return None;
+        let bytes = payload.strip_prefix(DPLPMTUD_ACK_PREFIX)?;
+        (DplpmtudControlKind::Ack, bytes)
     };
     let token = decode_wire_token(token_bytes)?;
     let ceiling = token.outer_ip_family.ceiling_udp_datagram_size().0;
@@ -984,6 +991,7 @@ pub(crate) fn build_encrypted_probe_plaintext(
 #[derive(Debug, Clone)]
 pub(crate) struct DplpmtudProbePlan {
     pub(crate) peer_id: String,
+    pub(crate) worker_owner_token: u64,
     pub(crate) path_identity: DplpmtudPathIdentity,
     pub(crate) probe_identity: DplpmtudProbeIdentity,
     pub(crate) wire_token: DplpmtudWireToken,
@@ -993,6 +1001,7 @@ pub(crate) struct DplpmtudProbePlan {
 #[derive(Debug)]
 pub(crate) struct DplpmtudWorkerLease {
     pub(crate) peer_id: String,
+    pub(crate) worker_owner_token: u64,
     pub(crate) identity: DplpmtudPathIdentity,
     pub(crate) cancel_rx: watch::Receiver<bool>,
     pub(crate) notify: Arc<Notify>,
@@ -1041,14 +1050,6 @@ impl DplpmtudWorkerIngress {
             notified.await;
         }
     }
-
-    #[cfg(test)]
-    fn pending_len(&self) -> usize {
-        self.state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len()
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1058,6 +1059,7 @@ pub(crate) enum DplpmtudInstallDecision {
     Unsupported,
     Closed,
     CapacityExceeded,
+    OwnerTokenExhausted,
 }
 
 #[derive(Debug)]
@@ -1069,6 +1071,7 @@ pub(crate) struct DplpmtudInstallResult {
 struct RuntimeEntry {
     machine: DplpmtudStateMachine,
     path_cookie: [u8; 16],
+    worker_owner_token: Option<u64>,
     cancel_tx: Option<watch::Sender<bool>>,
     notify: Arc<Notify>,
     worker_running: bool,
@@ -1079,20 +1082,73 @@ struct RuntimeEntry {
 struct RuntimeRegistry {
     entries: HashMap<String, RuntimeEntry>,
     supported_sessions: HashMap<String, u64>,
+    ack_response_times: HashMap<String, VecDeque<Instant>>,
     closed: bool,
 }
 
 /// Bounded, cloneable registry shared by one UDP publication, its scheduler,
 /// receive path and diagnostics. No network I/O occurs while the mutex is held.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct DplpmtudRuntime {
     registry: Arc<StdMutex<RuntimeRegistry>>,
     snapshots: Arc<StdRwLock<HashMap<String, DplpmtudSnapshot>>>,
+    next_worker_owner_token: Arc<AtomicU64>,
+}
+
+impl Default for DplpmtudRuntime {
+    fn default() -> Self {
+        Self {
+            registry: Arc::new(StdMutex::new(RuntimeRegistry::default())),
+            snapshots: Arc::new(StdRwLock::new(HashMap::new())),
+            next_worker_owner_token: Arc::new(AtomicU64::new(1)),
+        }
+    }
 }
 
 impl DplpmtudRuntime {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    fn allocate_worker_owner_token(&self) -> Option<u64> {
+        self.next_worker_owner_token
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current.checked_add(1)
+            })
+            .ok()
+            .filter(|token| *token != 0)
+    }
+
+    pub(crate) fn admit_probe_response(&self, peer_id: &str, now: Instant) -> bool {
+        let mut registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return false;
+        }
+        registry.ack_response_times.retain(|_, sent| {
+            while sent.front().is_some_and(|sent_at| {
+                now.saturating_duration_since(*sent_at) >= DPLPMTUD_ACK_RATE_WINDOW
+            }) {
+                sent.pop_front();
+            }
+            !sent.is_empty()
+        });
+        if !registry.ack_response_times.contains_key(peer_id)
+            && registry.ack_response_times.len() >= MAX_TRACKED_DPLPMTUD_PEERS
+        {
+            return false;
+        }
+        let sent = registry
+            .ack_response_times
+            .entry(peer_id.to_string())
+            .or_default();
+        if sent.len() >= DPLPMTUD_ACK_RATE_LIMIT_PER_PEER {
+            return false;
+        }
+        sent.push_back(now);
+        true
     }
 
     pub(crate) fn mark_supported(&self, peer_id: &str, peer_session_generation: u64) -> bool {
@@ -1151,14 +1207,36 @@ impl DplpmtudRuntime {
 
         if let Some(existing) = registry.entries.get_mut(&peer_id) {
             if existing.machine.identity() == Some(&identity) {
-                if supported && existing.worker_running {
+                if supported
+                    && existing.worker_running
+                    && existing.worker_owner_token.is_some()
+                    && !matches!(
+                        existing.machine.state(),
+                        DplpmtudState::Disabled | DplpmtudState::Unsupported
+                    )
+                {
                     return DplpmtudInstallResult {
                         decision: DplpmtudInstallDecision::Unchanged,
                         worker: None,
                     };
                 }
                 if supported {
+                    let Some(worker_owner_token) = self.allocate_worker_owner_token() else {
+                        return DplpmtudInstallResult {
+                            decision: DplpmtudInstallDecision::OwnerTokenExhausted,
+                            worker: None,
+                        };
+                    };
+                    if matches!(
+                        existing.machine.state(),
+                        DplpmtudState::Disabled | DplpmtudState::Unsupported
+                    ) {
+                        rand::thread_rng().fill_bytes(&mut existing.path_cookie);
+                        existing.machine =
+                            DplpmtudStateMachine::for_path(identity.clone(), true, now);
+                    }
                     let (cancel_tx, cancel_rx) = watch::channel(false);
+                    existing.worker_owner_token = Some(worker_owner_token);
                     existing.cancel_tx = Some(cancel_tx);
                     existing.worker_running = true;
                     existing.send_in_progress = false;
@@ -1168,6 +1246,7 @@ impl DplpmtudRuntime {
                         decision: DplpmtudInstallDecision::Spawned,
                         worker: Some(DplpmtudWorkerLease {
                             peer_id,
+                            worker_owner_token,
                             identity,
                             cancel_rx,
                             notify,
@@ -1177,6 +1256,7 @@ impl DplpmtudRuntime {
                 if let Some(cancel_tx) = existing.cancel_tx.take() {
                     let _ = cancel_tx.send(true);
                 }
+                existing.worker_owner_token = None;
                 existing.worker_running = false;
                 existing.send_in_progress = false;
                 existing.machine = DplpmtudStateMachine::for_path(identity, false, now);
@@ -1185,9 +1265,13 @@ impl DplpmtudRuntime {
                     decision: DplpmtudInstallDecision::Unsupported,
                     worker: None,
                 };
-            } else if let Some(cancel_tx) = existing.cancel_tx.take() {
+            }
+            if let Some(cancel_tx) = existing.cancel_tx.take() {
                 let _ = cancel_tx.send(true);
             }
+            existing.worker_owner_token = None;
+            existing.worker_running = false;
+            existing.send_in_progress = false;
         }
 
         let mut path_cookie = [0u8; 16];
@@ -1197,6 +1281,7 @@ impl DplpmtudRuntime {
             let entry = RuntimeEntry {
                 machine: DplpmtudStateMachine::for_path(identity, false, now),
                 path_cookie,
+                worker_owner_token: None,
                 cancel_tx: None,
                 notify,
                 worker_running: false,
@@ -1214,10 +1299,17 @@ impl DplpmtudRuntime {
             };
         }
 
+        let Some(worker_owner_token) = self.allocate_worker_owner_token() else {
+            return DplpmtudInstallResult {
+                decision: DplpmtudInstallDecision::OwnerTokenExhausted,
+                worker: None,
+            };
+        };
         let (cancel_tx, cancel_rx) = watch::channel(false);
         let entry = RuntimeEntry {
             machine: DplpmtudStateMachine::for_path(identity.clone(), true, now),
             path_cookie,
+            worker_owner_token: Some(worker_owner_token),
             cancel_tx: Some(cancel_tx),
             notify: notify.clone(),
             worker_running: true,
@@ -1233,6 +1325,7 @@ impl DplpmtudRuntime {
             decision: DplpmtudInstallDecision::Spawned,
             worker: Some(DplpmtudWorkerLease {
                 peer_id,
+                worker_owner_token,
                 identity,
                 cancel_rx,
                 notify,
@@ -1262,6 +1355,7 @@ impl DplpmtudRuntime {
                 });
             }
             registry.supported_sessions.remove(&peer_id);
+            registry.ack_response_times.remove(&peer_id);
             self.snapshots
                 .write()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -1297,6 +1391,7 @@ impl DplpmtudRuntime {
             if let Some(cancel_tx) = entry.cancel_tx.take() {
                 let _ = cancel_tx.send(true);
             }
+            entry.worker_owner_token = None;
             entry.worker_running = false;
             entry.send_in_progress = false;
             let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
@@ -1319,6 +1414,7 @@ impl DplpmtudRuntime {
         if let Some(cancel_tx) = entry.cancel_tx.take() {
             let _ = cancel_tx.send(true);
         }
+        entry.worker_owner_token = None;
         entry.worker_running = false;
         entry.send_in_progress = false;
         let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
@@ -1339,6 +1435,7 @@ impl DplpmtudRuntime {
             if let Some(cancel_tx) = entry.cancel_tx.take() {
                 let _ = cancel_tx.send(true);
             }
+            entry.worker_owner_token = None;
             entry.worker_running = false;
             entry.send_in_progress = false;
             let _ = entry.machine.apply(DplpmtudEvent::Cancelled {
@@ -1349,12 +1446,14 @@ impl DplpmtudRuntime {
             self.publish_snapshot_locked(peer_id, entry, now);
         }
         registry.supported_sessions.clear();
+        registry.ack_response_times.clear();
     }
 
     pub(crate) fn schedule_probe(
         &self,
         peer_id: &str,
         identity: &DplpmtudPathIdentity,
+        worker_owner_token: u64,
         now: Instant,
     ) -> Option<DplpmtudProbePlan> {
         let mut registry = self
@@ -1365,7 +1464,10 @@ impl DplpmtudRuntime {
             return None;
         }
         let entry = registry.entries.get_mut(peer_id)?;
-        if !entry.worker_running || entry.machine.identity() != Some(identity) {
+        if !entry.worker_running
+            || entry.worker_owner_token != Some(worker_owner_token)
+            || entry.machine.identity() != Some(identity)
+        {
             return None;
         }
         if entry.machine.state() == DplpmtudState::Base {
@@ -1417,6 +1519,7 @@ impl DplpmtudRuntime {
         self.publish_snapshot_locked(peer_id, entry, now);
         Some(DplpmtudProbePlan {
             peer_id: peer_id.to_string(),
+            worker_owner_token,
             path_identity: identity.clone(),
             probe_identity,
             wire_token,
@@ -1438,9 +1541,11 @@ impl DplpmtudRuntime {
             return false;
         };
         if !entry.worker_running
+            || entry.worker_owner_token != Some(plan.worker_owner_token)
             || entry.machine.identity() != Some(&plan.path_identity)
             || entry.machine.outstanding_identity() != Some(plan.probe_identity)
             || entry.send_in_progress
+            || Instant::now() >= plan.deadline
         {
             return false;
         }
@@ -1461,10 +1566,12 @@ impl DplpmtudRuntime {
         let Some(entry) = registry.entries.get_mut(&plan.peer_id) else {
             return;
         };
-        entry.send_in_progress = false;
-        if entry.machine.identity() != Some(&plan.path_identity) {
+        if entry.worker_owner_token != Some(plan.worker_owner_token)
+            || entry.machine.identity() != Some(&plan.path_identity)
+        {
             return;
         }
+        entry.send_in_progress = false;
         match result {
             Ok(()) => {
                 let _ = entry.machine.apply(DplpmtudEvent::ProbeSent {
@@ -1495,7 +1602,9 @@ impl DplpmtudRuntime {
         let Some(entry) = registry.entries.get_mut(&plan.peer_id) else {
             return DplpmtudTransitionDecision::Noop;
         };
-        if entry.machine.identity() != Some(&plan.path_identity) {
+        if entry.worker_owner_token != Some(plan.worker_owner_token)
+            || entry.machine.identity() != Some(&plan.path_identity)
+        {
             return DplpmtudTransitionDecision::Noop;
         }
         let decision = entry.machine.apply(DplpmtudEvent::ProbeTimedOut {
@@ -1556,6 +1665,7 @@ impl DplpmtudRuntime {
             .get(&plan.peer_id)
             .is_some_and(|entry| {
                 entry.worker_running
+                    && entry.worker_owner_token == Some(plan.worker_owner_token)
                     && entry.machine.identity() == Some(&plan.path_identity)
                     && entry.machine.outstanding_identity() == Some(plan.probe_identity)
             })
@@ -1565,6 +1675,7 @@ impl DplpmtudRuntime {
         &self,
         peer_id: &str,
         identity: &DplpmtudPathIdentity,
+        worker_owner_token: u64,
     ) -> Option<(
         DplpmtudState,
         Option<Instant>,
@@ -1575,7 +1686,10 @@ impl DplpmtudRuntime {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .entries
             .get(peer_id)
-            .filter(|entry| entry.machine.identity() == Some(identity))
+            .filter(|entry| {
+                entry.worker_owner_token == Some(worker_owner_token)
+                    && entry.machine.identity() == Some(identity)
+            })
             .map(|entry| {
                 (
                     entry.machine.state(),
@@ -1585,7 +1699,12 @@ impl DplpmtudRuntime {
             })
     }
 
-    pub(crate) fn finish_worker(&self, peer_id: &str, identity: &DplpmtudPathIdentity) {
+    pub(crate) fn finish_worker(
+        &self,
+        peer_id: &str,
+        identity: &DplpmtudPathIdentity,
+        worker_owner_token: u64,
+    ) {
         let mut registry = self
             .registry
             .lock()
@@ -1593,7 +1712,10 @@ impl DplpmtudRuntime {
         let Some(entry) = registry.entries.get_mut(peer_id) else {
             return;
         };
-        if entry.machine.identity() == Some(identity) {
+        if entry.worker_owner_token == Some(worker_owner_token)
+            && entry.machine.identity() == Some(identity)
+        {
+            entry.worker_owner_token = None;
             entry.worker_running = false;
             entry.send_in_progress = false;
             entry.cancel_tx = None;
@@ -1633,7 +1755,7 @@ impl DplpmtudRuntime {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .entries
             .values()
-            .filter(|entry| entry.worker_running)
+            .filter(|entry| entry.worker_running && entry.worker_owner_token.is_some())
             .count()
     }
 
@@ -1653,4 +1775,1163 @@ pub(crate) struct DplpmtudAckIngress {
     pub(crate) remote_endpoint: SocketAddr,
     pub(crate) local_endpoint: SocketAddr,
     pub(crate) socket: DplpmtudSocketIdentity,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataplane::OutboundPacket;
+    use crate::peer::PeerSessionGeneration;
+    use crate::transport::{DirectValidationKind, WireGuardTransport};
+    use p2pnet_crypto::NodeIdentity;
+    use p2pnet_wireguard::{HandshakeInitiator, HandshakeResponder, TransportSession};
+    use tokio::time::timeout;
+
+    fn test_identity(peer_id: &str) -> DplpmtudPathIdentity {
+        test_identity_with(peer_id, 7, 11, 13, 17, 19, 23, 0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn test_identity_with(
+        peer_id: &str,
+        network_generation: u64,
+        peer_session_generation: u64,
+        remote_candidate_epoch: u64,
+        validation_owner: u64,
+        validation_request: u16,
+        transport_instance_id: u64,
+        socket_index: usize,
+    ) -> DplpmtudPathIdentity {
+        DplpmtudPathIdentity {
+            peer_id: peer_id.to_string(),
+            epoch: PathEpoch::new(
+                network_generation,
+                PeerSessionGeneration::for_test(peer_session_generation),
+                remote_candidate_epoch,
+            ),
+            direct_validation_owner_token: validation_owner,
+            direct_validation_request_id: validation_request,
+            authenticated_remote_endpoint: "127.0.0.1:42002".parse().unwrap(),
+            local_endpoint: "127.0.0.1:42001".parse().unwrap(),
+            socket: DplpmtudSocketIdentity {
+                transport_instance_id,
+                socket_index,
+            },
+            outer_ip_family: OuterIpFamily::Ipv4,
+        }
+    }
+
+    fn deterministic_probe(
+        sequence: u64,
+        candidate_udp_datagram_size: UdpDatagramSize,
+    ) -> DplpmtudProbeIdentity {
+        DplpmtudProbeIdentity {
+            sequence,
+            nonce: [sequence as u8; 16],
+            path_cookie: [0x5a; 16],
+            candidate_udp_datagram_size,
+        }
+    }
+
+    fn schedule_and_mark_sent(
+        machine: &mut DplpmtudStateMachine,
+        now: Instant,
+    ) -> (DplpmtudProbeIdentity, Instant) {
+        if machine.state() == DplpmtudState::Base {
+            assert_eq!(
+                machine.apply(DplpmtudEvent::StartSearch { now }),
+                DplpmtudTransitionDecision::Applied
+            );
+        }
+        let (sequence, candidate, retry) = machine
+            .next_probe_components()
+            .expect("search must have a next candidate");
+        let probe = deterministic_probe(sequence, candidate);
+        let deadline = now + DPLPMTUD_PROBE_TIMEOUT;
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeScheduled {
+                probe,
+                retry,
+                now,
+                deadline,
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeSent {
+                probe,
+                now: now + Duration::from_millis(1),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        (probe, deadline)
+    }
+
+    #[test]
+    fn unsupported_peer_stays_fail_closed_without_a_probe() {
+        let now = Instant::now();
+        let machine = DplpmtudStateMachine::for_path(test_identity("peer"), false, now);
+        assert_eq!(machine.state(), DplpmtudState::Unsupported);
+        assert!(machine.next_probe_components().is_none());
+        let snapshot = machine.snapshot(now, false);
+        assert!(!snapshot.supported);
+        assert!(snapshot.outstanding_probe.is_none());
+    }
+
+    #[test]
+    fn supported_peer_moves_from_base_to_searching_and_ack_raises_lower_bound() {
+        let now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        let (probe, _) = schedule_and_mark_sent(&mut machine, now);
+        assert_eq!(machine.state(), DplpmtudState::Searching);
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeAcked {
+                probe,
+                now: now + Duration::from_millis(2),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert_eq!(
+            machine.confirmed_udp_datagram_size,
+            probe.candidate_udp_datagram_size
+        );
+        assert_eq!(machine.success_count, 1);
+    }
+
+    #[test]
+    fn timeout_retries_then_only_narrows_search_bounds() {
+        let mut now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        let original_upper = machine.search_upper_udp_datagram_size;
+        let mut failed_size = None;
+        for retry in 0..=DPLPMTUD_MAX_RETRIES {
+            let (probe, deadline) = schedule_and_mark_sent(&mut machine, now);
+            failed_size = Some(probe.candidate_udp_datagram_size);
+            assert_eq!(
+                machine.apply(DplpmtudEvent::ProbeTimedOut {
+                    probe,
+                    now: deadline,
+                }),
+                DplpmtudTransitionDecision::Applied
+            );
+            if retry < DPLPMTUD_MAX_RETRIES {
+                assert_eq!(machine.search_upper_udp_datagram_size, original_upper);
+                assert_eq!(
+                    machine.pending_candidate_udp_datagram_size,
+                    Some(probe.candidate_udp_datagram_size)
+                );
+            }
+            assert!(machine.supported);
+            assert_ne!(machine.state(), DplpmtudState::Disabled);
+            now = deadline + Duration::from_millis(1);
+        }
+        let failed_size = failed_size.unwrap();
+        assert!(
+            machine.search_upper_udp_datagram_size.0
+                <= failed_size.0.saturating_sub(DPLPMTUD_SEARCH_GRANULARITY)
+        );
+        assert_eq!(machine.timeout_count, u64::from(DPLPMTUD_MAX_RETRIES) + 1);
+    }
+
+    #[test]
+    fn bounded_search_converges_and_raise_timer_reopens_search() {
+        let threshold = 1397;
+        let mut now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        for _ in 0..64 {
+            if machine.state() == DplpmtudState::SearchComplete {
+                break;
+            }
+            let (probe, deadline) = schedule_and_mark_sent(&mut machine, now);
+            if probe.candidate_udp_datagram_size.0 <= threshold {
+                assert_eq!(
+                    machine.apply(DplpmtudEvent::ProbeAcked {
+                        probe,
+                        now: now + Duration::from_millis(2),
+                    }),
+                    DplpmtudTransitionDecision::Applied
+                );
+                now += Duration::from_millis(3);
+            } else {
+                assert_eq!(
+                    machine.apply(DplpmtudEvent::ProbeTimedOut {
+                        probe,
+                        now: deadline,
+                    }),
+                    DplpmtudTransitionDecision::Applied
+                );
+                now = deadline + Duration::from_millis(1);
+            }
+        }
+        assert_eq!(machine.state(), DplpmtudState::SearchComplete);
+        assert!(machine.confirmed_udp_datagram_size.0 <= threshold);
+        assert!(threshold - machine.confirmed_udp_datagram_size.0 <= DPLPMTUD_SEARCH_GRANULARITY);
+        let raise_at = machine
+            .raise_at
+            .expect("completed search owns a raise timer");
+        assert_eq!(
+            machine.apply(DplpmtudEvent::RaiseTimerExpired { now: raise_at }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert!(matches!(
+            machine.state(),
+            DplpmtudState::Searching | DplpmtudState::SearchComplete
+        ));
+    }
+
+    #[test]
+    fn exact_duplicate_ack_changes_only_the_duplicate_counter() {
+        let now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        let (probe, _) = schedule_and_mark_sent(&mut machine, now);
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeAcked {
+                probe,
+                now: now + Duration::from_millis(2),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        let revision = machine.revision;
+        let last_success_at = machine.last_success_at;
+        let success_count = machine.success_count;
+        let confirmed = machine.confirmed_udp_datagram_size;
+        let upper = machine.search_upper_udp_datagram_size;
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeAcked {
+                probe,
+                now: now + Duration::from_secs(20),
+            }),
+            DplpmtudTransitionDecision::Duplicate
+        );
+        assert_eq!(machine.revision, revision);
+        assert_eq!(machine.last_success_at, last_success_at);
+        assert_eq!(machine.success_count, success_count);
+        assert_eq!(machine.confirmed_udp_datagram_size, confirmed);
+        assert_eq!(machine.search_upper_udp_datagram_size, upper);
+        assert_eq!(machine.duplicate_ack_count, 1);
+    }
+
+    #[test]
+    fn stale_ack_dimensions_never_move_search_bounds() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let install = runtime.install_path(identity.clone(), true, now);
+        let lease = install
+            .worker
+            .expect("supported path must start one worker");
+        let plan = runtime
+            .schedule_probe("peer", &identity, lease.worker_owner_token, now)
+            .expect("probe must schedule");
+        assert!(runtime.begin_probe_send(&plan));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        let exact_ingress = DplpmtudAckIngress {
+            remote_endpoint: identity.authenticated_remote_endpoint,
+            local_endpoint: identity.local_endpoint,
+            socket: identity.socket,
+        };
+        let baseline = runtime.snapshots().remove("peer").unwrap();
+        let token = plan.wire_token;
+        let cases = [
+            (
+                DplpmtudWireToken {
+                    network_generation: token.network_generation + 1,
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                DplpmtudWireToken {
+                    peer_session_generation: token.peer_session_generation + 1,
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                DplpmtudWireToken {
+                    remote_candidate_epoch: token.remote_candidate_epoch + 1,
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                DplpmtudWireToken {
+                    direct_validation_owner_token: token.direct_validation_owner_token + 1,
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                DplpmtudWireToken {
+                    direct_validation_request_id: token.direct_validation_request_id + 1,
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                DplpmtudWireToken {
+                    nonce: [0x44; 16],
+                    ..token
+                },
+                exact_ingress,
+            ),
+            (
+                token,
+                DplpmtudAckIngress {
+                    remote_endpoint: "127.0.0.1:42999".parse().unwrap(),
+                    ..exact_ingress
+                },
+            ),
+            (
+                token,
+                DplpmtudAckIngress {
+                    local_endpoint: "127.0.0.1:42998".parse().unwrap(),
+                    ..exact_ingress
+                },
+            ),
+            (
+                token,
+                DplpmtudAckIngress {
+                    socket: DplpmtudSocketIdentity {
+                        transport_instance_id: identity.socket.transport_instance_id + 1,
+                        socket_index: identity.socket.socket_index,
+                    },
+                    ..exact_ingress
+                },
+            ),
+        ];
+        for (stale_token, ingress) in cases {
+            assert_eq!(
+                runtime.try_accept_ack(
+                    "peer",
+                    &identity,
+                    stale_token,
+                    ingress,
+                    now + Duration::from_millis(2),
+                ),
+                DplpmtudTransitionDecision::Stale
+            );
+            let snapshot = runtime.snapshots().remove("peer").unwrap();
+            assert_eq!(
+                snapshot.confirmed_udp_datagram_size,
+                baseline.confirmed_udp_datagram_size
+            );
+            assert_eq!(
+                snapshot.search_upper_udp_datagram_size,
+                baseline.search_upper_udp_datagram_size
+            );
+        }
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &identity,
+                token,
+                exact_ingress,
+                now + Duration::from_millis(3),
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+    }
+
+    #[test]
+    fn ack_after_probe_deadline_is_stale_and_expectation_remains_timeout_owned() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        let plan = runtime
+            .schedule_probe("peer", &identity, lease.worker_owner_token, now)
+            .unwrap();
+        assert!(runtime.begin_probe_send(&plan));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &identity,
+                plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: identity.authenticated_remote_endpoint,
+                    local_endpoint: identity.local_endpoint,
+                    socket: identity.socket,
+                },
+                plan.deadline + Duration::from_millis(1),
+            ),
+            DplpmtudTransitionDecision::Stale
+        );
+        assert!(runtime.outstanding_is_current(&plan));
+        assert_eq!(
+            runtime.timeout_probe(&plan, plan.deadline + Duration::from_millis(1)),
+            DplpmtudTransitionDecision::Applied
+        );
+    }
+
+    #[test]
+    fn worker_owner_token_closes_same_identity_exit_aba() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let first = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        runtime.cancel_peer(
+            "peer",
+            "relay_became_active",
+            now + Duration::from_millis(1),
+        );
+        let second = runtime
+            .install_path(identity.clone(), true, now + Duration::from_millis(2))
+            .worker
+            .expect("Direct becoming active again must start a fresh search");
+        assert_ne!(first.worker_owner_token, second.worker_owner_token);
+        runtime.finish_worker("peer", &identity, first.worker_owner_token);
+        assert_eq!(runtime.active_worker_count(), 1);
+        assert!(runtime
+            .schedule_probe(
+                "peer",
+                &identity,
+                first.worker_owner_token,
+                now + Duration::from_millis(3),
+            )
+            .is_none());
+        assert!(runtime
+            .schedule_probe(
+                "peer",
+                &identity,
+                second.worker_owner_token,
+                now + Duration::from_millis(3),
+            )
+            .is_some());
+        assert_eq!(
+            runtime
+                .install_path(identity, true, now + Duration::from_millis(4))
+                .decision,
+            DplpmtudInstallDecision::Unchanged
+        );
+    }
+
+    #[test]
+    fn path_replacement_resets_to_safe_baseline_and_invalidates_old_plan() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let first_identity = test_identity("peer");
+        let first = runtime
+            .install_path(first_identity.clone(), true, now)
+            .worker
+            .unwrap();
+        let old_plan = runtime
+            .schedule_probe("peer", &first_identity, first.worker_owner_token, now)
+            .unwrap();
+        assert!(runtime.begin_probe_send(&old_plan));
+        runtime.finish_probe_send(&old_plan, Ok(()), now + Duration::from_millis(1));
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &first_identity,
+                old_plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: first_identity.authenticated_remote_endpoint,
+                    local_endpoint: first_identity.local_endpoint,
+                    socket: first_identity.socket,
+                },
+                now + Duration::from_millis(2),
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+        let replacement = test_identity_with("peer", 8, 11, 14, 27, 29, 33, 1);
+        let second = runtime
+            .install_path(replacement.clone(), true, now + Duration::from_millis(3))
+            .worker
+            .unwrap();
+        let snapshot = runtime.snapshots().remove("peer").unwrap();
+        assert_eq!(
+            snapshot.confirmed_udp_datagram_size,
+            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+        );
+        assert_eq!(snapshot.state, DplpmtudState::Base);
+        assert!(!runtime.begin_probe_send(&old_plan));
+        runtime.finish_worker("peer", &first_identity, first.worker_owner_token);
+        assert_eq!(runtime.active_worker_count(), 1);
+        assert!(runtime
+            .schedule_probe(
+                "peer",
+                &replacement,
+                second.worker_owner_token,
+                now + Duration::from_millis(4),
+            )
+            .is_some());
+    }
+
+    #[test]
+    fn receipts_runtime_and_probe_responses_are_strictly_bounded() {
+        let mut receipts = VecDeque::new();
+        for sequence in 0..(MAX_CONSUMED_PROBE_RECEIPTS as u64 + 8) {
+            push_consumed_receipt(
+                &mut receipts,
+                deterministic_probe(sequence, UdpDatagramSize(1280)),
+            );
+        }
+        assert_eq!(receipts.len(), MAX_CONSUMED_PROBE_RECEIPTS);
+        assert_eq!(receipts.front().unwrap().sequence, 8);
+
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        for index in 0..MAX_TRACKED_DPLPMTUD_PEERS {
+            let identity =
+                test_identity_with(&format!("peer-{index}"), 1, index as u64 + 1, 1, 1, 1, 1, 0);
+            assert_eq!(
+                runtime.install_path(identity, false, now).decision,
+                DplpmtudInstallDecision::Unsupported
+            );
+        }
+        assert_eq!(runtime.tracked_peer_count(), MAX_TRACKED_DPLPMTUD_PEERS);
+        assert_eq!(
+            runtime
+                .install_path(test_identity("overflow-peer"), false, now)
+                .decision,
+            DplpmtudInstallDecision::CapacityExceeded
+        );
+
+        let rate_runtime = DplpmtudRuntime::new();
+        for _ in 0..DPLPMTUD_ACK_RATE_LIMIT_PER_PEER {
+            assert!(rate_runtime.admit_probe_response("peer", now));
+        }
+        assert!(!rate_runtime.admit_probe_response("peer", now));
+        assert!(rate_runtime.admit_probe_response("peer", now + DPLPMTUD_ACK_RATE_WINDOW));
+    }
+
+    #[test]
+    fn close_and_peer_left_remove_all_worker_ownership() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        assert_eq!(runtime.active_worker_count(), 1);
+        runtime.close("shutdown", now + Duration::from_millis(1));
+        assert_eq!(runtime.active_worker_count(), 0);
+        runtime.finish_worker("peer", &identity, lease.worker_owner_token);
+        assert_eq!(runtime.active_worker_count(), 0);
+
+        let runtime = DplpmtudRuntime::new();
+        runtime.install_path(test_identity("peer"), true, now);
+        runtime.retain_known_peers(&HashSet::new(), now + Duration::from_millis(1));
+        assert_eq!(runtime.tracked_peer_count(), 0);
+        assert!(!runtime.snapshots().contains_key("peer"));
+    }
+
+    #[test]
+    fn capability_extension_is_additive_and_legacy_packets_remain_decodable() {
+        let prefix = crate::DIRECT_VALIDATION_REQUEST_PAYLOAD;
+        let capability = direct_validation_capability_extension();
+        let modern_payload = crate::transport::build_direct_validation_payload(
+            DirectValidationKind::Request,
+            7,
+            9,
+            1,
+            11,
+        );
+        let modern_packet = Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            9,
+            1,
+            &modern_payload,
+        );
+        assert!(crate::transport::parse_direct_validation_token(&modern_packet).is_some());
+        assert!(direct_validation_supports_dplpmtud(&modern_packet));
+
+        let mut legacy_payload = Vec::new();
+        legacy_payload.extend_from_slice(prefix);
+        legacy_payload.extend_from_slice(&modern_payload[prefix.len() + capability.len()..]);
+        let legacy_packet = Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            9,
+            1,
+            &legacy_payload,
+        );
+        assert!(crate::transport::parse_direct_validation_token(&legacy_packet).is_some());
+        assert!(!direct_validation_supports_dplpmtud(&legacy_packet));
+
+        let mut unknown_payload = modern_payload.clone();
+        unknown_payload[prefix.len() + 4] = 99;
+        let unknown_packet = Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            9,
+            1,
+            &unknown_payload,
+        );
+        assert!(!direct_validation_supports_dplpmtud(&unknown_packet));
+    }
+
+    #[test]
+    fn codec_round_trip_uses_exact_udp_datagram_budget_and_compact_ack() {
+        let token = DplpmtudWireToken {
+            sequence: 7,
+            nonce: [1; 16],
+            path_cookie: [2; 16],
+            network_generation: 3,
+            peer_session_generation: 4,
+            remote_candidate_epoch: 5,
+            direct_validation_owner_token: 6,
+            direct_validation_request_id: 7,
+            candidate_udp_datagram_size: UdpDatagramSize(1400),
+            outer_ip_family: OuterIpFamily::Ipv4,
+        };
+        let probe = build_probe_inner_packet(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            token,
+        )
+        .unwrap();
+        assert_eq!(
+            probe.len() + WIREGUARD_UDP_DATAGRAM_OVERHEAD as usize,
+            token.candidate_udp_datagram_size.0 as usize
+        );
+        assert_eq!(parse_control_packet(&probe).unwrap().token, token);
+        let ack = build_ack_inner_packet(
+            Ipv4Addr::new(10, 20, 0, 2),
+            Ipv4Addr::new(10, 20, 0, 1),
+            token,
+        );
+        assert_eq!(
+            parse_control_packet(&ack).unwrap(),
+            DplpmtudControlPacket {
+                kind: DplpmtudControlKind::Ack,
+                token,
+            }
+        );
+        assert!(ack.len() < probe.len());
+        assert!(parse_control_packet(b"legacy-or-business-packet").is_none());
+    }
+
+    #[test]
+    fn ipv4_and_ipv6_budget_layers_are_never_mixed() {
+        let datagram = UdpDatagramSize(1400);
+        assert_eq!(
+            datagram.outer_ip_packet_size(OuterIpFamily::Ipv4),
+            OuterIpPacketSize(1428)
+        );
+        assert_eq!(
+            datagram.outer_ip_packet_size(OuterIpFamily::Ipv6),
+            OuterIpPacketSize(1448)
+        );
+        assert_eq!(
+            datagram.overlay_payload_budget(),
+            Some(OverlayPayloadBudget(1368))
+        );
+        assert_eq!(
+            OuterIpFamily::Ipv4.ceiling_udp_datagram_size(),
+            UdpDatagramSize(1472)
+        );
+        assert_eq!(
+            OuterIpFamily::Ipv6.ceiling_udp_datagram_size(),
+            UdpDatagramSize(1452)
+        );
+    }
+
+    #[test]
+    fn path_identity_rejects_mixed_local_and_remote_ip_families() {
+        let validation = crate::peer::DirectValidationIdentity::authenticated_ack(
+            PathEpoch::new(1, PeerSessionGeneration::for_test(2), 3),
+            4,
+            5,
+            Some("[::1]:42002".parse().unwrap()),
+            "[::1]:42002".parse().unwrap(),
+        );
+        assert!(DplpmtudPathIdentity::from_committed_validation(
+            "peer",
+            validation,
+            "[::1]:42002".parse().unwrap(),
+            "127.0.0.1:42001".parse().unwrap(),
+            6,
+            0,
+        )
+        .is_none());
+    }
+
+    fn establish_sessions() -> (TransportSession, TransportSession) {
+        let node_a = NodeIdentity::generate();
+        let node_b = NodeIdentity::generate();
+        let mut initiator = HandshakeInitiator::new(node_a, node_b.public_key(), None);
+        let mut responder = HandshakeResponder::new(node_b, None);
+        let initiation = initiator.create_initiation().unwrap();
+        let (response, node_b_keys) = responder
+            .consume_initiation_and_respond(&initiation)
+            .unwrap();
+        let node_a_keys = initiator.consume_response(&response).unwrap();
+        (
+            TransportSession::new(node_a_keys),
+            TransportSession::new(node_b_keys),
+        )
+    }
+
+    async fn receive_datagram(socket: &UdpSocket, expected_size: usize) -> (Vec<u8>, SocketAddr) {
+        let mut buffer = vec![0u8; 65_535];
+        let (size, source) = timeout(Duration::from_secs(1), socket.recv_from(&mut buffer))
+            .await
+            .expect("loopback datagram must arrive deterministically")
+            .expect("loopback UDP receive must succeed");
+        assert_eq!(size, expected_size);
+        buffer.truncate(size);
+        (buffer, source)
+    }
+
+    #[tokio::test]
+    async fn encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak() {
+        const BLACKHOLE_THRESHOLD: usize = 1397;
+        let socket_a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let socket_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let blackhole_sink = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let endpoint_a = socket_a.local_addr().unwrap();
+        let endpoint_b = socket_b.local_addr().unwrap();
+        let sink_endpoint = blackhole_sink.local_addr().unwrap();
+
+        let (session_a, session_b) = establish_sessions();
+        let (transport_a, _outbound_a) = WireGuardTransport::new();
+        let (transport_b, _outbound_b) = WireGuardTransport::new();
+        transport_a.add_session("peer-b", session_a).await;
+        transport_b.add_session("peer-a", session_b).await;
+
+        let initial_identity = DplpmtudPathIdentity {
+            peer_id: "peer-b".to_string(),
+            epoch: PathEpoch::new(7, PeerSessionGeneration::for_test(11), 13),
+            direct_validation_owner_token: 17,
+            direct_validation_request_id: 19,
+            authenticated_remote_endpoint: endpoint_b,
+            local_endpoint: endpoint_a,
+            socket: DplpmtudSocketIdentity {
+                transport_instance_id: 23,
+                socket_index: 0,
+            },
+            outer_ip_family: OuterIpFamily::Ipv4,
+        };
+        let runtime = DplpmtudRuntime::new();
+        let baseline_workers = runtime.active_worker_count();
+        let initial_lease = runtime
+            .install_path(initial_identity.clone(), true, Instant::now())
+            .worker
+            .unwrap();
+        assert_eq!(runtime.active_worker_count(), baseline_workers + 1);
+        let mut logical_now = Instant::now();
+        let mut observed_probe_sizes = Vec::new();
+        let mut duplicate_exercised = false;
+        // DPLPMTUD has no path-selection or Direct-health mutation API. Keep
+        // explicit side-effect sentinels around the real blackhole loop so a
+        // timeout can only change the search machine, never Direct/Relay state.
+        let direct_active = true;
+        let direct_health_failure_count = 0usize;
+        let relay_fallback_count = 0usize;
+
+        // Obtain an ACK through the complete encrypted UDP chain, then replace
+        // the Direct generation before committing it. The old ACK must fail
+        // closed against the newly committed exact path identity.
+        let generation_plan = runtime
+            .schedule_probe(
+                "peer-b",
+                &initial_identity,
+                initial_lease.worker_owner_token,
+                logical_now,
+            )
+            .unwrap();
+        let generation_plaintext = build_encrypted_probe_plaintext(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            &initial_identity,
+            &generation_plan,
+        )
+        .unwrap();
+        let generation_encrypted = transport_a
+            .encrypt_outbound(OutboundPacket {
+                peer_id: "peer-b".to_string(),
+                dst_ip: "10.20.0.2".to_string(),
+                packet: generation_plaintext,
+                trace: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let generation_probe_size = generation_encrypted.wire_bytes.len();
+        assert!(generation_probe_size <= BLACKHOLE_THRESHOLD);
+        assert_eq!(
+            generation_probe_size,
+            generation_plan.probe_identity.candidate_udp_datagram_size.0 as usize
+        );
+        assert!(runtime.begin_probe_send(&generation_plan));
+        socket_a
+            .send_to(&generation_encrypted.wire_bytes, endpoint_b)
+            .await
+            .unwrap();
+        runtime.finish_probe_send(
+            &generation_plan,
+            Ok(()),
+            logical_now + Duration::from_millis(1),
+        );
+        let (generation_wire, generation_source) =
+            receive_datagram(&socket_b, generation_probe_size).await;
+        assert_eq!(generation_source, endpoint_a);
+        let generation_inbound = transport_b
+            .decrypt_inbound(&generation_wire)
+            .await
+            .unwrap()
+            .unwrap();
+        let generation_control = parse_control_packet(&generation_inbound.packet).unwrap();
+        assert_eq!(generation_control.kind, DplpmtudControlKind::Probe);
+        let generation_ack_plaintext = build_ack_inner_packet(
+            Ipv4Addr::new(10, 20, 0, 2),
+            Ipv4Addr::new(10, 20, 0, 1),
+            generation_control.token,
+        );
+        let generation_ack_encrypted = transport_b
+            .encrypt_outbound(OutboundPacket {
+                peer_id: "peer-a".to_string(),
+                dst_ip: "10.20.0.1".to_string(),
+                packet: generation_ack_plaintext,
+                trace: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        socket_b
+            .send_to(&generation_ack_encrypted.wire_bytes, endpoint_a)
+            .await
+            .unwrap();
+        let (generation_ack_wire, generation_ack_source) =
+            receive_datagram(&socket_a, generation_ack_encrypted.wire_bytes.len()).await;
+        assert_eq!(generation_ack_source, endpoint_b);
+        let generation_ack_inbound = transport_a
+            .decrypt_inbound(&generation_ack_wire)
+            .await
+            .unwrap()
+            .unwrap();
+        let stale_generation_ack = parse_control_packet(&generation_ack_inbound.packet).unwrap();
+        assert_eq!(stale_generation_ack.kind, DplpmtudControlKind::Ack);
+
+        let identity = DplpmtudPathIdentity {
+            epoch: PathEpoch::new(8, PeerSessionGeneration::for_test(11), 14),
+            direct_validation_owner_token: 29,
+            direct_validation_request_id: 31,
+            ..initial_identity.clone()
+        };
+        let lease = runtime
+            .install_path(
+                identity.clone(),
+                true,
+                logical_now + Duration::from_millis(2),
+            )
+            .worker
+            .unwrap();
+        assert!(*initial_lease.cancel_rx.borrow());
+        assert_eq!(runtime.active_worker_count(), baseline_workers + 1);
+        let before_stale_generation = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(before_stale_generation.state, DplpmtudState::Base);
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer-b",
+                &identity,
+                stale_generation_ack.token,
+                DplpmtudAckIngress {
+                    remote_endpoint: endpoint_b,
+                    local_endpoint: endpoint_a,
+                    socket: identity.socket,
+                },
+                logical_now + Duration::from_millis(3),
+            ),
+            DplpmtudTransitionDecision::Stale
+        );
+        let after_stale_generation = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(
+            after_stale_generation.confirmed_udp_datagram_size,
+            before_stale_generation.confirmed_udp_datagram_size
+        );
+        assert_eq!(
+            after_stale_generation.search_upper_udp_datagram_size,
+            before_stale_generation.search_upper_udp_datagram_size
+        );
+        runtime.finish_worker(
+            "peer-b",
+            &initial_identity,
+            initial_lease.worker_owner_token,
+        );
+        assert_eq!(runtime.active_worker_count(), baseline_workers + 1);
+        logical_now += Duration::from_millis(4);
+
+        for _ in 0..64 {
+            let snapshot = runtime.snapshots().remove("peer-b").unwrap();
+            if snapshot.state == DplpmtudState::SearchComplete {
+                break;
+            }
+            let plan = runtime
+                .schedule_probe("peer-b", &identity, lease.worker_owner_token, logical_now)
+                .expect("bounded search must schedule until complete");
+            let plaintext = build_encrypted_probe_plaintext(
+                Ipv4Addr::new(10, 20, 0, 1),
+                Ipv4Addr::new(10, 20, 0, 2),
+                &identity,
+                &plan,
+            )
+            .unwrap();
+            let encrypted = transport_a
+                .encrypt_outbound(OutboundPacket {
+                    peer_id: "peer-b".to_string(),
+                    dst_ip: "10.20.0.2".to_string(),
+                    packet: plaintext,
+                    trace: None,
+                })
+                .await
+                .unwrap()
+                .unwrap();
+            let probe_size = encrypted.wire_bytes.len();
+            observed_probe_sizes.push(probe_size);
+            assert_eq!(
+                probe_size,
+                plan.probe_identity.candidate_udp_datagram_size.0 as usize
+            );
+            assert!(runtime.begin_probe_send(&plan));
+            let allowed = probe_size <= BLACKHOLE_THRESHOLD;
+            let target = if allowed { endpoint_b } else { sink_endpoint };
+            assert_eq!(
+                socket_a
+                    .send_to(&encrypted.wire_bytes, target)
+                    .await
+                    .unwrap(),
+                probe_size
+            );
+            runtime.finish_probe_send(&plan, Ok(()), logical_now + Duration::from_millis(1));
+
+            if allowed {
+                let (received, source) = receive_datagram(&socket_b, probe_size).await;
+                assert_eq!(source, endpoint_a);
+                let inbound = transport_b
+                    .decrypt_inbound(&received)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                let control = parse_control_packet(&inbound.packet).unwrap();
+                assert_eq!(control.kind, DplpmtudControlKind::Probe);
+                assert_eq!(control.token, plan.wire_token);
+
+                let ack_plaintext = build_ack_inner_packet(
+                    Ipv4Addr::new(10, 20, 0, 2),
+                    Ipv4Addr::new(10, 20, 0, 1),
+                    control.token,
+                );
+                let encrypted_ack = transport_b
+                    .encrypt_outbound(OutboundPacket {
+                        peer_id: "peer-a".to_string(),
+                        dst_ip: "10.20.0.1".to_string(),
+                        packet: ack_plaintext,
+                        trace: None,
+                    })
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(encrypted_ack.wire_bytes.len() <= probe_size);
+                socket_b
+                    .send_to(&encrypted_ack.wire_bytes, endpoint_a)
+                    .await
+                    .unwrap();
+                let (ack_wire, ack_source) =
+                    receive_datagram(&socket_a, encrypted_ack.wire_bytes.len()).await;
+                assert_eq!(ack_source, endpoint_b);
+                let ack_inbound = transport_a
+                    .decrypt_inbound(&ack_wire)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                let ack = parse_control_packet(&ack_inbound.packet).unwrap();
+                assert_eq!(ack.kind, DplpmtudControlKind::Ack);
+                assert_eq!(
+                    runtime.try_accept_ack(
+                        "peer-b",
+                        &identity,
+                        ack.token,
+                        DplpmtudAckIngress {
+                            remote_endpoint: endpoint_b,
+                            local_endpoint: endpoint_a,
+                            socket: identity.socket,
+                        },
+                        logical_now + Duration::from_millis(2),
+                    ),
+                    DplpmtudTransitionDecision::Applied
+                );
+
+                if !duplicate_exercised {
+                    let duplicate_plaintext = build_ack_inner_packet(
+                        Ipv4Addr::new(10, 20, 0, 2),
+                        Ipv4Addr::new(10, 20, 0, 1),
+                        control.token,
+                    );
+                    let duplicate_encrypted = transport_b
+                        .encrypt_outbound(OutboundPacket {
+                            peer_id: "peer-a".to_string(),
+                            dst_ip: "10.20.0.1".to_string(),
+                            packet: duplicate_plaintext,
+                            trace: None,
+                        })
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    socket_b
+                        .send_to(&duplicate_encrypted.wire_bytes, endpoint_a)
+                        .await
+                        .unwrap();
+                    let (duplicate_wire, _) =
+                        receive_datagram(&socket_a, duplicate_encrypted.wire_bytes.len()).await;
+                    let duplicate_inbound = transport_a
+                        .decrypt_inbound(&duplicate_wire)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    let duplicate = parse_control_packet(&duplicate_inbound.packet).unwrap();
+                    let before = runtime.snapshots().remove("peer-b").unwrap();
+                    assert_eq!(
+                        runtime.try_accept_ack(
+                            "peer-b",
+                            &identity,
+                            duplicate.token,
+                            DplpmtudAckIngress {
+                                remote_endpoint: endpoint_b,
+                                local_endpoint: endpoint_a,
+                                socket: identity.socket,
+                            },
+                            logical_now + Duration::from_millis(3),
+                        ),
+                        DplpmtudTransitionDecision::Duplicate
+                    );
+                    let after = runtime.snapshots().remove("peer-b").unwrap();
+                    assert_eq!(after.revision, before.revision);
+                    assert_eq!(after.success_count, before.success_count);
+                    assert_eq!(
+                        after.confirmed_udp_datagram_size,
+                        before.confirmed_udp_datagram_size
+                    );
+                    duplicate_exercised = true;
+                }
+                logical_now += Duration::from_millis(4);
+            } else {
+                let (dropped, source) = receive_datagram(&blackhole_sink, probe_size).await;
+                assert_eq!(source, endpoint_a);
+                assert_eq!(dropped.len(), probe_size);
+                assert_eq!(
+                    runtime.timeout_probe(&plan, plan.deadline),
+                    DplpmtudTransitionDecision::Applied
+                );
+                logical_now = plan.deadline + Duration::from_millis(1);
+            }
+        }
+
+        let result = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(result.state, DplpmtudState::SearchComplete);
+        assert!(result.confirmed_udp_datagram_size as usize <= BLACKHOLE_THRESHOLD);
+        assert!(
+            BLACKHOLE_THRESHOLD - result.confirmed_udp_datagram_size as usize
+                <= DPLPMTUD_SEARCH_GRANULARITY as usize
+        );
+        assert!(observed_probe_sizes
+            .iter()
+            .any(|size| *size <= BLACKHOLE_THRESHOLD));
+        assert!(observed_probe_sizes
+            .iter()
+            .any(|size| *size > BLACKHOLE_THRESHOLD));
+        assert!(direct_active);
+        assert_eq!(direct_health_failure_count, 0);
+        assert_eq!(relay_fallback_count, 0);
+        assert_eq!(runtime.active_worker_count(), baseline_workers + 1);
+        assert_eq!(runtime.path_identity("peer-b"), Some(identity.clone()));
+
+        // Start a fresh generation, leave one Probe outstanding, and deliver
+        // PeerLeft before the send linearization point. The cancellation watch
+        // fires, the old worker cannot send, and task ownership returns to the
+        // pre-test baseline without a sleep or scheduler race.
+        let peer_left_identity = DplpmtudPathIdentity {
+            epoch: PathEpoch::new(9, PeerSessionGeneration::for_test(12), 15),
+            direct_validation_owner_token: 37,
+            direct_validation_request_id: 41,
+            ..identity.clone()
+        };
+        let peer_left_lease = runtime
+            .install_path(peer_left_identity.clone(), true, logical_now)
+            .worker
+            .unwrap();
+        assert!(*lease.cancel_rx.borrow());
+        runtime.finish_worker("peer-b", &identity, lease.worker_owner_token);
+        assert_eq!(runtime.active_worker_count(), baseline_workers + 1);
+        let peer_left_plan = runtime
+            .schedule_probe(
+                "peer-b",
+                &peer_left_identity,
+                peer_left_lease.worker_owner_token,
+                logical_now,
+            )
+            .unwrap();
+        let peer_left_plaintext = build_encrypted_probe_plaintext(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            &peer_left_identity,
+            &peer_left_plan,
+        )
+        .unwrap();
+        let peer_left_encrypted = transport_a
+            .encrypt_outbound(OutboundPacket {
+                peer_id: "peer-b".to_string(),
+                dst_ip: "10.20.0.2".to_string(),
+                packet: peer_left_plaintext,
+                trace: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            peer_left_encrypted.wire_bytes.len(),
+            peer_left_plan.probe_identity.candidate_udp_datagram_size.0 as usize
+        );
+        assert_eq!(
+            runtime.snapshots().remove("peer-b").unwrap().state,
+            DplpmtudState::Searching
+        );
+        runtime.cancel_peer(
+            "peer-b",
+            "peer_left",
+            logical_now + Duration::from_millis(1),
+        );
+        assert!(*peer_left_lease.cancel_rx.borrow());
+        assert!(!runtime.begin_probe_send(&peer_left_plan));
+        assert_eq!(
+            runtime.timeout_probe(&peer_left_plan, peer_left_plan.deadline),
+            DplpmtudTransitionDecision::Noop
+        );
+        let peer_left_snapshot = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(peer_left_snapshot.state, DplpmtudState::Disabled);
+        assert_eq!(
+            peer_left_snapshot.reset_reason.as_deref(),
+            Some("peer_left")
+        );
+        runtime.finish_worker(
+            "peer-b",
+            &peer_left_identity,
+            peer_left_lease.worker_owner_token,
+        );
+        assert_eq!(runtime.active_worker_count(), baseline_workers);
+        println!(
+            "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} direct_active={} direct_health_failure_count={} relay_fallback_count={} generation_switch_stale_ack=true peer_left_cancelled=true stale_ack_count={} duplicate_ack_count={} task_leak=false",
+            BLACKHOLE_THRESHOLD,
+            result.confirmed_udp_datagram_size,
+            result.search_upper_udp_datagram_size,
+            result.probe_count,
+            result.timeout_count,
+            direct_active,
+            direct_health_failure_count,
+            relay_fallback_count,
+            result.stale_ack_count,
+            result.duplicate_ack_count,
+        );
+    }
 }

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -1760,6 +1760,35 @@ impl DplpmtudRuntime {
     }
 
     #[cfg(test)]
+    fn current_probe_token(
+        &self,
+        peer_id: &str,
+        identity: &DplpmtudPathIdentity,
+    ) -> Option<DplpmtudWireToken> {
+        let registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = registry.entries.get(peer_id)?;
+        if entry.machine.identity() != Some(identity) {
+            return None;
+        }
+        let probe = entry.machine.outstanding.as_ref()?.identity;
+        Some(DplpmtudWireToken {
+            sequence: probe.sequence,
+            nonce: probe.nonce,
+            path_cookie: probe.path_cookie,
+            network_generation: identity.epoch.network_generation,
+            peer_session_generation: identity.epoch.peer_session_generation.value(),
+            remote_candidate_epoch: identity.epoch.remote_candidate_epoch,
+            direct_validation_owner_token: identity.direct_validation_owner_token,
+            direct_validation_request_id: identity.direct_validation_request_id,
+            candidate_udp_datagram_size: probe.candidate_udp_datagram_size,
+            outer_ip_family: identity.outer_ip_family,
+        })
+    }
+
+    #[cfg(test)]
     pub(crate) fn tracked_peer_count(&self) -> usize {
         self.registry
             .lock()
@@ -2821,6 +2850,7 @@ mod tests {
         let mut observed_blackhole_drops = 0;
         let mut observed_timeouts = 0;
         let mut observed_successes = 0;
+        let mut last_success_token = None;
         loop {
             let snapshot = runtime
                 .snapshots()
@@ -2840,6 +2870,7 @@ mod tests {
             let candidate = outstanding.candidate_udp_datagram_size as usize;
             observed_probe_sizes.push(candidate);
             if candidate <= BLACKHOLE_THRESHOLD {
+                last_success_token = runtime.current_probe_token("peer-b", &identity);
                 let expected_successes = observed_successes + 1;
                 yield_until(
                     || {
@@ -2876,7 +2907,7 @@ mod tests {
             }
         }
 
-        let result = runtime.snapshots().remove("peer-b").unwrap();
+        let mut result = runtime.snapshots().remove("peer-b").unwrap();
         assert_eq!(result.state, DplpmtudState::SearchComplete);
         assert!(result.confirmed_udp_datagram_size as usize <= BLACKHOLE_THRESHOLD);
         assert!(
@@ -2899,6 +2930,151 @@ mod tests {
         assert!(a_overlay_rx.try_recv().is_err());
         assert!(b_overlay_rx.try_recv().is_err());
 
+        // Send a second, independently encrypted ACK for the final successful
+        // probe. WireGuard replay protection accepts it as a new envelope,
+        // while the DPLPMTUD receipt identity must classify it as Duplicate
+        // without changing the converged result.
+        let duplicate_token = last_success_token.expect("a successful probe must converge");
+        let duplicate_ack_plaintext = build_ack_inner_packet(
+            Ipv4Addr::new(10, 20, 0, 2),
+            Ipv4Addr::new(10, 20, 0, 1),
+            duplicate_token,
+        );
+        let duplicate_ack_encrypted = wireguard_b
+            .encrypt_outbound(OutboundPacket {
+                peer_id: "peer-a".to_string(),
+                dst_ip: "10.20.0.1".to_string(),
+                packet: duplicate_ack_plaintext,
+                trace: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let (_, peer_b_socket) = udp_b
+            .socket_for_peer(Some("peer-a"))
+            .await
+            .expect("the responder must retain its primary UDP socket");
+        peer_b_socket
+            .send_to(&duplicate_ack_encrypted.wire_bytes, router_endpoint)
+            .await
+            .unwrap();
+        let expected_duplicate_acks = result.duplicate_ack_count + 1;
+        yield_until(
+            || {
+                runtime
+                    .snapshots()
+                    .get("peer-b")
+                    .is_some_and(|value| value.duplicate_ack_count >= expected_duplicate_acks)
+            },
+            "a second encrypted ACK must be classified as a duplicate by production inbound handling",
+        )
+        .await;
+        let after_duplicate = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(after_duplicate.revision, result.revision);
+        assert_eq!(after_duplicate.success_count, result.success_count);
+        assert_eq!(
+            after_duplicate.confirmed_udp_datagram_size,
+            result.confirmed_udp_datagram_size
+        );
+        assert_eq!(
+            after_duplicate.search_upper_udp_datagram_size,
+            result.search_upper_udp_datagram_size
+        );
+        assert_eq!(after_duplicate.duplicate_ack_count, expected_duplicate_acks);
+        result = after_duplicate;
+
+        // A real network-generation transition cancels the old exact path.
+        // Recommit a fresh Direct identity, then deliver an authenticated ACK
+        // carrying the old token through the live UDP reader. The production
+        // ACK handler must count it as stale and leave the new search intact.
+        let old_search_result = result.clone();
+        let next_generation = peers_a
+            .advance_network_generation("dplpmtud production generation fence")
+            .await;
+        yield_until(
+            || runtime.active_worker_count() == 0,
+            "network-generation advance must cancel the old DPLPMTUD worker",
+        )
+        .await;
+        let next_identity = commit_test_direct_path(
+            &peers_a,
+            &udp_a,
+            "peer-b",
+            router_endpoint,
+            endpoint_a,
+            43,
+            47,
+        )
+        .await;
+        assert_eq!(next_identity.epoch.network_generation, next_generation);
+        assert!(runtime.is_supported(
+            "peer-b",
+            next_identity.epoch.peer_session_generation.value()
+        ));
+        yield_until(
+            || {
+                runtime.path_identity("peer-b") == Some(next_identity.clone())
+                    && runtime.active_worker_count() == 1
+            },
+            "a recommitted Direct identity must start exactly one replacement worker",
+        )
+        .await;
+        let old_ack_plaintext = build_ack_inner_packet(
+            Ipv4Addr::new(10, 20, 0, 2),
+            Ipv4Addr::new(10, 20, 0, 1),
+            duplicate_token,
+        );
+        let old_ack_encrypted = wireguard_b
+            .encrypt_outbound(OutboundPacket {
+                peer_id: "peer-a".to_string(),
+                dst_ip: "10.20.0.1".to_string(),
+                packet: old_ack_plaintext,
+                trace: None,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let (_, peer_b_socket) = udp_b
+            .socket_for_peer(Some("peer-a"))
+            .await
+            .expect("the responder must retain its primary UDP socket");
+        peer_b_socket
+            .send_to(&old_ack_encrypted.wire_bytes, router_endpoint)
+            .await
+            .unwrap();
+        let expected_stale_acks = old_search_result.stale_ack_count + 1;
+        yield_until(
+            || {
+                runtime
+                    .snapshots()
+                    .get("peer-b")
+                    .is_some_and(|value| value.stale_ack_count >= expected_stale_acks)
+            },
+            "an authenticated ACK from the previous network generation must be stale",
+        )
+        .await;
+        let after_stale_generation = runtime.snapshots().remove("peer-b").unwrap();
+        assert_eq!(
+            after_stale_generation.confirmed_udp_datagram_size,
+            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+        );
+        assert_eq!(after_stale_generation.duplicate_ack_count, 0);
+        let observed_stale_ack_count = after_stale_generation.stale_ack_count;
+
+        // PeerLeft is exercised through the actual PeerManager lifecycle. It
+        // must withdraw the committed path, cancel the worker and remove the
+        // runtime entry before shutdown is signalled.
+        peers_a.remove_peer("peer-b").await;
+        yield_until(
+            || {
+                runtime.active_worker_count() == 0
+                    && runtime.tracked_peer_count() == 0
+                    && runtime.path_identity("peer-b").is_none()
+            },
+            "PeerLeft must cancel and remove the DPLPMTUD worker entry",
+        )
+        .await;
+
         shutdown_tx.send(true).unwrap();
         scheduler.await.unwrap();
         assert_eq!(runtime.active_worker_count(), 0);
@@ -2915,7 +3091,7 @@ mod tests {
         let _ = b_transport.await;
         let _ = router_task.await;
         println!(
-            "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} success_count={} dropped_probe_count={} direct_active=true direct_health_failure_count={} relay_fallback_count=0 task_leak={}",
+            "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} success_count={} dropped_probe_count={} direct_active=true direct_health_failure_count={} relay_fallback_count=0 generation_switch_stale_ack=true peer_left_cancelled=true stale_ack_count={} duplicate_ack_count={} task_leak={}",
             BLACKHOLE_THRESHOLD,
             result.confirmed_udp_datagram_size,
             result.search_upper_udp_datagram_size,
@@ -2924,6 +3100,8 @@ mod tests {
             result.success_count,
             dropped_probe_count.load(AtomicOrdering::Relaxed),
             connection.direct_health.failure_count,
+            observed_stale_ack_count,
+            result.duplicate_ack_count,
             runtime.active_worker_count() != 0,
         );
     }

--- a/client/daemon/src/lib.rs
+++ b/client/daemon/src/lib.rs
@@ -38,9 +38,6 @@ pub mod control;
 pub mod dataplane;
 pub mod diagnostics;
 pub mod dns;
-// The bounded MTU decision state is currently exercised as a pure module and
-// is not wired into the live probe scheduler yet.
-#[allow(dead_code)]
 pub(crate) mod dplpmtud;
 pub mod error;
 pub mod gateway_mapping;

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -1083,7 +1083,10 @@ async fn run_dplpmtud_worker(
                                         .dplpmtud_path_is_current_sync(&send_identity)
                                     || send_socket.local_addr().ok()
                                         != Some(send_identity.local_endpoint)
-                                    || !send_runtime.begin_probe_send(&send_plan)
+                                    || !send_runtime.begin_probe_send(
+                                        &send_plan,
+                                        tokio::time::Instant::now(),
+                                    )
                                 {
                                     return Err(DaemonError::Network(
                                         "DPLPMTUD exact path was cancelled before UDP send"

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -997,6 +997,7 @@ async fn run_dplpmtud_worker(
     } = start;
     let identity = lease.identity.clone();
     let peer_id = lease.peer_id.clone();
+    let worker_owner_token = lease.worker_owner_token;
     let notify = lease.notify.clone();
     let mut cancel_rx = lease.cancel_rx;
     let publication_owner = udp.inbound_publication_owner();
@@ -1027,7 +1028,12 @@ async fn run_dplpmtud_worker(
             break;
         }
 
-        if let Some(plan) = runtime.schedule_probe(&peer_id, &identity, now) {
+        if let Some(plan) =
+            runtime.schedule_probe(&peer_id, &identity, worker_owner_token, now)
+        {
+            if !runtime.outstanding_is_current(&plan) {
+                continue;
+            }
             emit_dplpmtud_timeline(
                 &peers,
                 "dplpmtud_probe_scheduled",
@@ -1135,7 +1141,9 @@ async fn run_dplpmtud_worker(
             continue;
         }
 
-        let Some((state, wakeup, outstanding)) = runtime.worker_state(&peer_id, &identity) else {
+        let Some((state, wakeup, outstanding)) =
+            runtime.worker_state(&peer_id, &identity, worker_owner_token)
+        else {
             break;
         };
         if matches!(
@@ -1171,6 +1179,7 @@ async fn run_dplpmtud_worker(
                 if let Some(outstanding) = outstanding {
                     let plan = crate::dplpmtud::DplpmtudProbePlan {
                         peer_id: peer_id.clone(),
+                        worker_owner_token,
                         path_identity: identity.clone(),
                         probe_identity: outstanding,
                         wire_token: crate::dplpmtud::DplpmtudWireToken {
@@ -1219,7 +1228,7 @@ async fn run_dplpmtud_worker(
         }
     }
 
-    runtime.finish_worker(&peer_id, &identity);
+    runtime.finish_worker(&peer_id, &identity, worker_owner_token);
     emit_dplpmtud_timeline(
         &peers,
         "dplpmtud_cancelled",

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -286,6 +286,13 @@ async fn run_udp_direct_instance(
     } else {
         udp
     };
+    let dplpmtud_local_virtual_ip = direct_validation_local_ip
+        .parse::<Ipv4Addr>()
+        .map_err(|error| {
+            DaemonError::Network(format!(
+                "invalid local virtual IPv4 address for DPLPMTUD: {direct_validation_local_ip}: {error}"
+            ))
+        })?;
     let peer_reflexive_ingress = PeerReflexiveIngress::new();
     // Every source of direct-validation evidence feeds this bounded
     // per-peer reachability-ranked ingress. The scheduler is the only place
@@ -296,7 +303,8 @@ async fn run_udp_direct_instance(
         .with_local_node_id(local_node_id.clone())
         .with_wireguard_transport(direct_validation_transport.clone())
         .with_inbound_channel(udp_inbound_tx.clone())
-        .with_peer_reflexive_observer(peer_reflexive_ingress.clone());
+        .with_peer_reflexive_observer(peer_reflexive_ingress.clone())
+        .with_dplpmtud_local_virtual_ip(dplpmtud_local_virtual_ip);
     // Matched ACKs enter the same scheduler as peer-reflexive
     // observations. The ingress is synchronous/nonblocking for the
     // UDP reader and retains the highest-ranked queued endpoint, with newest
@@ -327,6 +335,12 @@ async fn run_udp_direct_instance(
             direct_validation_worker_permits,
             lease.shutdown_receiver(),
         ));
+    let dplpmtud_scheduler_worker = tokio::spawn(run_dplpmtud_scheduler_until_cancelled(
+        udp.clone(),
+        peers.clone(),
+        direct_validation_transport.clone(),
+        lease.shutdown_receiver(),
+    ));
     let peer_reflexive_worker = tokio::spawn(run_peer_reflexive_signal_loop_until_cancelled(
         peer_reflexive_ingress,
         control.clone(),
@@ -753,6 +767,10 @@ async fn run_udp_direct_instance(
     // superseded worker gets `false` here and therefore cannot erase the
     // replacement published by a newer owner.
     udp.cancel_all_direct_validation_sessions().await;
+    udp.dplpmtud_runtime().close(
+        "udp_transport_withdrawn",
+        tokio::time::Instant::now(),
+    );
     udp.cancel_all_relay_backoff_heartbeats();
     let withdrew_current = udp_transport_publication
         .clear_if_owner(lease.owner())
@@ -787,6 +805,7 @@ async fn run_udp_direct_instance(
         }
     }
     stop_direct_validation_scheduler_worker(validation_scheduler_worker).await;
+    stop_dplpmtud_scheduler_worker(dplpmtud_scheduler_worker).await;
     stop_peer_reflexive_signal_worker(peer_reflexive_worker).await;
     outcome
 }
@@ -935,6 +954,336 @@ async fn wait_for_udp_direct_stop(
     tokio::select! {
         _ = wait_for_udp_direct_shutdown(daemon_shutdown_rx) => {},
         _ = wait_for_udp_direct_shutdown(instance_shutdown_rx) => {},
+    }
+}
+
+fn emit_dplpmtud_timeline(
+    peers: &PeerManager,
+    event: &'static str,
+    identity: &crate::dplpmtud::DplpmtudPathIdentity,
+    detail: impl Into<String>,
+) {
+    peers.emit_timeline(
+        event,
+        Some("direct"),
+        None,
+        Some(format!(
+            "peer={} network_generation={} peer_session_generation={} remote_candidate_epoch={} local_endpoint={} remote_endpoint={} transport_instance_id={} socket_index={} {}",
+            identity.peer_id,
+            identity.epoch.network_generation,
+            identity.epoch.peer_session_generation.value(),
+            identity.epoch.remote_candidate_epoch,
+            identity.local_endpoint,
+            identity.authenticated_remote_endpoint,
+            identity.socket.transport_instance_id,
+            identity.socket.socket_index,
+            detail.into(),
+        )),
+    );
+}
+
+async fn run_dplpmtud_worker(
+    start: crate::dplpmtud::DplpmtudWorkerStart,
+    udp: UdpTransport,
+    peers: Arc<PeerManager>,
+    transport: WireGuardTransport,
+) {
+    let runtime = udp.dplpmtud_runtime();
+    let crate::dplpmtud::DplpmtudWorkerStart {
+        lease,
+        socket,
+        local_virtual_ip,
+        peer_virtual_ip,
+    } = start;
+    let identity = lease.identity.clone();
+    let peer_id = lease.peer_id.clone();
+    let notify = lease.notify.clone();
+    let mut cancel_rx = lease.cancel_rx;
+    let publication_owner = udp.inbound_publication_owner();
+    let hard_deadline =
+        tokio::time::Instant::now() + crate::dplpmtud::DPLPMTUD_WORKER_MAX_LIFETIME;
+
+    emit_dplpmtud_timeline(
+        &peers,
+        "dplpmtud_started",
+        &identity,
+        format!(
+            "outer_ip_family={:?} base_udp_datagram_size={}",
+            identity.outer_ip_family,
+            crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+        ),
+    );
+
+    loop {
+        let now = tokio::time::Instant::now();
+        if *cancel_rx.borrow()
+            || now >= hard_deadline
+            || publication_owner == 0
+            || udp.inbound_publication_owner() != publication_owner
+            || udp.transport_instance_id() != identity.socket.transport_instance_id
+            || socket.local_addr().ok() != Some(identity.local_endpoint)
+            || !peers.dplpmtud_path_is_current_sync(&identity)
+        {
+            break;
+        }
+
+        if let Some(plan) = runtime.schedule_probe(&peer_id, &identity, now) {
+            emit_dplpmtud_timeline(
+                &peers,
+                "dplpmtud_probe_scheduled",
+                &identity,
+                format!(
+                    "sequence={} candidate_udp_datagram_size={} deadline_ms={}",
+                    plan.probe_identity.sequence,
+                    plan.probe_identity.candidate_udp_datagram_size.0,
+                    crate::dplpmtud::DPLPMTUD_PROBE_TIMEOUT.as_millis(),
+                ),
+            );
+
+            let plaintext = crate::dplpmtud::build_encrypted_probe_plaintext(
+                local_virtual_ip,
+                peer_virtual_ip,
+                &identity,
+                &plan,
+            );
+            let send_result = match plaintext {
+                Ok(plaintext) => {
+                    let target_size = plan.probe_identity.candidate_udp_datagram_size.0 as usize;
+                    let send_udp = udp.clone();
+                    let send_socket = socket.clone();
+                    let send_runtime = runtime.clone();
+                    let send_plan = plan.clone();
+                    let send_peers = peers.clone();
+                    let send_identity = identity.clone();
+                    let remote_endpoint = identity.authenticated_remote_endpoint;
+                    transport
+                        .encrypt_and_emit_outbound_with_lock_timeout(
+                            OutboundPacket {
+                                peer_id: peer_id.clone(),
+                                dst_ip: peer_virtual_ip.to_string(),
+                                packet: plaintext,
+                                trace: None,
+                            },
+                            crate::transport::DIRECT_VALIDATION_EMIT_LOCK_TIMEOUT,
+                            move |encrypted| async move {
+                                if encrypted.wire_bytes.len() != target_size {
+                                    return Err(DaemonError::Network(format!(
+                                        "DPLPMTUD encrypted datagram size mismatch: built={} expected={target_size}",
+                                        encrypted.wire_bytes.len(),
+                                    )));
+                                }
+                                if send_udp.inbound_publication_owner() != publication_owner
+                                    || !send_peers
+                                        .dplpmtud_path_is_current_sync(&send_identity)
+                                    || send_socket.local_addr().ok()
+                                        != Some(send_identity.local_endpoint)
+                                    || !send_runtime.begin_probe_send(&send_plan)
+                                {
+                                    return Err(DaemonError::Network(
+                                        "DPLPMTUD exact path was cancelled before UDP send"
+                                            .to_string(),
+                                    ));
+                                }
+                                send_udp
+                                    .send_encrypted_packet_on_socket(
+                                        &send_socket,
+                                        send_identity.socket.socket_index,
+                                        &encrypted,
+                                        remote_endpoint,
+                                    )
+                                    .await
+                                    .map(|_| ())
+                            },
+                        )
+                        .await
+                }
+                Err(error) => Err(DaemonError::Network(error)),
+            };
+
+            match send_result {
+                Ok(crate::transport::BoundedEmitOutcome::Sent) => {
+                    runtime.finish_probe_send(&plan, Ok(()), tokio::time::Instant::now());
+                    emit_dplpmtud_timeline(
+                        &peers,
+                        "dplpmtud_probe_sent",
+                        &identity,
+                        format!(
+                            "sequence={} candidate_udp_datagram_size={}",
+                            plan.probe_identity.sequence,
+                            plan.probe_identity.candidate_udp_datagram_size.0,
+                        ),
+                    );
+                }
+                Ok(
+                    crate::transport::BoundedEmitOutcome::LockTimeout
+                    | crate::transport::BoundedEmitOutcome::SessionUnavailable,
+                )
+                | Err(_) => {
+                    runtime.finish_probe_send(&plan, Err(()), tokio::time::Instant::now());
+                    emit_dplpmtud_timeline(
+                        &peers,
+                        "dplpmtud_probe_send_failed",
+                        &identity,
+                        format!(
+                            "sequence={} candidate_udp_datagram_size={}",
+                            plan.probe_identity.sequence,
+                            plan.probe_identity.candidate_udp_datagram_size.0,
+                        ),
+                    );
+                }
+            }
+            continue;
+        }
+
+        let Some((state, wakeup, outstanding)) = runtime.worker_state(&peer_id, &identity) else {
+            break;
+        };
+        if matches!(
+            state,
+            crate::dplpmtud::DplpmtudState::Disabled
+                | crate::dplpmtud::DplpmtudState::Unsupported
+        ) {
+            break;
+        }
+
+        let wait_until = wakeup.unwrap_or(hard_deadline).min(hard_deadline);
+        if state == crate::dplpmtud::DplpmtudState::SearchComplete {
+            emit_dplpmtud_timeline(
+                &peers,
+                "dplpmtud_raise_timer_started",
+                &identity,
+                format!(
+                    "raise_in_ms={}",
+                    wait_until
+                        .saturating_duration_since(tokio::time::Instant::now())
+                        .as_millis()
+                ),
+            );
+        }
+        tokio::select! {
+            changed = cancel_rx.changed() => {
+                if changed.is_err() || *cancel_rx.borrow_and_update() {
+                    break;
+                }
+            }
+            _ = notify.notified() => {}
+            _ = tokio::time::sleep_until(wait_until) => {
+                if let Some(outstanding) = outstanding {
+                    let plan = crate::dplpmtud::DplpmtudProbePlan {
+                        peer_id: peer_id.clone(),
+                        path_identity: identity.clone(),
+                        probe_identity: outstanding,
+                        wire_token: crate::dplpmtud::DplpmtudWireToken {
+                            sequence: outstanding.sequence,
+                            nonce: outstanding.nonce,
+                            path_cookie: outstanding.path_cookie,
+                            network_generation: identity.epoch.network_generation,
+                            peer_session_generation: identity.epoch.peer_session_generation.value(),
+                            remote_candidate_epoch: identity.epoch.remote_candidate_epoch,
+                            direct_validation_owner_token: identity.direct_validation_owner_token,
+                            direct_validation_request_id: identity.direct_validation_request_id,
+                            candidate_udp_datagram_size: outstanding.candidate_udp_datagram_size,
+                            outer_ip_family: identity.outer_ip_family,
+                        },
+                        deadline: wait_until,
+                    };
+                    if runtime.timeout_probe(&plan, tokio::time::Instant::now())
+                        == crate::dplpmtud::DplpmtudTransitionDecision::Applied
+                    {
+                        let snapshot = runtime.snapshots().remove(&peer_id);
+                        emit_dplpmtud_timeline(
+                            &peers,
+                            "dplpmtud_probe_timeout",
+                            &identity,
+                            format!(
+                                "sequence={} candidate_udp_datagram_size={} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                                outstanding.sequence,
+                                outstanding.candidate_udp_datagram_size.0,
+                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
+                            ),
+                        );
+                        emit_dplpmtud_timeline(
+                            &peers,
+                            "dplpmtud_search_bounds_updated",
+                            &identity,
+                            format!(
+                                "confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    runtime.finish_worker(&peer_id, &identity);
+    emit_dplpmtud_timeline(
+        &peers,
+        "dplpmtud_cancelled",
+        &identity,
+        "worker exited after cancellation, lifecycle change, publication replacement, or intrinsic deadline",
+    );
+}
+
+async fn run_dplpmtud_scheduler_until_cancelled(
+    udp: UdpTransport,
+    peers: Arc<PeerManager>,
+    transport: WireGuardTransport,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    let ingress = udp.dplpmtud_worker_ingress();
+    let mut path_changes = peers.subscribe_committed_business_path_changes();
+    let mut workers = tokio::task::JoinSet::new();
+    udp.reconcile_dplpmtud_paths().await;
+
+    loop {
+        if *shutdown_rx.borrow_and_update() {
+            break;
+        }
+        tokio::select! {
+            start = ingress.next() => {
+                let worker_udp = udp.clone();
+                let worker_peers = peers.clone();
+                let worker_transport = transport.clone();
+                workers.spawn(async move {
+                    run_dplpmtud_worker(start, worker_udp, worker_peers, worker_transport).await;
+                });
+            }
+            changed = path_changes.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                udp.reconcile_dplpmtud_paths().await;
+            }
+            joined = workers.join_next(), if !workers.is_empty() => {
+                if let Some(Err(error)) = joined {
+                    debug!(?error, "DPLPMTUD worker stopped unexpectedly");
+                }
+                udp.reconcile_dplpmtud_paths().await;
+            }
+            changed = shutdown_rx.changed() => {
+                if changed.is_err() || *shutdown_rx.borrow_and_update() {
+                    break;
+                }
+            }
+        }
+    }
+
+    udp.dplpmtud_runtime().close(
+        "udp_transport_scheduler_stopped",
+        tokio::time::Instant::now(),
+    );
+    workers.abort_all();
+    while workers.join_next().await.is_some() {}
+}
+
+async fn stop_dplpmtud_scheduler_worker(mut worker: tokio::task::JoinHandle<()>) {
+    if timeout(Duration::from_secs(1), &mut worker).await.is_err() {
+        worker.abort();
+        let _ = worker.await;
     }
 }
 

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -179,6 +179,10 @@ impl PeerSessionGeneration {
     /// `PeerMembershipState::publish` before path work is admitted.
     pub(crate) const UNBOUND: Self = Self(0);
 
+    pub(crate) const fn value(self) -> u64 {
+        self.0
+    }
+
     #[cfg(test)]
     pub(crate) const fn for_test(value: u64) -> Self {
         Self(value)

--- a/client/daemon/src/peer/diagnostics/peer.rs
+++ b/client/daemon/src/peer/diagnostics/peer.rs
@@ -115,6 +115,11 @@ pub struct PeerDiagnostics {
     pub direct_events: Vec<DirectTraversalEventDiagnostics>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fresh_mapping: Vec<FreshMappingDiag>,
+    /// Read-only DPLPMTUD snapshot for the exact committed Direct UDP path.
+    /// The discovered size is diagnostic in this phase and is not consumed by
+    /// normal business-packet sizing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dplpmtud: Option<crate::dplpmtud::DplpmtudSnapshot>,
     /// Failure-recovery epoch budget report (probe credit, fresh-mapping
     /// generations, HTTP publishes remaining), when a recovery epoch is
     /// active for the peer.
@@ -549,6 +554,7 @@ impl PeerDiagnostics {
                         .collect()
                 })
                 .unwrap_or_default(),
+            dplpmtud: None,
             recovery: None,
         }
     }

--- a/client/daemon/src/peer/diagnostics/peer.rs
+++ b/client/daemon/src/peer/diagnostics/peer.rs
@@ -119,7 +119,7 @@ pub struct PeerDiagnostics {
     /// The discovered size is diagnostic in this phase and is not consumed by
     /// normal business-packet sizing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dplpmtud: Option<crate::dplpmtud::DplpmtudSnapshot>,
+    pub(crate) dplpmtud: Option<crate::dplpmtud::DplpmtudSnapshot>,
     /// Failure-recovery epoch budget report (probe credit, fresh-mapping
     /// generations, HTTP publishes remaining), when a recovery epoch is
     /// active for the peer.

--- a/client/daemon/src/peer/manager/candidates/signaled.rs
+++ b/client/daemon/src/peer/manager/candidates/signaled.rs
@@ -375,6 +375,8 @@ impl PeerManager {
                 .await;
             self.cancel_direct_validation_for_remote_candidate_change(node_id)
                 .await;
+            self.cancel_dplpmtud_for_remote_candidate_change(node_id)
+                .await;
             if retire_hard_hard {
                 // Candidate handover retires the complete direct transport
                 // context. Control-event ingress applies the candidate set

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -45,6 +45,7 @@ impl PeerManager {
             network_generation_sync: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             network_epoch_gate: Arc::new(tokio::sync::Mutex::new(())),
             direct_validation_registry: Arc::new(RwLock::new(None)),
+            dplpmtud_runtime: Arc::new(RwLock::new(None)),
             local_nat_profile: Arc::new(RwLock::new(None)),
             local_profile_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             local_interface_networks: Arc::new(RwLock::new(Vec::new())),
@@ -518,6 +519,93 @@ impl PeerManager {
         }
     }
 
+    /// Publish the DPLPMTUD runtime owned by the active UDP transport.
+    /// Replacing a transport closes every old worker before the new handle is
+    /// visible, so a rebound socket cannot reuse a stale Probe/ACK identity.
+    pub(crate) async fn register_dplpmtud_runtime(
+        &self,
+        runtime: crate::dplpmtud::DplpmtudRuntime,
+    ) {
+        let epoch_gate = self.network_epoch_gate();
+        let _epoch_guard = epoch_gate.lock().await;
+        let previous = self.dplpmtud_runtime.write().await.replace(runtime);
+        if let Some(previous) = previous {
+            previous.close(
+                "udp_transport_replaced",
+                tokio::time::Instant::now(),
+            );
+        }
+    }
+
+    pub(crate) async fn current_dplpmtud_runtime(
+        &self,
+    ) -> Option<crate::dplpmtud::DplpmtudRuntime> {
+        self.dplpmtud_runtime.read().await.clone()
+    }
+
+    /// Cancel the current exact-path worker at a peer lifecycle boundary.
+    pub(crate) async fn cancel_active_dplpmtud_for_peer(
+        &self,
+        peer_id: &str,
+        reason: &str,
+    ) {
+        let epoch_gate = self.network_epoch_gate();
+        let _epoch_guard = epoch_gate.lock().await;
+        if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+            runtime.cancel_peer(peer_id, reason, tokio::time::Instant::now());
+        }
+    }
+
+    /// Candidate publication already owns `network_epoch_gate`; do not acquire
+    /// it again here.
+    pub(crate) async fn cancel_dplpmtud_for_remote_candidate_change(
+        &self,
+        peer_id: &str,
+    ) {
+        if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+            runtime.cancel_peer(
+                peer_id,
+                "remote_candidate_generation_changed",
+                tokio::time::Instant::now(),
+            );
+        }
+    }
+
+    /// Exact no-await fence used immediately before a Probe send and while an
+    /// ACK is consumed.  The state-machine snapshot is the active-path
+    /// authority; the Direct-pair mirror additionally binds the local socket
+    /// endpoint committed by the encrypted validation transaction.
+    pub(crate) fn dplpmtud_path_is_current_sync(
+        &self,
+        identity: &crate::dplpmtud::DplpmtudPathIdentity,
+    ) -> bool {
+        let committed = self
+            .committed_business_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&identity.peer_id)
+            .cloned();
+        let Some(committed) = committed else {
+            return false;
+        };
+        if !identity.matches_committed_path(
+            committed.lifecycle,
+            committed.epoch,
+            &committed.active,
+        ) {
+            return false;
+        }
+        self.direct_commit_pair_mirror
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&identity.peer_id)
+            .is_some_and(|pair| {
+                pair.generation == identity.epoch.network_generation
+                    && pair.remote_candidate_epoch == identity.epoch.remote_candidate_epoch
+                    && pair.local_endpoint == Some(identity.local_endpoint)
+            })
+    }
+
     /// Whether a peer connection currently exists, readable without awaiting
     /// or contending on the async connection map.
     ///
@@ -666,6 +754,13 @@ impl PeerManager {
         if let Some(registry) = self.direct_validation_registry.read().await.clone() {
             registry.cancel_before_generation(generation).await;
         }
+        if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+            runtime.cancel_before_network_generation(
+                generation,
+                "network_generation_advanced",
+                tokio::time::Instant::now(),
+            );
+        }
 
         let mut direct_reclaim_count = 0usize;
         let mut relay_confirmation_cancellations = Vec::new();
@@ -742,6 +837,13 @@ impl PeerManager {
         };
         if let Some(registry) = self.direct_validation_registry.read().await.clone() {
             registry.cancel_before_generation(generation).await;
+        }
+        if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+            runtime.cancel_before_network_generation(
+                generation,
+                "candidate_refresh_generation_advanced",
+                tokio::time::Instant::now(),
+            );
         }
 
         let mut retained_confirmed_direct_count = 0usize;

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -143,6 +143,11 @@ impl PeerManager {
             .map(|history| history.clone())
             .unwrap_or_default();
         let recovery_reports = self.recovery_epoch_diagnostics();
+        let dplpmtud_reports = self
+            .current_dplpmtud_runtime()
+            .await
+            .map(|runtime| runtime.snapshots())
+            .unwrap_or_default();
         // `try_read` also fails when a writer is merely queued.  During normal
         // probe/control activity that made `/peers` intermittently return an
         // empty roster even though the control poll had already joined the
@@ -169,6 +174,9 @@ impl PeerManager {
                 .collect(),
             Err(_) => self.cached_diagnostics(),
         };
+        for peer in &mut peers {
+            peer.dplpmtud = dplpmtud_reports.get(&peer.node_id).cloned();
+        }
         peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         self.cache_diagnostics(&peers);
         peers
@@ -210,6 +218,11 @@ impl PeerManager {
             .map(|history| history.clone())
             .unwrap_or_default();
         let recovery_reports = self.recovery_epoch_diagnostics();
+        let dplpmtud_reports = self
+            .current_dplpmtud_runtime()
+            .await
+            .map(|runtime| runtime.snapshots())
+            .unwrap_or_default();
         let mut peers: Vec<_> = match self.connections.try_read() {
             Ok(connections) => connections
                 .values()
@@ -240,6 +253,9 @@ impl PeerManager {
                 .collect(),
             Err(_) => self.cached_diagnostics(),
         };
+        for peer in &mut peers {
+            peer.dplpmtud = dplpmtud_reports.get(&peer.node_id).cloned();
+        }
         peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         self.cache_diagnostics(&peers);
         peers
@@ -273,6 +289,10 @@ impl PeerManager {
             .map(|history| history.clone())
             .unwrap_or_default();
         let recovery = self.recovery_epoch_diagnostics().remove(node_id);
+        let dplpmtud = self
+            .current_dplpmtud_runtime()
+            .await
+            .and_then(|runtime| runtime.snapshots().remove(node_id));
         let generation = self.current_network_generation_sync();
         let profile_generation = self.current_local_profile_generation_sync();
         let local_nat_capabilities = self
@@ -306,6 +326,7 @@ impl PeerManager {
             Some(&traversal_history),
             Some(&fresh_mapping_history),
         );
+        diagnostics.dplpmtud = dplpmtud;
         diagnostics.recovery = recovery;
         Some((generation, diagnostics))
     }

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -714,6 +714,12 @@ impl PeerManager {
         let (removed_virtual_ip, removed_relay_expectation) = {
             let epoch_gate = self.network_epoch_gate();
             let _epoch_guard = epoch_gate.lock().await;
+            // Snapshot the current runtime while the epoch fence is held, but
+            // before taking the connection writer.  Cancellation mutates the
+            // DPLPMTUD registry synchronously; awaiting its manager lock
+            // while `conns` is held would invert the diagnostics/transport
+            // lock order and extend the PeerLeft write critical section.
+            let dplpmtud_runtime = self.dplpmtud_runtime.read().await.clone();
             // PeerLeft is an authoritative quarantine lifecycle boundary.
             // Remove both the backoff metadata and the no-await dataplane
             // mirror under the same epoch used for membership removal, before
@@ -763,7 +769,7 @@ impl PeerManager {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .remove(node_id);
-            if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+            if let Some(runtime) = dplpmtud_runtime {
                 runtime.cancel_peer(
                     node_id,
                     "peer_left",

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -763,6 +763,13 @@ impl PeerManager {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .remove(node_id);
+            if let Some(runtime) = self.dplpmtud_runtime.read().await.clone() {
+                runtime.cancel_peer(
+                    node_id,
+                    "peer_left",
+                    tokio::time::Instant::now(),
+                );
+            }
             // PeerLeft is a terminal boundary for the current peer session.
             // Cancel the forced-relay token while the same epoch gate covers
             // removal, so an old ACK cannot race a later re-add of this node

--- a/client/daemon/src/peer/manager/recovery_epoch.rs
+++ b/client/daemon/src/peer/manager/recovery_epoch.rs
@@ -1393,6 +1393,17 @@ impl PeerManager {
             );
     }
 
+    pub(crate) fn direct_commit_pair_snapshot_sync(
+        &self,
+        peer_id: &str,
+    ) -> Option<DirectCommitPairSnapshot> {
+        self.direct_commit_pair_mirror
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(peer_id)
+            .copied()
+    }
+
     /// Check the latest exact Direct pair without touching the async
     /// connection map.  `is_direct_sync` is checked separately from the pair
     /// snapshot so a transition to Relay/Closed cannot leave a stale exact

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -352,6 +352,10 @@ pub struct PeerManager {
     /// it while holding `network_epoch_gate` to revoke old validation owners
     /// and their ACK expectations atomically with the new generation.
     direct_validation_registry: Arc<RwLock<Option<crate::udp::DirectValidationRegistry>>>,
+    /// DPLPMTUD registry published by the current UDP transport.  It is kept
+    /// beside the validation registry so lifecycle/generation transitions can
+    /// cancel exact-path probe ownership under the same network epoch fence.
+    dplpmtud_runtime: Arc<RwLock<Option<crate::dplpmtud::DplpmtudRuntime>>>,
     /// Latest local NAT profile used to decide whether bounded birthday probing is suitable.
     local_nat_profile: Arc<RwLock<Option<NatProfile>>>,
     /// Monotonic generation of the local NAT profile itself.  This is a

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -458,8 +458,11 @@ pub(crate) fn build_direct_validation_payload(
         DirectValidationKind::Request => crate::DIRECT_VALIDATION_REQUEST_PAYLOAD,
         DirectValidationKind::Ack => crate::DIRECT_VALIDATION_ACK_PAYLOAD,
     };
-    let mut payload = Vec::with_capacity(prefix.len() + DIRECT_VALIDATION_TOKEN_BYTES);
+    let capability = crate::dplpmtud::direct_validation_capability_extension();
+    let mut payload =
+        Vec::with_capacity(prefix.len() + capability.len() + DIRECT_VALIDATION_TOKEN_BYTES);
     payload.extend_from_slice(prefix);
+    payload.extend_from_slice(&capability);
     payload.extend_from_slice(&generation.to_be_bytes());
     payload.extend_from_slice(&request_id.to_be_bytes());
     payload.push(sequence);
@@ -742,6 +745,7 @@ pub(crate) fn is_real_overlay_business_packet(packet: &[u8]) -> bool {
         && !is_relay_validation_packet(packet)
         && !is_rekey_confirmation_packet(packet)
         && parse_direct_validation_token(packet).is_none()
+        && crate::dplpmtud::parse_control_packet(packet).is_none()
         && crate::relay_probe::parse_relay_probe_token(packet).is_none()
         && crate::path_commit::parse_path_commit_token(packet).is_none()
 }
@@ -3056,6 +3060,9 @@ impl WireGuardTransport {
                     // delivery.
                     let internal_rekey_confirmation = is_rekey_confirmation_packet(&inbound.packet);
                     let direct_validation = parse_direct_validation_token(&inbound.packet);
+                    let direct_validation_dplpmtud_capability = direct_validation.is_some()
+                        && crate::dplpmtud::direct_validation_supports_dplpmtud(&inbound.packet);
+                    let dplpmtud = crate::dplpmtud::parse_control_packet(&inbound.packet);
                     let relay_probe = crate::relay_probe::parse_relay_probe_token(&inbound.packet);
                     let path_commit = crate::path_commit::parse_path_commit_token(&inbound.packet);
                     if session_evidence_eligible {
@@ -3236,6 +3243,74 @@ impl WireGuardTransport {
                                 );
                             }
                             drop(binding_guard);
+                            if let Some(control) = dplpmtud {
+                                if owns_direct_packet {
+                                    let control_kind = control.kind;
+                                    let peer_session_generation =
+                                        peers.peer_session_generation_sync(&inbound.peer_id);
+                                    let session_guard = if control_kind
+                                        == crate::dplpmtud::DplpmtudControlKind::Ack
+                                    {
+                                        self.acquire_current_session_evidence_guard(
+                                            &inbound.peer_id,
+                                            inbound.session_instance,
+                                        )
+                                        .await
+                                    } else {
+                                        None
+                                    };
+                                    let session_current = if inbound.session_instance.is_none() {
+                                        true
+                                    } else if control_kind
+                                        == crate::dplpmtud::DplpmtudControlKind::Ack
+                                    {
+                                        session_guard.is_some()
+                                    } else {
+                                        self.session_instance_is_current(
+                                            &inbound.peer_id,
+                                            inbound.session_instance,
+                                        )
+                                        .await
+                                    };
+                                    if let (true, Some(peer_session_generation), Some(udp)) =
+                                        (session_current, peer_session_generation, udp.as_ref())
+                                    {
+                                        self.handle_dplpmtud_packet(
+                                            peers,
+                                            udp,
+                                            &inbound.peer_id,
+                                            &inbound.packet,
+                                            packet.wire_bytes.len(),
+                                            source,
+                                            local_endpoint,
+                                            socket_index,
+                                            direct_socket.clone(),
+                                            peer_session_generation,
+                                            control,
+                                        )
+                                        .await;
+                                    } else {
+                                        peers.emit_timeline(
+                                            "dplpmtud_stale_ack_rejected",
+                                            Some("direct"),
+                                            Some("session_replaced_or_removed"),
+                                            Some(format!(
+                                                "peer={} session_instance={:?} control_kind={:?}",
+                                                inbound.peer_id,
+                                                inbound.session_instance,
+                                                control_kind,
+                                            )),
+                                        );
+                                    }
+                                    drop(session_guard);
+                                } else {
+                                    debug!(
+                                        peer_id = %inbound.peer_id,
+                                        packet_owner = ?udp_transport_owner,
+                                        "ignored DPLPMTUD packet from retired or unpublished UDP transport"
+                                    );
+                                }
+                            }
                             if let Some(token) = direct_validation {
                                 // Daemon-internal direct-validation packets are
                                 // consumed here and never forwarded to TUN: the
@@ -3275,6 +3350,14 @@ impl WireGuardTransport {
                                     if let (true, Some(peer_session_generation)) =
                                         (session_current, peer_session_generation)
                                     {
+                                        if direct_validation_dplpmtud_capability {
+                                            if let Some(udp) = udp.as_ref() {
+                                                udp.mark_peer_dplpmtud_supported(
+                                                    &inbound.peer_id,
+                                                    peer_session_generation,
+                                                );
+                                            }
+                                        }
                                         self.handle_direct_validation_packet(
                                             peers,
                                             udp.as_ref(),
@@ -3283,11 +3366,16 @@ impl WireGuardTransport {
                                             source,
                                             local_endpoint,
                                             socket_index,
-                                            direct_socket,
+                                            direct_socket.clone(),
                                             peer_session_generation,
                                             token,
                                         )
                                         .await;
+                                        if direct_validation_dplpmtud_capability {
+                                            if let Some(udp) = udp.as_ref() {
+                                                udp.reconcile_dplpmtud_paths().await;
+                                            }
+                                        }
                                     } else {
                                         peers.emit_timeline(
                                             "stale_session_evidence",
@@ -3316,11 +3404,13 @@ impl WireGuardTransport {
                                         inbound.peer_id
                                     );
                                 }
-                                if should_request_direct_validation_after_decrypt(
-                                    owns_direct_packet,
-                                    Some(source),
-                                    direct_validation,
-                                ) {
+                                if dplpmtud.is_none()
+                                    && should_request_direct_validation_after_decrypt(
+                                        owns_direct_packet,
+                                        Some(source),
+                                        direct_validation,
+                                    )
+                                {
                                     let session_guard = self
                                         .acquire_current_session_evidence_guard(
                                             &inbound.peer_id,
@@ -3449,6 +3539,7 @@ impl WireGuardTransport {
                     }
                     if internal_rekey_confirmation
                         || direct_validation.is_some()
+                        || dplpmtud.is_some()
                         || relay_probe.is_some()
                         || path_commit.is_some()
                     {
@@ -3691,6 +3782,296 @@ impl WireGuardTransport {
         }
 
         Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_dplpmtud_packet(
+        &self,
+        peers: &Arc<PeerManager>,
+        udp: &crate::udp::UdpTransport,
+        peer_id: &str,
+        packet: &[u8],
+        received_udp_datagram_size: usize,
+        source: Option<SocketAddr>,
+        local_endpoint: Option<SocketAddr>,
+        socket_index: Option<usize>,
+        direct_socket: Option<Arc<tokio::net::UdpSocket>>,
+        peer_session_generation: PeerSessionGeneration,
+        control: crate::dplpmtud::DplpmtudControlPacket,
+    ) {
+        let token = control.token;
+        match control.kind {
+            crate::dplpmtud::DplpmtudControlKind::Probe => {
+                let (Some(source), Some(local_endpoint), Some(socket_index)) =
+                    (source, local_endpoint, socket_index)
+                else {
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("probe_ingress_identity_incomplete"),
+                        Some(format!("peer={peer_id}")),
+                    );
+                    return;
+                };
+                if received_udp_datagram_size != token.candidate_udp_datagram_size.0 as usize
+                    || crate::dplpmtud::OuterIpFamily::from_ip(source.ip()) != token.outer_ip_family
+                {
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("probe_size_or_family_mismatch"),
+                        Some(format!(
+                            "peer={peer_id} received_udp_datagram_size={received_udp_datagram_size} claimed_udp_datagram_size={} source={source}",
+                            token.candidate_udp_datagram_size.0,
+                        )),
+                    );
+                    return;
+                }
+                let Ok(ip) = Ipv4Packet::new(packet) else {
+                    return;
+                };
+                let ack_packet =
+                    crate::dplpmtud::build_ack_inner_packet(ip.dst_addr(), ip.src_addr(), token);
+                let publication_owner = udp.inbound_publication_owner();
+                let send_udp = udp.clone();
+                let send_peers = peers.clone();
+                let peer_id_owned = peer_id.to_string();
+                let receive_socket = direct_socket;
+                let result = self
+                    .encrypt_and_emit_outbound_with_lock_timeout(
+                        OutboundPacket {
+                            peer_id: peer_id_owned.clone(),
+                            dst_ip: ip.src_addr().to_string(),
+                            packet: ack_packet,
+                            trace: None,
+                        },
+                        DIRECT_VALIDATION_EMIT_LOCK_TIMEOUT,
+                        move |encrypted| async move {
+                            if encrypted.wire_bytes.len() > received_udp_datagram_size {
+                                return Err(DaemonError::Network(format!(
+                                    "DPLPMTUD ACK amplification refused: ack={} probe={received_udp_datagram_size}",
+                                    encrypted.wire_bytes.len(),
+                                )));
+                            }
+                            if publication_owner == 0
+                                || send_udp.inbound_publication_owner() != publication_owner
+                                || !send_peers.peer_session_is_current_sync(
+                                    &peer_id_owned,
+                                    peer_session_generation,
+                                )
+                            {
+                                return Err(DaemonError::Network(
+                                    "DPLPMTUD Probe lifecycle changed before ACK send"
+                                        .to_string(),
+                                ));
+                            }
+                            if let Some(receive_socket) = receive_socket {
+                                if receive_socket.local_addr().ok() != Some(local_endpoint) {
+                                    return Err(DaemonError::Network(
+                                        "DPLPMTUD receiving socket endpoint changed"
+                                            .to_string(),
+                                    ));
+                                }
+                                send_udp
+                                    .send_encrypted_packet_on_socket(
+                                        &receive_socket,
+                                        socket_index,
+                                        &encrypted,
+                                        source,
+                                    )
+                                    .await
+                                    .map(|_| ())
+                            } else {
+                                send_udp
+                                    .send_packet_on_socket_index(
+                                        &encrypted,
+                                        socket_index,
+                                        source,
+                                    )
+                                    .await
+                                    .map(|_| ())
+                            }
+                        },
+                    )
+                    .await;
+                match result {
+                    Ok(BoundedEmitOutcome::Sent) => {
+                        debug!(
+                            event = "dplpmtud_ack_sent",
+                            peer_id = %peer_id,
+                            remote_endpoint = %source,
+                            local_endpoint = %local_endpoint,
+                            socket_index,
+                            sequence = token.sequence,
+                            candidate_udp_datagram_size = token.candidate_udp_datagram_size.0,
+                            "sent authenticated DPLPMTUD ACK on the receiving Direct socket"
+                        );
+                    }
+                    Ok(
+                        BoundedEmitOutcome::LockTimeout | BoundedEmitOutcome::SessionUnavailable,
+                    )
+                    | Err(_) => {
+                        peers.emit_timeline(
+                            "dplpmtud_probe_send_failed",
+                            Some("direct"),
+                            Some("ack_send_failed"),
+                            Some(format!(
+                                "peer={peer_id} sequence={} remote_endpoint={source} local_endpoint={local_endpoint} socket_index={socket_index}",
+                                token.sequence,
+                            )),
+                        );
+                    }
+                }
+            }
+            crate::dplpmtud::DplpmtudControlKind::Ack => {
+                let (Some(source), Some(local_endpoint), Some(socket_index)) =
+                    (source, local_endpoint, socket_index)
+                else {
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("ack_ingress_identity_incomplete"),
+                        Some(format!("peer={peer_id} sequence={}", token.sequence)),
+                    );
+                    return;
+                };
+                if crate::dplpmtud::OuterIpFamily::from_ip(source.ip()) != token.outer_ip_family {
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("ack_outer_ip_family_mismatch"),
+                        Some(format!(
+                            "peer={peer_id} sequence={} source={source}",
+                            token.sequence,
+                        )),
+                    );
+                    return;
+                }
+
+                // Canonical order: the transport inbound path retained the
+                // per-peer emit guard for an ACK; below it we take adoption,
+                // then the global network epoch, then the non-awaiting runtime
+                // try-lock.  No socket I/O occurs in this transaction.
+                let adoption_guard = udp.lock_peer_adoption_for_direct_validation(peer_id).await;
+                let epoch_gate = peers.network_epoch_gate();
+                let epoch_guard = epoch_gate.lock().await;
+                if !peers.peer_session_is_current_sync(peer_id, peer_session_generation) {
+                    drop(epoch_guard);
+                    drop(adoption_guard);
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("peer_lifecycle_changed"),
+                        Some(format!("peer={peer_id} sequence={}", token.sequence)),
+                    );
+                    return;
+                }
+                let runtime = udp.dplpmtud_runtime();
+                let Some(current_path) = runtime.path_identity(peer_id) else {
+                    drop(epoch_guard);
+                    drop(adoption_guard);
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("no_current_probe_path"),
+                        Some(format!("peer={peer_id} sequence={}", token.sequence)),
+                    );
+                    return;
+                };
+                if !peers.dplpmtud_path_is_current_sync(&current_path) {
+                    drop(epoch_guard);
+                    drop(adoption_guard);
+                    peers.emit_timeline(
+                        "dplpmtud_stale_ack_rejected",
+                        Some("direct"),
+                        Some("path_identity_changed"),
+                        Some(format!("peer={peer_id} sequence={}", token.sequence)),
+                    );
+                    return;
+                }
+                let decision = runtime.try_accept_ack(
+                    peer_id,
+                    &current_path,
+                    token,
+                    crate::dplpmtud::DplpmtudAckIngress {
+                        remote_endpoint: source,
+                        local_endpoint,
+                        socket: crate::dplpmtud::DplpmtudSocketIdentity {
+                            transport_instance_id: udp.transport_instance_id(),
+                            socket_index,
+                        },
+                    },
+                    tokio::time::Instant::now(),
+                );
+                drop(epoch_guard);
+                drop(adoption_guard);
+
+                let snapshot = runtime.snapshots().remove(peer_id);
+                match decision {
+                    crate::dplpmtud::DplpmtudTransitionDecision::Applied => {
+                        peers.emit_timeline(
+                            "dplpmtud_probe_acked",
+                            Some("direct"),
+                            None,
+                            Some(format!(
+                                "peer={peer_id} sequence={} candidate_udp_datagram_size={} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                                token.sequence,
+                                token.candidate_udp_datagram_size.0,
+                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
+                            )),
+                        );
+                        peers.emit_timeline(
+                            "dplpmtud_search_bounds_updated",
+                            Some("direct"),
+                            None,
+                            Some(format!(
+                                "peer={peer_id} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
+                            )),
+                        );
+                        if snapshot.as_ref().is_some_and(|value| {
+                            value.state == crate::dplpmtud::DplpmtudState::SearchComplete
+                        }) {
+                            peers.emit_timeline(
+                                "dplpmtud_search_complete",
+                                Some("direct"),
+                                None,
+                                Some(format!(
+                                    "peer={peer_id} confirmed_udp_datagram_size={}",
+                                    snapshot
+                                        .as_ref()
+                                        .map_or(0, |value| value.confirmed_udp_datagram_size),
+                                )),
+                            );
+                        }
+                    }
+                    crate::dplpmtud::DplpmtudTransitionDecision::Duplicate => {
+                        peers.emit_timeline(
+                            "dplpmtud_duplicate_ack",
+                            Some("direct"),
+                            Some("duplicate_ack"),
+                            Some(format!("peer={peer_id} sequence={}", token.sequence)),
+                        );
+                    }
+                    crate::dplpmtud::DplpmtudTransitionDecision::Stale
+                    | crate::dplpmtud::DplpmtudTransitionDecision::Busy
+                    | crate::dplpmtud::DplpmtudTransitionDecision::Noop
+                    | crate::dplpmtud::DplpmtudTransitionDecision::Rejected => {
+                        peers.emit_timeline(
+                            "dplpmtud_stale_ack_rejected",
+                            Some("direct"),
+                            Some("identity_or_expectation_mismatch"),
+                            Some(format!(
+                                "peer={peer_id} sequence={} decision={decision:?}",
+                                token.sequence,
+                            )),
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -3827,6 +3827,21 @@ impl WireGuardTransport {
                     );
                     return;
                 }
+                if !udp
+                    .dplpmtud_runtime()
+                    .admit_probe_response(peer_id, tokio::time::Instant::now())
+                {
+                    peers.emit_timeline(
+                        "dplpmtud_probe_send_failed",
+                        Some("direct"),
+                        Some("probe_response_rate_limited"),
+                        Some(format!(
+                            "peer={peer_id} sequence={} candidate_udp_datagram_size={}",
+                            token.sequence, token.candidate_udp_datagram_size.0,
+                        )),
+                    );
+                    return;
+                }
                 let Ok(ip) = Ipv4Packet::new(packet) else {
                     return;
                 };

--- a/client/daemon/src/udp.rs
+++ b/client/daemon/src/udp.rs
@@ -29,8 +29,8 @@ use tracing::{debug, info, trace, warn};
 use crate::dataplane::global_dataplane_profiler;
 use crate::error::{DaemonError, Result};
 use crate::peer::{
-    is_public_probe_endpoint, DirectValidationIdentity, PeerManager, PeerSessionGeneration,
-    ProbeKeyRole, REASON_DIRECT_SEND_FAILED,
+    is_public_probe_endpoint, ActiveBusinessPath, DirectValidationIdentity, PeerManager,
+    PeerPathLifecycle, PeerSessionGeneration, ProbeKeyRole, REASON_DIRECT_SEND_FAILED,
 };
 use crate::transport::{
     EncryptedPeerPacket, ReceivedEncryptedPacket, ResponderSessionConfirmation, WireGuardTransport,

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -382,6 +382,15 @@ impl UdpTransport {
                 .dplpmtud
                 .is_supported(&snapshot.peer_id, epoch.peer_session_generation.value());
             let install = self.dplpmtud.install_path(identity, supported, now);
+            if install.decision != crate::dplpmtud::DplpmtudInstallDecision::Spawned {
+                debug!(
+                    peer_id = %snapshot.peer_id,
+                    decision = ?install.decision,
+                    supported,
+                    "DPLPMTUD path reconciliation did not spawn a worker"
+                );
+                continue;
+            }
             let Some(lease) = install.worker else {
                 continue;
             };

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -145,6 +145,11 @@ pub struct UdpTransport {
     /// clone so a network-generation transition cancels old ownership while
     /// it is still inside the shared epoch gate.
     direct_validation: DirectValidationRegistry,
+    /// DPLPMTUD state, capability receipts and exact-path workers owned by
+    /// this concrete UDP publication.
+    dplpmtud: crate::dplpmtud::DplpmtudRuntime,
+    dplpmtud_worker_ingress: crate::dplpmtud::DplpmtudWorkerIngress,
+    dplpmtud_local_virtual_ip: Option<Ipv4Addr>,
     /// Adaptive-prediction learner state for the current network generation.
     ///
     /// The fresh-mapping generator feeds each batch's observed ports into a
@@ -183,6 +188,8 @@ impl UdpTransport {
         peers
             .register_direct_validation_registry(direct_validation.clone())
             .await;
+        let dplpmtud = crate::dplpmtud::DplpmtudRuntime::new();
+        peers.register_dplpmtud_runtime(dplpmtud.clone()).await;
 
         Ok(Self {
             transport_instance_id: NEXT_UDP_TRANSPORT_INSTANCE.fetch_add(1, Ordering::Relaxed),
@@ -236,6 +243,9 @@ impl UdpTransport {
             local_node_id: None,
             wireguard_transport: None,
             direct_validation,
+            dplpmtud,
+            dplpmtud_worker_ingress: crate::dplpmtud::DplpmtudWorkerIngress::default(),
+            dplpmtud_local_virtual_ip: None,
             learning_cache: Arc::new(Mutex::new(LearningCache::new())),
         })
     }
@@ -249,6 +259,156 @@ impl UdpTransport {
     /// and cache-fencing metadata only; it is never sent on the wire.
     pub(crate) fn transport_instance_id(&self) -> u64 {
         self.transport_instance_id
+    }
+
+    pub(crate) fn with_dplpmtud_local_virtual_ip(mut self, local_virtual_ip: Ipv4Addr) -> Self {
+        self.dplpmtud_local_virtual_ip = Some(local_virtual_ip);
+        self
+    }
+
+    pub(crate) fn dplpmtud_runtime(&self) -> crate::dplpmtud::DplpmtudRuntime {
+        self.dplpmtud.clone()
+    }
+
+    pub(crate) fn dplpmtud_worker_ingress(
+        &self,
+    ) -> crate::dplpmtud::DplpmtudWorkerIngress {
+        self.dplpmtud_worker_ingress.clone()
+    }
+
+    pub(crate) fn mark_peer_dplpmtud_supported(
+        &self,
+        peer_id: &str,
+        peer_session_generation: PeerSessionGeneration,
+    ) -> bool {
+        self.dplpmtud
+            .mark_supported(peer_id, peer_session_generation.value())
+    }
+
+    /// Reconcile DPLPMTUD only from the authoritative committed-path mirror.
+    /// This never selects a path; it starts or cancels a worker for the exact
+    /// Direct state which the Path State Machine already committed.
+    pub(crate) async fn reconcile_dplpmtud_paths(&self) {
+        let now = tokio::time::Instant::now();
+        let snapshots = self.peers.committed_business_path_snapshots_sync();
+        let known_peers = snapshots
+            .iter()
+            .map(|snapshot| snapshot.peer_id.clone())
+            .collect::<HashSet<_>>();
+        self.dplpmtud.retain_known_peers(&known_peers, now);
+
+        let Some(local_virtual_ip) = self.dplpmtud_local_virtual_ip else {
+            return;
+        };
+
+        for snapshot in snapshots {
+            let validation = match snapshot.active {
+                ActiveBusinessPath::Direct(validation)
+                    if snapshot.lifecycle == PeerPathLifecycle::Online => validation,
+                _ => {
+                    self.dplpmtud.cancel_peer(
+                        &snapshot.peer_id,
+                        "active_path_not_direct",
+                        now,
+                    );
+                    continue;
+                }
+            };
+            let Some(epoch) = snapshot.epoch else {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "path_identity_unbound", now);
+                continue;
+            };
+            if validation.epoch != epoch {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "path_epoch_mismatch", now);
+                continue;
+            }
+            let Some(remote_endpoint) = validation.commit_endpoint() else {
+                self.dplpmtud.cancel_peer(
+                    &snapshot.peer_id,
+                    "direct_validation_not_authenticated",
+                    now,
+                );
+                continue;
+            };
+            let Some(pair) = self
+                .peers
+                .direct_commit_pair_snapshot_sync(&snapshot.peer_id)
+            else {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "direct_pair_missing", now);
+                continue;
+            };
+            let Some(local_endpoint) = pair.local_endpoint else {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "local_endpoint_missing", now);
+                continue;
+            };
+            if pair.generation != epoch.network_generation
+                || pair.remote_candidate_epoch != epoch.remote_candidate_epoch
+            {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "direct_pair_stale", now);
+                continue;
+            }
+            let Some((socket_index, socket)) = self.socket_for_peer(Some(&snapshot.peer_id)).await
+            else {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "local_socket_missing", now);
+                continue;
+            };
+            if socket.local_addr().ok() != Some(local_endpoint) {
+                self.dplpmtud
+                    .cancel_peer(&snapshot.peer_id, "local_socket_changed", now);
+                continue;
+            }
+            let Some(identity) = crate::dplpmtud::DplpmtudPathIdentity::from_committed_validation(
+                snapshot.peer_id.clone(),
+                validation,
+                remote_endpoint,
+                local_endpoint,
+                self.transport_instance_id,
+                socket_index,
+            ) else {
+                self.dplpmtud.cancel_peer(
+                    &snapshot.peer_id,
+                    "direct_validation_identity_incomplete",
+                    now,
+                );
+                continue;
+            };
+            let supported = self
+                .dplpmtud
+                .is_supported(&snapshot.peer_id, epoch.peer_session_generation.value());
+            let install = self.dplpmtud.install_path(identity, supported, now);
+            let Some(lease) = install.worker else {
+                continue;
+            };
+            let Ok(peer_virtual_ip) = snapshot.virtual_ip.parse::<Ipv4Addr>() else {
+                self.dplpmtud.cancel_peer(
+                    &snapshot.peer_id,
+                    "peer_virtual_ip_not_ipv4",
+                    now,
+                );
+                continue;
+            };
+            if !self
+                .dplpmtud_worker_ingress
+                .submit(crate::dplpmtud::DplpmtudWorkerStart {
+                    lease,
+                    socket,
+                    local_virtual_ip,
+                    peer_virtual_ip,
+                })
+            {
+                self.dplpmtud.cancel_peer(
+                    &snapshot.peer_id,
+                    "worker_ingress_capacity_exceeded",
+                    now,
+                );
+            }
+        }
     }
 
     #[cfg(test)]
@@ -1131,6 +1291,9 @@ impl UdpTransport {
         self.peers
             .cancel_active_direct_validation_for_peer(peer_id)
             .await;
+        self.peers
+            .cancel_active_dplpmtud_for_peer(peer_id, reason)
+            .await;
         if remove_connection {
             // The connection removal runs INSIDE the adoption-lock
             // transaction: an ACK that already passed its peer-existence
@@ -1143,6 +1306,9 @@ impl UdpTransport {
             // as well; `begin_or_merge` also refuses the now-absent peer.
             self.peers
                 .cancel_active_direct_validation_for_peer(peer_id)
+                .await;
+            self.peers
+                .cancel_active_dplpmtud_for_peer(peer_id, reason)
                 .await;
         }
         // Bump the cleanup epoch and drop the peer's pending probes under the

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -378,10 +378,51 @@ impl UdpTransport {
                 );
                 continue;
             };
+            let previous_identity = self.dplpmtud.path_identity(&snapshot.peer_id);
+            let previous_snapshot = self
+                .dplpmtud
+                .snapshots()
+                .get(&snapshot.peer_id)
+                .cloned();
+            if previous_identity.as_ref().is_some_and(|previous| previous != &identity) {
+                self.peers.emit_timeline(
+                    "dplpmtud_reset",
+                    Some("direct"),
+                    Some("path_identity_changed"),
+                    Some(format!(
+                        "peer={} previous_identity={:?} next_identity={:?}",
+                        snapshot.peer_id, previous_identity, identity,
+                    )),
+                );
+            }
             let supported = self
                 .dplpmtud
                 .is_supported(&snapshot.peer_id, epoch.peer_session_generation.value());
+            let identity_summary = identity.summary();
             let install = self.dplpmtud.install_path(identity, supported, now);
+            if !supported
+                && install.decision == crate::dplpmtud::DplpmtudInstallDecision::Unsupported
+                && !previous_snapshot.is_some_and(|previous| {
+                    previous.state == crate::dplpmtud::DplpmtudState::Unsupported
+                        && previous.path_identity.as_ref() == Some(&identity_summary)
+                })
+            {
+                self.peers.emit_timeline(
+                    "dplpmtud_unsupported",
+                    Some("direct"),
+                    Some("capability_not_negotiated"),
+                    Some(format!(
+                        "peer={} path_identity={:?} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                        snapshot.peer_id,
+                        identity_summary,
+                        crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+                        identity_summary
+                            .outer_ip_family
+                            .ceiling_udp_datagram_size()
+                            .0,
+                    )),
+                );
+            }
             if install.decision != crate::dplpmtud::DplpmtudInstallDecision::Spawned {
                 debug!(
                     peer_id = %snapshot.peer_id,

--- a/docs/dplpmtud-runtime-foundation.md
+++ b/docs/dplpmtud-runtime-foundation.md
@@ -43,9 +43,10 @@ The DPLPMTUD worker is owned by the Direct UDP scheduler in
 4. releases DPLPMTUD state locks;
 5. takes the existing per-peer WireGuard emit-order lock through encryption and
    the UDP handoff;
-6. revalidates the path identity and worker owner before the actual send;
-7. commits either `ProbeSent` or `ProbeSendFailed` only if the same expectation
-   still owns the slot;
+6. revalidates the path identity and worker owner, then marks `ProbeSent` at
+   the send linearization point immediately before the actual socket send;
+7. commits `ProbeSendFailed` only if the same expectation still owns the slot
+   when the handoff reports an error;
 8. waits on the worker notification, cancellation watch, probe deadline, raise
    timer, or the worker hard deadline.
 
@@ -280,9 +281,10 @@ Every worker also has a one-hour intrinsic hard lifetime.
 ## 8. Timer and task ownership
 
 A bounded scheduler owns DPLPMTUD workers in a `JoinSet`. Reconciliation is
-triggered by UDP publication/path notifications and a bounded periodic tick;
-it does not put a long-lived timer into a serial control branch that must poll
-other work to make progress.
+triggered by committed-path notifications and worker completion; each worker
+owns its bounded probe, raise, and hard-lifetime deadlines. The scheduler does
+not put a long-lived timer into a serial control branch that must poll other
+work to make progress.
 
 For each exact peer/path there is at most one owner token and one worker. The
 worker owns:
@@ -313,10 +315,11 @@ short DPLPMTUD registry transaction: schedule expectation
 release registry
 WireGuard per-peer emit lock
 short session lock / encrypt
-exact-path + owner + expectation recheck (`begin_probe_send`)
+exact-path + owner + expectation recheck and `ProbeSent` linearization
+(`begin_probe_send`)
 UDP handoff on the bound socket
 release emit lock
-short DPLPMTUD registry transaction: finish send
+short DPLPMTUD registry transaction: finish send outcome
 ```
 
 The `begin_probe_send` recheck includes the worker owner, exact identity,

--- a/docs/dplpmtud-runtime-foundation.md
+++ b/docs/dplpmtud-runtime-foundation.md
@@ -1,0 +1,482 @@
+# Direct UDP DPLPMTUD runtime foundation
+
+## 1. Scope and baseline
+
+This document records the Phase 2A implementation on top of
+`a7f2e71281fb40917dc89249377df384878f0fe7`. The phase adds a bounded,
+authenticated Datagram Packetization Layer Path MTU Discovery (DPLPMTUD)
+control loop for an already committed Direct UDP path.
+
+The Path State Machine remains the only authority for whether Direct or Relay
+is active. DPLPMTUD consumes the committed Direct-path snapshot; it does not
+select, promote, demote, fail, or recover a network path.
+
+This phase deliberately does **not**:
+
+- discover an MTU for Relay;
+- change TUN or per-route MTU;
+- fragment or reassemble overlay traffic;
+- generate ICMP Fragmentation Needed or Packet Too Big messages;
+- size, split, reject, or reroute ordinary business packets using the result;
+- turn a probe timeout into Direct-health failure or Relay fallback;
+- add UI, release, version, or signing changes.
+
+The only output intended for the next phase is the read-only confirmed UDP
+size and derived overlay payload budget attached to the exact current Direct
+path identity.
+
+## 2. Audited current data path
+
+### 2.1 Outbound Direct UDP
+
+Ordinary data is routed to the peer, encrypted by `WireGuardTransport`, and
+emitted by `UdpTransport` on a concrete UDP socket. DPLPMTUD uses the same
+cryptographic and UDP transport components, but its plaintext is an internal
+ICMP-shaped control packet consumed by the daemon rather than the TUN.
+
+The DPLPMTUD worker is owned by the Direct UDP scheduler in
+`lib/daemon/udp_direct.rs`. For each candidate probe it:
+
+1. snapshots the exact committed Direct identity;
+2. atomically registers one outstanding probe in `DplpmtudRuntime`;
+3. builds an inner authenticated probe of the requested size;
+4. releases DPLPMTUD state locks;
+5. takes the existing per-peer WireGuard emit-order lock through encryption and
+   the UDP handoff;
+6. revalidates the path identity and worker owner before the actual send;
+7. commits either `ProbeSent` or `ProbeSendFailed` only if the same expectation
+   still owns the slot;
+8. waits on the worker notification, cancellation watch, probe deadline, raise
+   timer, or the worker hard deadline.
+
+### 2.2 Inbound Direct UDP
+
+A UDP reader records the real source address, local endpoint, socket index,
+UDP publication owner, and network generation in `ReceivedEncryptedPacket`.
+`WireGuardTransport::run_inbound_with_udp_source` authenticates and decrypts
+the datagram before parsing DPLPMTUD.
+
+A Probe is answered only after successful WireGuard decryption and only when:
+
+- the UDP publication still owns the datagram;
+- the packet was authenticated by the current WireGuard session;
+- source/local endpoint and socket index are present;
+- outer IP family matches the token;
+- the per-peer response rate limit admits it.
+
+The ACK is encrypted and sent on the exact receiving Direct socket. It mirrors
+the probe token and is compact, so it is never larger than the probe.
+
+An ACK is committed only after decryption, session-current validation,
+per-peer adoption serialization, the network-epoch gate, current committed
+Direct-path validation, exact ingress validation, and atomic consumption of
+the outstanding expectation.
+
+### 2.3 Existing size layers and overhead
+
+The implementation uses three strong types and never calls all three values
+"MTU":
+
+- `OuterIpPacketSize`: complete outer IP packet;
+- `UdpDatagramSize`: bytes passed to `UdpSocket::send_to`;
+- `OverlayPayloadBudget`: authenticated WireGuard plaintext capacity.
+
+For this transport:
+
+```text
+outer_ip_packet_size = udp_datagram_size + outer_ip_udp_overhead
+outer IPv4 + UDP overhead = 20 + 8 = 28 bytes
+outer IPv6 + UDP overhead = 40 + 8 = 48 bytes
+
+overlay_payload_budget = udp_datagram_size - wireguard_datagram_overhead
+wireguard_datagram_overhead = 16-byte transport header + 16-byte AEAD tag
+                            = 32 bytes
+```
+
+The conservative UDP datagram base is 1200 bytes. The current internal hard
+ceilings preserve an Ethernet-sized 1500-byte outer packet:
+
+- IPv4 UDP datagram ceiling: 1472 bytes;
+- IPv6 UDP datagram ceiling: 1452 bytes.
+
+The code does not infer outer-family overhead from a virtual/inner IPv4 packet.
+It binds the DPLPMTUD identity and wire token to the real Direct endpoint's
+outer IP family.
+
+## 3. Capability compatibility
+
+The existing Direct-validation request/ACK format ends with a fixed token that
+legacy parsers locate from the end of the payload. Phase 2A inserts an additive
+six-byte extension immediately before that tail:
+
+```text
+"DPM1" | capability_version=1 | dplpmtud_version=1
+```
+
+New peers recognize the exact extension and record support against the current
+peer-session generation. A legacy peer still finds the unchanged Direct-
+validation tail, ignores the intervening bytes, and continues normal Direct or
+Relay communication. Missing, legacy, or malformed capability bytes are
+fail-closed and produce `Unsupported`; no DPLPMTUD probe is sent.
+
+Support is bounded by the same per-runtime peer limit and is invalidated when
+the peer-session generation changes.
+
+## 4. Exact path identity
+
+`DplpmtudPathIdentity` identifies one concrete, already-authenticated Direct
+UDP path. It contains:
+
+```text
+peer_id
+PathEpoch {
+  network_generation,
+  peer_session_generation,
+  remote_candidate_epoch
+}
+direct_validation_owner_token
+direct_validation_request_id
+authenticated_remote_endpoint
+local_endpoint
+DplpmtudSocketIdentity {
+  transport_instance_id,
+  socket_index
+}
+outer_ip_family
+```
+
+The identity is constructed from the committed `DirectValidationIdentity`, the
+committed candidate pair, and the current UDP publication/socket. Mixed local
+and remote address families are rejected.
+
+Any change to any field creates a different path. Reconciliation cancels the
+old worker and installs a fresh Base/Unsupported state. An arriving ACK is
+never reinterpreted using a newly read generation or endpoint; it must match
+the expectation and the current exact path that originally issued it.
+
+## 5. Probe and ACK wire format
+
+DPLPMTUD control packets are daemon-internal ICMP echo-request-shaped inner
+IPv4 packets. They are encrypted as ordinary WireGuard transport data and are
+consumed before TUN delivery.
+
+Prefixes:
+
+```text
+Probe: p2wlan-dplpmtud-probe-v1
+ACK:   p2wlan-dplpmtud-ack-v1
+```
+
+The fixed big-endian token is 79 bytes:
+
+```text
+sequence                         u64
+nonce                            [u8; 16]
+path_cookie                      [u8; 16]
+network_generation               u64
+peer_session_generation          u64
+remote_candidate_epoch           u64
+direct_validation_owner_token    u64
+direct_validation_request_id     u16
+candidate_udp_datagram_size      u32
+outer_ip_family                  u8  (4 or 6)
+```
+
+The protocol/version is carried by the versioned prefix. Sequence, nonce, path
+cookie, complete path epoch, Direct-validation owner/request, candidate size,
+and outer family prevent two probes or two path incarnations from being
+confused.
+
+For a Probe, padding is placed between the prefix and token. The builder solves
+for the exact plaintext size so that after WireGuard's 32-byte overhead the
+actual `send_to` datagram length is exactly `candidate_udp_datagram_size`.
+The parser locates the fixed token at the end and accepts the variable padding
+only after a complete authenticated packet was received.
+
+The ACK contains the ACK prefix and the exact mirrored token without probe
+padding. It therefore cannot amplify the request.
+
+## 6. State machine
+
+Each exact Direct path owns an independent pure reducer with these states:
+
+```text
+Disabled
+Unsupported
+Base
+Searching
+SearchComplete
+Error
+```
+
+State summary:
+
+```text
+Direct committed + unsupported capability -> Unsupported
+Direct committed + supported capability   -> Base
+Base + StartSearch                         -> Searching
+Searching + matching ACK                  -> Searching or SearchComplete
+Searching + exhausted timeout             -> narrower Searching or SearchComplete
+SearchComplete + raise timer               -> Searching or renewed SearchComplete
+send failure                               -> Error
+Error + retry timer                        -> Searching or SearchComplete
+identity/lifecycle cancellation            -> Disabled
+new identity                               -> new Base or Unsupported machine
+```
+
+The machine records the exact identity, conservative base, confirmed lower
+bound, search upper bound, pending candidate, at most one outstanding probe,
+sequence/nonce/path cookie, deadline, retry, fixed granularity, raise deadline,
+last success/timeout/failure, reset reason/count, revision, and diagnostic
+counters.
+
+Reducer state changes and network side effects are separate. `reduce` produces
+a transition; `commit` applies only accepted state changes. Duplicate ACKs are
+a special diagnostic decision: they increment only the duplicate counter and
+do not change revision, timestamps, bounds, or success count. Stale ACKs
+increment only the stale counter and do not move the search interval.
+
+## 7. Bounded search
+
+The implementation uses a deterministic aligned binary search because the
+current phase has a conservative base and fixed internal ceiling, and because
+the required result is a bounded safe datagram size rather than continuous
+congestion adaptation.
+
+For confirmed lower bound `L`, upper bound `U`, and granularity `G=8`:
+
+1. choose an aligned midpoint strictly greater than `L` and no greater than
+   `U`;
+2. send one exact-size encrypted probe;
+3. on a matching ACK, set `L=max(L,candidate)`;
+4. on timeout, retry the same candidate at most two times;
+5. after retries are exhausted, set
+   `U=min(U,max(L,candidate-G))`;
+6. continue until no candidate greater than `L` remains.
+
+The final interval step is not skipped: when `U` is only one granularity step
+above `L`, `U` itself is probed. This makes the final confirmed value no more
+than one configured granularity below a deterministic blackhole threshold.
+
+A successful ACK is accepted only when all of the following hold:
+
+- the runtime entry and worker owner are current;
+- the exact path identity matches;
+- sequence, nonce, path cookie, candidate size, and all epoch/validation fields
+  match the outstanding probe;
+- remote endpoint, local endpoint, socket identity, and outer family match;
+- the probe was actually sent;
+- the ACK arrives no later than the probe deadline;
+- the receipt has not already been consumed.
+
+A timeout narrows only this search interval. The DPLPMTUD API has no operation
+that records Direct failure, degrades Direct, selects Relay, or ends an already
+confirmed Direct path.
+
+After SearchComplete, a ten-minute raise timer reopens the upper interval to
+the family ceiling. A send failure enters Error with a five-second retry timer.
+Every worker also has a one-hour intrinsic hard lifetime.
+
+## 8. Timer and task ownership
+
+A bounded scheduler owns DPLPMTUD workers in a `JoinSet`. Reconciliation is
+triggered by UDP publication/path notifications and a bounded periodic tick;
+it does not put a long-lived timer into a serial control branch that must poll
+other work to make progress.
+
+For each exact peer/path there is at most one owner token and one worker. The
+worker owns:
+
+- one cancellation `watch` receiver;
+- one `Notify` used for ACK/state wakeups;
+- the current probe deadline or raise deadline;
+- a hard lifetime deadline.
+
+Worker ingress is bounded to 256 entries. Runtime peer entries, negotiated
+support entries, and response-rate buckets are also bounded to 256 peers.
+Each state machine keeps at most one outstanding probe and at most 32 consumed
+receipt identities. ACK responses are rate-limited to 8 per peer per second.
+
+Owner tokens prevent an old worker's exit from clearing a replacement worker
+installed for the same peer and identity. A wrapping/exhausted owner allocator
+fails closed rather than sharing ownership.
+
+## 9. Lock order and network I/O
+
+No DPLPMTUD registry lock is held over a timer wait, WireGuard operation, or
+socket send.
+
+Actual send-side order:
+
+```text
+short DPLPMTUD registry transaction: schedule expectation
+release registry
+WireGuard per-peer emit lock
+short session lock / encrypt
+exact-path + owner + expectation recheck (`begin_probe_send`)
+UDP handoff on the bound socket
+release emit lock
+short DPLPMTUD registry transaction: finish send
+```
+
+The `begin_probe_send` recheck includes the worker owner, exact identity,
+outstanding identity, no concurrent send, and a live deadline. Cancellation or
+path replacement before that linearization point prevents the send.
+
+Actual ACK commit order after decryption:
+
+```text
+current WireGuard session evidence/emit guard (retained by inbound caller)
+per-peer UDP adoption lock
+network epoch gate
+current peer lifecycle and exact committed Direct path checks
+non-awaiting DPLPMTUD registry try-lock and expectation consumption
+release network epoch gate
+release adoption lock
+emit diagnostics outside the state transaction
+```
+
+The nonblocking runtime `try_lock` fails closed as `Busy`; it does not wait for
+an upper-layer lock while holding the network epoch. No network I/O occurs in
+this transaction. The implementation does not hold the network epoch,
+PeerConnection writer, handshake arbiter, or candidate-map guard across UDP
+send or timer wait.
+
+## 10. Lifecycle and cancellation
+
+DPLPMTUD is reconciled exclusively from the authoritative committed-path
+mirror. It starts only for `Online + ActiveBusinessPath::Direct` with a complete
+current `PathEpoch`, authenticated Direct-validation identity, candidate pair,
+local endpoint, live UDP publication, and matching socket.
+
+The current entry is cancelled/reset for, among other reasons:
+
+- active path is not Direct (including Relay active);
+- peer leaves or becomes non-online;
+- identity reset or Direct path failure;
+- network generation advances;
+- peer-session generation changes;
+- remote candidate epoch advances;
+- Direct validation owner/request/endpoint changes;
+- local endpoint, socket index, or UDP transport instance changes;
+- Direct pair disappears or becomes stale;
+- UDP publication replacement or shutdown;
+- daemon shutdown.
+
+A repeated notification for the same exact identity is idempotent: it does not
+reset state, create a second worker, or schedule a second outstanding probe.
+
+Cancellation sets the watch, disables the machine, clears outstanding work,
+and preserves a reason in the read-only snapshot. A stale worker may still
+reach its exit path, but owner-token comparison prevents it from erasing the
+replacement. A cancelled worker cannot pass `begin_probe_send` and cannot
+publish an old retry kick.
+
+## 11. Stale and duplicate handling
+
+The following are rejected without changing search bounds:
+
+- old network generation;
+- old peer-session generation;
+- old remote candidate epoch;
+- old Direct-validation owner or request ID;
+- wrong sequence, nonce, path cookie, or candidate size;
+- wrong remote endpoint;
+- wrong local endpoint, socket index, or UDP publication identity;
+- wrong outer IP family;
+- ACK authenticated by a replaced/previous session for current-path evidence;
+- ACK after the deadline;
+- ACK with no current expectation;
+- ACK arriving while the exact state transaction cannot be acquired.
+
+A consumed exact receipt is classified as duplicate. Receipt storage is a
+bounded FIFO, and duplicate handling changes only `duplicate_ack_count`.
+Malformed, legacy, or unrelated control packets are ignored by the DPLPMTUD
+parser and continue through the existing handling rules.
+
+## 12. Diagnostics and status
+
+Stable timeline events include:
+
+- `dplpmtud_started`
+- `dplpmtud_unsupported`
+- `dplpmtud_probe_scheduled`
+- `dplpmtud_probe_sent`
+- `dplpmtud_probe_acked`
+- `dplpmtud_probe_timeout`
+- `dplpmtud_search_bounds_updated`
+- `dplpmtud_search_complete`
+- `dplpmtud_raise_timer_started`
+- `dplpmtud_reset`
+- `dplpmtud_cancelled`
+- `dplpmtud_stale_ack_rejected`
+- `dplpmtud_duplicate_ack`
+- `dplpmtud_probe_send_failed`
+
+Events carry the available peer, path epoch, endpoints, socket publication,
+sequence, candidate datagram size, bounds, and reason/decision details.
+
+Peer diagnostics and status expose a read-only `DplpmtudSnapshot` containing:
+state, capability support, path identity summary, base/confirmed/upper UDP
+sizes, derived outer packet size and overlay budget, outstanding probe,
+relative success/timeout/failure ages, reset reason/count, revision, probe and
+result counters, stale/duplicate counters, and whether the owner worker is
+live.
+
+Snapshots are copied into a separate read-optimized map after state commits.
+Status reads do not take or hold the mutable DPLPMTUD registry lock and cannot
+block a worker.
+
+## 13. Verification strategy
+
+Reducer and runtime tests cover unsupported peers, Base-to-Searching,
+successful lower-bound growth, timeout/retry and upper-bound reduction,
+convergence, raise timer, exact duplicate invariants, every stale identity
+dimension, deadline rejection, owner-token ABA, path replacement, bounded
+containers/rate limiting, PeerLeft/shutdown cleanup, additive capability
+compatibility, exact datagram padding, and IPv4/IPv6 separation.
+
+The deterministic Linux blackhole test runs the real chain:
+
+```text
+scheduler/runtime plan
+-> probe codec and exact padding
+-> WireGuard encryption/authentication
+-> loopback UDP send
+-> threshold blackhole sink or peer UDP receive
+-> WireGuard decrypt/authenticate
+-> ACK codec and encryption
+-> ACK UDP receive and decrypt
+-> exact state commit
+```
+
+Datagrams at or below 1397 bytes are delivered; larger datagrams are silently
+sent to a sink and timed out. The test observes actual encrypted UDP lengths,
+requires a success below and failure above the threshold, bounds the result to
+one 8-byte step, verifies duplicate no-op behavior, switches generation while
+an authenticated ACK is in flight, performs PeerLeft with an outstanding probe
+before send linearization, asserts Direct remains active with zero Direct
+health failures and zero Relay fallbacks, and returns worker ownership to the
+baseline without sleeps.
+
+The required workflow repeats that same blackhole test five times on the exact
+PR Head SHA and prints threshold, confirmed/upper bounds, probe/timeout counts,
+Direct/fallback sentinels, stale/duplicate counts, generation/PeerLeft results,
+and task-leak status.
+
+## 14. Phase boundary and next-step API
+
+Phase 2A exposes only a read-only snapshot of:
+
+```text
+confirmed_udp_datagram_size
+overlay_payload_budget
+outer_ip_family
+exact path identity
+```
+
+No normal packet producer consumes those values in this phase. A later phase
+may define a single, generation-bound API for business-packet sizing or
+fragmentation policy. That consumer must revalidate the same exact path
+identity and must not treat a DPLPMTUD timeout as path health or path-selection
+evidence.


### PR DESCRIPTION
## Phase 2A — Direct UDP DPLPMTUD runtime foundation

Base: `a7f2e71281fb40917dc89249377df384878f0fe7`
Final PR head: `da7b0fb6ef464e9027f0ab9cc3a881dbc7040306`
Branch: `feat/dplpmtud-runtime-foundation-20260830`

This PR implements the Phase 2A Direct UDP DPLPMTUD runtime, lifecycle fences, authenticated encrypted Probe/ACK path, diagnostics, deterministic production E2E coverage, and formal required gates.

### Scope

- Typed outer IP packet, UDP datagram, and overlay payload-budget layers. IPv4 and IPv6 budgets remain separate.
- Exact path identity: peer, network generation, peer-session generation, remote-candidate epoch, Direct-validation owner/request, authenticated remote endpoint, local endpoint, concrete UDP publication/socket, and outer IP family.
- Pure reducer with Disabled, Unsupported, Base, Searching, SearchComplete, and Error states.
- One outstanding probe per exact path; bounded retries, aligned binary search, bounded receipts/rate limits, raise/error timers, owner-token cancellation, and intrinsic worker lifetime.
- Real WireGuard-encrypted/authenticated ICMP-shaped Probe and ACK packets.
- Additive capability extension at the existing Direct-validation tail. Legacy peers remain decodable and do not receive DPLPMTUD probes.
- Read-only diagnostics snapshots and timeline events. DPLPMTUD never selects Direct/Relay, records Direct health failure, triggers fallback, or changes business packet sizing in Phase 2A.

Design: [docs/dplpmtud-runtime-foundation.md](https://github.com/yhan-sun/p2wlan/blob/da7b0fb6ef464e9027f0ab9cc3a881dbc7040306/docs/dplpmtud-runtime-foundation.md)

### Production lifecycle and safety

DPLPMTUD reconciles only from the authoritative committed Path State Machine mirror. DirectCommitted starts or reuses the exact worker; repeated commits are idempotent. Relay active, PeerLeft, Direct replacement/failure, identity reset, network-generation advance, remote-candidate advance, local socket/publication replacement, and shutdown cancel the worker and fence old ACKs. Unsupported same-identity replay is idempotent.

The send path records ProbeSent at the send linearization point, after the final path/owner/expectation recheck, so a fast authenticated ACK cannot race send bookkeeping. ACK handling is decryption-first, then current-session evidence, adoption lock, network epoch gate, exact path/ingress validation, nonblocking registry try-lock, and state commit. Registry contention fails closed.

Lock order is documented and tested:

1. Short DPLPMTUD registry transaction schedules an expectation.
2. Registry is released.
3. Per-peer WireGuard emit-order/session lock encrypts.
4. Exact path, owner, and expectation are rechecked; ProbeSent is linearized.
5. UDP handoff uses the concrete socket without network epoch, PeerConnection writer, handshake arbiter, or candidate-map guards.
6. A short registry transaction records send failure only if the same owner still holds the expectation.

### Deterministic production blackhole E2E

The canonical test is `encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak`. It starts the production scheduler and live UDP reader/transport loops, builds exact-size probes, encrypts them with WireGuard, routes them through loopback, silently drops encrypted datagrams above 1397 bytes, decrypts accepted probes on the receiving production path, emits an authenticated ACK on the receiving socket, and commits the ACK through the production inbound handler.

Each run proves: `threshold=1397`, `confirmed=1392`, `upper=1392`, `probe_count=8`, `timeout_count=3`, `success_count=5`, `dropped_probe_count=3`, `direct_active=true`, `direct_health_failure_count=0`, `relay_fallback_count=0`, `generation_switch_stale_ack=true`, `peer_left_cancelled=true`, `stale_ack_count=1`, `duplicate_ack_count=1`, `task_leak=false`.

All five required runs checked out and executed the exact final head:

| Run | Result |
|---|---|
| [blackhole run 1](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99233703676) | success; exact-head validation and canonical evidence |
| [blackhole run 2](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99233703696) | success; exact-head validation and canonical evidence |
| [blackhole run 3](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99233703751) | success; exact-head validation and canonical evidence |
| [blackhole run 4](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99233703745) | success; exact-head validation and canonical evidence |
| [blackhole run 5](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99233703748) | success; exact-head validation and canonical evidence |

### Local validation

Passed on the final candidate:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p p2wlan-daemon --lib dplpmtud::tests -- --test-threads=1` — 19 passed
- `cargo test -p p2wlan-daemon --lib tests::hard_hard_random_random_birthday_no_collision_cleans_up_without_direct -- --exact --nocapture --test-threads=1`
- `cargo test --workspace` — daemon library 1178 passed; all workspace tests and doctests passed
- `git diff --check`

### Final-head remote gates

Every required check below completed successfully on `da7b0fb6ef464e9027f0ab9cc3a881dbc7040306`:

- [DPLPMTUD Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711402/job/99235892630), including Linux, Windows, and the five blackhole jobs.
- [Path State Machine Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711415/job/99235867860).
- [NAT Topology Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711388/job/99234182223).
- [Windows Lifecycle Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711432/job/99233698073).
- [Mobile Lifecycle Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711383/job/99233679931).
- [CI Required](https://github.com/yhan-sun/p2wlan/actions/runs/33302711446/job/99235057253).
- Flutter concrete jobs: [Analyze and Test](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233680032), [Android arm64 Release APK](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233679878), [Linux x64 Release Bundle](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233680046), [macOS Release Apps](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233680002), [Windows x64 Release Bundle](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233679960), and [iOS Compile](https://github.com/yhan-sun/p2wlan/actions/runs/33302711369/job/99233680009).
- Package concrete jobs: [macOS arm64 test DMG](https://github.com/yhan-sun/p2wlan/actions/runs/33302711358/job/99233679917) and [Android arm64 test APK](https://github.com/yhan-sun/p2wlan/actions/runs/33302711358/job/99233679915).

### Conflict and boundary notes

The latest `origin/main` remains `a7f2e71281fb40917dc89249377df384878f0fe7`. The final working tree is clean; the actual three-way trial merge is conflict-free; whitespace and conflict-marker checks are clean. The implementation keeps committed business-path authority separate from DPLPMTUD observations and preserves the existing Direct/Relay selection, endpoint validation, UDP receive/send, WireGuard codec, diagnostics, and lifecycle lock-order contracts.

Known Phase 2A limitation: discovered PLPMTU is diagnostic/runtime state only; business packet sizing and fragmentation policy are intentionally deferred. Phase 2B can consume the bounded confirmed result through the documented read-only snapshot/API without allowing DPLPMTUD to choose a network path.

No release, signing, version, tag, or branch-deletion changes are included. This PR remains open until the final safety merge operation.