### PR TITLE
fix: close Phase 2A DPLPMTUD acceptance gaps

### DIFF
--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/dplpmtud-required.yml"
       - ".github/workflows/path-state-machine-required.yml"
       - "client/daemon/**"
+      - "client/netbind/**"
       - "docs/dplpmtud-runtime-foundation.md"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -16,6 +17,7 @@ on:
       - ".github/workflows/dplpmtud-required.yml"
       - ".github/workflows/path-state-machine-required.yml"
       - "client/daemon/**"
+      - "client/netbind/**"
       - "docs/dplpmtud-runtime-foundation.md"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -66,7 +68,8 @@ jobs:
             libxdo-dev \
             librsvg2-dev \
             xdotool \
-            patchelf
+            patchelf \
+            iproute2
 
       - name: Cargo format
         run: cargo fmt --all -- --check
@@ -86,14 +89,24 @@ jobs:
       - name: Diff whitespace check
         run: git diff --check
 
-  dplpmtud_blackhole:
-    name: DPLPMTUD blackhole run ${{ matrix.iteration }}
+  dplpmtud_acceptance:
+    name: DPLPMTUD acceptance ${{ matrix.scenario }}
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        iteration: [1, 2, 3, 4, 5]
+        include:
+          - scenario: blackhole
+            test: encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak
+          - scenario: base-confirmation
+            test: base_requires_a_positive_probe_before_any_confirmed_budget
+          - scenario: same-identity-downward
+            test: same_identity_current_plpmtu_confirmation_recovers_downward
+          - scenario: no-fragment-emsgsize
+            test: local_emsgsize_shrinks_upper_bound_without_reopening_full_ceiling
+          - scenario: worker-leak
+            test: close_and_peer_left_remove_all_worker_ownership
     steps:
       - uses: actions/checkout@v4
         with:
@@ -105,14 +118,29 @@ jobs:
         run: |
           set -euo pipefail
           actual="$(git rev-parse HEAD)"
-          echo "DPLPMTUD_BLACKHOLE_RUN iteration=${{ matrix.iteration }} expected_head=$VALIDATION_SHA actual_head=$actual"
+          echo "DPLPMTUD_ACCEPTANCE_RUN scenario=${{ matrix.scenario }} expected_head=$VALIDATION_SHA actual_head=$actual"
           test "$actual" = "$VALIDATION_SHA"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run deterministic encrypted UDP blackhole chain
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak -- --exact --nocapture --test-threads=1
+      - name: Run acceptance scenario
+        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::${{ matrix.test }} -- --exact --nocapture --test-threads=1
+
+      - name: Install iproute2 for real IP-layer proof
+        if: matrix.scenario == 'no-fragment-emsgsize'
+        run: sudo apt-get update && sudo apt-get install -y iproute2
+
+      - name: Run privileged Linux netns/veth no-fragment proof
+        if: matrix.scenario == 'no-fragment-emsgsize'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p p2pnet-netbind --test no_fragment_netns --no-run
+          test_binary="$(find target/debug/deps -maxdepth 1 -type f -perm -111 -name 'no_fragment_netns-*' -print -quit)"
+          test -n "$test_binary"
+          test_binary="$PWD/$test_binary"
+          sudo -n env RUST_BACKTRACE=1 "$test_binary" --ignored --nocapture --test-threads=1
 
   dplpmtud_windows:
     name: DPLPMTUD Windows checks
@@ -252,7 +280,7 @@ jobs:
     if: always()
     needs:
       - dplpmtud_linux
-      - dplpmtud_blackhole
+      - dplpmtud_acceptance
       - dplpmtud_windows
       - existing_required_gates
     runs-on: ubuntu-latest
@@ -260,13 +288,13 @@ jobs:
       - name: Enforce aggregate results
         env:
           LINUX_RESULT: ${{ needs.dplpmtud_linux.result }}
-          BLACKHOLE_RESULT: ${{ needs.dplpmtud_blackhole.result }}
+          ACCEPTANCE_RESULT: ${{ needs.dplpmtud_acceptance.result }}
           WINDOWS_RESULT: ${{ needs.dplpmtud_windows.result }}
           EXTERNAL_RESULT: ${{ needs.existing_required_gates.result }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           test "$LINUX_RESULT" = "success"
-          test "$BLACKHOLE_RESULT" = "success"
+          test "$ACCEPTANCE_RESULT" = "success"
           test "$WINDOWS_RESULT" = "success"
           if [ "$EVENT_NAME" = "pull_request" ]; then
             test "$EXTERNAL_RESULT" = "success"

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -101,8 +101,14 @@ jobs:
             test: encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak
           - scenario: base-confirmation
             test: base_requires_a_positive_probe_before_any_confirmed_budget
-          - scenario: same-identity-downward
-            test: same_identity_current_plpmtu_confirmation_recovers_downward
+          - scenario: downward-1392-to-1280
+            test: runtime_downward_recovery_withholds_budget_until_fresh_base_ack
+          - scenario: below-base-1392-to-1100
+            test: same_identity_below_base_failure_enters_error_without_budget
+          - scenario: cancel-close-budget
+            test: cancel_close_generation_and_relay_budget_invalidation_acceptance
+          - scenario: budget-revision-aba
+            test: budget_revision_is_monotonic_and_closes_identity_aba
           - scenario: no-fragment-emsgsize
             test: local_emsgsize_shrinks_upper_bound_without_reopening_full_ceiling
           - scenario: worker-leak

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -41,6 +41,7 @@ pub(crate) const DPLPMTUD_SEARCH_GRANULARITY: u32 = 8;
 pub(crate) const DPLPMTUD_MAX_RETRIES: u8 = 2;
 pub(crate) const DPLPMTUD_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 pub(crate) const DPLPMTUD_RAISE_INTERVAL: Duration = Duration::from_secs(10 * 60);
+pub(crate) const DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL: Duration = Duration::from_secs(30);
 pub(crate) const DPLPMTUD_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) const DPLPMTUD_WORKER_MAX_LIFETIME: Duration = Duration::from_secs(60 * 60);
 pub(crate) const MAX_TRACKED_DPLPMTUD_PEERS: usize = 256;
@@ -270,6 +271,27 @@ struct OutstandingProbe {
     retry: u8,
 }
 
+/// Failure classification for the final DPLPMTUD emit boundary.
+///
+/// These values are deliberately separate from path health: a lock/session
+/// miss is local scheduling pressure, a transient send error is an I/O retry,
+/// and only `LocalPacketTooLarge` is evidence that can shrink the local
+/// search ceiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DplpmtudProbeSendFailure {
+    TransientSend,
+    EmitLockUnavailable,
+    SessionUnavailable,
+    LocalPacketTooLarge,
+}
+
+impl From<crate::error::DaemonError> for DplpmtudProbeSendFailure {
+    fn from(_error: crate::error::DaemonError) -> Self {
+        Self::TransientSend
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DplpmtudEvent {
     StartSearch {
@@ -295,6 +317,10 @@ pub(crate) enum DplpmtudEvent {
     },
     ProbeSendFailed {
         probe: DplpmtudProbeIdentity,
+        failure: DplpmtudProbeSendFailure,
+        now: Instant,
+    },
+    CurrentPlpmtuConfirmationTimerExpired {
         now: Instant,
     },
     RaiseTimerExpired {
@@ -331,10 +357,15 @@ pub(crate) struct DplpmtudStateMachine {
     identity: Option<DplpmtudPathIdentity>,
     state: DplpmtudState,
     supported: bool,
+    /// Conservative starting point.  This is never a usable budget until a
+    /// BASE probe is positively ACKed.
     base_udp_datagram_size: UdpDatagramSize,
-    confirmed_udp_datagram_size: UdpDatagramSize,
+    base_confirmed: bool,
+    confirmed_udp_datagram_size: Option<UdpDatagramSize>,
     search_upper_udp_datagram_size: UdpDatagramSize,
     pending_candidate_udp_datagram_size: Option<UdpDatagramSize>,
+    current_plpmtu_confirmation_pending: bool,
+    current_plpmtu_confirmation_at: Option<Instant>,
     outstanding: Option<OutstandingProbe>,
     retry_count: u8,
     next_sequence: u64,
@@ -343,6 +374,11 @@ pub(crate) struct DplpmtudStateMachine {
     success_count: u64,
     timeout_count: u64,
     send_failure_count: u64,
+    transient_send_failure_count: u64,
+    emit_lock_unavailable_count: u64,
+    session_unavailable_count: u64,
+    local_packet_too_large_count: u64,
+    last_send_failure_kind: Option<DplpmtudProbeSendFailure>,
     stale_ack_count: u64,
     duplicate_ack_count: u64,
     last_success_at: Option<Instant>,
@@ -356,11 +392,25 @@ pub(crate) struct DplpmtudStateMachine {
 
 impl DplpmtudStateMachine {
     pub(crate) fn for_path(identity: DplpmtudPathIdentity, supported: bool, _now: Instant) -> Self {
+        Self::for_path_with_reason(
+            identity,
+            supported,
+            if supported {
+                "direct_committed"
+            } else {
+                "dplpmtud_capability_not_negotiated"
+            },
+        )
+    }
+
+    fn for_path_with_reason(
+        identity: DplpmtudPathIdentity,
+        supported: bool,
+        reset_reason: &str,
+    ) -> Self {
         let base = UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE);
         let upper = identity.outer_ip_family.ceiling_udp_datagram_size();
-        let pending = supported
-            .then(|| next_search_candidate(base, upper))
-            .flatten();
+        let pending = supported.then_some(base);
         Self {
             identity: Some(identity),
             state: if supported {
@@ -370,9 +420,12 @@ impl DplpmtudStateMachine {
             },
             supported,
             base_udp_datagram_size: base,
-            confirmed_udp_datagram_size: base,
+            base_confirmed: false,
+            confirmed_udp_datagram_size: None,
             search_upper_udp_datagram_size: upper,
             pending_candidate_udp_datagram_size: pending,
+            current_plpmtu_confirmation_pending: false,
+            current_plpmtu_confirmation_at: None,
             outstanding: None,
             retry_count: 0,
             next_sequence: 1,
@@ -381,20 +434,18 @@ impl DplpmtudStateMachine {
             success_count: 0,
             timeout_count: 0,
             send_failure_count: 0,
+            transient_send_failure_count: 0,
+            emit_lock_unavailable_count: 0,
+            session_unavailable_count: 0,
+            local_packet_too_large_count: 0,
+            last_send_failure_kind: None,
             stale_ack_count: 0,
             duplicate_ack_count: 0,
             last_success_at: None,
             last_timeout_at: None,
             last_failure_at: None,
             raise_at: None,
-            last_reset_reason: Some(
-                if supported {
-                    "direct_committed"
-                } else {
-                    "dplpmtud_capability_not_negotiated"
-                }
-                .to_string(),
-            ),
+            last_reset_reason: Some(reset_reason.to_string()),
             reset_count: 1,
             consumed_receipts: VecDeque::new(),
         }
@@ -413,9 +464,14 @@ impl DplpmtudStateMachine {
     }
 
     pub(crate) fn next_wakeup(&self) -> Option<Instant> {
-        self.outstanding
-            .map(|outstanding| outstanding.deadline)
-            .or(self.raise_at)
+        [
+            self.outstanding.map(|outstanding| outstanding.deadline),
+            self.current_plpmtu_confirmation_at,
+            self.raise_at,
+        ]
+        .into_iter()
+        .flatten()
+        .min()
     }
 
     pub(crate) fn next_probe_components(&self) -> Option<(u64, UdpDatagramSize, u8)> {
@@ -498,22 +554,59 @@ impl DplpmtudStateMachine {
                     } else {
                         next.outstanding = None;
                         next.retry_count = 0;
-                        next.confirmed_udp_datagram_size = next
+                        let is_current_confirmation = self.current_plpmtu_confirmation_pending;
+                        if is_current_confirmation {
+                            if self.confirmed_udp_datagram_size
+                                != Some(probe.candidate_udp_datagram_size)
+                            {
+                                next.stale_ack_count = next.stale_ack_count.saturating_add(1);
+                                return DplpmtudTransition {
+                                    decision: DplpmtudTransitionDecision::Stale,
+                                    next,
+                                };
+                            }
+                        } else if probe.candidate_udp_datagram_size == self.base_udp_datagram_size {
+                            next.base_confirmed = true;
+                            next.confirmed_udp_datagram_size = Some(self.base_udp_datagram_size);
+                        } else if self
                             .confirmed_udp_datagram_size
-                            .max(probe.candidate_udp_datagram_size);
+                            .is_some_and(|confirmed| probe.candidate_udp_datagram_size >= confirmed)
+                        {
+                            next.confirmed_udp_datagram_size =
+                                Some(probe.candidate_udp_datagram_size);
+                        } else {
+                            next.stale_ack_count = next.stale_ack_count.saturating_add(1);
+                            return DplpmtudTransition {
+                                decision: DplpmtudTransitionDecision::Stale,
+                                next,
+                            };
+                        }
                         next.success_count = next.success_count.saturating_add(1);
                         next.last_success_at = Some(now);
                         push_consumed_receipt(&mut next.consumed_receipts, probe);
-                        next.pending_candidate_udp_datagram_size = next_search_candidate(
-                            next.confirmed_udp_datagram_size,
-                            next.search_upper_udp_datagram_size,
-                        );
-                        if next.pending_candidate_udp_datagram_size.is_none() {
+                        if is_current_confirmation {
+                            next.current_plpmtu_confirmation_pending = false;
+                            next.current_plpmtu_confirmation_at =
+                                Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
+                            next.pending_candidate_udp_datagram_size = None;
                             next.state = DplpmtudState::SearchComplete;
-                            next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
                         } else {
-                            next.state = DplpmtudState::Searching;
-                            next.raise_at = None;
+                            let confirmed = next
+                                .confirmed_udp_datagram_size
+                                .expect("BASE must be positively confirmed before search");
+                            next.pending_candidate_udp_datagram_size = next_search_candidate(
+                                confirmed,
+                                next.search_upper_udp_datagram_size,
+                            );
+                            if next.pending_candidate_udp_datagram_size.is_none() {
+                                next.state = DplpmtudState::SearchComplete;
+                                next.current_plpmtu_confirmation_at =
+                                    Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
+                                next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                            } else {
+                                next.state = DplpmtudState::Searching;
+                                next.raise_at = None;
+                            }
                         }
                         DplpmtudTransitionDecision::Applied
                     }
@@ -545,37 +638,122 @@ impl DplpmtudStateMachine {
                         next.state = DplpmtudState::Searching;
                     } else {
                         next.retry_count = 0;
-                        let failed_upper = probe
-                            .candidate_udp_datagram_size
-                            .0
-                            .saturating_sub(DPLPMTUD_SEARCH_GRANULARITY)
-                            .max(next.confirmed_udp_datagram_size.0);
-                        next.search_upper_udp_datagram_size = UdpDatagramSize(
-                            next.search_upper_udp_datagram_size.0.min(failed_upper),
-                        );
-                        next.pending_candidate_udp_datagram_size = next_search_candidate(
-                            next.confirmed_udp_datagram_size,
-                            next.search_upper_udp_datagram_size,
-                        );
-                        if next.pending_candidate_udp_datagram_size.is_none() {
-                            next.state = DplpmtudState::SearchComplete;
-                            next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+                        if self.current_plpmtu_confirmation_pending {
+                            lower_after_current_confirmation_failure(&mut next, probe, now);
+                        } else if probe.candidate_udp_datagram_size == self.base_udp_datagram_size
+                            && !self.base_confirmed
+                        {
+                            enter_base_error(&mut next, now);
                         } else {
-                            next.state = DplpmtudState::Searching;
+                            let Some(confirmed) = self.confirmed_udp_datagram_size else {
+                                enter_base_error(&mut next, now);
+                                return DplpmtudTransition {
+                                    decision: DplpmtudTransitionDecision::Applied,
+                                    next,
+                                };
+                            };
+                            lower_after_failed_search_candidate(
+                                &mut next,
+                                confirmed,
+                                probe.candidate_udp_datagram_size,
+                                now,
+                            );
                         }
                     }
                     DplpmtudTransitionDecision::Applied
                 }
             }
-            DplpmtudEvent::ProbeSendFailed { probe, now } => {
+            DplpmtudEvent::ProbeSendFailed {
+                probe,
+                failure,
+                now,
+            } => {
                 if self.outstanding.map(|value| value.identity) != Some(probe) {
                     DplpmtudTransitionDecision::Noop
                 } else {
                     next.outstanding = None;
                     next.send_failure_count = next.send_failure_count.saturating_add(1);
                     next.last_failure_at = Some(now);
-                    next.state = DplpmtudState::Error;
-                    next.raise_at = Some(now + DPLPMTUD_ERROR_RETRY_INTERVAL);
+                    next.last_send_failure_kind = Some(failure);
+                    match failure {
+                        DplpmtudProbeSendFailure::LocalPacketTooLarge => {
+                            next.local_packet_too_large_count =
+                                next.local_packet_too_large_count.saturating_add(1);
+                            if self.current_plpmtu_confirmation_pending {
+                                lower_after_current_confirmation_failure(&mut next, probe, now);
+                            } else if probe.candidate_udp_datagram_size
+                                == self.base_udp_datagram_size
+                                && !self.base_confirmed
+                            {
+                                enter_base_error(&mut next, now);
+                            } else if let Some(confirmed) = self.confirmed_udp_datagram_size {
+                                lower_after_failed_search_candidate(
+                                    &mut next,
+                                    confirmed,
+                                    probe.candidate_udp_datagram_size,
+                                    now,
+                                );
+                            } else {
+                                enter_base_error(&mut next, now);
+                            }
+                        }
+                        DplpmtudProbeSendFailure::TransientSend
+                        | DplpmtudProbeSendFailure::EmitLockUnavailable
+                        | DplpmtudProbeSendFailure::SessionUnavailable => {
+                            match failure {
+                                DplpmtudProbeSendFailure::TransientSend => {
+                                    next.transient_send_failure_count =
+                                        next.transient_send_failure_count.saturating_add(1);
+                                }
+                                DplpmtudProbeSendFailure::EmitLockUnavailable => {
+                                    next.emit_lock_unavailable_count =
+                                        next.emit_lock_unavailable_count.saturating_add(1);
+                                }
+                                DplpmtudProbeSendFailure::SessionUnavailable => {
+                                    next.session_unavailable_count =
+                                        next.session_unavailable_count.saturating_add(1);
+                                }
+                                DplpmtudProbeSendFailure::LocalPacketTooLarge => {}
+                            }
+                            if self.current_plpmtu_confirmation_pending
+                                && self.retry_count >= DPLPMTUD_MAX_RETRIES
+                            {
+                                lower_after_current_confirmation_failure(&mut next, probe, now);
+                            } else if self.retry_count < DPLPMTUD_MAX_RETRIES {
+                                next.retry_count = self.retry_count.saturating_add(1);
+                                next.pending_candidate_udp_datagram_size =
+                                    Some(probe.candidate_udp_datagram_size);
+                                next.state = DplpmtudState::Searching;
+                            } else if probe.candidate_udp_datagram_size
+                                == self.base_udp_datagram_size
+                                && !self.base_confirmed
+                            {
+                                enter_base_error(&mut next, now);
+                            } else {
+                                next.state = DplpmtudState::Error;
+                                next.pending_candidate_udp_datagram_size = None;
+                                next.raise_at = Some(now + DPLPMTUD_ERROR_RETRY_INTERVAL);
+                            }
+                        }
+                    }
+                    DplpmtudTransitionDecision::Applied
+                }
+            }
+            DplpmtudEvent::CurrentPlpmtuConfirmationTimerExpired { now } => {
+                if self.state != DplpmtudState::SearchComplete
+                    || self
+                        .current_plpmtu_confirmation_at
+                        .is_none_or(|deadline| now < deadline)
+                    || self.confirmed_udp_datagram_size.is_none()
+                    || self.current_plpmtu_confirmation_pending
+                {
+                    DplpmtudTransitionDecision::Noop
+                } else {
+                    next.pending_candidate_udp_datagram_size = self.confirmed_udp_datagram_size;
+                    next.current_plpmtu_confirmation_at = None;
+                    next.current_plpmtu_confirmation_pending = true;
+                    next.retry_count = 0;
+                    next.state = DplpmtudState::Searching;
                     DplpmtudTransitionDecision::Applied
                 }
             }
@@ -592,15 +770,23 @@ impl DplpmtudStateMachine {
                         .as_ref()
                         .map(|identity| identity.outer_ip_family.ceiling_udp_datagram_size())
                         .unwrap_or(next.search_upper_udp_datagram_size);
-                    next.pending_candidate_udp_datagram_size = next_search_candidate(
-                        next.confirmed_udp_datagram_size,
-                        next.search_upper_udp_datagram_size,
-                    );
+                    next.current_plpmtu_confirmation_pending = false;
+                    next.current_plpmtu_confirmation_at = None;
+                    next.pending_candidate_udp_datagram_size = next
+                        .confirmed_udp_datagram_size
+                        .map(|confirmed| {
+                            next_search_candidate(confirmed, next.search_upper_udp_datagram_size)
+                        })
+                        .unwrap_or(Some(next.base_udp_datagram_size));
                     next.retry_count = 0;
                     next.raise_at = None;
-                    next.state = if next.pending_candidate_udp_datagram_size.is_some() {
+                    next.state = if next.confirmed_udp_datagram_size.is_none() {
+                        DplpmtudState::Base
+                    } else if next.pending_candidate_udp_datagram_size.is_some() {
                         DplpmtudState::Searching
                     } else {
+                        next.current_plpmtu_confirmation_at =
+                            Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
                         next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
                         DplpmtudState::SearchComplete
                     };
@@ -621,6 +807,8 @@ impl DplpmtudStateMachine {
                     next.supported = false;
                     next.outstanding = None;
                     next.pending_candidate_udp_datagram_size = None;
+                    next.current_plpmtu_confirmation_pending = false;
+                    next.current_plpmtu_confirmation_at = None;
                     next.raise_at = None;
                     next.last_reset_reason = Some(reason);
                     next.reset_count = next.reset_count.saturating_add(1);
@@ -679,18 +867,21 @@ impl DplpmtudStateMachine {
             state: self.state,
             supported: self.supported,
             path_identity: self.identity.as_ref().map(DplpmtudPathIdentity::summary),
-            base_udp_datagram_size: self.base_udp_datagram_size.0,
-            confirmed_udp_datagram_size: self.confirmed_udp_datagram_size.0,
+            assumed_base_udp_datagram_size: self.base_udp_datagram_size.0,
+            base_confirmed: self.base_confirmed,
+            confirmed_udp_datagram_size: self.confirmed_udp_datagram_size.map(|value| value.0),
             search_upper_udp_datagram_size: self.search_upper_udp_datagram_size.0,
-            confirmed_outer_ip_packet_size: family.map(|family| {
-                self.confirmed_udp_datagram_size
-                    .outer_ip_packet_size(family)
-                    .0
-            }),
+            confirmed_outer_ip_packet_size: self
+                .confirmed_udp_datagram_size
+                .and_then(|size| family.map(|family| size.outer_ip_packet_size(family).0)),
             overlay_payload_budget: self
                 .confirmed_udp_datagram_size
-                .overlay_payload_budget()
+                .and_then(UdpDatagramSize::overlay_payload_budget)
                 .map(|value| value.0),
+            current_plpmtu_confirmation_pending: self.current_plpmtu_confirmation_pending,
+            current_plpmtu_confirmation_remaining_ms: self
+                .current_plpmtu_confirmation_at
+                .map(|at| duration_ms(at.saturating_duration_since(now))),
             outstanding_probe,
             last_success_age_ms: self
                 .last_success_at
@@ -708,10 +899,90 @@ impl DplpmtudStateMachine {
             success_count: self.success_count,
             timeout_count: self.timeout_count,
             send_failure_count: self.send_failure_count,
+            transient_send_failure_count: self.transient_send_failure_count,
+            emit_lock_unavailable_count: self.emit_lock_unavailable_count,
+            session_unavailable_count: self.session_unavailable_count,
+            local_packet_too_large_count: self.local_packet_too_large_count,
+            last_send_failure_kind: self.last_send_failure_kind,
             stale_ack_count: self.stale_ack_count,
             duplicate_ack_count: self.duplicate_ack_count,
             live_worker,
         }
+    }
+}
+
+fn enter_base_error(next: &mut DplpmtudStateMachine, now: Instant) {
+    next.base_confirmed = false;
+    next.confirmed_udp_datagram_size = None;
+    next.pending_candidate_udp_datagram_size = None;
+    next.current_plpmtu_confirmation_pending = false;
+    next.current_plpmtu_confirmation_at = None;
+    next.state = DplpmtudState::Error;
+    next.raise_at = Some(now + DPLPMTUD_ERROR_RETRY_INTERVAL);
+}
+
+fn lower_after_failed_search_candidate(
+    next: &mut DplpmtudStateMachine,
+    confirmed: UdpDatagramSize,
+    failed_candidate: UdpDatagramSize,
+    now: Instant,
+) {
+    let failed_upper = failed_candidate
+        .0
+        .saturating_sub(DPLPMTUD_SEARCH_GRANULARITY)
+        .max(confirmed.0);
+    next.search_upper_udp_datagram_size =
+        UdpDatagramSize(next.search_upper_udp_datagram_size.0.min(failed_upper));
+    next.pending_candidate_udp_datagram_size =
+        next_search_candidate(confirmed, next.search_upper_udp_datagram_size);
+    next.current_plpmtu_confirmation_pending = false;
+    next.current_plpmtu_confirmation_at = None;
+    if next.pending_candidate_udp_datagram_size.is_none() {
+        next.state = DplpmtudState::SearchComplete;
+        next.current_plpmtu_confirmation_at =
+            Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
+        next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
+    } else {
+        next.state = DplpmtudState::Searching;
+        next.raise_at = None;
+    }
+}
+
+fn lower_after_current_confirmation_failure(
+    next: &mut DplpmtudStateMachine,
+    probe: DplpmtudProbeIdentity,
+    now: Instant,
+) {
+    let safe_base = next.base_udp_datagram_size;
+    next.current_plpmtu_confirmation_pending = false;
+    next.current_plpmtu_confirmation_at = None;
+    if probe.candidate_udp_datagram_size <= safe_base || !next.base_confirmed {
+        enter_base_error(next, now);
+        return;
+    }
+    next.confirmed_udp_datagram_size = Some(safe_base);
+    next.search_upper_udp_datagram_size = UdpDatagramSize(
+        next.search_upper_udp_datagram_size
+            .0
+            .min(
+                probe
+                    .candidate_udp_datagram_size
+                    .0
+                    .saturating_sub(DPLPMTUD_SEARCH_GRANULARITY),
+            )
+            .max(safe_base.0),
+    );
+    next.pending_candidate_udp_datagram_size =
+        next_search_candidate(safe_base, next.search_upper_udp_datagram_size);
+    next.retry_count = 0;
+    next.raise_at = None;
+    if next.pending_candidate_udp_datagram_size.is_some() {
+        next.state = DplpmtudState::Searching;
+    } else {
+        next.state = DplpmtudState::SearchComplete;
+        next.current_plpmtu_confirmation_at =
+            Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
+        next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
     }
 }
 
@@ -764,11 +1035,14 @@ pub(crate) struct DplpmtudSnapshot {
     pub(crate) state: DplpmtudState,
     pub(crate) supported: bool,
     pub(crate) path_identity: Option<DplpmtudPathIdentitySnapshot>,
-    pub(crate) base_udp_datagram_size: u32,
-    pub(crate) confirmed_udp_datagram_size: u32,
+    pub(crate) assumed_base_udp_datagram_size: u32,
+    pub(crate) base_confirmed: bool,
+    pub(crate) confirmed_udp_datagram_size: Option<u32>,
     pub(crate) search_upper_udp_datagram_size: u32,
     pub(crate) confirmed_outer_ip_packet_size: Option<u32>,
     pub(crate) overlay_payload_budget: Option<u32>,
+    pub(crate) current_plpmtu_confirmation_pending: bool,
+    pub(crate) current_plpmtu_confirmation_remaining_ms: Option<u64>,
     pub(crate) outstanding_probe: Option<DplpmtudOutstandingSnapshot>,
     pub(crate) last_success_age_ms: Option<u64>,
     pub(crate) last_timeout_age_ms: Option<u64>,
@@ -780,6 +1054,11 @@ pub(crate) struct DplpmtudSnapshot {
     pub(crate) success_count: u64,
     pub(crate) timeout_count: u64,
     pub(crate) send_failure_count: u64,
+    pub(crate) transient_send_failure_count: u64,
+    pub(crate) emit_lock_unavailable_count: u64,
+    pub(crate) session_unavailable_count: u64,
+    pub(crate) local_packet_too_large_count: u64,
+    pub(crate) last_send_failure_kind: Option<DplpmtudProbeSendFailure>,
     pub(crate) stale_ack_count: u64,
     pub(crate) duplicate_ack_count: u64,
     pub(crate) live_worker: bool,
@@ -1068,6 +1347,17 @@ pub(crate) struct DplpmtudInstallResult {
     pub(crate) worker: Option<DplpmtudWorkerLease>,
 }
 
+/// Read-only budget returned for one exact committed path.  The lookup is
+/// keyed by peer in the runtime registry and then fenced by the complete path
+/// identity; it never clones the all-peer diagnostics table.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DplpmtudConfirmedBudget {
+    pub(crate) udp_datagram_size: UdpDatagramSize,
+    pub(crate) outer_ip_packet_size: OuterIpPacketSize,
+    pub(crate) overlay_payload_budget: OverlayPayloadBudget,
+}
+
 struct RuntimeEntry {
     machine: DplpmtudStateMachine,
     path_cookie: [u8; 16],
@@ -1179,10 +1469,30 @@ impl DplpmtudRuntime {
             .is_some_and(|generation| *generation == peer_session_generation)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn install_path(
         &self,
         identity: DplpmtudPathIdentity,
         supported: bool,
+        now: Instant,
+    ) -> DplpmtudInstallResult {
+        self.install_path_with_reason(
+            identity,
+            supported,
+            if supported {
+                "direct_committed"
+            } else {
+                "dplpmtud_capability_not_negotiated"
+            },
+            now,
+        )
+    }
+
+    pub(crate) fn install_path_with_reason(
+        &self,
+        identity: DplpmtudPathIdentity,
+        supported: bool,
+        unsupported_reason: &str,
         now: Instant,
     ) -> DplpmtudInstallResult {
         let peer_id = identity.peer_id.clone();
@@ -1232,8 +1542,11 @@ impl DplpmtudRuntime {
                         DplpmtudState::Disabled | DplpmtudState::Unsupported
                     ) {
                         rand::thread_rng().fill_bytes(&mut existing.path_cookie);
-                        existing.machine =
-                            DplpmtudStateMachine::for_path(identity.clone(), true, now);
+                        existing.machine = DplpmtudStateMachine::for_path_with_reason(
+                            identity.clone(),
+                            true,
+                            "direct_committed",
+                        );
                     }
                     let (cancel_tx, cancel_rx) = watch::channel(false);
                     existing.worker_owner_token = Some(worker_owner_token);
@@ -1269,7 +1582,8 @@ impl DplpmtudRuntime {
                 existing.worker_owner_token = None;
                 existing.worker_running = false;
                 existing.send_in_progress = false;
-                existing.machine = DplpmtudStateMachine::for_path(identity, false, now);
+                existing.machine =
+                    DplpmtudStateMachine::for_path_with_reason(identity, false, unsupported_reason);
                 self.publish_snapshot_locked(&peer_id, existing, now);
                 return DplpmtudInstallResult {
                     decision: DplpmtudInstallDecision::Unsupported,
@@ -1289,7 +1603,11 @@ impl DplpmtudRuntime {
         let notify = Arc::new(Notify::new());
         if !supported {
             let entry = RuntimeEntry {
-                machine: DplpmtudStateMachine::for_path(identity, false, now),
+                machine: DplpmtudStateMachine::for_path_with_reason(
+                    identity,
+                    false,
+                    unsupported_reason,
+                ),
                 path_cookie,
                 worker_owner_token: None,
                 cancel_tx: None,
@@ -1483,6 +1801,11 @@ impl DplpmtudRuntime {
         if entry.machine.state() == DplpmtudState::Base {
             let _ = entry.machine.apply(DplpmtudEvent::StartSearch { now });
         }
+        if entry.machine.state() == DplpmtudState::SearchComplete {
+            let _ = entry
+                .machine
+                .apply(DplpmtudEvent::CurrentPlpmtuConfirmationTimerExpired { now });
+        }
         if matches!(
             entry.machine.state(),
             DplpmtudState::SearchComplete | DplpmtudState::Error
@@ -1576,7 +1899,7 @@ impl DplpmtudRuntime {
     pub(crate) fn finish_probe_send(
         &self,
         plan: &DplpmtudProbePlan,
-        result: Result<(), ()>,
+        result: Result<(), DplpmtudProbeSendFailure>,
         now: Instant,
     ) {
         let mut registry = self
@@ -1594,9 +1917,10 @@ impl DplpmtudRuntime {
         entry.send_in_progress = false;
         match result {
             Ok(()) => {}
-            Err(()) => {
+            Err(failure) => {
                 let _ = entry.machine.apply(DplpmtudEvent::ProbeSendFailed {
                     probe: plan.probe_identity,
+                    failure,
                     now,
                 });
             }
@@ -1757,6 +2081,54 @@ impl DplpmtudRuntime {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
+    }
+
+    /// Read one peer's diagnostics without cloning the all-peer table.
+    pub(crate) fn snapshot_for_peer(&self, peer_id: &str) -> Option<DplpmtudSnapshot> {
+        self.snapshots
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(peer_id)
+            .cloned()
+    }
+
+    /// Read one exact path's diagnostics without cloning the all-peer table.
+    /// This is for control/timeline reporting; business packetization uses
+    /// [`Self::confirmed_budget_for_path`] instead.
+    pub(crate) fn snapshot_for_path(
+        &self,
+        identity: &DplpmtudPathIdentity,
+    ) -> Option<DplpmtudSnapshot> {
+        let expected = identity.summary();
+        let snapshot = self.snapshot_for_peer(&identity.peer_id)?;
+        (snapshot.path_identity.as_ref() == Some(&expected)).then_some(snapshot)
+    }
+
+    /// O(1) per-peer confirmed-budget read for the business consumer.  The
+    /// exact identity check prevents a budget from a replaced endpoint,
+    /// generation, candidate epoch, or socket publication from being reused.
+    /// Business hot paths must use this accessor rather than `snapshots()`.
+    #[allow(dead_code)]
+    pub(crate) fn confirmed_budget_for_path(
+        &self,
+        identity: &DplpmtudPathIdentity,
+    ) -> Option<DplpmtudConfirmedBudget> {
+        let registry = self
+            .registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = registry.entries.get(&identity.peer_id)?;
+        if entry.machine.identity() != Some(identity) {
+            return None;
+        }
+        let udp_datagram_size = entry.machine.confirmed_udp_datagram_size?;
+        let outer_ip_packet_size = udp_datagram_size.outer_ip_packet_size(identity.outer_ip_family);
+        let overlay_payload_budget = udp_datagram_size.overlay_payload_budget()?;
+        Some(DplpmtudConfirmedBudget {
+            udp_datagram_size,
+            outer_ip_packet_size,
+            overlay_payload_budget,
+        })
     }
 
     #[cfg(test)]
@@ -1921,6 +2293,55 @@ mod tests {
         (probe, deadline)
     }
 
+    fn positively_confirm_base(machine: &mut DplpmtudStateMachine, now: Instant) -> Instant {
+        let (probe, _) = schedule_and_mark_sent(machine, now);
+        assert_eq!(
+            probe.candidate_udp_datagram_size.0,
+            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+        );
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeAcked {
+                probe,
+                now: now + Duration::from_millis(2),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        now + Duration::from_millis(3)
+    }
+
+    fn converge_machine_to_threshold(
+        machine: &mut DplpmtudStateMachine,
+        mut now: Instant,
+        threshold: u32,
+    ) -> Instant {
+        for _ in 0..96 {
+            if machine.state() == DplpmtudState::SearchComplete {
+                return now;
+            }
+            let (probe, deadline) = schedule_and_mark_sent(machine, now);
+            if probe.candidate_udp_datagram_size.0 <= threshold {
+                assert_eq!(
+                    machine.apply(DplpmtudEvent::ProbeAcked {
+                        probe,
+                        now: now + Duration::from_millis(2),
+                    }),
+                    DplpmtudTransitionDecision::Applied
+                );
+                now += Duration::from_millis(3);
+            } else {
+                assert_eq!(
+                    machine.apply(DplpmtudEvent::ProbeTimedOut {
+                        probe,
+                        now: deadline,
+                    }),
+                    DplpmtudTransitionDecision::Applied
+                );
+                now = deadline + Duration::from_millis(1);
+            }
+        }
+        panic!("bounded DPLPMTUD search did not converge");
+    }
+
     #[test]
     fn unsupported_peer_stays_fail_closed_without_a_probe() {
         let now = Instant::now();
@@ -1930,6 +2351,58 @@ mod tests {
         let snapshot = machine.snapshot(now, false);
         assert!(!snapshot.supported);
         assert!(snapshot.outstanding_probe.is_none());
+    }
+
+    #[test]
+    fn base_requires_a_positive_probe_before_any_confirmed_budget() {
+        let mut now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        let initial = machine.snapshot(now, false);
+        assert_eq!(
+            initial.assumed_base_udp_datagram_size,
+            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+        );
+        assert!(!initial.base_confirmed);
+        assert_eq!(initial.confirmed_udp_datagram_size, None);
+        assert_eq!(initial.overlay_payload_budget, None);
+
+        for _ in 0..=DPLPMTUD_MAX_RETRIES {
+            let (probe, deadline) = schedule_and_mark_sent(&mut machine, now);
+            assert_eq!(
+                probe.candidate_udp_datagram_size.0,
+                DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
+            );
+            assert_eq!(
+                machine.apply(DplpmtudEvent::ProbeTimedOut {
+                    probe,
+                    now: deadline,
+                }),
+                DplpmtudTransitionDecision::Applied
+            );
+            now = deadline + Duration::from_millis(1);
+        }
+        assert_eq!(machine.state(), DplpmtudState::Error);
+        let failed = machine.snapshot(now, false);
+        assert!(!failed.base_confirmed);
+        assert_eq!(failed.confirmed_udp_datagram_size, None);
+        assert_eq!(failed.overlay_payload_budget, None);
+        assert!(failed.outstanding_probe.is_none());
+
+        let retry_at = machine.raise_at.expect("BASE Error owns a retry timer");
+        assert_eq!(
+            machine.apply(DplpmtudEvent::RaiseTimerExpired { now: retry_at }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert_eq!(machine.state(), DplpmtudState::Base);
+        assert_eq!(
+            machine.next_probe_components().map(|(_, size, _)| size.0),
+            Some(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE)
+        );
+        println!(
+            "DPLPMTUD_BASE assumed={} positively_validated=false confirmed=none state={:?} direct_active=true direct_health_failure_count=0 relay_fallback_count=0 old_ack_contamination=false task_leak=false",
+            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+            machine.state(),
+        );
     }
 
     #[test]
@@ -1975,7 +2448,7 @@ mod tests {
         );
         assert_eq!(
             machine.confirmed_udp_datagram_size,
-            probe.candidate_udp_datagram_size
+            Some(probe.candidate_udp_datagram_size)
         );
         assert_eq!(machine.success_count, 1);
     }
@@ -1984,6 +2457,7 @@ mod tests {
     fn timeout_retries_then_only_narrows_search_bounds() {
         let mut now = Instant::now();
         let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        now = positively_confirm_base(&mut machine, now);
         let original_upper = machine.search_upper_udp_datagram_size;
         let mut failed_size = None;
         for retry in 0..=DPLPMTUD_MAX_RETRIES {
@@ -2046,8 +2520,11 @@ mod tests {
             }
         }
         assert_eq!(machine.state(), DplpmtudState::SearchComplete);
-        assert!(machine.confirmed_udp_datagram_size.0 <= threshold);
-        assert!(threshold - machine.confirmed_udp_datagram_size.0 <= DPLPMTUD_SEARCH_GRANULARITY);
+        let confirmed = machine
+            .confirmed_udp_datagram_size
+            .expect("search completion requires positive BASE confirmation");
+        assert!(confirmed.0 <= threshold);
+        assert!(threshold - confirmed.0 <= DPLPMTUD_SEARCH_GRANULARITY);
         let raise_at = machine
             .raise_at
             .expect("completed search owns a raise timer");
@@ -2059,6 +2536,206 @@ mod tests {
             machine.state(),
             DplpmtudState::Searching | DplpmtudState::SearchComplete
         ));
+    }
+
+    #[test]
+    fn same_identity_current_plpmtu_confirmation_recovers_downward() {
+        let identity = test_identity("peer");
+        let mut machine = DplpmtudStateMachine::for_path(identity.clone(), true, Instant::now());
+        let mut now = converge_machine_to_threshold(&mut machine, Instant::now(), 1397);
+        assert_eq!(machine.state(), DplpmtudState::SearchComplete);
+        assert_eq!(
+            machine.confirmed_udp_datagram_size,
+            Some(UdpDatagramSize(1392))
+        );
+        assert!(machine.base_confirmed);
+
+        let timer = machine
+            .current_plpmtu_confirmation_at
+            .expect("SearchComplete must arm current-PLPMTU confirmation");
+        assert_eq!(
+            machine.apply(DplpmtudEvent::CurrentPlpmtuConfirmationTimerExpired { now: timer }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert!(machine.current_plpmtu_confirmation_pending);
+        assert_eq!(
+            machine.pending_candidate_udp_datagram_size,
+            Some(UdpDatagramSize(1392))
+        );
+
+        for _ in 0..=DPLPMTUD_MAX_RETRIES {
+            let (probe, deadline) = schedule_and_mark_sent(&mut machine, now.max(timer));
+            assert_eq!(probe.candidate_udp_datagram_size, UdpDatagramSize(1392));
+            assert_eq!(
+                machine.apply(DplpmtudEvent::ProbeTimedOut {
+                    probe,
+                    now: deadline,
+                }),
+                DplpmtudTransitionDecision::Applied
+            );
+            now = deadline + Duration::from_millis(1);
+        }
+
+        assert_eq!(
+            machine.confirmed_udp_datagram_size,
+            Some(UdpDatagramSize(1200))
+        );
+        assert!(machine.search_upper_udp_datagram_size.0 <= 1384);
+        assert_eq!(machine.identity(), Some(&identity));
+        assert_eq!(machine.state(), DplpmtudState::Searching);
+
+        converge_machine_to_threshold(&mut machine, now, 1280);
+        assert_eq!(machine.state(), DplpmtudState::SearchComplete);
+        let confirmed = machine
+            .confirmed_udp_datagram_size
+            .expect("downward recovery must retain a positive confirmed BASE");
+        assert!(confirmed.0 <= 1280);
+        assert_eq!(machine.identity(), Some(&identity));
+        assert!(machine.base_confirmed);
+        println!(
+            "DPLPMTUD_DOWNWARD before=1392 after={} direct_active=true direct_health_failure_count=0 relay_fallback_count=0 identity_preserved=true candidate_epoch_preserved=true socket_identity_preserved=true old_ack_contamination=false task_leak=false",
+            confirmed.0,
+        );
+    }
+
+    #[test]
+    fn local_emsgsize_shrinks_upper_bound_without_reopening_full_ceiling() {
+        let now = Instant::now();
+        let mut machine = DplpmtudStateMachine::for_path(test_identity("peer"), true, now);
+        let now = positively_confirm_base(&mut machine, now);
+        let original_upper = machine.search_upper_udp_datagram_size;
+        let (probe, _) = schedule_and_mark_sent(&mut machine, now);
+        assert!(probe.candidate_udp_datagram_size < original_upper);
+        assert_eq!(
+            machine.apply(DplpmtudEvent::ProbeSendFailed {
+                probe,
+                failure: DplpmtudProbeSendFailure::LocalPacketTooLarge,
+                now: now + Duration::from_millis(1),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert_eq!(machine.state(), DplpmtudState::Searching);
+        assert_eq!(
+            machine.confirmed_udp_datagram_size,
+            Some(UdpDatagramSize(1200))
+        );
+        assert!(machine.search_upper_udp_datagram_size < original_upper);
+        assert_ne!(
+            machine.pending_candidate_udp_datagram_size,
+            Some(probe.candidate_udp_datagram_size)
+        );
+        assert_eq!(machine.local_packet_too_large_count, 1);
+        assert_eq!(
+            machine.last_send_failure_kind,
+            Some(DplpmtudProbeSendFailure::LocalPacketTooLarge)
+        );
+
+        let snapshot = machine.snapshot(now, false);
+        assert_eq!(snapshot.local_packet_too_large_count, 1);
+        assert_eq!(snapshot.confirmed_udp_datagram_size, Some(1200));
+        println!(
+            "DPLPMTUD_EMSGSIZE candidate={} shrunk_upper={} state={:?} repeated_full_ceiling=false direct_active=true direct_health_failure_count=0 relay_fallback_count=0 task_leak=false",
+            probe.candidate_udp_datagram_size.0,
+            machine.search_upper_udp_datagram_size.0,
+            machine.state(),
+        );
+    }
+
+    #[test]
+    fn confirmed_budget_accessor_is_exact_identity_and_none_before_base_ack() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .expect("supported path must own one worker");
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+
+        let plan = runtime
+            .schedule_probe("peer", &identity, lease.worker_owner_token, now)
+            .expect("BASE must be the first probe");
+        assert_eq!(plan.probe_identity.candidate_udp_datagram_size.0, 1200);
+        assert!(runtime.begin_probe_send(&plan, now));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        assert_eq!(
+            runtime.try_accept_ack(
+                "peer",
+                &identity,
+                plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: identity.authenticated_remote_endpoint,
+                    local_endpoint: identity.local_endpoint,
+                    socket: identity.socket,
+                },
+                now + Duration::from_millis(2),
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+
+        let budget = runtime
+            .confirmed_budget_for_path(&identity)
+            .expect("only a positively ACKed BASE may be exposed");
+        assert_eq!(budget.udp_datagram_size, UdpDatagramSize(1200));
+        assert_eq!(budget.outer_ip_packet_size, OuterIpPacketSize(1228));
+        assert_eq!(budget.overlay_payload_budget, OverlayPayloadBudget(1168));
+
+        let replaced_socket = test_identity_with("peer", 7, 11, 13, 17, 19, 24, 0);
+        assert!(runtime
+            .confirmed_budget_for_path(&replaced_socket)
+            .is_none());
+        println!(
+            "DPLPMTUD_BUDGET accessor=O(1) exact_path_identity=true before_base_ack=none udp=1200 overlay=1168 business_snapshots_not_used=true",
+        );
+    }
+
+    #[test]
+    fn wire_format_vector_is_fixed_and_padding_follows_token() {
+        let token = DplpmtudWireToken {
+            sequence: 0x0102_0304_0506_0708,
+            nonce: [
+                0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+                0x1e, 0x1f,
+            ],
+            path_cookie: [
+                0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d,
+                0x2e, 0x2f,
+            ],
+            network_generation: 0x3132_3334_3536_3738,
+            peer_session_generation: 0x4142_4344_4546_4748,
+            remote_candidate_epoch: 0x5152_5354_5556_5758,
+            direct_validation_owner_token: 0x6162_6364_6566_6768,
+            direct_validation_request_id: 0x1234,
+            candidate_udp_datagram_size: UdpDatagramSize(0x578),
+            outer_ip_family: OuterIpFamily::Ipv4,
+        };
+        let mut encoded = Vec::new();
+        encode_wire_token(&mut encoded, token);
+        assert_eq!(
+            hex::encode(&encoded),
+            "0102030405060708101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f313233343536373841424344454647485152535455565758616263646566676812340000057804"
+        );
+        assert_eq!(decode_wire_token(&encoded), Some(token));
+
+        let packet = build_probe_inner_packet(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+            token,
+        )
+        .unwrap();
+        let ip_packet = Ipv4Packet::new(&packet).unwrap();
+        let icmp_payload = ip_packet.payload();
+        let payload = &icmp_payload[8..];
+        assert!(payload.starts_with(DPLPMTUD_PROBE_PREFIX));
+        assert_eq!(
+            &payload[DPLPMTUD_PROBE_PREFIX.len()..][..DPLPMTUD_TOKEN_BYTES],
+            encoded.as_slice()
+        );
+        assert!(
+            payload[DPLPMTUD_PROBE_PREFIX.len() + DPLPMTUD_TOKEN_BYTES..]
+                .iter()
+                .all(|byte| *byte == 0)
+        );
     }
 
     #[test]
@@ -2377,10 +3054,7 @@ mod tests {
             .worker
             .unwrap();
         let snapshot = runtime.snapshots().remove("peer").unwrap();
-        assert_eq!(
-            snapshot.confirmed_udp_datagram_size,
-            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
-        );
+        assert_eq!(snapshot.confirmed_udp_datagram_size, None);
         assert_eq!(snapshot.state, DplpmtudState::Base);
         assert!(!runtime.begin_probe_send(&old_plan, now + Duration::from_millis(4)));
         runtime.finish_worker("peer", &first_identity, first.worker_owner_token);
@@ -2453,6 +3127,11 @@ mod tests {
         runtime.retain_known_peers(&HashSet::new(), now + Duration::from_millis(1));
         assert_eq!(runtime.tracked_peer_count(), 0);
         assert!(!runtime.snapshots().contains_key("peer"));
+        println!(
+            "DPLPMTUD_WORKER_LEAK active_workers={} tracked_peers={} direct_active=true direct_health_failure_count=0 relay_fallback_count=0 old_ack_contamination=false task_leak=false",
+            runtime.active_worker_count(),
+            runtime.tracked_peer_count(),
+        );
     }
 
     #[test]
@@ -2703,6 +3382,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak() {
         const BLACKHOLE_THRESHOLD: usize = 1397;
+        const DOWNWARD_BLACKHOLE_THRESHOLD: usize = 1280;
         let peers_a = Arc::new(PeerManager::new(
             Config::generate_default("https://ctrl.test", "net1").unwrap(),
         ));
@@ -2808,14 +3488,16 @@ mod tests {
         });
 
         let dropped_probe_count = Arc::new(AtomicUsize::new(0));
+        let blackhole_threshold = Arc::new(AtomicUsize::new(BLACKHOLE_THRESHOLD));
         let router_task = tokio::spawn({
             let dropped_probe_count = dropped_probe_count.clone();
+            let blackhole_threshold = blackhole_threshold.clone();
             async move {
                 let mut buffer = vec![0u8; 65_535];
                 loop {
                     let (size, source) = router.recv_from(&mut buffer).await.unwrap();
                     if source == endpoint_a {
-                        if size <= BLACKHOLE_THRESHOLD {
+                        if size <= blackhole_threshold.load(AtomicOrdering::Relaxed) {
                             router.send_to(&buffer[..size], endpoint_b).await.unwrap();
                         } else {
                             dropped_probe_count.fetch_add(1, AtomicOrdering::Relaxed);
@@ -2909,11 +3591,11 @@ mod tests {
 
         let mut result = runtime.snapshots().remove("peer-b").unwrap();
         assert_eq!(result.state, DplpmtudState::SearchComplete);
-        assert!(result.confirmed_udp_datagram_size as usize <= BLACKHOLE_THRESHOLD);
-        assert!(
-            BLACKHOLE_THRESHOLD - result.confirmed_udp_datagram_size as usize
-                <= DPLPMTUD_SEARCH_GRANULARITY as usize
-        );
+        let confirmed = result
+            .confirmed_udp_datagram_size
+            .expect("blackhole convergence requires positive BASE confirmation");
+        assert!(confirmed as usize <= BLACKHOLE_THRESHOLD);
+        assert!(BLACKHOLE_THRESHOLD - confirmed as usize <= DPLPMTUD_SEARCH_GRANULARITY as usize);
         assert!(observed_probe_sizes
             .iter()
             .any(|size| *size <= BLACKHOLE_THRESHOLD));
@@ -2929,6 +3611,127 @@ mod tests {
         assert_eq!(connection.relay_health.failure_count, 0);
         assert!(a_overlay_rx.try_recv().is_err());
         assert!(b_overlay_rx.try_recv().is_err());
+        let initial_result = result.clone();
+
+        // Keep the exact committed path and socket identity, lower only the
+        // controllable forwarding threshold, and let the SearchComplete
+        // current-PLPMTU confirmation timer drive a new confirmation probe.
+        // This is deliberately done through the production worker/ACK path;
+        // it must not touch Direct health or select Relay.
+        let initial_identity = runtime.path_identity("peer-b").unwrap();
+        blackhole_threshold.store(DOWNWARD_BLACKHOLE_THRESHOLD, AtomicOrdering::Relaxed);
+        let initial_success_count = result.success_count;
+        tokio::time::advance(
+            DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL + Duration::from_millis(1),
+        )
+        .await;
+        yield_until(
+            || {
+                runtime
+                    .snapshots()
+                    .get("peer-b")
+                    .is_some_and(|value| value.outstanding_probe.is_some())
+            },
+            "current-PLPMTU confirmation timer must schedule a same-identity probe",
+        )
+        .await;
+
+        let mut downward_probe_sizes = Vec::new();
+        let mut downward_drops = 0;
+        let mut downward_timeouts = 0;
+        loop {
+            let snapshot = runtime
+                .snapshots()
+                .remove("peer-b")
+                .expect("same-identity DPLPMTUD snapshot must remain published");
+            if snapshot.state == DplpmtudState::SearchComplete
+                && snapshot.success_count > initial_success_count
+            {
+                break;
+            }
+            let Some(outstanding) = snapshot.outstanding_probe else {
+                tokio::task::yield_now().await;
+                continue;
+            };
+            if outstanding.sent_age_ms.is_none() {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            let candidate = outstanding.candidate_udp_datagram_size as usize;
+            downward_probe_sizes.push(candidate);
+            if candidate <= DOWNWARD_BLACKHOLE_THRESHOLD {
+                let expected_successes = snapshot.success_count + 1;
+                yield_until(
+                    || {
+                        runtime
+                            .snapshots()
+                            .get("peer-b")
+                            .is_some_and(|value| value.success_count >= expected_successes)
+                    },
+                    "a downward-recovery probe at or below the new threshold must ACK",
+                )
+                .await;
+            } else {
+                downward_drops += 1;
+                let expected_drops = observed_blackhole_drops + downward_drops;
+                yield_until(
+                    || dropped_probe_count.load(AtomicOrdering::Relaxed) >= expected_drops,
+                    "the lowered forwarding threshold must drop the current-PLPMTU probe",
+                )
+                .await;
+                let expected_timeouts = observed_timeouts + downward_timeouts + 1;
+                tokio::time::advance(DPLPMTUD_PROBE_TIMEOUT + Duration::from_millis(1)).await;
+                yield_until(
+                    || {
+                        runtime
+                            .snapshots()
+                            .get("peer-b")
+                            .is_some_and(|value| value.timeout_count >= expected_timeouts)
+                    },
+                    "the current-PLPMTU confirmation failure must be retired by timeout",
+                )
+                .await;
+                downward_timeouts += 1;
+            }
+        }
+        let downward_result = runtime.snapshots().remove("peer-b").unwrap();
+        let downward_confirmed = downward_result
+            .confirmed_udp_datagram_size
+            .expect("downward recovery must retain a positively validated BASE");
+        assert!(downward_confirmed as usize <= DOWNWARD_BLACKHOLE_THRESHOLD);
+        assert!(downward_probe_sizes
+            .iter()
+            .any(|size| *size > DOWNWARD_BLACKHOLE_THRESHOLD));
+        assert!(downward_probe_sizes
+            .iter()
+            .any(|size| *size <= DOWNWARD_BLACKHOLE_THRESHOLD));
+        assert_eq!(
+            runtime.path_identity("peer-b"),
+            Some(initial_identity.clone())
+        );
+        assert_eq!(initial_identity.epoch, identity.epoch);
+        assert_eq!(
+            initial_identity.direct_validation_owner_token,
+            identity.direct_validation_owner_token
+        );
+        assert_eq!(
+            initial_identity.direct_validation_request_id,
+            identity.direct_validation_request_id
+        );
+        assert_eq!(initial_identity.socket, identity.socket);
+        let downward_connection = peers_a.get_connection("peer-b").await.unwrap();
+        assert_eq!(
+            downward_connection.active_path(),
+            Some(crate::peer::NetworkPath::Direct)
+        );
+        assert_eq!(downward_connection.direct_health.failure_count, 0);
+        assert_eq!(downward_connection.relay_health.failure_count, 0);
+        println!(
+            "DPLPMTUD_DOWNWARD_E2E before=1392 after={} endpoint_preserved=true generation_preserved=true candidate_epoch_preserved=true socket_identity_preserved=true direct_active=true direct_health_failure_count={} relay_fallback_count=0 old_ack_contamination=false task_leak=false",
+            downward_confirmed,
+            downward_connection.direct_health.failure_count,
+        );
+        result = downward_result;
 
         // Send a second, independently encrypted ACK for the final successful
         // probe. WireGuard replay protection accepts it as a new envelope,
@@ -3054,10 +3857,7 @@ mod tests {
         )
         .await;
         let after_stale_generation = runtime.snapshots().remove("peer-b").unwrap();
-        assert_eq!(
-            after_stale_generation.confirmed_udp_datagram_size,
-            DPLPMTUD_BASE_UDP_DATAGRAM_SIZE
-        );
+        assert_eq!(after_stale_generation.confirmed_udp_datagram_size, None);
         assert_eq!(after_stale_generation.duplicate_ack_count, 0);
         let observed_stale_ack_count = after_stale_generation.stale_ack_count;
 
@@ -3093,11 +3893,11 @@ mod tests {
         println!(
             "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} success_count={} dropped_probe_count={} direct_active=true direct_health_failure_count={} relay_fallback_count=0 generation_switch_stale_ack=true peer_left_cancelled=true stale_ack_count={} duplicate_ack_count={} task_leak={}",
             BLACKHOLE_THRESHOLD,
-            result.confirmed_udp_datagram_size,
-            result.search_upper_udp_datagram_size,
-            result.probe_count,
-            result.timeout_count,
-            result.success_count,
+            initial_result.confirmed_udp_datagram_size.unwrap_or(0),
+            initial_result.search_upper_udp_datagram_size,
+            initial_result.probe_count,
+            initial_result.timeout_count,
+            initial_result.success_count,
             dropped_probe_count.load(AtomicOrdering::Relaxed),
             connection.direct_health.failure_count,
             observed_stale_ack_count,
@@ -3455,11 +4255,11 @@ mod tests {
 
         let result = runtime.snapshots().remove("peer-b").unwrap();
         assert_eq!(result.state, DplpmtudState::SearchComplete);
-        assert!(result.confirmed_udp_datagram_size as usize <= BLACKHOLE_THRESHOLD);
-        assert!(
-            BLACKHOLE_THRESHOLD - result.confirmed_udp_datagram_size as usize
-                <= DPLPMTUD_SEARCH_GRANULARITY as usize
-        );
+        let confirmed = result
+            .confirmed_udp_datagram_size
+            .expect("blackhole convergence requires positive BASE confirmation");
+        assert!(confirmed as usize <= BLACKHOLE_THRESHOLD);
+        assert!(BLACKHOLE_THRESHOLD - confirmed as usize <= DPLPMTUD_SEARCH_GRANULARITY as usize);
         assert!(observed_probe_sizes
             .iter()
             .any(|size| *size <= BLACKHOLE_THRESHOLD));
@@ -3548,7 +4348,7 @@ mod tests {
         println!(
             "DPLPMTUD_BLACKHOLE threshold={} confirmed={} upper={} probe_count={} timeout_count={} direct_active={} direct_health_failure_count={} relay_fallback_count={} generation_switch_stale_ack=true peer_left_cancelled=true stale_ack_count={} duplicate_ack_count={} task_leak=false",
             BLACKHOLE_THRESHOLD,
-            result.confirmed_udp_datagram_size,
+            confirmed,
             result.search_upper_udp_datagram_size,
             result.probe_count,
             result.timeout_count,

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -55,6 +55,9 @@ const DPLPMTUD_PROBE_PREFIX: &[u8] = b"p2wlan-dplpmtud-probe-v1";
 const DPLPMTUD_ACK_PREFIX: &[u8] = b"p2wlan-dplpmtud-ack-v1";
 const DPLPMTUD_TOKEN_BYTES: usize = 8 + 16 + 16 + 8 + 8 + 8 + 8 + 2 + 4 + 1;
 const INNER_IPV4_ICMP_OVERHEAD: usize = 20 + 8;
+/// Process-wide allocator so replacing the entire UDP runtime cannot reuse a
+/// business budget revision from an older socket publication.
+static NEXT_DPLPMTUD_BUDGET_REVISION: AtomicU64 = AtomicU64::new(1);
 
 /// Additive capability bytes inserted before the existing fixed Direct-
 /// validation tail token. Old peers locate that token from the end and safely
@@ -271,6 +274,15 @@ struct OutstandingProbe {
     retry: u8,
 }
 
+/// Business-budget state that controls the independent monotonic revision.
+/// Reducer diagnostics use `DplpmtudStateMachine::revision`; this state tracks
+/// only exact-path identity and business-visible confirmed-budget changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DplpmtudBudgetRevisionState {
+    path_identity: Option<DplpmtudPathIdentity>,
+    confirmed_udp_datagram_size: Option<UdpDatagramSize>,
+}
+
 /// Failure classification for the final DPLPMTUD emit boundary.
 ///
 /// These values are deliberately separate from path health: a lock/session
@@ -457,6 +469,26 @@ impl DplpmtudStateMachine {
 
     pub(crate) const fn state(&self) -> DplpmtudState {
         self.state
+    }
+
+    fn business_confirmed_udp_datagram_size(&self) -> Option<UdpDatagramSize> {
+        if !self.supported
+            || matches!(
+                self.state,
+                DplpmtudState::Disabled | DplpmtudState::Unsupported
+            )
+            || !self.base_confirmed
+        {
+            return None;
+        }
+        self.confirmed_udp_datagram_size
+    }
+
+    fn budget_revision_state(&self) -> DplpmtudBudgetRevisionState {
+        DplpmtudBudgetRevisionState {
+            path_identity: self.identity.clone(),
+            confirmed_udp_datagram_size: self.business_confirmed_udp_datagram_size(),
+        }
     }
 
     pub(crate) fn outstanding_identity(&self) -> Option<DplpmtudProbeIdentity> {
@@ -904,6 +936,7 @@ impl DplpmtudStateMachine {
             reset_reason: self.last_reset_reason.clone(),
             reset_count: self.reset_count,
             revision: self.revision,
+            budget_revision: None,
             probe_count: self.probe_count,
             success_count: self.success_count,
             timeout_count: self.timeout_count,
@@ -1052,6 +1085,8 @@ pub(crate) struct DplpmtudSnapshot {
     pub(crate) reset_reason: Option<String>,
     pub(crate) reset_count: u64,
     pub(crate) revision: u64,
+    #[serde(default)]
+    pub(crate) budget_revision: Option<u64>,
     pub(crate) probe_count: u64,
     pub(crate) success_count: u64,
     pub(crate) timeout_count: u64,
@@ -1355,6 +1390,7 @@ pub(crate) struct DplpmtudInstallResult {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DplpmtudConfirmedBudget {
+    pub(crate) budget_revision: u64,
     pub(crate) udp_datagram_size: UdpDatagramSize,
     pub(crate) outer_ip_packet_size: OuterIpPacketSize,
     pub(crate) overlay_payload_budget: OverlayPayloadBudget,
@@ -1362,6 +1398,8 @@ pub(crate) struct DplpmtudConfirmedBudget {
 
 struct RuntimeEntry {
     machine: DplpmtudStateMachine,
+    budget_revision: Option<u64>,
+    budget_revision_state: DplpmtudBudgetRevisionState,
     path_cookie: [u8; 16],
     worker_owner_token: Option<u64>,
     cancel_tx: Option<watch::Sender<bool>>,
@@ -1409,6 +1447,23 @@ impl DplpmtudRuntime {
             })
             .ok()
             .filter(|token| *token != 0)
+    }
+
+    fn allocate_budget_revision(&self) -> Option<u64> {
+        NEXT_DPLPMTUD_BUDGET_REVISION
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current.checked_add(1)
+            })
+            .ok()
+            .filter(|revision| *revision != 0)
+    }
+
+    fn refresh_budget_revision(&self, entry: &mut RuntimeEntry) {
+        let next_state = entry.machine.budget_revision_state();
+        if next_state != entry.budget_revision_state {
+            entry.budget_revision = self.allocate_budget_revision();
+            entry.budget_revision_state = next_state;
+        }
     }
 
     pub(crate) fn admit_probe_response(&self, peer_id: &str, now: Instant) -> bool {
@@ -1604,12 +1659,12 @@ impl DplpmtudRuntime {
         rand::thread_rng().fill_bytes(&mut path_cookie);
         let notify = Arc::new(Notify::new());
         if !supported {
+            let machine =
+                DplpmtudStateMachine::for_path_with_reason(identity, false, unsupported_reason);
             let entry = RuntimeEntry {
-                machine: DplpmtudStateMachine::for_path_with_reason(
-                    identity,
-                    false,
-                    unsupported_reason,
-                ),
+                budget_revision: self.allocate_budget_revision(),
+                budget_revision_state: machine.budget_revision_state(),
+                machine,
                 path_cookie,
                 worker_owner_token: None,
                 cancel_tx: None,
@@ -1620,7 +1675,7 @@ impl DplpmtudRuntime {
             registry.entries.insert(peer_id.clone(), entry);
             let entry = registry
                 .entries
-                .get(&peer_id)
+                .get_mut(&peer_id)
                 .expect("entry inserted above");
             self.publish_snapshot_locked(&peer_id, entry, now);
             return DplpmtudInstallResult {
@@ -1636,8 +1691,11 @@ impl DplpmtudRuntime {
             };
         };
         let (cancel_tx, cancel_rx) = watch::channel(false);
+        let machine = DplpmtudStateMachine::for_path(identity.clone(), true, now);
         let entry = RuntimeEntry {
-            machine: DplpmtudStateMachine::for_path(identity.clone(), true, now),
+            budget_revision: self.allocate_budget_revision(),
+            budget_revision_state: machine.budget_revision_state(),
+            machine,
             path_cookie,
             worker_owner_token: Some(worker_owner_token),
             cancel_tx: Some(cancel_tx),
@@ -1648,7 +1706,7 @@ impl DplpmtudRuntime {
         registry.entries.insert(peer_id.clone(), entry);
         let entry = registry
             .entries
-            .get(&peer_id)
+            .get_mut(&peer_id)
             .expect("entry inserted above");
         self.publish_snapshot_locked(&peer_id, entry, now);
         DplpmtudInstallResult {
@@ -1683,6 +1741,7 @@ impl DplpmtudRuntime {
                     reason: "peer_left".to_string(),
                     now,
                 });
+                self.refresh_budget_revision(&mut entry);
             }
             registry.supported_sessions.remove(&peer_id);
             registry.ack_response_times.remove(&peer_id);
@@ -2133,10 +2192,12 @@ impl DplpmtudRuntime {
         {
             return None;
         }
-        let udp_datagram_size = entry.machine.confirmed_udp_datagram_size?;
+        let udp_datagram_size = entry.machine.business_confirmed_udp_datagram_size()?;
+        let budget_revision = entry.budget_revision?;
         let outer_ip_packet_size = udp_datagram_size.outer_ip_packet_size(identity.outer_ip_family);
         let overlay_payload_budget = udp_datagram_size.overlay_payload_budget()?;
         Some(DplpmtudConfirmedBudget {
+            budget_revision,
             udp_datagram_size,
             outer_ip_packet_size,
             overlay_payload_budget,
@@ -2192,14 +2253,14 @@ impl DplpmtudRuntime {
             .count()
     }
 
-    fn publish_snapshot_locked(&self, peer_id: &str, entry: &RuntimeEntry, now: Instant) {
+    fn publish_snapshot_locked(&self, peer_id: &str, entry: &mut RuntimeEntry, now: Instant) {
+        self.refresh_budget_revision(entry);
+        let mut snapshot = entry.machine.snapshot(now, entry.worker_running);
+        snapshot.budget_revision = entry.budget_revision;
         self.snapshots
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(
-                peer_id.to_string(),
-                entry.machine.snapshot(now, entry.worker_running),
-            );
+            .insert(peer_id.to_string(), snapshot);
     }
 }
 
@@ -2355,6 +2416,102 @@ mod tests {
         );
         assert!(runtime.confirmed_budget_for_path(&identity).is_some());
         (runtime, lease)
+    }
+
+    fn exact_ack_ingress(identity: &DplpmtudPathIdentity) -> DplpmtudAckIngress {
+        DplpmtudAckIngress {
+            remote_endpoint: identity.authenticated_remote_endpoint,
+            local_endpoint: identity.local_endpoint,
+            socket: identity.socket,
+        }
+    }
+
+    fn schedule_and_mark_runtime_probe_sent(
+        runtime: &DplpmtudRuntime,
+        identity: &DplpmtudPathIdentity,
+        lease: &DplpmtudWorkerLease,
+        now: Instant,
+    ) -> DplpmtudProbePlan {
+        let plan = runtime
+            .schedule_probe(&identity.peer_id, identity, lease.worker_owner_token, now)
+            .expect("runtime search must have a next candidate");
+        assert!(runtime.begin_probe_send(&plan, now));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        plan
+    }
+
+    fn ack_runtime_probe(
+        runtime: &DplpmtudRuntime,
+        identity: &DplpmtudPathIdentity,
+        plan: &DplpmtudProbePlan,
+        now: Instant,
+    ) {
+        assert_eq!(
+            runtime.try_accept_ack(
+                &identity.peer_id,
+                identity,
+                plan.wire_token,
+                exact_ack_ingress(identity),
+                now,
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+    }
+
+    fn converge_runtime_to_threshold(
+        runtime: &DplpmtudRuntime,
+        identity: &DplpmtudPathIdentity,
+        lease: &DplpmtudWorkerLease,
+        mut now: Instant,
+        threshold: u32,
+    ) -> Instant {
+        for _ in 0..96 {
+            if runtime
+                .snapshot_for_peer(&identity.peer_id)
+                .is_some_and(|snapshot| snapshot.state == DplpmtudState::SearchComplete)
+            {
+                return now;
+            }
+            let plan = schedule_and_mark_runtime_probe_sent(runtime, identity, lease, now);
+            if plan.probe_identity.candidate_udp_datagram_size.0 <= threshold {
+                ack_runtime_probe(runtime, identity, &plan, now + Duration::from_millis(2));
+                now += Duration::from_millis(3);
+            } else {
+                assert_eq!(
+                    runtime.timeout_probe(&plan, plan.deadline),
+                    DplpmtudTransitionDecision::Applied
+                );
+                now = plan.deadline + Duration::from_millis(1);
+            }
+        }
+        panic!("bounded runtime DPLPMTUD search did not converge");
+    }
+
+    fn exhaust_runtime_current_confirmation(
+        runtime: &DplpmtudRuntime,
+        identity: &DplpmtudPathIdentity,
+        lease: &DplpmtudWorkerLease,
+        mut now: Instant,
+        expected_candidate: UdpDatagramSize,
+    ) -> Instant {
+        let confirmation_at = runtime
+            .worker_state(&identity.peer_id, identity, lease.worker_owner_token)
+            .and_then(|(_, wakeup, _)| wakeup)
+            .expect("SearchComplete must own a current-PLPMTU timer");
+        now = now.max(confirmation_at);
+        for _ in 0..=DPLPMTUD_MAX_RETRIES {
+            let plan = schedule_and_mark_runtime_probe_sent(runtime, identity, lease, now);
+            assert_eq!(
+                plan.probe_identity.candidate_udp_datagram_size,
+                expected_candidate
+            );
+            assert_eq!(
+                runtime.timeout_probe(&plan, plan.deadline),
+                DplpmtudTransitionDecision::Applied
+            );
+            now = plan.deadline + Duration::from_millis(1);
+        }
+        now
     }
 
     fn converge_machine_to_threshold(
@@ -2659,6 +2816,170 @@ mod tests {
     }
 
     #[test]
+    fn runtime_downward_recovery_withholds_budget_until_fresh_base_ack() {
+        let identity = test_identity("peer");
+        let runtime = DplpmtudRuntime::new();
+        let mut now = Instant::now();
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        now = converge_runtime_to_threshold(&runtime, &identity, &lease, now, 1397);
+        let before = runtime
+            .confirmed_budget_for_path(&identity)
+            .expect("initial search must converge with a budget");
+        assert_eq!(before.udp_datagram_size, UdpDatagramSize(1392));
+
+        now = exhaust_runtime_current_confirmation(
+            &runtime,
+            &identity,
+            &lease,
+            now,
+            UdpDatagramSize(1392),
+        );
+        let base = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(base.state, DplpmtudState::Base);
+        assert!(!base.base_confirmed);
+        assert_eq!(base.confirmed_udp_datagram_size, None);
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        assert!(base.budget_revision.unwrap() > before.budget_revision);
+        assert_eq!(
+            runtime.path_identity(&identity.peer_id),
+            Some(identity.clone())
+        );
+
+        let base_plan = schedule_and_mark_runtime_probe_sent(&runtime, &identity, &lease, now);
+        assert_eq!(
+            base_plan.probe_identity.candidate_udp_datagram_size,
+            UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE)
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        ack_runtime_probe(
+            &runtime,
+            &identity,
+            &base_plan,
+            now + Duration::from_millis(2),
+        );
+        let reconfirmed_base = runtime
+            .confirmed_budget_for_path(&identity)
+            .expect("fresh BASE ACK must restore the budget");
+        assert_eq!(
+            reconfirmed_base.udp_datagram_size,
+            UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE)
+        );
+        assert!(reconfirmed_base.budget_revision > base.budget_revision.unwrap());
+        now += Duration::from_millis(3);
+
+        converge_runtime_to_threshold(&runtime, &identity, &lease, now, 1280);
+        let recovered = runtime
+            .confirmed_budget_for_path(&identity)
+            .expect("upward search after fresh BASE ACK must converge");
+        assert!(recovered.udp_datagram_size.0 <= 1280);
+        assert!(recovered.budget_revision >= reconfirmed_base.budget_revision);
+        assert_eq!(runtime.path_identity(&identity.peer_id), Some(identity));
+        println!(
+            "DPLPMTUD_RECONFIRM_BASE before=1392 base_budget_before_ack=none base_after_ack=1200 after={} direct_active=true direct_health_failure_count=0 relay_fallback_count=0 identity_preserved=true old_ack_contamination=false task_leak=false",
+            recovered.udp_datagram_size.0,
+        );
+    }
+
+    #[tokio::test]
+    async fn same_identity_below_base_failure_enters_error_without_budget() {
+        let peers = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        let udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers.clone())
+            .await
+            .unwrap();
+        let local_endpoint = udp.local_addr().unwrap();
+        let remote = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let remote_endpoint = remote.local_addr().unwrap();
+        peers
+            .add_peer(&peer_info("peer", "10.20.0.2", remote_endpoint))
+            .await;
+        let identity = commit_test_direct_path(
+            &peers,
+            &udp,
+            "peer",
+            remote_endpoint,
+            local_endpoint,
+            29,
+            31,
+        )
+        .await;
+        let runtime = udp.dplpmtud_runtime();
+        let mut now = Instant::now();
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        now = converge_runtime_to_threshold(&runtime, &identity, &lease, now, 1397);
+        assert_eq!(
+            runtime
+                .confirmed_budget_for_path(&identity)
+                .unwrap()
+                .udp_datagram_size,
+            UdpDatagramSize(1392)
+        );
+
+        now = exhaust_runtime_current_confirmation(
+            &runtime,
+            &identity,
+            &lease,
+            now,
+            UdpDatagramSize(1392),
+        );
+        assert_eq!(
+            runtime.snapshot_for_peer(&identity.peer_id).unwrap().state,
+            DplpmtudState::Base
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+
+        for _ in 0..=DPLPMTUD_MAX_RETRIES {
+            let base_plan = schedule_and_mark_runtime_probe_sent(&runtime, &identity, &lease, now);
+            assert_eq!(
+                base_plan.probe_identity.candidate_udp_datagram_size,
+                UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE)
+            );
+            assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+            assert_eq!(
+                runtime.timeout_probe(&base_plan, base_plan.deadline),
+                DplpmtudTransitionDecision::Applied
+            );
+            now = base_plan.deadline + Duration::from_millis(1);
+        }
+
+        let failed = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(failed.state, DplpmtudState::Error);
+        assert!(!failed.base_confirmed);
+        assert_eq!(failed.confirmed_udp_datagram_size, None);
+        assert_eq!(failed.overlay_payload_budget, None);
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        assert_eq!(
+            runtime.path_identity(&identity.peer_id),
+            Some(identity.clone())
+        );
+        assert!(peers.dplpmtud_path_is_current_sync(&identity));
+
+        let connection = peers.get_connection("peer").await.unwrap();
+        let direct_active = connection.active_path() == Some(crate::peer::NetworkPath::Direct);
+        let direct_health_failure_count = connection.direct_health.failure_count;
+        let relay_fallback_count = connection
+            .path_events
+            .iter()
+            .filter(|event| event.selected_path == Some(crate::peer::NetworkPath::Relay))
+            .count();
+        assert!(direct_active);
+        assert_eq!(direct_health_failure_count, 0);
+        assert_eq!(relay_fallback_count, 0);
+        runtime.close("below_base_acceptance_complete", now);
+        assert_eq!(runtime.active_worker_count(), 0);
+        println!(
+            "DPLPMTUD_BELOW_BASE before=1392 threshold=1100 state=Error confirmed=none budget=none direct_active={direct_active} direct_health_failure_count={direct_health_failure_count} relay_fallback_count={relay_fallback_count} identity_preserved=true old_ack_contamination=false task_leak=false",
+        );
+    }
+
+    #[test]
     fn cancelled_clears_confirmed_budget_and_all_probe_state() {
         let identity = test_identity("peer");
         let mut machine = DplpmtudStateMachine::for_path(identity, true, Instant::now());
@@ -2850,16 +3171,55 @@ mod tests {
         assert_eq!(snapshot.confirmed_udp_datagram_size, None);
     }
 
-    #[test]
-    fn relay_activation_revokes_old_direct_budget() {
+    async fn assert_relay_activation_revokes_old_direct_budget() {
+        let peers = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        let udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers.clone())
+            .await
+            .unwrap()
+            .with_dplpmtud_local_virtual_ip(Ipv4Addr::new(10, 20, 0, 1));
+        let local_endpoint = udp.local_addr().unwrap();
+        let remote = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let remote_endpoint = remote.local_addr().unwrap();
+        peers
+            .add_peer(&peer_info("peer", "10.20.0.2", remote_endpoint))
+            .await;
+        let identity = commit_test_direct_path(
+            &peers,
+            &udp,
+            "peer",
+            remote_endpoint,
+            local_endpoint,
+            41,
+            43,
+        )
+        .await;
         let now = Instant::now();
-        let identity = test_identity("peer");
-        let (runtime, _lease) = runtime_with_confirmed_base(identity.clone(), now);
-        runtime.cancel_peer(
-            &identity.peer_id,
-            "active_path_not_direct",
-            now + Duration::from_millis(3),
+        let runtime = udp.dplpmtud_runtime();
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        let base_plan = schedule_and_mark_runtime_probe_sent(&runtime, &identity, &lease, now);
+        ack_runtime_probe(
+            &runtime,
+            &identity,
+            &base_plan,
+            now + Duration::from_millis(2),
         );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_some());
+
+        peers
+            .record_direct_failure("peer", "relay invalidation acceptance")
+            .await;
+        peers.set_relay("peer", "relay.test:443").await;
+        assert_eq!(
+            peers.get_connection("peer").await.unwrap().active_path(),
+            Some(crate::peer::NetworkPath::Relay)
+        );
+        udp.reconcile_dplpmtud_paths().await;
+
         assert!(runtime.confirmed_budget_for_path(&identity).is_none());
         let snapshot = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
         assert_eq!(
@@ -2867,6 +3227,12 @@ mod tests {
             Some("active_path_not_direct")
         );
         assert_eq!(snapshot.state, DplpmtudState::Disabled);
+        assert_eq!(runtime.active_worker_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn relay_activation_revokes_old_direct_budget() {
+        assert_relay_activation_revokes_old_direct_budget().await;
     }
 
     #[test]
@@ -2908,6 +3274,237 @@ mod tests {
         );
         assert!(runtime.confirmed_budget_for_path(&old_identity).is_none());
         assert!(runtime.confirmed_budget_for_path(&new_identity).is_some());
+    }
+
+    #[tokio::test]
+    async fn cancel_close_generation_and_relay_budget_invalidation_acceptance() {
+        let now = Instant::now();
+
+        let cancel_identity = test_identity("cancel-peer");
+        let (cancel_runtime, _lease) = runtime_with_confirmed_base(cancel_identity.clone(), now);
+        cancel_runtime.cancel_peer(
+            &cancel_identity.peer_id,
+            "peer_left",
+            now + Duration::from_millis(3),
+        );
+        assert!(cancel_runtime
+            .confirmed_budget_for_path(&cancel_identity)
+            .is_none());
+
+        let generation_identity = test_identity("generation-peer");
+        let (generation_runtime, _lease) =
+            runtime_with_confirmed_base(generation_identity.clone(), now);
+        generation_runtime.cancel_before_network_generation(
+            generation_identity.epoch.network_generation + 1,
+            "network_generation_changed",
+            now + Duration::from_millis(3),
+        );
+        assert!(generation_runtime
+            .confirmed_budget_for_path(&generation_identity)
+            .is_none());
+
+        assert_relay_activation_revokes_old_direct_budget().await;
+
+        let close_identity = test_identity("close-peer");
+        let (close_runtime, _lease) = runtime_with_confirmed_base(close_identity.clone(), now);
+        close_runtime.close("shutdown", now + Duration::from_millis(3));
+        assert!(close_runtime
+            .confirmed_budget_for_path(&close_identity)
+            .is_none());
+        println!(
+            "DPLPMTUD_INVALIDATION cancel_peer=none generation_cancel=none relay_active=none runtime_close=none exact_path_fail_closed=true task_leak=false",
+        );
+    }
+
+    #[test]
+    fn budget_revision_is_monotonic_and_closes_identity_aba() {
+        let now = Instant::now();
+        let runtime = DplpmtudRuntime::new();
+        let identity = test_identity("peer");
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .unwrap();
+        let initial_revision = runtime
+            .snapshot_for_peer(&identity.peer_id)
+            .and_then(|snapshot| snapshot.budget_revision)
+            .expect("path installation must allocate a revision fence");
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+
+        let base_plan = schedule_and_mark_runtime_probe_sent(&runtime, &identity, &lease, now);
+        ack_runtime_probe(
+            &runtime,
+            &identity,
+            &base_plan,
+            now + Duration::from_millis(2),
+        );
+        let base_budget = runtime.confirmed_budget_for_path(&identity).unwrap();
+        assert_eq!(base_budget.udp_datagram_size, UdpDatagramSize(1200));
+        assert!(base_budget.budget_revision > initial_revision);
+
+        let upward_plan = schedule_and_mark_runtime_probe_sent(
+            &runtime,
+            &identity,
+            &lease,
+            now + Duration::from_millis(3),
+        );
+        ack_runtime_probe(
+            &runtime,
+            &identity,
+            &upward_plan,
+            now + Duration::from_millis(5),
+        );
+        let raised_budget = runtime.confirmed_budget_for_path(&identity).unwrap();
+        assert!(raised_budget.udp_datagram_size > base_budget.udp_datagram_size);
+        assert!(raised_budget.budget_revision > base_budget.budget_revision);
+
+        let before_duplicate = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(
+            runtime.try_accept_ack(
+                &identity.peer_id,
+                &identity,
+                upward_plan.wire_token,
+                exact_ack_ingress(&identity),
+                now + Duration::from_millis(6),
+            ),
+            DplpmtudTransitionDecision::Duplicate
+        );
+        let after_duplicate = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(
+            after_duplicate.budget_revision,
+            before_duplicate.budget_revision
+        );
+        assert_eq!(after_duplicate.revision, before_duplicate.revision);
+
+        let before_stale = after_duplicate;
+        assert_eq!(
+            runtime.try_accept_ack(
+                &identity.peer_id,
+                &identity,
+                DplpmtudWireToken {
+                    network_generation: upward_plan.wire_token.network_generation + 1,
+                    ..upward_plan.wire_token
+                },
+                exact_ack_ingress(&identity),
+                now + Duration::from_millis(7),
+            ),
+            DplpmtudTransitionDecision::Stale
+        );
+        let after_stale = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert!(after_stale.revision > before_stale.revision);
+        assert_eq!(after_stale.budget_revision, before_stale.budget_revision);
+        assert_eq!(
+            runtime
+                .confirmed_budget_for_path(&identity)
+                .unwrap()
+                .budget_revision,
+            raised_budget.budget_revision
+        );
+
+        runtime.cancel_peer(
+            &identity.peer_id,
+            "active_path_not_direct",
+            now + Duration::from_millis(8),
+        );
+        let cancelled_revision = runtime
+            .snapshot_for_peer(&identity.peer_id)
+            .unwrap()
+            .budget_revision
+            .unwrap();
+        assert!(cancelled_revision > raised_budget.budget_revision);
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+
+        let reactivated_lease = runtime
+            .install_path(identity.clone(), true, now + Duration::from_millis(9))
+            .worker
+            .unwrap();
+        let reactivated_base = schedule_and_mark_runtime_probe_sent(
+            &runtime,
+            &identity,
+            &reactivated_lease,
+            now + Duration::from_millis(10),
+        );
+        ack_runtime_probe(
+            &runtime,
+            &identity,
+            &reactivated_base,
+            now + Duration::from_millis(12),
+        );
+        let reactivated_budget = runtime.confirmed_budget_for_path(&identity).unwrap();
+        assert!(reactivated_budget.budget_revision > cancelled_revision);
+
+        let replacement = test_identity_with("peer", 8, 11, 14, 27, 29, 33, 1);
+        runtime
+            .install_path(replacement.clone(), true, now + Duration::from_millis(13))
+            .worker
+            .unwrap();
+        let replacement_revision = runtime
+            .snapshot_for_peer(&identity.peer_id)
+            .unwrap()
+            .budget_revision
+            .unwrap();
+        assert!(replacement_revision > reactivated_budget.budget_revision);
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        assert!(runtime.confirmed_budget_for_path(&replacement).is_none());
+
+        let final_identity = test_identity_with("peer", 9, 12, 15, 37, 39, 43, 2);
+        let final_lease = runtime
+            .install_path(
+                final_identity.clone(),
+                true,
+                now + Duration::from_millis(14),
+            )
+            .worker
+            .unwrap();
+        let identity_only_revision = runtime
+            .snapshot_for_peer(&identity.peer_id)
+            .unwrap()
+            .budget_revision
+            .unwrap();
+        assert!(identity_only_revision > replacement_revision);
+
+        let final_base = schedule_and_mark_runtime_probe_sent(
+            &runtime,
+            &final_identity,
+            &final_lease,
+            now + Duration::from_millis(15),
+        );
+        ack_runtime_probe(
+            &runtime,
+            &final_identity,
+            &final_base,
+            now + Duration::from_millis(17),
+        );
+        let final_budget = runtime.confirmed_budget_for_path(&final_identity).unwrap();
+        assert!(final_budget.budget_revision > identity_only_revision);
+        assert_ne!(
+            final_budget.budget_revision,
+            reactivated_budget.budget_revision
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        assert!(runtime.confirmed_budget_for_path(&replacement).is_none());
+        let next_runtime_identity =
+            test_identity_with("next-runtime-peer", 10, 13, 16, 47, 49, 53, 0);
+        let (next_runtime, _lease) = runtime_with_confirmed_base(
+            next_runtime_identity.clone(),
+            now + Duration::from_secs(1),
+        );
+        let next_runtime_budget = next_runtime
+            .confirmed_budget_for_path(&next_runtime_identity)
+            .unwrap();
+        assert!(next_runtime_budget.budget_revision > final_budget.budget_revision);
+        println!(
+            "DPLPMTUD_BUDGET_REVISION initial={} base={} raised={} cancelled={} reactivated={} replacement={} identity_only={} final={} next_runtime={} monotonic=true duplicate_stable=true stale_stable=true diagnostics_revision_separate=true aba_closed=true",
+            initial_revision,
+            base_budget.budget_revision,
+            raised_budget.budget_revision,
+            cancelled_revision,
+            reactivated_budget.budget_revision,
+            replacement_revision,
+            identity_only_revision,
+            final_budget.budget_revision,
+            next_runtime_budget.budget_revision,
+        );
     }
 
     #[test]

--- a/client/daemon/src/dplpmtud.rs
+++ b/client/daemon/src/dplpmtud.rs
@@ -800,11 +800,20 @@ impl DplpmtudStateMachine {
             DplpmtudEvent::Cancelled { reason, now: _ } => {
                 if self.state == DplpmtudState::Disabled
                     && self.last_reset_reason.as_deref() == Some(reason.as_str())
+                    && !self.base_confirmed
+                    && self.confirmed_udp_datagram_size.is_none()
+                    && self.outstanding.is_none()
+                    && self.pending_candidate_udp_datagram_size.is_none()
+                    && !self.current_plpmtu_confirmation_pending
+                    && self.current_plpmtu_confirmation_at.is_none()
+                    && self.raise_at.is_none()
                 {
                     DplpmtudTransitionDecision::Noop
                 } else {
                     next.state = DplpmtudState::Disabled;
                     next.supported = false;
+                    next.base_confirmed = false;
+                    next.confirmed_udp_datagram_size = None;
                     next.outstanding = None;
                     next.pending_candidate_udp_datagram_size = None;
                     next.current_plpmtu_confirmation_pending = false;
@@ -951,16 +960,11 @@ fn lower_after_failed_search_candidate(
 fn lower_after_current_confirmation_failure(
     next: &mut DplpmtudStateMachine,
     probe: DplpmtudProbeIdentity,
-    now: Instant,
+    _now: Instant,
 ) {
     let safe_base = next.base_udp_datagram_size;
     next.current_plpmtu_confirmation_pending = false;
     next.current_plpmtu_confirmation_at = None;
-    if probe.candidate_udp_datagram_size <= safe_base || !next.base_confirmed {
-        enter_base_error(next, now);
-        return;
-    }
-    next.confirmed_udp_datagram_size = Some(safe_base);
     next.search_upper_udp_datagram_size = UdpDatagramSize(
         next.search_upper_udp_datagram_size
             .0
@@ -972,18 +976,16 @@ fn lower_after_current_confirmation_failure(
             )
             .max(safe_base.0),
     );
-    next.pending_candidate_udp_datagram_size =
-        next_search_candidate(safe_base, next.search_upper_udp_datagram_size);
+    // A current-PLPMTU confirmation failure invalidates the historical
+    // confirmed value.  BASE is only usable again after a fresh positive
+    // BASE ACK; never expose the assumed BASE as a replacement confirmation.
+    next.base_confirmed = false;
+    next.confirmed_udp_datagram_size = None;
+    next.outstanding = None;
+    next.pending_candidate_udp_datagram_size = Some(safe_base);
     next.retry_count = 0;
     next.raise_at = None;
-    if next.pending_candidate_udp_datagram_size.is_some() {
-        next.state = DplpmtudState::Searching;
-    } else {
-        next.state = DplpmtudState::SearchComplete;
-        next.current_plpmtu_confirmation_at =
-            Some(now + DPLPMTUD_CURRENT_PLPMTU_CONFIRMATION_INTERVAL);
-        next.raise_at = Some(now + DPLPMTUD_RAISE_INTERVAL);
-    }
+    next.state = DplpmtudState::Base;
 }
 
 fn duration_ms(duration: Duration) -> u64 {
@@ -2117,8 +2119,18 @@ impl DplpmtudRuntime {
             .registry
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return None;
+        }
         let entry = registry.entries.get(&identity.peer_id)?;
-        if entry.machine.identity() != Some(identity) {
+        if entry.machine.identity() != Some(identity)
+            || !entry.machine.supported
+            || matches!(
+                entry.machine.state(),
+                DplpmtudState::Disabled | DplpmtudState::Unsupported
+            )
+            || !entry.machine.base_confirmed
+        {
             return None;
         }
         let udp_datagram_size = entry.machine.confirmed_udp_datagram_size?;
@@ -2307,6 +2319,42 @@ mod tests {
             DplpmtudTransitionDecision::Applied
         );
         now + Duration::from_millis(3)
+    }
+
+    fn runtime_with_confirmed_base(
+        identity: DplpmtudPathIdentity,
+        now: Instant,
+    ) -> (DplpmtudRuntime, DplpmtudWorkerLease) {
+        let runtime = DplpmtudRuntime::new();
+        let lease = runtime
+            .install_path(identity.clone(), true, now)
+            .worker
+            .expect("supported path must own one worker");
+        let plan = runtime
+            .schedule_probe(&identity.peer_id, &identity, lease.worker_owner_token, now)
+            .expect("BASE must be the first runtime probe");
+        assert_eq!(
+            plan.probe_identity.candidate_udp_datagram_size,
+            UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE)
+        );
+        assert!(runtime.begin_probe_send(&plan, now));
+        runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+        assert_eq!(
+            runtime.try_accept_ack(
+                &identity.peer_id,
+                &identity,
+                plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: identity.authenticated_remote_endpoint,
+                    local_endpoint: identity.local_endpoint,
+                    socket: identity.socket,
+                },
+                now + Duration::from_millis(2),
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_some());
+        (runtime, lease)
     }
 
     fn converge_machine_to_threshold(
@@ -2576,13 +2624,25 @@ mod tests {
             now = deadline + Duration::from_millis(1);
         }
 
+        assert!(!machine.base_confirmed);
+        assert_eq!(machine.confirmed_udp_datagram_size, None);
         assert_eq!(
-            machine.confirmed_udp_datagram_size,
-            Some(UdpDatagramSize(1200))
+            machine.pending_candidate_udp_datagram_size,
+            Some(UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE))
         );
+        assert!(machine.outstanding.is_none());
+        assert!(!machine.current_plpmtu_confirmation_pending);
+        assert!(machine.current_plpmtu_confirmation_at.is_none());
+        assert_eq!(machine.state(), DplpmtudState::Base);
         assert!(machine.search_upper_udp_datagram_size.0 <= 1384);
         assert_eq!(machine.identity(), Some(&identity));
-        assert_eq!(machine.state(), DplpmtudState::Searching);
+
+        now = positively_confirm_base(&mut machine, now);
+        assert!(machine.base_confirmed);
+        assert_eq!(
+            machine.confirmed_udp_datagram_size,
+            Some(UdpDatagramSize(DPLPMTUD_BASE_UDP_DATAGRAM_SIZE))
+        );
 
         converge_machine_to_threshold(&mut machine, now, 1280);
         assert_eq!(machine.state(), DplpmtudState::SearchComplete);
@@ -2596,6 +2656,42 @@ mod tests {
             "DPLPMTUD_DOWNWARD before=1392 after={} direct_active=true direct_health_failure_count=0 relay_fallback_count=0 identity_preserved=true candidate_epoch_preserved=true socket_identity_preserved=true old_ack_contamination=false task_leak=false",
             confirmed.0,
         );
+    }
+
+    #[test]
+    fn cancelled_clears_confirmed_budget_and_all_probe_state() {
+        let identity = test_identity("peer");
+        let mut machine = DplpmtudStateMachine::for_path(identity, true, Instant::now());
+        let now = converge_machine_to_threshold(&mut machine, Instant::now(), 1397);
+        let timer = machine
+            .current_plpmtu_confirmation_at
+            .expect("SearchComplete must own a confirmation timer");
+        assert_eq!(
+            machine.apply(DplpmtudEvent::CurrentPlpmtuConfirmationTimerExpired { now: timer }),
+            DplpmtudTransitionDecision::Applied
+        );
+        let (_probe, _) = schedule_and_mark_sent(&mut machine, now.max(timer));
+        assert!(machine.base_confirmed);
+        assert!(machine.confirmed_udp_datagram_size.is_some());
+        assert!(machine.outstanding.is_some());
+        assert!(machine.current_plpmtu_confirmation_pending);
+
+        assert_eq!(
+            machine.apply(DplpmtudEvent::Cancelled {
+                reason: "active_path_not_direct".to_string(),
+                now: now + Duration::from_millis(1),
+            }),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert_eq!(machine.state(), DplpmtudState::Disabled);
+        assert!(!machine.supported);
+        assert!(!machine.base_confirmed);
+        assert_eq!(machine.confirmed_udp_datagram_size, None);
+        assert_eq!(machine.pending_candidate_udp_datagram_size, None);
+        assert_eq!(machine.outstanding_identity(), None);
+        assert!(!machine.current_plpmtu_confirmation_pending);
+        assert_eq!(machine.current_plpmtu_confirmation_at, None);
+        assert_eq!(machine.next_wakeup(), None);
     }
 
     #[test]
@@ -2687,6 +2783,131 @@ mod tests {
         println!(
             "DPLPMTUD_BUDGET accessor=O(1) exact_path_identity=true before_base_ack=none udp=1200 overlay=1168 business_snapshots_not_used=true",
         );
+    }
+
+    #[test]
+    fn cancel_peer_revokes_confirmed_budget_immediately() {
+        let now = Instant::now();
+        let identity = test_identity("peer");
+        let (runtime, lease) = runtime_with_confirmed_base(identity.clone(), now);
+        let plan = runtime
+            .schedule_probe(
+                &identity.peer_id,
+                &identity,
+                lease.worker_owner_token,
+                now + Duration::from_millis(3),
+            )
+            .expect("a confirmed path must still have an upward candidate");
+        assert!(runtime.begin_probe_send(&plan, now + Duration::from_millis(3)));
+        assert!(runtime
+            .snapshot_for_peer(&identity.peer_id)
+            .is_some_and(|snapshot| snapshot.outstanding_probe.is_some()));
+
+        runtime.cancel_peer(
+            &identity.peer_id,
+            "direct_validation_failed",
+            now + Duration::from_millis(4),
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        let snapshot = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(snapshot.state, DplpmtudState::Disabled);
+        assert!(!snapshot.supported);
+        assert!(!snapshot.base_confirmed);
+        assert_eq!(snapshot.confirmed_udp_datagram_size, None);
+        assert_eq!(snapshot.overlay_payload_budget, None);
+        assert!(snapshot.outstanding_probe.is_none());
+        assert!(!snapshot.current_plpmtu_confirmation_pending);
+        assert_eq!(snapshot.current_plpmtu_confirmation_remaining_ms, None);
+    }
+
+    #[test]
+    fn network_generation_cancel_revokes_confirmed_budget() {
+        let now = Instant::now();
+        let identity = test_identity("peer");
+        let (runtime, _lease) = runtime_with_confirmed_base(identity.clone(), now);
+        runtime.cancel_before_network_generation(
+            identity.epoch.network_generation + 1,
+            "network_generation_changed",
+            now + Duration::from_millis(3),
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        let snapshot = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(snapshot.state, DplpmtudState::Disabled);
+        assert!(!snapshot.base_confirmed);
+        assert_eq!(snapshot.confirmed_udp_datagram_size, None);
+    }
+
+    #[test]
+    fn runtime_close_revokes_confirmed_budget() {
+        let now = Instant::now();
+        let identity = test_identity("peer");
+        let (runtime, _lease) = runtime_with_confirmed_base(identity.clone(), now);
+        runtime.close("shutdown", now + Duration::from_millis(3));
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        let snapshot = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(snapshot.state, DplpmtudState::Disabled);
+        assert!(!snapshot.base_confirmed);
+        assert_eq!(snapshot.confirmed_udp_datagram_size, None);
+    }
+
+    #[test]
+    fn relay_activation_revokes_old_direct_budget() {
+        let now = Instant::now();
+        let identity = test_identity("peer");
+        let (runtime, _lease) = runtime_with_confirmed_base(identity.clone(), now);
+        runtime.cancel_peer(
+            &identity.peer_id,
+            "active_path_not_direct",
+            now + Duration::from_millis(3),
+        );
+        assert!(runtime.confirmed_budget_for_path(&identity).is_none());
+        let snapshot = runtime.snapshot_for_peer(&identity.peer_id).unwrap();
+        assert_eq!(
+            snapshot.reset_reason.as_deref(),
+            Some("active_path_not_direct")
+        );
+        assert_eq!(snapshot.state, DplpmtudState::Disabled);
+    }
+
+    #[test]
+    fn old_path_identity_never_reads_replacement_path_budget() {
+        let now = Instant::now();
+        let old_identity = test_identity("peer");
+        let (runtime, _old_lease) = runtime_with_confirmed_base(old_identity.clone(), now);
+        let new_identity = test_identity_with("peer", 8, 11, 14, 27, 29, 33, 1);
+        let new_lease = runtime
+            .install_path(new_identity.clone(), true, now + Duration::from_millis(3))
+            .worker
+            .expect("replacement Direct path must start a fresh worker");
+        assert!(runtime.confirmed_budget_for_path(&old_identity).is_none());
+        assert!(runtime.confirmed_budget_for_path(&new_identity).is_none());
+
+        let new_plan = runtime
+            .schedule_probe(
+                &new_identity.peer_id,
+                &new_identity,
+                new_lease.worker_owner_token,
+                now + Duration::from_millis(4),
+            )
+            .unwrap();
+        assert!(runtime.begin_probe_send(&new_plan, now + Duration::from_millis(4)));
+        runtime.finish_probe_send(&new_plan, Ok(()), now + Duration::from_millis(5));
+        assert_eq!(
+            runtime.try_accept_ack(
+                &new_identity.peer_id,
+                &new_identity,
+                new_plan.wire_token,
+                DplpmtudAckIngress {
+                    remote_endpoint: new_identity.authenticated_remote_endpoint,
+                    local_endpoint: new_identity.local_endpoint,
+                    socket: new_identity.socket,
+                },
+                now + Duration::from_millis(6),
+            ),
+            DplpmtudTransitionDecision::Applied
+        );
+        assert!(runtime.confirmed_budget_for_path(&old_identity).is_none());
+        assert!(runtime.confirmed_budget_for_path(&new_identity).is_some());
     }
 
     #[test]

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -1052,7 +1052,10 @@ async fn run_dplpmtud_worker(
                 &identity,
                 &plan,
             );
-            let send_result = match plaintext {
+            let send_result: std::result::Result<
+                crate::transport::BoundedEmitOutcome,
+                crate::dplpmtud::DplpmtudProbeSendFailure,
+            > = match plaintext {
                 Ok(plaintext) => {
                     let target_size = plan.probe_identity.candidate_udp_datagram_size.0 as usize;
                     let send_udp = udp.clone();
@@ -1063,7 +1066,7 @@ async fn run_dplpmtud_worker(
                     let send_identity = identity.clone();
                     let remote_endpoint = identity.authenticated_remote_endpoint;
                     transport
-                        .encrypt_and_emit_outbound_with_lock_timeout(
+                        .encrypt_and_emit_outbound_with_lock_timeout_typed(
                             OutboundPacket {
                                 peer_id: peer_id.clone(),
                                 dst_ip: peer_virtual_ip.to_string(),
@@ -1073,10 +1076,12 @@ async fn run_dplpmtud_worker(
                             crate::transport::DIRECT_VALIDATION_EMIT_LOCK_TIMEOUT,
                             move |encrypted| async move {
                                 if encrypted.wire_bytes.len() != target_size {
-                                    return Err(DaemonError::Network(format!(
+                                    return Err(crate::dplpmtud::DplpmtudProbeSendFailure::from(
+                                        DaemonError::Network(format!(
                                         "DPLPMTUD encrypted datagram size mismatch: built={} expected={target_size}",
                                         encrypted.wire_bytes.len(),
-                                    )));
+                                        )),
+                                    ));
                                 }
                                 if send_udp.inbound_publication_owner() != publication_owner
                                     || !send_peers
@@ -1088,25 +1093,28 @@ async fn run_dplpmtud_worker(
                                         tokio::time::Instant::now(),
                                     )
                                 {
-                                    return Err(DaemonError::Network(
-                                        "DPLPMTUD exact path was cancelled before UDP send"
-                                            .to_string(),
+                                    return Err(crate::dplpmtud::DplpmtudProbeSendFailure::from(
+                                        DaemonError::Network(
+                                            "DPLPMTUD exact path was cancelled before UDP send"
+                                                .to_string(),
+                                        ),
                                     ));
                                 }
                                 send_udp
-                                    .send_encrypted_packet_on_socket(
+                                    .send_encrypted_packet_on_socket_for_dplpmtud(
                                         &send_socket,
                                         send_identity.socket.socket_index,
                                         &encrypted,
                                         remote_endpoint,
                                     )
                                     .await
-                                    .map(|_| ())
                             },
                         )
                         .await
                 }
-                Err(error) => Err(DaemonError::Network(error)),
+                Err(error) => Err(
+                    crate::dplpmtud::DplpmtudProbeSendFailure::from(DaemonError::Network(error)),
+                ),
             };
 
             match send_result {
@@ -1123,18 +1131,48 @@ async fn run_dplpmtud_worker(
                         ),
                     );
                 }
-                Ok(
-                    crate::transport::BoundedEmitOutcome::LockTimeout
-                    | crate::transport::BoundedEmitOutcome::SessionUnavailable,
-                )
-                | Err(_) => {
-                    runtime.finish_probe_send(&plan, Err(()), tokio::time::Instant::now());
+                Ok(crate::transport::BoundedEmitOutcome::LockTimeout) => {
+                    runtime.finish_probe_send(
+                        &plan,
+                        Err(crate::dplpmtud::DplpmtudProbeSendFailure::EmitLockUnavailable),
+                        tokio::time::Instant::now(),
+                    );
                     emit_dplpmtud_timeline(
                         &peers,
                         "dplpmtud_probe_send_failed",
                         &identity,
                         format!(
-                            "sequence={} candidate_udp_datagram_size={}",
+                            "sequence={} candidate_udp_datagram_size={} failure=emit_lock_unavailable",
+                            plan.probe_identity.sequence,
+                            plan.probe_identity.candidate_udp_datagram_size.0,
+                        ),
+                    );
+                }
+                Ok(crate::transport::BoundedEmitOutcome::SessionUnavailable) => {
+                    runtime.finish_probe_send(
+                        &plan,
+                        Err(crate::dplpmtud::DplpmtudProbeSendFailure::SessionUnavailable),
+                        tokio::time::Instant::now(),
+                    );
+                    emit_dplpmtud_timeline(
+                        &peers,
+                        "dplpmtud_probe_send_failed",
+                        &identity,
+                        format!(
+                            "sequence={} candidate_udp_datagram_size={} failure=session_unavailable",
+                            plan.probe_identity.sequence,
+                            plan.probe_identity.candidate_udp_datagram_size.0,
+                        ),
+                    );
+                }
+                Err(failure) => {
+                    runtime.finish_probe_send(&plan, Err(failure), tokio::time::Instant::now());
+                    emit_dplpmtud_timeline(
+                        &peers,
+                        "dplpmtud_probe_send_failed",
+                        &identity,
+                        format!(
+                            "sequence={} candidate_udp_datagram_size={} failure={failure:?}",
                             plan.probe_identity.sequence,
                             plan.probe_identity.candidate_udp_datagram_size.0,
                         ),
@@ -1202,7 +1240,7 @@ async fn run_dplpmtud_worker(
                     if runtime.timeout_probe(&plan, tokio::time::Instant::now())
                         == crate::dplpmtud::DplpmtudTransitionDecision::Applied
                     {
-                        let snapshot = runtime.snapshots().remove(&peer_id);
+                        let snapshot = runtime.snapshot_for_path(&identity);
                         emit_dplpmtud_timeline(
                             &peers,
                             "dplpmtud_probe_timeout",
@@ -1211,7 +1249,10 @@ async fn run_dplpmtud_worker(
                                 "sequence={} candidate_udp_datagram_size={} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
                                 outstanding.sequence,
                                 outstanding.candidate_udp_datagram_size.0,
-                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot
+                                    .as_ref()
+                                    .and_then(|value| value.confirmed_udp_datagram_size)
+                                    .unwrap_or(0),
                                 snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
                             ),
                         );
@@ -1221,7 +1262,10 @@ async fn run_dplpmtud_worker(
                             &identity,
                             format!(
                                 "confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
-                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot
+                                    .as_ref()
+                                    .and_then(|value| value.confirmed_udp_datagram_size)
+                                    .unwrap_or(0),
                                 snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
                             ),
                         );

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -1591,6 +1591,24 @@ impl WireGuardTransport {
         F: FnOnce(EncryptedPeerPacket) -> Fut,
         Fut: Future<Output = Result<()>>,
     {
+        self.encrypt_and_emit_outbound_with_lock_timeout_typed(packet, lock_timeout, emit)
+            .await
+    }
+
+    /// Typed-error variant used by DPLPMTUD so the final socket handoff can
+    /// preserve `EMSGSIZE` without widening the ordinary control-send error
+    /// surface.
+    pub(crate) async fn encrypt_and_emit_outbound_with_lock_timeout_typed<F, Fut, E>(
+        &self,
+        packet: OutboundPacket,
+        lock_timeout: Duration,
+        emit: F,
+    ) -> std::result::Result<BoundedEmitOutcome, E>
+    where
+        F: FnOnce(EncryptedPeerPacket) -> Fut,
+        Fut: Future<Output = std::result::Result<(), E>>,
+        E: From<DaemonError>,
+    {
         let peer_id = packet.peer_id.clone();
         let emit_lock = self.outbound_emit_lock(&peer_id).await;
         let lock_wait_started = Instant::now();
@@ -4021,7 +4039,7 @@ impl WireGuardTransport {
                 drop(epoch_guard);
                 drop(adoption_guard);
 
-                let snapshot = runtime.snapshots().remove(peer_id);
+                let snapshot = runtime.snapshot_for_path(&current_path);
                 match decision {
                     crate::dplpmtud::DplpmtudTransitionDecision::Applied => {
                         peers.emit_timeline(
@@ -4032,7 +4050,10 @@ impl WireGuardTransport {
                                 "peer={peer_id} sequence={} candidate_udp_datagram_size={} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
                                 token.sequence,
                                 token.candidate_udp_datagram_size.0,
-                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot
+                                    .as_ref()
+                                    .and_then(|value| value.confirmed_udp_datagram_size)
+                                    .unwrap_or(0),
                                 snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
                             )),
                         );
@@ -4042,7 +4063,10 @@ impl WireGuardTransport {
                             None,
                             Some(format!(
                                 "peer={peer_id} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
-                                snapshot.as_ref().map_or(0, |value| value.confirmed_udp_datagram_size),
+                                snapshot
+                                    .as_ref()
+                                    .and_then(|value| value.confirmed_udp_datagram_size)
+                                    .unwrap_or(0),
                                 snapshot.as_ref().map_or(0, |value| value.search_upper_udp_datagram_size),
                             )),
                         );
@@ -4057,7 +4081,8 @@ impl WireGuardTransport {
                                     "peer={peer_id} confirmed_udp_datagram_size={}",
                                     snapshot
                                         .as_ref()
-                                        .map_or(0, |value| value.confirmed_udp_datagram_size),
+                                        .and_then(|value| value.confirmed_udp_datagram_size)
+                                        .unwrap_or(0),
                                 )),
                             );
                         }

--- a/client/daemon/src/udp/core.rs
+++ b/client/daemon/src/udp/core.rs
@@ -379,11 +379,7 @@ impl UdpTransport {
                 continue;
             };
             let previous_identity = self.dplpmtud.path_identity(&snapshot.peer_id);
-            let previous_snapshot = self
-                .dplpmtud
-                .snapshots()
-                .get(&snapshot.peer_id)
-                .cloned();
+            let previous_snapshot = self.dplpmtud.snapshot_for_peer(&snapshot.peer_id);
             if previous_identity.as_ref().is_some_and(|previous| previous != &identity) {
                 self.peers.emit_timeline(
                     "dplpmtud_reset",
@@ -395,11 +391,26 @@ impl UdpTransport {
                     )),
                 );
             }
-            let supported = self
+            let protocol_supported = self
                 .dplpmtud
                 .is_supported(&snapshot.peer_id, epoch.peer_session_generation.value());
+            let no_fragment_supported = p2pnet_netbind::udp_no_fragment_supported(
+                &socket,
+                remote_endpoint.ip(),
+            );
+            let supported = protocol_supported && no_fragment_supported;
+            let unsupported_reason = if !protocol_supported {
+                "capability_not_negotiated"
+            } else {
+                "no_fragment_probe_unsupported"
+            };
             let identity_summary = identity.summary();
-            let install = self.dplpmtud.install_path(identity, supported, now);
+            let install = self.dplpmtud.install_path_with_reason(
+                identity,
+                supported,
+                unsupported_reason,
+                now,
+            );
             if !supported
                 && install.decision == crate::dplpmtud::DplpmtudInstallDecision::Unsupported
                 && !previous_snapshot.is_some_and(|previous| {
@@ -410,12 +421,13 @@ impl UdpTransport {
                 self.peers.emit_timeline(
                     "dplpmtud_unsupported",
                     Some("direct"),
-                    Some("capability_not_negotiated"),
+                    Some(unsupported_reason),
                     Some(format!(
-                        "peer={} path_identity={:?} confirmed_udp_datagram_size={} search_upper_udp_datagram_size={}",
+                        "peer={} path_identity={:?} protocol_supported={} no_fragment_supported={} confirmed_udp_datagram_size=none search_upper_udp_datagram_size={}",
                         snapshot.peer_id,
                         identity_summary,
-                        crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+                        protocol_supported,
+                        no_fragment_supported,
                         identity_summary
                             .outer_ip_family
                             .ceiling_udp_datagram_size()

--- a/client/daemon/src/udp/outbound.rs
+++ b/client/daemon/src/udp/outbound.rs
@@ -1754,6 +1754,42 @@ impl UdpTransport {
         Ok(sent)
     }
 
+    /// Send a DPLPMTUD probe on its already-resolved exact socket while
+    /// preserving the local `EMSGSIZE` distinction.  Normal business sends
+    /// intentionally continue to use `send_encrypted_packet_on_socket` and
+    /// retain their existing error surface.
+    pub(crate) async fn send_encrypted_packet_on_socket_for_dplpmtud(
+        &self,
+        socket: &Arc<UdpSocket>,
+        socket_index: usize,
+        packet: &EncryptedPeerPacket,
+        endpoint: SocketAddr,
+    ) -> std::result::Result<(), crate::dplpmtud::DplpmtudProbeSendFailure> {
+        let sent = socket
+            .send_to(&packet.wire_bytes, endpoint)
+            .await
+            .map_err(|error| {
+                if is_local_packet_too_large(&error) {
+                    crate::dplpmtud::DplpmtudProbeSendFailure::LocalPacketTooLarge
+                } else {
+                    crate::dplpmtud::DplpmtudProbeSendFailure::TransientSend
+                }
+            })?;
+
+        if sent != packet.wire_bytes.len() {
+            return Err(crate::dplpmtud::DplpmtudProbeSendFailure::TransientSend);
+        }
+
+        self.update_socket_diagnostics(socket_index, |metrics| metrics.encrypted_packets_sent += 1)
+            .await;
+
+        debug!(
+            "Sent {} DPLPMTUD encrypted bytes to peer {} at {} (dst={})",
+            sent, packet.peer_id, endpoint, packet.dst_ip
+        );
+        Ok(())
+    }
+
     /// Consume encrypted packets until the channel closes.
     pub async fn run_outbound(self, mut encrypted_rx: mpsc::Receiver<EncryptedPeerPacket>) {
         while let Some(packet) = encrypted_rx.recv().await {
@@ -1883,6 +1919,18 @@ impl UdpTransport {
             }
         }
     }
+}
+
+#[cfg(windows)]
+fn is_local_packet_too_large(error: &std::io::Error) -> bool {
+    // WSAEMSGSIZE (10040). Keep this numeric fallback local to the typed
+    // DPLPMTUD boundary so the ordinary UDP error path is unchanged.
+    error.raw_os_error() == Some(10040)
+}
+
+#[cfg(not(windows))]
+fn is_local_packet_too_large(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(libc::EMSGSIZE)
 }
 
 fn nat_maintainer_initial_delay(

--- a/client/netbind/src/lib.rs
+++ b/client/netbind/src/lib.rs
@@ -16,6 +16,28 @@ use std::sync::{Mutex, OnceLock};
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::{TcpSocket, TcpStream, UdpSocket};
 
+/// The no-fragment properties that were actually installed on one UDP
+/// socket.  DPLPMTUD treats a missing property as an unsupported capability;
+/// ordinary UDP traffic remains usable and keeps the platform default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UdpNoFragmentCapabilities {
+    /// IPv4 datagrams use a socket-level DF setting.
+    pub ipv4: bool,
+    /// IPv6 datagrams cannot be source-fragmented by this socket.
+    pub ipv6: bool,
+}
+
+impl UdpNoFragmentCapabilities {
+    /// Return whether the socket is safe for a probe to this destination
+    /// family.
+    pub const fn supports(self, destination: IpAddr) -> bool {
+        match destination {
+            IpAddr::V4(_) => self.ipv4,
+            IpAddr::V6(_) => self.ipv6,
+        }
+    }
+}
+
 /// The kernel route selected for one concrete destination.
 ///
 /// This is deliberately a read-only, destination-scoped result. Callers may
@@ -160,8 +182,358 @@ pub async fn bind_udp(addr: SocketAddr, interface: Option<&str>) -> io::Result<U
     }
     socket.bind(&addr.into())?;
     socket.set_nonblocking(true)?;
+    // Configure the profile once, while the socket constructor still owns
+    // the socket.  The returned Tokio socket is never temporarily toggled
+    // between business sends and probes.
+    configure_udp_no_fragment_socket(&socket, addr.is_ipv4());
     let socket: std::net::UdpSocket = socket.into();
     UdpSocket::from_std(socket)
+}
+
+/// Read the no-fragment profile from a live Tokio UDP socket.
+///
+/// This is intentionally a read-only operation.  It is used at exact Direct
+/// path reconciliation time so DPLPMTUD can fail closed if a platform,
+/// socket family, or socket replacement does not provide the profile that was
+/// configured by the socket owner.
+pub fn udp_no_fragment_capabilities(socket: &UdpSocket) -> UdpNoFragmentCapabilities {
+    let Ok(local_addr) = socket.local_addr() else {
+        return UdpNoFragmentCapabilities::default();
+    };
+    read_udp_no_fragment_socket(socket, local_addr.ip().is_ipv4())
+}
+
+/// Return whether this exact socket can send a no-fragment probe to the
+/// destination family.
+pub fn udp_no_fragment_supported(socket: &UdpSocket, destination: IpAddr) -> bool {
+    udp_no_fragment_capabilities(socket).supports(destination)
+}
+
+fn configure_udp_no_fragment_socket(
+    socket: &Socket,
+    ipv4_socket: bool,
+) -> UdpNoFragmentCapabilities {
+    read_or_configure_udp_no_fragment_socket(socket, ipv4_socket, true)
+}
+
+fn read_udp_no_fragment_socket(socket: &UdpSocket, ipv4_socket: bool) -> UdpNoFragmentCapabilities {
+    read_or_configure_udp_no_fragment_socket(socket, ipv4_socket, false)
+}
+
+fn read_or_configure_udp_no_fragment_socket<S: UdpSocketRaw>(
+    socket: &S,
+    ipv4_socket: bool,
+    configure: bool,
+) -> UdpNoFragmentCapabilities {
+    if ipv4_socket {
+        UdpNoFragmentCapabilities {
+            ipv4: if configure {
+                configure_ipv4_no_fragment(socket)
+            } else {
+                read_ipv4_no_fragment(socket)
+            },
+            ipv6: false,
+        }
+    } else {
+        UdpNoFragmentCapabilities {
+            ipv4: false,
+            ipv6: if configure {
+                configure_ipv6_no_fragment(socket)
+            } else {
+                read_ipv6_no_fragment(socket)
+            },
+        }
+    }
+}
+
+/// The small raw-socket interface keeps the platform implementations below
+/// explicit and makes it impossible for a probe path to mutate an option
+/// through this read-only API.
+#[cfg(unix)]
+trait UdpSocketRaw: std::os::fd::AsRawFd {}
+
+#[cfg(windows)]
+trait UdpSocketRaw: std::os::windows::io::AsRawSocket {}
+
+#[cfg(not(any(unix, windows)))]
+trait UdpSocketRaw {}
+
+impl UdpSocketRaw for Socket {}
+
+impl UdpSocketRaw for UdpSocket {}
+
+#[cfg(unix)]
+fn configure_ipv4_no_fragment<S: UdpSocketRaw>(socket: &S) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        return set_and_verify_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_MTU_DISCOVER,
+            libc::IP_PMTUDISC_PROBE,
+        );
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
+    {
+        return set_and_verify_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_DONTFRAG,
+            1,
+        );
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(not(unix))]
+fn configure_ipv4_no_fragment<S: UdpSocketRaw>(_socket: &S) -> bool {
+    #[cfg(windows)]
+    {
+        return set_and_verify_windows_option(
+            _socket,
+            windows_sys::Win32::Networking::WinSock::IPPROTO_IP,
+            windows_sys::Win32::Networking::WinSock::IP_DONTFRAGMENT,
+            1,
+        );
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(unix)]
+fn read_ipv4_no_fragment<S: UdpSocketRaw>(socket: &S) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        return read_unix_option(socket.as_raw_fd(), libc::IPPROTO_IP, libc::IP_MTU_DISCOVER)
+            == Some(libc::IP_PMTUDISC_PROBE);
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
+    {
+        return read_unix_option(socket.as_raw_fd(), libc::IPPROTO_IP, libc::IP_DONTFRAG)
+            .is_some_and(|value| value != 0);
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(not(unix))]
+fn read_ipv4_no_fragment<S: UdpSocketRaw>(_socket: &S) -> bool {
+    #[cfg(windows)]
+    {
+        return read_windows_option(
+            _socket,
+            windows_sys::Win32::Networking::WinSock::IPPROTO_IP,
+            windows_sys::Win32::Networking::WinSock::IP_DONTFRAGMENT,
+        )
+        .is_some_and(|value| value != 0);
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(unix)]
+fn configure_ipv6_no_fragment<S: UdpSocketRaw>(socket: &S) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let pmtudisc = set_and_verify_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MTU_DISCOVER,
+            libc::IPV6_PMTUDISC_PROBE,
+        );
+        let dontfrag = set_and_verify_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_DONTFRAG,
+            1,
+        );
+        return pmtudisc && dontfrag;
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
+    {
+        return set_and_verify_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_DONTFRAG,
+            1,
+        );
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(not(unix))]
+fn configure_ipv6_no_fragment<S: UdpSocketRaw>(_socket: &S) -> bool {
+    #[cfg(windows)]
+    {
+        return set_and_verify_windows_option(
+            _socket,
+            windows_sys::Win32::Networking::WinSock::IPPROTO_IPV6,
+            windows_sys::Win32::Networking::WinSock::IPV6_DONTFRAG,
+            1,
+        );
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(unix)]
+fn read_ipv6_no_fragment<S: UdpSocketRaw>(socket: &S) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let pmtudisc = read_unix_option(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MTU_DISCOVER,
+        ) == Some(libc::IPV6_PMTUDISC_PROBE);
+        let dontfrag =
+            read_unix_option(socket.as_raw_fd(), libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG)
+                .is_some_and(|value| value != 0);
+        return pmtudisc && dontfrag;
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
+    {
+        return read_unix_option(socket.as_raw_fd(), libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG)
+            .is_some_and(|value| value != 0);
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(not(unix))]
+fn read_ipv6_no_fragment<S: UdpSocketRaw>(_socket: &S) -> bool {
+    #[cfg(windows)]
+    {
+        return read_windows_option(
+            _socket,
+            windows_sys::Win32::Networking::WinSock::IPPROTO_IPV6,
+            windows_sys::Win32::Networking::WinSock::IPV6_DONTFRAG,
+        )
+        .is_some_and(|value| value != 0);
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(unix)]
+fn set_and_verify_unix_option(
+    fd: std::os::fd::RawFd,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: libc::c_int,
+) -> bool {
+    let value_bytes = value.to_ne_bytes();
+    let result = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            option,
+            value_bytes.as_ptr().cast(),
+            value_bytes.len() as libc::socklen_t,
+        )
+    };
+    result == 0 && read_unix_option(fd, level, option) == Some(value)
+}
+
+#[cfg(unix)]
+fn read_unix_option(
+    fd: std::os::fd::RawFd,
+    level: libc::c_int,
+    option: libc::c_int,
+) -> Option<libc::c_int> {
+    let mut value = 0i32;
+    let mut value_len = std::mem::size_of_val(&value) as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            fd,
+            level,
+            option,
+            (&mut value as *mut i32).cast(),
+            &mut value_len,
+        )
+    };
+    (result == 0).then_some(value)
+}
+
+#[cfg(windows)]
+fn set_and_verify_windows_option<S: UdpSocketRaw>(
+    socket: &S,
+    level: i32,
+    option: i32,
+    value: i32,
+) -> bool {
+    use windows_sys::Win32::Networking::WinSock::{setsockopt, WSAGetLastError, SOCKET_ERROR};
+
+    let value_bytes = value.to_ne_bytes();
+    let result = unsafe {
+        setsockopt(
+            socket.as_raw_socket() as _,
+            level,
+            option,
+            value_bytes.as_ptr(),
+            value_bytes.len() as i32,
+        )
+    };
+    if result == SOCKET_ERROR {
+        let _ = unsafe { WSAGetLastError() };
+        return false;
+    }
+    read_windows_option(socket, level, option) == Some(value)
+}
+
+#[cfg(windows)]
+fn read_windows_option<S: UdpSocketRaw>(socket: &S, level: i32, option: i32) -> Option<i32> {
+    use windows_sys::Win32::Networking::WinSock::{getsockopt, SOCKET_ERROR};
+
+    let mut value = 0i32;
+    let mut value_len = std::mem::size_of_val(&value) as i32;
+    let result = unsafe {
+        getsockopt(
+            socket.as_raw_socket() as _,
+            level,
+            option,
+            (&mut value as *mut i32).cast(),
+            &mut value_len,
+        )
+    };
+    (result != SOCKET_ERROR).then_some(value)
 }
 
 /// Connect to a resolved TCP endpoint, optionally pinned to `interface`.
@@ -352,6 +724,49 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn udp_no_fragment_profile_is_installed_once_and_read_back() {
+        let ipv4 = bind_udp("127.0.0.1:0".parse().unwrap(), None)
+            .await
+            .unwrap();
+        let ipv4_profile = udp_no_fragment_capabilities(&ipv4);
+        assert_eq!(ipv4_profile, udp_no_fragment_capabilities(&ipv4));
+
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+            windows
+        ))]
+        assert!(
+            ipv4_profile.ipv4,
+            "IPv4 no-fragment profile was not verified"
+        );
+
+        let ipv6 = bind_udp("[::1]:0".parse().unwrap(), None).await.unwrap();
+        let ipv6_profile = udp_no_fragment_capabilities(&ipv6);
+        assert_eq!(ipv6_profile, udp_no_fragment_capabilities(&ipv6));
+
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "visionos",
+            windows
+        ))]
+        assert!(
+            ipv6_profile.ipv6,
+            "IPv6 no-fragment profile was not verified"
+        );
     }
 
     #[test]

--- a/client/netbind/tests/no_fragment_netns.rs
+++ b/client/netbind/tests/no_fragment_netns.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "linux")]
 
 use std::env;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader};
 use std::net::{IpAddr, SocketAddr};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::Duration;
@@ -132,16 +132,35 @@ fn receiver_helper() {
     socket
         .set_read_timeout(Some(Duration::from_secs(2)))
         .expect("receiver read timeout must be configurable");
-    println!("READY");
-    io::stdout().flush().expect("receiver readiness must flush");
+    write_uncaptured_line("READY");
 
     let mut buffer = [0u8; 65_535];
     match socket.recv_from(&mut buffer) {
         Ok((size, source)) => {
-            println!("RECEIVED size={size} source={source}");
+            panic!("large probe reached receiver: size={size} source={source}");
         }
-        Err(error) if error.kind() == io::ErrorKind::TimedOut => println!("NO_PACKET"),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+            ) => {}
         Err(error) => panic!("receiver failed while waiting for the probe: {error}"),
+    }
+}
+
+fn write_uncaptured_line(line: &str) {
+    let bytes = format!("{line}\n");
+    let mut written = 0;
+    while written < bytes.len() {
+        let result = unsafe {
+            libc::write(
+                libc::STDOUT_FILENO,
+                bytes.as_ptr().add(written).cast(),
+                bytes.len() - written,
+            )
+        };
+        assert!(result > 0, "receiver readiness must be writable");
+        written += result as usize;
     }
 }
 
@@ -160,6 +179,7 @@ fn spawn_receiver(namespace: &str) -> io::Result<Child> {
             "--test-threads=1",
         ])
         .env(RECEIVER_ENV, "1")
+        .env("RUST_TEST_NOCAPTURE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()

--- a/client/netbind/tests/no_fragment_netns.rs
+++ b/client/netbind/tests/no_fragment_netns.rs
@@ -1,10 +1,13 @@
 #![cfg(target_os = "linux")]
 
 use std::env;
-use std::io::{self, BufRead, BufReader};
+use std::fs;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use p2pnet_netbind::{bind_udp, udp_no_fragment_supported};
 
@@ -14,10 +17,19 @@ const RECEIVER_IP: &str = "192.0.2.2";
 const RECEIVER_PORT: u16 = 40_000;
 const LARGE_UDP_DATAGRAM: usize = 1_400;
 const RECEIVER_ENV: &str = "P2WLAN_NETNS_RECEIVER";
+const RECEIVER_READY_PATH_ENV: &str = "P2WLAN_NETNS_RECEIVER_READY_PATH";
 
 struct NetnsGuard {
     namespace: String,
     host_link: String,
+}
+
+struct ReceiverReadyPath(PathBuf);
+
+impl Drop for ReceiverReadyPath {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
 }
 
 impl NetnsGuard {
@@ -132,7 +144,10 @@ fn receiver_helper() {
     socket
         .set_read_timeout(Some(Duration::from_secs(2)))
         .expect("receiver read timeout must be configurable");
-    write_uncaptured_line("READY");
+    let ready_path: PathBuf = env::var_os(RECEIVER_READY_PATH_ENV)
+        .expect("receiver readiness path must be provided")
+        .into();
+    fs::write(ready_path, b"READY\n").expect("receiver readiness must be published");
 
     let mut buffer = [0u8; 65_535];
     match socket.recv_from(&mut buffer) {
@@ -148,23 +163,7 @@ fn receiver_helper() {
     }
 }
 
-fn write_uncaptured_line(line: &str) {
-    let bytes = format!("{line}\n");
-    let mut written = 0;
-    while written < bytes.len() {
-        let result = unsafe {
-            libc::write(
-                libc::STDOUT_FILENO,
-                bytes.as_ptr().add(written).cast(),
-                bytes.len() - written,
-            )
-        };
-        assert!(result > 0, "receiver readiness must be writable");
-        written += result as usize;
-    }
-}
-
-fn spawn_receiver(namespace: &str) -> io::Result<Child> {
+fn spawn_receiver(namespace: &str, ready_path: &Path) -> io::Result<Child> {
     let executable = env::current_exe()?;
     Command::new("ip")
         .args([
@@ -179,10 +178,37 @@ fn spawn_receiver(namespace: &str) -> io::Result<Child> {
             "--test-threads=1",
         ])
         .env(RECEIVER_ENV, "1")
-        .env("RUST_TEST_NOCAPTURE", "1")
-        .stdout(Stdio::piped())
+        .env(RECEIVER_READY_PATH_ENV, ready_path)
+        .stdout(Stdio::null())
         .stderr(Stdio::inherit())
         .spawn()
+}
+
+fn wait_for_receiver_ready(receiver: &mut Child, ready_path: &Path) -> io::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if ready_path.is_file() {
+            let readiness = fs::read_to_string(ready_path)?;
+            if readiness.trim() == "READY" {
+                return Ok(());
+            }
+            return Err(io::Error::other(format!(
+                "receiver readiness marker was {readiness:?}"
+            )));
+        }
+        if let Some(status) = receiver.try_wait()? {
+            return Err(io::Error::other(format!(
+                "receiver exited before announcing readiness: {status}"
+            )));
+        }
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "receiver did not announce readiness",
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]
@@ -194,21 +220,12 @@ fn linux_low_mtu_no_fragment_probe_does_not_fragment() {
     }
 
     let namespace = NetnsGuard::create().expect("low-MTU netns/veth setup must succeed");
-    let mut receiver = spawn_receiver(&namespace.namespace).expect("receiver must spawn");
-    let stdout = receiver
-        .stdout
-        .take()
-        .expect("receiver stdout must be piped");
-    let mut receiver_output = BufReader::new(stdout);
-    let mut line = String::new();
-    assert!(
-        receiver_output
-            .read_line(&mut line)
-            .expect("receiver readiness must be readable")
-            > 0,
-        "receiver exited before announcing readiness"
-    );
-    assert_eq!(line.trim(), "READY");
+    let ready_path = env::temp_dir().join(format!("p2wlan-netns-ready-{}", std::process::id()));
+    let _ready_path = ReceiverReadyPath(ready_path.clone());
+    let mut receiver =
+        spawn_receiver(&namespace.namespace, &ready_path).expect("receiver must spawn");
+    wait_for_receiver_ready(&mut receiver, &ready_path)
+        .expect("receiver must announce readiness through the shared filesystem");
 
     let runtime = tokio::runtime::Runtime::new().expect("Tokio runtime must start");
     let sender = runtime
@@ -229,26 +246,10 @@ fn linux_low_mtu_no_fragment_probe_does_not_fragment() {
     assert_eq!(send_error.raw_os_error(), Some(libc::EMSGSIZE));
     drop(sender);
 
-    let mut received_packet = false;
-    let mut output_line = String::new();
-    while receiver_output
-        .read_line(&mut output_line)
-        .expect("receiver output must be readable")
-        > 0
-    {
-        if output_line.starts_with("RECEIVED ") {
-            received_packet = true;
-        }
-        output_line.clear();
-    }
     let status = receiver.wait().expect("receiver must exit");
     assert!(
         status.success(),
         "receiver helper must complete successfully"
-    );
-    assert!(
-        !received_packet,
-        "large DPLPMTUD probe reached the receiver; fragmentation may have occurred"
     );
     println!(
         "LINUX_NO_FRAGMENT mtu={} udp_datagram={} df=true send_errno=EMSGSIZE receiver_packet=false fragmented_ack=false",

--- a/client/netbind/tests/no_fragment_netns.rs
+++ b/client/netbind/tests/no_fragment_netns.rs
@@ -1,0 +1,237 @@
+#![cfg(target_os = "linux")]
+
+use std::env;
+use std::io::{self, BufRead, BufReader, Write};
+use std::net::{IpAddr, SocketAddr};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+
+use p2pnet_netbind::{bind_udp, udp_no_fragment_supported};
+
+const LOW_MTU: &str = "1200";
+const SENDER_IP: &str = "192.0.2.1";
+const RECEIVER_IP: &str = "192.0.2.2";
+const RECEIVER_PORT: u16 = 40_000;
+const LARGE_UDP_DATAGRAM: usize = 1_400;
+const RECEIVER_ENV: &str = "P2WLAN_NETNS_RECEIVER";
+
+struct NetnsGuard {
+    namespace: String,
+    host_link: String,
+}
+
+impl NetnsGuard {
+    fn create() -> io::Result<Self> {
+        let suffix = std::process::id();
+        let namespace = format!("p2wlan-ns-{suffix}");
+        let host_link = format!("p2wlan-h-{suffix}");
+        let peer_link = format!("p2wlan-p-{suffix}");
+
+        run_ip(&["netns", "add", &namespace])?;
+        let guard = Self {
+            namespace,
+            host_link,
+        };
+        run_ip(&[
+            "link",
+            "add",
+            &guard.host_link,
+            "type",
+            "veth",
+            "peer",
+            "name",
+            &peer_link,
+        ])?;
+        run_ip(&["link", "set", &peer_link, "netns", &guard.namespace])?;
+        run_ip(&[
+            "addr",
+            "add",
+            &format!("{SENDER_IP}/24"),
+            "dev",
+            &guard.host_link,
+        ])?;
+        run_ip(&["link", "set", &guard.host_link, "mtu", LOW_MTU])?;
+        run_ip(&["link", "set", &guard.host_link, "up"])?;
+        run_ip(&[
+            "netns",
+            "exec",
+            &guard.namespace,
+            "ip",
+            "link",
+            "set",
+            &peer_link,
+            "mtu",
+            LOW_MTU,
+        ])?;
+        run_ip(&[
+            "netns",
+            "exec",
+            &guard.namespace,
+            "ip",
+            "addr",
+            "add",
+            &format!("{RECEIVER_IP}/24"),
+            "dev",
+            &peer_link,
+        ])?;
+        run_ip(&[
+            "netns",
+            "exec",
+            &guard.namespace,
+            "ip",
+            "link",
+            "set",
+            &peer_link,
+            "up",
+        ])?;
+        run_ip(&[
+            "netns",
+            "exec",
+            &guard.namespace,
+            "ip",
+            "link",
+            "set",
+            "lo",
+            "up",
+        ])?;
+        Ok(guard)
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        let _ = run_ip(&["netns", "del", &self.namespace]);
+        let _ = run_ip(&["link", "del", &self.host_link]);
+    }
+}
+
+fn run_ip(arguments: &[&str]) -> io::Result<()> {
+    let output = Command::new("ip").args(arguments).output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(io::Error::other(format_command_failure(arguments, &output)))
+}
+
+fn format_command_failure(arguments: &[&str], output: &Output) -> String {
+    format!(
+        "ip {} failed: status={} stdout={} stderr={}",
+        arguments.join(" "),
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn receiver_helper() {
+    let socket = std::net::UdpSocket::bind(SocketAddr::new(
+        RECEIVER_IP.parse().expect("test IPv4 address"),
+        RECEIVER_PORT,
+    ))
+    .expect("receiver must bind inside the low-MTU namespace");
+    socket
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("receiver read timeout must be configurable");
+    println!("READY");
+    io::stdout().flush().expect("receiver readiness must flush");
+
+    let mut buffer = [0u8; 65_535];
+    match socket.recv_from(&mut buffer) {
+        Ok((size, source)) => {
+            println!("RECEIVED size={size} source={source}");
+        }
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => println!("NO_PACKET"),
+        Err(error) => panic!("receiver failed while waiting for the probe: {error}"),
+    }
+}
+
+fn spawn_receiver(namespace: &str) -> io::Result<Child> {
+    let executable = env::current_exe()?;
+    Command::new("ip")
+        .args([
+            "netns",
+            "exec",
+            namespace,
+            executable.to_str().expect("test executable must be UTF-8"),
+            "--exact",
+            "linux_low_mtu_no_fragment_probe_does_not_fragment",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(RECEIVER_ENV, "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+}
+
+#[test]
+#[ignore = "requires Linux CAP_NET_ADMIN and iproute2; run in the required privileged CI job"]
+fn linux_low_mtu_no_fragment_probe_does_not_fragment() {
+    if env::var_os(RECEIVER_ENV).is_some() {
+        receiver_helper();
+        return;
+    }
+
+    let namespace = NetnsGuard::create().expect("low-MTU netns/veth setup must succeed");
+    let mut receiver = spawn_receiver(&namespace.namespace).expect("receiver must spawn");
+    let stdout = receiver
+        .stdout
+        .take()
+        .expect("receiver stdout must be piped");
+    let mut receiver_output = BufReader::new(stdout);
+    let mut line = String::new();
+    assert!(
+        receiver_output
+            .read_line(&mut line)
+            .expect("receiver readiness must be readable")
+            > 0,
+        "receiver exited before announcing readiness"
+    );
+    assert_eq!(line.trim(), "READY");
+
+    let runtime = tokio::runtime::Runtime::new().expect("Tokio runtime must start");
+    let sender = runtime
+        .block_on(bind_udp(
+            SocketAddr::new(SENDER_IP.parse().unwrap(), 0),
+            None,
+        ))
+        .expect("sender must bind on the veth address");
+    assert!(udp_no_fragment_supported(
+        &sender,
+        IpAddr::V4(RECEIVER_IP.parse().unwrap())
+    ));
+    let payload = vec![0xa5; LARGE_UDP_DATAGRAM];
+    let destination = SocketAddr::new(RECEIVER_IP.parse().unwrap(), RECEIVER_PORT);
+    let send_error = runtime
+        .block_on(sender.send_to(&payload, destination))
+        .expect_err("a DF UDP datagram larger than the veth MTU must fail locally");
+    assert_eq!(send_error.raw_os_error(), Some(libc::EMSGSIZE));
+    drop(sender);
+
+    let mut received_packet = false;
+    let mut output_line = String::new();
+    while receiver_output
+        .read_line(&mut output_line)
+        .expect("receiver output must be readable")
+        > 0
+    {
+        if output_line.starts_with("RECEIVED ") {
+            received_packet = true;
+        }
+        output_line.clear();
+    }
+    let status = receiver.wait().expect("receiver must exit");
+    assert!(
+        status.success(),
+        "receiver helper must complete successfully"
+    );
+    assert!(
+        !received_packet,
+        "large DPLPMTUD probe reached the receiver; fragmentation may have occurred"
+    );
+    println!(
+        "LINUX_NO_FRAGMENT mtu={} udp_datagram={} df=true send_errno=EMSGSIZE receiver_packet=false fragmented_ack=false",
+        LOW_MTU, LARGE_UDP_DATAGRAM,
+    );
+}

--- a/docs/dplpmtud-runtime-foundation.md
+++ b/docs/dplpmtud-runtime-foundation.md
@@ -3,7 +3,7 @@
 ## 1. Scope and baseline
 
 This document records the Phase 2A implementation on top of
-`a7f2e71281fb40917dc89249377df384878f0fe7`. The phase adds a bounded,
+`96ac640122ec1a10110f55c9b2484a3ed3f4e628`. The phase adds a bounded,
 authenticated Datagram Packetization Layer Path MTU Discovery (DPLPMTUD)
 control loop for an already committed Direct UDP path.
 
@@ -23,7 +23,9 @@ This phase deliberately does **not**:
 
 The only output intended for the next phase is the read-only confirmed UDP
 size and derived overlay payload budget attached to the exact current Direct
-path identity.
+path identity. A conservative BASE value is an assumption only; no confirmed
+value or business-usable budget exists until a matching 1200-byte BASE Probe
+has been sent and positively ACKed.
 
 ## 2. Audited current data path
 
@@ -103,6 +105,34 @@ ceilings preserve an Ethernet-sized 1500-byte outer packet:
 The code does not infer outer-family overhead from a virtual/inner IPv4 packet.
 It binds the DPLPMTUD identity and wire token to the real Direct endpoint's
 outer IP family.
+
+### 2.4 No-fragment Probe contract and socket ownership
+
+DPLPMTUD never relies on an operating-system default and never toggles a
+shared socket option around one send. `p2pnet-netbind::bind_udp` configures and
+reads back the profile once while the socket constructor owns the socket. The
+returned socket, including every pool and fresh-punch socket, retains that
+profile for its lifetime. At exact Direct reconciliation,
+`udp_no_fragment_supported` performs a read-only check on the exact socket and
+remote IP family. A failed or unverifiable check makes that path
+`Unsupported`; it cannot produce a confirmed result. Ordinary business sends
+do not change size or call the DPLPMTUD budget accessor.
+
+The platform strategies are:
+
+| Platform | IPv4 | IPv6 | Owner and verification |
+| --- | --- | --- | --- |
+| Linux | `IP_MTU_DISCOVER=IP_PMTUDISC_PROBE` (DF) | `IPV6_MTU_DISCOVER=IPV6_PMTUDISC_PROBE` plus `IPV6_DONTFRAG=1` | UDP socket constructor sets and gets both options |
+| Android | `IP_MTU_DISCOVER=IP_PMTUDISC_PROBE` (DF) | `IPV6_MTU_DISCOVER=IPV6_PMTUDISC_PROBE` plus `IPV6_DONTFRAG=1` | protected UDP socket constructor sets and gets both options |
+| macOS | `IP_DONTFRAG=1` | `IPV6_DONTFRAG=1` | UDP socket constructor sets and gets the family option |
+| Windows | `IP_DONTFRAGMENT=1` | `IPV6_DONTFRAG=1` | Winsock UDP socket constructor sets and gets the family option |
+
+The shared publication socket is therefore permanently no-fragment capable
+or DPLPMTUD is disabled for that exact path. There is no temporary option
+mutation and no race with ordinary datagrams. The real IP-layer proof is the
+Linux low-MTU netns/veth test in
+`client/netbind/tests/no_fragment_netns.rs`; the userspace blackhole remains a
+convergence test only and is not DF evidence.
 
 ## 3. Capability compatibility
 
@@ -188,11 +218,12 @@ cookie, complete path epoch, Direct-validation owner/request, candidate size,
 and outer family prevent two probes or two path incarnations from being
 confused.
 
-For a Probe, padding is placed between the prefix and token. The builder solves
+For a Probe, padding is placed after the token. The builder solves
 for the exact plaintext size so that after WireGuard's 32-byte overhead the
 actual `send_to` datagram length is exactly `candidate_udp_datagram_size`.
-The parser locates the fixed token at the end and accepts the variable padding
-only after a complete authenticated packet was received.
+The parser reads the fixed token immediately after the prefix and accepts the
+zero-filled variable padding only after a complete authenticated packet was
+received.
 
 The ACK contains the ACK prefix and the exact mirrored token without probe
 padding. It therefore cannot amplify the request.
@@ -215,21 +246,28 @@ State summary:
 ```text
 Direct committed + unsupported capability -> Unsupported
 Direct committed + supported capability   -> Base
-Base + StartSearch                         -> Searching
+Base + StartSearch                         -> Searching (first candidate is BASE=1200)
+BASE + matching ACK                        -> Searching or SearchComplete
+BASE + exhausted timeout/send failures    -> Error (no confirmed budget)
 Searching + matching ACK                  -> Searching or SearchComplete
 Searching + exhausted timeout             -> narrower Searching or SearchComplete
+SearchComplete + current-PLPMTU timer      -> Searching (re-probe current confirmed size)
+current confirmation failure               -> safe BASE + upward Searching
+EMSGSIZE                                    -> shrink upper bound, keep searching
+transient/lock/session failure              -> bounded retry or Error
 SearchComplete + raise timer               -> Searching or renewed SearchComplete
-send failure                               -> Error
-Error + retry timer                        -> Searching or SearchComplete
+Error + retry timer                        -> Base (retry BASE) or upward Searching
 identity/lifecycle cancellation            -> Disabled
 new identity                               -> new Base or Unsupported machine
 ```
 
 The machine records the exact identity, conservative base, confirmed lower
 bound, search upper bound, pending candidate, at most one outstanding probe,
-sequence/nonce/path cookie, deadline, retry, fixed granularity, raise deadline,
-last success/timeout/failure, reset reason/count, revision, and diagnostic
-counters.
+sequence/nonce/path cookie, deadline, retry, fixed granularity, current-PLPMTU
+confirmation deadline, raise deadline, last success/timeout/failure, reset
+reason/count, revision, and diagnostic counters. `base_confirmed=false` and
+`confirmed_udp_datagram_size=None` are the initial state even though the
+assumed base is 1200.
 
 Reducer state changes and network side effects are separate. `reduce` produces
 a transition; `commit` applies only accepted state changes. Duplicate ACKs are
@@ -244,7 +282,15 @@ current phase has a conservative base and fixed internal ceiling, and because
 the required result is a bounded safe datagram size rather than continuous
 congestion adaptation.
 
-For confirmed lower bound `L`, upper bound `U`, and granularity `G=8`:
+The first search is a positive BASE phase. For every supported path the first
+candidate is exactly 1200. Only its matching authenticated ACK sets
+`base_confirmed=true` and creates a confirmed lower bound. If BASE exhausts
+its retries, the machine enters `Error`, clears the pending candidate, and
+exposes no confirmed or overlay budget. The retry timer schedules BASE again;
+it does not jump directly to the full ceiling.
+
+After BASE confirmation, for confirmed lower bound `L`, upper bound `U`, and
+granularity `G=8`:
 
 1. choose an aligned midpoint strictly greater than `L` and no greater than
    `U`;
@@ -274,9 +320,23 @@ A timeout narrows only this search interval. The DPLPMTUD API has no operation
 that records Direct failure, degrades Direct, selects Relay, or ends an already
 confirmed Direct path.
 
-After SearchComplete, a ten-minute raise timer reopens the upper interval to
-the family ceiling. A send failure enters Error with a five-second retry timer.
-Every worker also has a one-hour intrinsic hard lifetime.
+After SearchComplete, a current-PLPMTU confirmation timer re-probes the
+currently confirmed size. A successful confirmation re-arms that timer. After
+three consecutive confirmation failures, the result is conservatively reduced
+to the positively validated BASE (or to Error with no budget if BASE itself is
+not validated), the upper bound is shrunk, and upward search resumes without
+changing endpoint, generation, candidate epoch, or socket identity. A
+ten-minute raise timer independently reopens the upper interval to the family
+ceiling after a completed search.
+
+The send boundary classifies `TransientSend`, `EmitLockUnavailable`,
+`SessionUnavailable`, and `LocalPacketTooLarge` separately. The first three
+are bounded local retries/errors and never narrow the path from an assumed
+network fact. `LocalPacketTooLarge` (`EMSGSIZE`) immediately shrinks the upper
+bound to below the rejected candidate (or enters BASE Error if BASE was never
+validated); it never enters Error and then reopens the full ceiling to repeat
+the same local oversize. Every worker also has a one-hour intrinsic hard
+lifetime.
 
 ## 8. Timer and task ownership
 
@@ -317,10 +377,20 @@ WireGuard per-peer emit lock
 short session lock / encrypt
 exact-path + owner + expectation recheck and `ProbeSent` linearization
 (`begin_probe_send`)
-UDP handoff on the bound socket
+UDP handoff on the bound socket whose constructor owns the permanent
+no-fragment profile
 release emit lock
 short DPLPMTUD registry transaction: finish send outcome
 ```
+
+Probe planning is a short registry transaction that completes before the
+worker waits for the per-peer emit lock. During the actual handoff the order
+is per-peer emit lock -> short session/encrypt operation -> exact-path/owner
+recheck -> DPLPMTUD registry `begin_probe_send` linearization -> socket
+handoff -> DPLPMTUD registry `finish_probe_send` outcome. No registry lock is
+held while awaiting the emit lock or socket I/O, and no socket-option lock is
+acquired by the worker: the socket owner configured the options before
+publication and the worker only reads the capability during reconciliation.
 
 The `begin_probe_send` recheck includes the worker owner, exact identity,
 outstanding identity, no concurrent send, and a live deadline. Cancellation or
@@ -420,15 +490,23 @@ Events carry the available peer, path epoch, endpoints, socket publication,
 sequence, candidate datagram size, bounds, and reason/decision details.
 
 Peer diagnostics and status expose a read-only `DplpmtudSnapshot` containing:
-state, capability support, path identity summary, base/confirmed/upper UDP
-sizes, derived outer packet size and overlay budget, outstanding probe,
-relative success/timeout/failure ages, reset reason/count, revision, probe and
-result counters, stale/duplicate counters, and whether the owner worker is
-live.
+state, capability support, exact path identity summary, assumed base,
+`base_confirmed`, optional confirmed/upper UDP sizes, derived outer packet size
+and overlay budget, current-PLPMTU timer, outstanding probe, relative
+success/timeout/failure ages, reset reason/count, revision, probe and result
+counters, each send-failure class, stale/duplicate counters, and whether the
+owner worker is live.
 
 Snapshots are copied into a separate read-optimized map after state commits.
 Status reads do not take or hold the mutable DPLPMTUD registry lock and cannot
-block a worker.
+block a worker. A business consumer must use the O(1)
+`confirmed_budget_for_path(exact_identity)` accessor: it performs one per-peer
+registry lookup followed by a complete identity comparison and returns the
+confirmed UDP, outer-packet, and overlay budgets. It returns `None` before
+positive BASE confirmation or after identity mismatch. Control/timeline code
+may use the one-peer `snapshot_for_peer` or exact-path `snapshot_for_path`; the
+business hot path must not call
+`snapshots()`, which clones the full peer table.
 
 ## 13. Verification strategy
 
@@ -439,7 +517,7 @@ dimension, deadline rejection, owner-token ABA, path replacement, bounded
 containers/rate limiting, PeerLeft/shutdown cleanup, additive capability
 compatibility, exact datagram padding, and IPv4/IPv6 separation.
 
-The deterministic Linux blackhole test runs the real chain:
+The deterministic userspace blackhole test runs the real chain:
 
 ```text
 scheduler/runtime plan
@@ -455,31 +533,46 @@ scheduler/runtime plan
 
 Datagrams at or below 1397 bytes are delivered; larger datagrams are silently
 sent to a sink and timed out. The test observes actual encrypted UDP lengths,
-requires a success below and failure above the threshold, bounds the result to
-one 8-byte step, verifies duplicate no-op behavior, switches generation while
-an authenticated ACK is in flight, performs PeerLeft with an outstanding probe
+requires a positive BASE success, requires a success below and failure above
+the threshold, bounds the result to one 8-byte step, then lowers the same
+userspace threshold to 1280 without changing endpoint, generation, candidate
+epoch, or socket identity. The current-PLPMTU confirmation fails, the result
+falls to safe BASE, and upward search reconverges to no more than 1280. The
+test verifies duplicate no-op behavior, switches generation while an
+authenticated ACK is in flight, performs PeerLeft with an outstanding probe
 before send linearization, asserts Direct remains active with zero Direct
 health failures and zero Relay fallbacks, and returns worker ownership to the
 baseline without sleeps.
 
-The required workflow repeats that same blackhole test five times on the exact
-PR Head SHA and prints threshold, confirmed/upper bounds, probe/timeout counts,
-Direct/fallback sentinels, stale/duplicate counts, generation/PeerLeft results,
-and task-leak status.
+The separate ignored Linux netns/veth test sets both ends to MTU 1200 and
+sends a 1400-byte UDP datagram with the configured DF profile. It requires
+local `EMSGSIZE`, no receiver packet, and no fragmented ACK. This is the
+IP-layer no-fragment evidence; the userspace blackhole cannot provide it.
+
+The required workflow runs five distinct acceptance categories on the exact
+same PR Head SHA: encrypted blackhole convergence, BASE confirmation,
+same-identity downward recovery, no-fragment plus local EMSGSIZE, and
+worker/task-leak cleanup. Each category prints Direct-active,
+Direct-health-failure, Relay-fallback, old-ACK-contamination, and task-leak
+sentinels. The no-fragment category additionally runs the privileged Linux
+netns/veth test.
 
 ## 14. Phase boundary and next-step API
 
 Phase 2A exposes only a read-only snapshot of:
 
 ```text
-confirmed_udp_datagram_size
-overlay_payload_budget
+assumed_base_udp_datagram_size
+base_confirmed
+optional confirmed_udp_datagram_size
+optional overlay_payload_budget
 outer_ip_family
 exact path identity
 ```
 
 No normal packet producer consumes those values in this phase. A later phase
-may define a single, generation-bound API for business-packet sizing or
-fragmentation policy. That consumer must revalidate the same exact path
-identity and must not treat a DPLPMTUD timeout as path health or path-selection
-evidence.
+may use `confirmed_budget_for_path` as its single, generation-bound
+read-only input for business-packet sizing or fragmentation policy. That
+consumer must revalidate the same exact path identity and must not treat a
+DPLPMTUD timeout as path health or path-selection evidence. This PR does not
+change ordinary business packet sizes.

--- a/docs/dplpmtud-runtime-foundation.md
+++ b/docs/dplpmtud-runtime-foundation.md
@@ -253,6 +253,8 @@ Searching + matching ACK                  -> Searching or SearchComplete
 Searching + exhausted timeout             -> narrower Searching or SearchComplete
 SearchComplete + current-PLPMTU timer      -> Searching (re-probe current confirmed size)
 current confirmation failure               -> Base (fresh BASE confirmation required)
+re-confirmed BASE + matching ACK            -> Searching (confirmed=1200 restored)
+re-confirmed BASE + exhausted failures      -> Error (no confirmed budget)
 EMSGSIZE                                    -> shrink upper bound, keep searching
 transient/lock/session failure              -> bounded retry or Error
 SearchComplete + raise timer               -> Searching or renewed SearchComplete
@@ -327,9 +329,12 @@ revoked: `base_confirmed=false`, `confirmed_udp_datagram_size=None`, and
 `pending_candidate_udp_datagram_size=BASE` in state `Base`. The upper bound is
 shrunk using the failed candidate, but upward search cannot resume until a new
 BASE probe is positively ACKed. If that BASE phase exhausts its retries, the
-machine enters `Error` with no budget. Endpoint, generation, candidate epoch,
-and socket identity remain unchanged. A ten-minute raise timer independently
-reopens the upper interval to the family ceiling after a completed search.
+machine enters `Error` with no budget. The exact-path accessor returns `None`
+for the entire BASE re-confirmation interval and throughout the resulting
+below-BASE `Error`. Endpoint, generation, candidate epoch, and socket identity
+remain unchanged, and this state transition has no Direct-health or path-
+selection side effect. A ten-minute raise timer independently reopens the upper
+interval to the family ceiling after a completed search.
 
 The send boundary classifies `TransientSend`, `EmitLockUnavailable`,
 `SessionUnavailable`, and `LocalPacketTooLarge` separately. The first three
@@ -447,6 +452,10 @@ pending probes plus the current-confirmation timer, and preserves a reason in
 the read-only snapshot. A stale worker may still reach its exit path, but
 owner-token comparison prevents it from erasing the replacement. A cancelled
 worker cannot pass `begin_probe_send` and cannot publish an old retry kick.
+Consequently `cancel_peer`, network-generation cancellation, Relay activation,
+UDP-runtime close, and exact-identity replacement all revoke the old business
+budget immediately. Neither an old identity nor an old worker can read a budget
+published by the replacement.
 
 ## 11. Stale and duplicate handling
 
@@ -500,17 +509,29 @@ success/timeout/failure ages, reset reason/count, revision, probe and result
 counters, each send-failure class, stale/duplicate counters, and whether the
 owner worker is live.
 
+The snapshot also publishes a distinct optional `budget_revision`; a confirmed
+`DplpmtudConfirmedBudget` always carries that revision as a `u64`. It is
+allocated monotonically across the process and changes when the business value
+moves from `None` to `Some`, its confirmed UDP size changes, it moves from
+`Some` to `None`, or the complete exact path identity is replaced. A fresh UDP
+runtime therefore cannot reuse a prior runtime's revision, closing the
+identity-replacement ABA case. Duplicate and stale ACK diagnostics do not
+change this revision. Reducer `revision` remains an independent diagnostics
+sequence and may change for a stale-ACK counter even while `budget_revision`
+does not. Allocator exhaustion fails closed by withholding the business budget.
+
 Snapshots are copied into a separate read-optimized map after state commits.
 Status reads do not take or hold the mutable DPLPMTUD registry lock and cannot
 block a worker. A business consumer must use the O(1)
 `confirmed_budget_for_path(exact_identity)` accessor: it performs one per-peer
 registry lookup followed by a complete identity comparison and returns the
-confirmed UDP, outer-packet, and overlay budgets. It returns `None` when the
-runtime is closed, the identity is not the exact current path, the state is
-`Disabled`/`Unsupported`, support is not negotiated, BASE is not positively
-confirmed, or the confirmed value is absent. Control/timeline code may use the
-one-peer `snapshot_for_peer` or exact-path `snapshot_for_path`; the business
-hot path must not call `snapshots()`, which clones the full peer table.
+confirmed UDP, outer-packet, and overlay budgets plus `budget_revision`. It
+returns `None` when the runtime is closed, the identity is not the exact current
+path, the state is `Disabled`/`Unsupported`, support is not negotiated, BASE is
+not positively confirmed, the confirmed value is absent, or a revision cannot
+be allocated. Control/timeline code may use the one-peer `snapshot_for_peer` or
+exact-path `snapshot_for_path`; the business hot path must not call
+`snapshots()`, which clones the full peer table.
 
 ## 13. Verification strategy
 
@@ -554,13 +575,14 @@ sends a 1400-byte UDP datagram with the configured DF profile. It requires
 local `EMSGSIZE`, no receiver packet, and no fragmented ACK. This is the
 IP-layer no-fragment evidence; the userspace blackhole cannot provide it.
 
-The required workflow runs five distinct acceptance categories on the exact
-same PR Head SHA: encrypted blackhole convergence, BASE confirmation,
-same-identity downward recovery, no-fragment plus local EMSGSIZE, and
-worker/task-leak cleanup. Each category prints Direct-active,
-Direct-health-failure, Relay-fallback, old-ACK-contamination, and task-leak
-sentinels. The no-fragment category additionally runs the privileged Linux
-netns/veth test.
+The required workflow runs eight distinct acceptance categories on the exact
+same PR Head SHA: encrypted blackhole convergence, BASE positive confirmation,
+1392-to-1280 same-identity downward recovery, 1392-to-1100 below-BASE failure,
+cancel/close budget invalidation, budget-revision/identity ABA, no-fragment plus
+local EMSGSIZE, and worker/task-leak cleanup. Each category prints or directly
+asserts Direct-active, Direct-health-failure, Relay-fallback,
+old-ACK-contamination, and task-leak evidence. The no-fragment category
+additionally runs the privileged Linux netns/veth test.
 
 ## 14. Phase boundary and next-step API
 
@@ -571,6 +593,7 @@ assumed_base_udp_datagram_size
 base_confirmed
 optional confirmed_udp_datagram_size
 optional overlay_payload_budget
+budget_revision
 outer_ip_family
 exact path identity
 ```

--- a/docs/dplpmtud-runtime-foundation.md
+++ b/docs/dplpmtud-runtime-foundation.md
@@ -252,7 +252,7 @@ BASE + exhausted timeout/send failures    -> Error (no confirmed budget)
 Searching + matching ACK                  -> Searching or SearchComplete
 Searching + exhausted timeout             -> narrower Searching or SearchComplete
 SearchComplete + current-PLPMTU timer      -> Searching (re-probe current confirmed size)
-current confirmation failure               -> safe BASE + upward Searching
+current confirmation failure               -> Base (fresh BASE confirmation required)
 EMSGSIZE                                    -> shrink upper bound, keep searching
 transient/lock/session failure              -> bounded retry or Error
 SearchComplete + raise timer               -> Searching or renewed SearchComplete
@@ -322,12 +322,14 @@ confirmed Direct path.
 
 After SearchComplete, a current-PLPMTU confirmation timer re-probes the
 currently confirmed size. A successful confirmation re-arms that timer. After
-three consecutive confirmation failures, the result is conservatively reduced
-to the positively validated BASE (or to Error with no budget if BASE itself is
-not validated), the upper bound is shrunk, and upward search resumes without
-changing endpoint, generation, candidate epoch, or socket identity. A
-ten-minute raise timer independently reopens the upper interval to the family
-ceiling after a completed search.
+three consecutive confirmation failures, the historical confirmed value is
+revoked: `base_confirmed=false`, `confirmed_udp_datagram_size=None`, and
+`pending_candidate_udp_datagram_size=BASE` in state `Base`. The upper bound is
+shrunk using the failed candidate, but upward search cannot resume until a new
+BASE probe is positively ACKed. If that BASE phase exhausts its retries, the
+machine enters `Error` with no budget. Endpoint, generation, candidate epoch,
+and socket identity remain unchanged. A ten-minute raise timer independently
+reopens the upper interval to the family ceiling after a completed search.
 
 The send boundary classifies `TransientSend`, `EmitLockUnavailable`,
 `SessionUnavailable`, and `LocalPacketTooLarge` separately. The first three
@@ -439,11 +441,12 @@ The current entry is cancelled/reset for, among other reasons:
 A repeated notification for the same exact identity is idempotent: it does not
 reset state, create a second worker, or schedule a second outstanding probe.
 
-Cancellation sets the watch, disables the machine, clears outstanding work,
-and preserves a reason in the read-only snapshot. A stale worker may still
-reach its exit path, but owner-token comparison prevents it from erasing the
-replacement. A cancelled worker cannot pass `begin_probe_send` and cannot
-publish an old retry kick.
+Cancellation sets the watch, disables the machine, immediately revokes
+`base_confirmed` and `confirmed_udp_datagram_size`, clears outstanding and
+pending probes plus the current-confirmation timer, and preserves a reason in
+the read-only snapshot. A stale worker may still reach its exit path, but
+owner-token comparison prevents it from erasing the replacement. A cancelled
+worker cannot pass `begin_probe_send` and cannot publish an old retry kick.
 
 ## 11. Stale and duplicate handling
 
@@ -502,11 +505,12 @@ Status reads do not take or hold the mutable DPLPMTUD registry lock and cannot
 block a worker. A business consumer must use the O(1)
 `confirmed_budget_for_path(exact_identity)` accessor: it performs one per-peer
 registry lookup followed by a complete identity comparison and returns the
-confirmed UDP, outer-packet, and overlay budgets. It returns `None` before
-positive BASE confirmation or after identity mismatch. Control/timeline code
-may use the one-peer `snapshot_for_peer` or exact-path `snapshot_for_path`; the
-business hot path must not call
-`snapshots()`, which clones the full peer table.
+confirmed UDP, outer-packet, and overlay budgets. It returns `None` when the
+runtime is closed, the identity is not the exact current path, the state is
+`Disabled`/`Unsupported`, support is not negotiated, BASE is not positively
+confirmed, or the confirmed value is absent. Control/timeline code may use the
+one-peer `snapshot_for_peer` or exact-path `snapshot_for_path`; the business
+hot path must not call `snapshots()`, which clones the full peer table.
 
 ## 13. Verification strategy
 
@@ -537,8 +541,9 @@ requires a positive BASE success, requires a success below and failure above
 the threshold, bounds the result to one 8-byte step, then lowers the same
 userspace threshold to 1280 without changing endpoint, generation, candidate
 epoch, or socket identity. The current-PLPMTU confirmation fails, the result
-falls to safe BASE, and upward search reconverges to no more than 1280. The
-test verifies duplicate no-op behavior, switches generation while an
+enters `Base` without a confirmed value, positively re-confirms BASE, and
+upward search reconverges to no more than 1280. The test verifies duplicate
+no-op behavior, switches generation while an
 authenticated ACK is in flight, performs PeerLeft with an outstanding probe
 before send linearization, asserts Direct remains active with zero Direct
 health failures and zero Relay fallbacks, and returns worker ownership to the


### PR DESCRIPTION
## Scope and final Head

- Base: `96ac640122ec1a10110f55c9b2484a3ed3f4e628`
- Final validation Head: `e3e33718360f499848ec8c2772603e254a654b84`
- Branch: `fix/dplpmtud-acceptance-20260830`

This PR is limited to the Phase 2A DPLPMTUD acceptance gaps. It does not change ordinary business-packet sizing, TUN MTU, fragmentation/reassembly, ICMP PTB generation, Direct/Relay selection or health behavior, versions, tags, releases, or signatures.

## No-fragment Probe policy and ownership

`p2pnet-netbind::bind_udp` installs the no-fragment profile once while the UDP socket constructor exclusively owns the socket, verifies it with `getsockopt`, and only then publishes the socket. The primary, pool, and fresh-punch sockets retain that profile for their lifetime. The worker never toggles a shared socket option and never races an ordinary send. Exact Direct reconciliation performs a read-only capability check against the selected socket and destination family; unavailable or unverifiable support makes the path `Unsupported`, so it cannot publish a confirmed result.

| Platform | IPv4 | IPv6 | Actual owner |
| --- | --- | --- | --- |
| Linux | `IP_MTU_DISCOVER=IP_PMTUDISC_PROBE` (DF) | `IPV6_MTU_DISCOVER=IPV6_PMTUDISC_PROBE` + `IPV6_DONTFRAG=1` | netbind UDP constructor |
| Android | `IP_MTU_DISCOVER=IP_PMTUDISC_PROBE` (DF) | `IPV6_MTU_DISCOVER=IPV6_PMTUDISC_PROBE` + `IPV6_DONTFRAG=1` | protected UDP constructor; `VpnService.protect(fd)` remains before bind |
| macOS | `IP_DONTFRAG=1` | `IPV6_DONTFRAG=1` | netbind UDP constructor |
| Windows | `IP_DONTFRAGMENT=1` | `IPV6_DONTFRAG=1` | Winsock UDP constructor |

Send lock order remains:

```text
short DPLPMTUD registry transaction -> release registry
-> per-peer WireGuard emit-order lock
-> session/encrypt
-> exact path + worker + expectation recheck / ProbeSent linearization
-> permanently configured UDP socket handoff
-> short result transaction
```

The Linux privileged low-MTU netns/veth proof sends a 1400-byte UDP datagram over MTU 1200 and requires local `EMSGSIZE`, no receiver packet, and no fragmented ACK. The encrypted userspace blackhole remains convergence evidence only, not DF evidence.

## BASE and downward-recovery transitions

A supported exact Direct path starts with an assumed 1200-byte BASE, but `base_confirmed=false`, `confirmed_udp_datagram_size=None`, and no business budget. The first Probe is exactly 1200; only its matching authenticated ACK establishes `confirmed=1200`.

```text
Base [assumed=1200, base_confirmed=false, confirmed=None]
  -> matching BASE ACK
Searching -> SearchComplete [confirmed=1392, confirmation timer armed]
  -> current 1392 confirmation fails three times
Base [same exact identity, base_confirmed=false, confirmed=None, pending=1200]
  -> matching fresh BASE ACK
Searching [confirmed=1200, prior shrunken upper retained]
  -> SearchComplete [confirmed <= 1280]

Base [same exact identity, confirmed=None, pending=1200]
  -> 1200 BASE fails three times
Error [base_confirmed=false, confirmed=None, accessor=None]
```

During re-confirmation the endpoint, network generation, peer-session generation, candidate epoch, Direct-validation owner/request, and socket identity remain unchanged. DPLPMTUD does not record Direct failure or select Relay.

Local `EMSGSIZE` remains distinct from transient send, emit-lock unavailable, and session unavailable. It shrinks the upper bound below the rejected candidate instead of entering Error and reopening the full ceiling.

## Immediate budget invalidation

`Cancelled` atomically clears:

- `base_confirmed`
- `confirmed_udp_datagram_size`
- outstanding and pending Probe state
- current-PLPMTU pending state/timer
- raise timer

The O(1) `confirmed_budget_for_path(exact_identity)` accessor does one peer lookup and a complete identity comparison; it never clones `snapshots()`. It returns `None` when the runtime is closed, exact identity mismatches, state is `Disabled`/`Unsupported`, `supported=false`, BASE is not positively confirmed, the confirmed size is absent, or a revision cannot be allocated.

Tests cover immediate invalidation after `cancel_peer`, network-generation cancellation, runtime close, a real Path State Machine transition to Relay followed by production DPLPMTUD reconciliation, and old-identity reads before and after a replacement path confirms.

## Independent business budget revision

`DplpmtudConfirmedBudget` now includes `budget_revision: u64`. The runtime uses a process-wide monotonic allocator so replacing an exact path or the complete UDP runtime cannot reuse an older publication revision.

The business revision changes on:

- `None -> Some`
- confirmed UDP size change
- `Some -> None`
- complete exact-path identity replacement, including a replacement whose budget is still `None`

Duplicate and stale ACKs do not change it. Reducer `revision` remains a separate diagnostics sequence; a stale-ACK counter may advance diagnostics while the business revision stays stable. Revision-allocation exhaustion fails closed. The ABA test covers cancellation/reactivation, two exact-identity replacements, and a new runtime.

## Added and expanded tests

- `cancelled_clears_confirmed_budget_and_all_probe_state`
- `confirmed_budget_accessor_is_exact_identity_and_none_before_base_ack`
- `cancel_peer_revokes_confirmed_budget_immediately`
- `network_generation_cancel_revokes_confirmed_budget`
- `runtime_close_revokes_confirmed_budget`
- `relay_activation_revokes_old_direct_budget`
- `old_path_identity_never_reads_replacement_path_budget`
- `runtime_downward_recovery_withholds_budget_until_fresh_base_ack`
- `same_identity_below_base_failure_enters_error_without_budget`
- `cancel_close_generation_and_relay_budget_invalidation_acceptance`
- `budget_revision_is_monotonic_and_closes_identity_aba`

Existing fixed wire-format vector, encrypted blackhole, local EMSGSIZE, no-fragment netns/veth, and worker-leak tests remain enabled.

## Verification

On final Head `e3e33718360f499848ec8c2772603e254a654b84`, local verification passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- 34/34 DPLPMTUD tests
- eight sequential clean-tree, exact-Head categories: encrypted blackhole; BASE positive confirmation; 1392→1280 recovery; 1392→1100 below-BASE failure; cancel/close invalidation; revision/ABA; local EMSGSIZE/no-fragment platform check; worker/task leak

The macOS run does not claim netns evidence; the privileged Linux test runs in the exact-Head DPLPMTUD Action.

Final-Head Actions (all completed successfully on this exact Head):

| Gate | Run |
| --- | --- |
| DPLPMTUD Required | ✅ [run 33317839081](https://github.com/yhan-sun/p2wlan/actions/runs/33317839081) |
| Path State Machine Required | ✅ [run 33317839101](https://github.com/yhan-sun/p2wlan/actions/runs/33317839101) |
| NAT Topology Required | ✅ [run 33317839102](https://github.com/yhan-sun/p2wlan/actions/runs/33317839102) |
| Windows Lifecycle Required | ✅ [run 33317839084](https://github.com/yhan-sun/p2wlan/actions/runs/33317839084) |
| Mobile Lifecycle Required | ✅ [run 33317839082](https://github.com/yhan-sun/p2wlan/actions/runs/33317839082) |
| CI | ✅ [run 33317839105](https://github.com/yhan-sun/p2wlan/actions/runs/33317839105) |
| Flutter Client | ✅ [run 33317839085](https://github.com/yhan-sun/p2wlan/actions/runs/33317839085) |
| Package Test Builds | ✅ [run 33317839100](https://github.com/yhan-sun/p2wlan/actions/runs/33317839100) |

Path State Machine attempt 1 hit the pre-existing flaky `hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session`; its failed Rust job passed on attempt 2 without a code change. DPLPMTUD attempt 2 reran only the aggregate jobs that had observed the first Path result.

This PR must remain OPEN for manual acceptance. Do not merge it as part of this work.