### PR TITLE
fix: keep Relay first-packet lifecycle nonblocking

### DIFF
--- a/.github/workflows/nat-topology-gate.yml
+++ b/.github/workflows/nat-topology-gate.yml
@@ -90,14 +90,29 @@ jobs:
           retention-days: 14
 
   relay:
-    name: Relay blackhole topology
+    name: Relay blackhole topology ${{ matrix.run }}/5
     needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        run: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Pull-request checkout otherwise uses the synthetic merge ref. Each
+          # independent Relay run must execute the exact same PR Head tree.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify exact Relay topology Head
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          actual_head_sha="$(git rev-parse HEAD)"
+          test "$actual_head_sha" = "$EXPECTED_HEAD_SHA"
+          echo "relay_topology_head_sha=$actual_head_sha replica=${{ matrix.run }}/5"
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
@@ -107,12 +122,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
       - name: Run deterministic Relay topology
+        env:
+          NAT_TOPOLOGY_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          NAT_TOPOLOGY_REPLICA: ${{ matrix.run }}
         run: bash scripts/nat-sim/run-ci-topology.sh relay
       - name: Upload Relay evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.run }}-of-5
           path: |
             ${{ runner.temp }}/p2wlan-nat-topology-*.log
             ${{ runner.temp }}/p2wlan-nat-topology-*/**

--- a/client/daemon/src/diagnostics/snapshot.rs
+++ b/client/daemon/src/diagnostics/snapshot.rs
@@ -71,7 +71,7 @@ async fn build_snapshot(context: DiagnosticsContext) -> DiagnosticsSnapshot {
         revision: stable_peers.capture_revision,
         captured_revision: stable_peers.capture_revision,
         captured_at_ms: stable_peers.captured_at_ms,
-        peer_snapshot_stale: false,
+        peer_snapshot_stale: stable_peers.stale,
         peer_snapshot_age_ms,
         peer_snapshot_shape: stable_peers.shape,
         ready_phase: derive_ready_phase(
@@ -120,27 +120,41 @@ struct StablePeerSnapshot {
     captured_at_ms: u64,
     captured_at: std::time::Instant,
     shape: String,
+    stale: bool,
 }
 
-/// Build a peer array without using PeerManager's best-effort full-diagnostics
-/// cache. Each peer-scoped read is live-only (`try_read` returns None under
-/// contention), and the event revision plus a second connection-state shape
-/// are checked before accepting the capture. The outer `/status` timeout turns
-/// sustained contention into a 503 rather than old peers carrying a new
-/// revision.
+/// Build a peer array using only non-queuing connection-map reads.  A fully
+/// validated capture is preferred; when Tokio's writer-preferred `RwLock`
+/// rejects a reader (an active or queued writer can do so), return the last
+/// internally consistent capture as explicitly stale instead of putting
+/// `/status` behind the same writer and eventually returning HTTP 503.
 async fn capture_stable_peer_snapshot(
     context: &DiagnosticsContext,
     relay_connected: bool,
     direct_retry_after: Duration,
     udp_local_endpoint: Option<std::net::SocketAddr>,
 ) -> StablePeerSnapshot {
-    loop {
+    const MAX_CAPTURE_ATTEMPTS: usize = 8;
+
+    for attempt in 0..MAX_CAPTURE_ATTEMPTS {
         let revision_before = context.status_events.current_seq();
         let generation_before = context.peers.current_network_generation_sync();
-        let mut node_ids: Vec<_> = context
-            .peers
-            .all_connections()
-            .await
+        let Some(connections_before) = context.peers.try_all_connections() else {
+            emit_status_connection_map_contention(
+                context,
+                generation_before,
+                "initial_read",
+                attempt,
+            );
+            return cached_or_best_effort_peer_snapshot(
+                context,
+                relay_connected,
+                direct_retry_after,
+                udp_local_endpoint,
+            )
+            .await;
+        };
+        let mut node_ids: Vec<_> = connections_before
             .into_iter()
             .map(|connection| connection.node_id)
             .collect();
@@ -168,12 +182,32 @@ async fn capture_stable_peer_snapshot(
             }
         }
         if retry {
+            emit_status_connection_map_contention(
+                context,
+                generation_before,
+                "peer_diagnostic_read",
+                attempt,
+            );
             tokio::task::yield_now().await;
             continue;
         }
         peers.sort_by(|left, right| left.node_id.cmp(&right.node_id));
 
-        let live_after = context.peers.all_connections().await;
+        let Some(live_after) = context.peers.try_all_connections() else {
+            emit_status_connection_map_contention(
+                context,
+                generation_before,
+                "validation_read",
+                attempt,
+            );
+            return cached_or_best_effort_peer_snapshot(
+                context,
+                relay_connected,
+                direct_retry_after,
+                udp_local_endpoint,
+            )
+            .await;
+        };
         let revision_after = context.status_events.current_seq();
         let generation_after = context.peers.current_network_generation_sync();
         if revision_before != revision_after
@@ -188,6 +222,7 @@ async fn capture_stable_peer_snapshot(
         let shape = peer_snapshot_shape(&peers);
         let cached = CachedPeerSnapshot {
             peers: peers.clone(),
+            network_generation: generation_after,
             capture_revision: revision_after,
             captured_at: std::time::Instant::now(),
             captured_at_ms,
@@ -210,7 +245,92 @@ async fn capture_stable_peer_snapshot(
             captured_at_ms,
             captured_at,
             shape,
+            stale: false,
         };
+    }
+
+    let generation = context.peers.current_network_generation_sync();
+    emit_status_connection_map_contention(
+        context,
+        generation,
+        "coherency_retry_exhausted",
+        MAX_CAPTURE_ATTEMPTS,
+    );
+    cached_or_best_effort_peer_snapshot(
+        context,
+        relay_connected,
+        direct_retry_after,
+        udp_local_endpoint,
+    )
+    .await
+}
+
+fn emit_status_connection_map_contention(
+    context: &DiagnosticsContext,
+    generation: u64,
+    phase: &'static str,
+    attempt: usize,
+) {
+    context.timeline.emit_first_scoped(
+        &format!("status:{generation}"),
+        "status_connection_map_read_contended",
+        None,
+        Some("writer_active_or_fairly_queued"),
+        Some(format!(
+            "generation={generation} phase={phase} attempt={attempt} wait_us=0 nonblocking_read=true fair_rwlock_queued_writer_possible=true fallback=validated_cache"
+        )),
+    );
+}
+
+async fn cached_or_best_effort_peer_snapshot(
+    context: &DiagnosticsContext,
+    relay_connected: bool,
+    direct_retry_after: Duration,
+    udp_local_endpoint: Option<std::net::SocketAddr>,
+) -> StablePeerSnapshot {
+    let cached = context
+        .peer_snapshot_cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(cached) = cached {
+        return StablePeerSnapshot {
+            cached_peer_count: cached.peers.len(),
+            peers: cached.peers,
+            network_generation: cached.network_generation,
+            capture_revision: cached.capture_revision,
+            captured_at_ms: cached.captured_at_ms,
+            captured_at: cached.captured_at,
+            shape: cached.shape,
+            stale: true,
+        };
+    }
+
+    // The first status request can race startup before a validated capture
+    // exists.  PeerManager's diagnostics path is itself non-queuing and uses
+    // its bounded last-good cache; an empty array is preferable to blocking
+    // the health endpoint, and is explicitly marked stale.
+    let peers = context
+        .peers
+        .diagnostics_with_path_selection(
+            context.config.relay.prefer_direct,
+            relay_connected,
+            direct_retry_after,
+            udp_local_endpoint,
+        )
+        .await;
+    let captured_at = std::time::Instant::now();
+    let captured_at_ms = context.timeline.uptime_ms();
+    let shape = peer_snapshot_shape(&peers);
+    StablePeerSnapshot {
+        cached_peer_count: peers.len(),
+        peers,
+        network_generation: context.peers.current_network_generation_sync(),
+        capture_revision: context.status_events.current_seq(),
+        captured_at_ms,
+        captured_at,
+        shape,
+        stale: true,
     }
 }
 

--- a/client/daemon/src/diagnostics/tests.rs
+++ b/client/daemon/src/diagnostics/tests.rs
@@ -314,6 +314,7 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let cached = cache.as_ref().expect("validated peer capture is cached");
+            assert_eq!(cached.network_generation, snapshot.network_generation);
             assert_eq!(cached.capture_revision, snapshot.captured_revision);
             assert_eq!(cached.captured_at_ms, snapshot.captured_at_ms);
             assert_eq!(cached.peers.len(), snapshot.peers.len());
@@ -323,6 +324,64 @@ mod tests {
                     >= snapshot.peer_snapshot_age_ms as u128
             );
         }
+
+        // Reproduce the fair-RwLock status outage deterministically: retain a
+        // reader, queue a writer behind it, then issue /status. Tokio blocks
+        // new readers behind the queued writer; /status must use the validated
+        // cache and remain HTTP 200 without waiting for either owner.
+        let connection_reader = context_probe
+            .peers
+            .hold_connections_reader_for_test()
+            .await;
+        let queued_writer_manager = context_probe.peers.clone();
+        let writer_started = Arc::new(tokio::sync::Notify::new());
+        let writer_started_task = writer_started.clone();
+        let queued_writer = tokio::spawn(async move {
+            writer_started_task.notify_one();
+            let _writer = queued_writer_manager
+                .hold_connections_writer_for_test()
+                .await;
+        });
+        writer_started.notified().await;
+        for _ in 0..64 {
+            if context_probe.peers.try_all_connections().is_none() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            context_probe.peers.try_all_connections().is_none(),
+            "the writer must be fairly queued before the status request"
+        );
+
+        let mut contended_status = TcpStream::connect(addr).await.unwrap();
+        contended_status
+            .write_all(
+                b"GET /status HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer diag-test-token\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let mut contended_response = String::new();
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            contended_status.read_to_string(&mut contended_response),
+        )
+        .await
+        .expect("/status must not wait behind a fairly queued writer")
+        .unwrap();
+        assert!(contended_response.starts_with("HTTP/1.1 200 OK"));
+        let contended_body = contended_response.split("\r\n\r\n").nth(1).unwrap();
+        let contended_snapshot: DiagnosticsSnapshot =
+            serde_json::from_str(contended_body).unwrap();
+        assert!(contended_snapshot.peer_snapshot_stale);
+        assert_eq!(contended_snapshot.peers.len(), snapshot.peers.len());
+        assert_eq!(
+            contended_snapshot.peer_snapshot_shape,
+            snapshot.peer_snapshot_shape
+        );
+
+        drop(connection_reader);
+        queued_writer.await.unwrap();
         assert_eq!(
             snapshot.protocol.handshake,
             "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s"

--- a/client/daemon/src/diagnostics/types.rs
+++ b/client/daemon/src/diagnostics/types.rs
@@ -113,9 +113,8 @@ pub struct DiagnosticsSnapshot {
     /// `/status.uptime_ms` and timeline-event `at_ms` clock; it is not Unix time.
     #[serde(default)]
     pub captured_at_ms: u64,
-    /// Whether `peers` came from an older validated capture. The current
-    /// endpoint fails closed with 503 under sustained lock contention, so a
-    /// successful response always sets this to false.
+    /// Whether `peers` came from an older validated capture because a live
+    /// connection-map read was blocked by an active or fairly queued writer.
     #[serde(default)]
     pub peer_snapshot_stale: bool,
     /// Age of the validated peer capture when this response was assembled.
@@ -455,6 +454,7 @@ impl DiagnosticsContext {
 #[derive(Debug, Clone)]
 struct CachedPeerSnapshot {
     peers: Vec<PeerDiagnostics>,
+    network_generation: u64,
     capture_revision: u64,
     captured_at: std::time::Instant,
     captured_at_ms: u64,

--- a/client/daemon/src/lib.rs
+++ b/client/daemon/src/lib.rs
@@ -121,9 +121,9 @@ use p2pnet_wireguard::{
 };
 use peer::{
     CandidateSetApplyResult, ConnectionState, DirectProbeTargetSet, HardHardSessionRecord,
-    HardHardSessionState, PeerManager, PeerSessionGeneration, PendingRecoveryTarget,
-    ProbeBindingStage, RecoveryAdmission, DIRECT_RETRY_BASE_INTERVAL, REASON_DIRECT_PROBE_FAILED,
-    REASON_HANDSHAKE_TIMEOUT, RECOVERY_EPOCH_ACK_FEEDBACK_WINDOW,
+    HardHardSessionState, PeerManager, PeerSessionGeneration, PendingProbeBindingCommitOutcome,
+    PendingRecoveryTarget, ProbeBindingStage, RecoveryAdmission, DIRECT_RETRY_BASE_INTERVAL,
+    REASON_DIRECT_PROBE_FAILED, REASON_HANDSHAKE_TIMEOUT, RECOVERY_EPOCH_ACK_FEEDBACK_WINDOW,
 };
 use port_mapping::PortMappingManager;
 #[cfg(test)]

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -178,6 +178,38 @@ enum RemoteIncarnationResetWork {
     PreserveResponder,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteIncarnationResetOutcome {
+    Unchanged,
+    Changed,
+    RejectedIdentity,
+    RejectedLifecycle,
+    PendingCleanup,
+    ContendedEpoch,
+    ContendedConnections,
+}
+
+impl RemoteIncarnationResetOutcome {
+    const fn retryable(self) -> bool {
+        matches!(
+            self,
+            Self::PendingCleanup | Self::ContendedEpoch | Self::ContendedConnections
+        )
+    }
+
+    const fn reason_code(self) -> &'static str {
+        match self {
+            Self::Unchanged => "unchanged",
+            Self::Changed => "changed",
+            Self::RejectedIdentity => "stale_sender_identity",
+            Self::RejectedLifecycle => "remote_incarnation_cleanup_rejected",
+            Self::PendingCleanup => "remote_incarnation_cleanup_pending",
+            Self::ContendedEpoch => "network_epoch_busy",
+            Self::ContendedConnections => "connections_busy",
+        }
+    }
+}
+
 impl Daemon {
     fn clear_peer_handshake_lifecycle(&self, peer_id: &str, phase: &'static str) {
         let identity = HandshakeLeaseIdentity::new(
@@ -240,136 +272,156 @@ impl Daemon {
             pending_work,
         )
         .await
-        .unwrap_or(false)
+            == RemoteIncarnationResetOutcome::Changed
     }
 
-    /// Identity-aware production preflight. `None` means the signal belonged
-    /// to a retired public key and must be dropped wholesale; `Some(changed)`
-    /// preserves the original restart-result contract for legacy callers.
+    /// Identity-aware production preflight.  Responder/candidate owners use
+    /// the non-queuing claim and receive explicit contention; other lifecycle
+    /// callers retain their existing serialized claim transaction.
     async fn reset_peer_for_remote_incarnation_if_needed_for_identity(
         &self,
         peer_id: &str,
         candidate_generation: u64,
         sender_public_key: Option<&str>,
         pending_work: RemoteIncarnationResetWork,
-    ) -> Option<bool> {
+    ) -> RemoteIncarnationResetOutcome {
         if pending_work == RemoteIncarnationResetWork::PreserveResponder {
-            // `responder_work` is cooperatively polled by the serial control
-            // loop. If it held the arbiter while awaiting transport/UDP actors,
-            // a lifecycle branch could wait for that arbiter and stop polling
-            // its owner forever. Run the complete claim/cleanup/commit turn in
-            // an independently scheduled task so the owner keeps progressing.
-            let transport = self.transport.clone();
-            let punch_attempts = self.punch_attempts.clone();
-            let udp_transport = self.udp_transport.clone();
-            let peers = self.peers.clone();
-            let pending_handshakes = self.pending_handshakes.clone();
-            let timeline = self.timeline.clone();
-            let peer_id = peer_id.to_string();
-            let peer_id_for_error = peer_id.clone();
-            let sender_public_key = sender_public_key.map(str::to_string);
-            return match tokio::spawn(async move {
-                let claim = peers
-                    .claim_remote_candidate_incarnation_for_identity(
-                        &peer_id,
-                        candidate_generation,
-                        sender_public_key.as_deref(),
-                    )
-                    .await;
-                let (old_incarnation, claimed_incarnation) = match claim {
-                    crate::peer::RemoteCandidateIncarnationClaim::IdentityMismatch => {
-                        peers
-                            .record_direct_event(
-                                &peer_id,
-                                "remote_signal_stale_identity",
-                                None,
-                                None,
-                                None,
-                                format!(
-                                    "ignored signal before incarnation/handshake/candidate mutation candidate_generation={candidate_generation}"
-                                ),
-                            )
-                            .await;
-                        timeline.emit(
-                            "remote_signal_rejected",
+            // A claim publishes the incarnation high-water before its slow
+            // transport cleanup commits. Candidate and responder futures are
+            // independently polled, so fence that interval explicitly: the
+            // second future must not reinterpret the claimed high-water as a
+            // completed NoReset lifecycle.
+            if let Some(pending_incarnation) = self
+                .pending_handshakes
+                .lock()
+                .remote_incarnation_reset_in_progress(peer_id)
+            {
+                return if crate::control::candidate_generation_incarnation(candidate_generation)
+                    .is_some_and(|incoming| incoming < pending_incarnation)
+                {
+                    RemoteIncarnationResetOutcome::RejectedLifecycle
+                } else {
+                    RemoteIncarnationResetOutcome::PendingCleanup
+                };
+            }
+            let claim = self
+                .peers
+                .try_claim_remote_candidate_incarnation_for_identity(
+                    peer_id,
+                    candidate_generation,
+                    sender_public_key,
+                );
+            let (old_incarnation, claimed_incarnation) = match claim {
+                crate::peer::RemoteCandidateIncarnationTryClaim::ContendedEpoch => {
+                    return RemoteIncarnationResetOutcome::ContendedEpoch;
+                }
+                crate::peer::RemoteCandidateIncarnationTryClaim::ContendedConnections => {
+                    return RemoteIncarnationResetOutcome::ContendedConnections;
+                }
+                crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+                    crate::peer::RemoteCandidateIncarnationClaim::IdentityMismatch,
+                ) => {
+                    self.peers
+                        .record_direct_event(
+                            peer_id,
+                            "remote_signal_stale_identity",
                             None,
-                            Some("stale_sender_identity"),
-                            Some(format!(
-                                "peer={peer_id} candidate_generation={candidate_generation}"
-                            )),
-                        );
-                        return None;
-                    }
-                    crate::peer::RemoteCandidateIncarnationClaim::NoReset => {
-                        return Some(false);
-                    }
+                            None,
+                            None,
+                            format!(
+                                "ignored signal before incarnation/handshake/candidate mutation candidate_generation={candidate_generation}"
+                            ),
+                        )
+                        .await;
+                    self.timeline.emit(
+                        "remote_signal_rejected",
+                        None,
+                        Some("stale_sender_identity"),
+                        Some(format!(
+                            "peer={peer_id} candidate_generation={candidate_generation}"
+                        )),
+                    );
+                    return RemoteIncarnationResetOutcome::RejectedIdentity;
+                }
+                crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+                    crate::peer::RemoteCandidateIncarnationClaim::RejectedLifecycle,
+                ) => return RemoteIncarnationResetOutcome::RejectedLifecycle,
+                crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+                    crate::peer::RemoteCandidateIncarnationClaim::NoReset,
+                ) => return RemoteIncarnationResetOutcome::Unchanged,
+                crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
                     crate::peer::RemoteCandidateIncarnationClaim::Reset {
                         old_incarnation,
                         new_incarnation,
-                    } => (old_incarnation, new_incarnation),
-                };
+                    },
+                ) => (old_incarnation, new_incarnation),
+            };
+            if !self
+                .pending_handshakes
+                .lock()
+                .begin_remote_incarnation_reset(peer_id, claimed_incarnation)
+            {
+                return RemoteIncarnationResetOutcome::PendingCleanup;
+            }
 
-                let retiring_peer_session = peers.peer_session_generation_sync(&peer_id);
-                if let Some(retiring_peer_session) = retiring_peer_session {
-                    punch_attempts.retire_peer_session(&peer_id, retiring_peer_session);
-                } else {
-                    punch_attempts.cancel(&peer_id);
-                }
-                info!(
-                    event = "peer_restart_detected",
-                    peer_id = %peer_id,
+            let retiring_peer_session = self.peers.peer_session_generation_sync(peer_id);
+            if let Some(retiring_peer_session) = retiring_peer_session {
+                self.punch_attempts
+                    .retire_peer_session(peer_id, retiring_peer_session);
+            } else {
+                self.punch_attempts.cancel(peer_id);
+            }
+            info!(
+                event = "peer_restart_detected",
+                peer_id = %peer_id,
+                old_incarnation,
+                new_incarnation = claimed_incarnation,
+                caller = "control_events.remote_incarnation_responder",
+                "remote daemon incarnation advanced; rotating the peer session"
+            );
+            self.transport
+                .remove_session_with_reason(
+                    peer_id,
+                    "remote_incarnation_changed",
+                    "control_events.remote_incarnation_responder",
+                )
+                .await;
+            let udp_slot = self.udp_transport.read().await;
+            let changed = if let Some(udp) = udp_slot.clone() {
+                // Keep the UDP adoption fence held from old-session cleanup
+                // through publication of the rotated PeerSessionGeneration.
+                udp.cleanup_peer_lifecycle_and_finish_remote_incarnation_reset(
+                    peer_id,
+                    "remote_incarnation_changed",
                     old_incarnation,
-                    new_incarnation = claimed_incarnation,
-                    caller = "control_events.remote_incarnation_responder",
-                    "remote daemon incarnation advanced; rotating the peer session"
-                );
-                transport
-                    .remove_session_with_reason(
-                        &peer_id,
-                        "remote_incarnation_changed",
-                        "control_events.remote_incarnation_responder",
-                    )
-                    .await;
-                let udp_slot = udp_transport.read().await;
-                let changed = if let Some(udp) = udp_slot.clone() {
-                    // Keep the UDP adoption fence held from old-session cleanup
-                    // through publication of the rotated PeerSessionGeneration.
-                    udp.cleanup_peer_lifecycle_and_finish_remote_incarnation_reset(
-                        &peer_id,
-                        "remote_incarnation_changed",
+                    claimed_incarnation,
+                )
+                .await
+            } else {
+                // The slot read guard prevents a replacement UDP transport
+                // from publishing before the reset commit completes.
+                self.peers
+                    .finish_claimed_remote_incarnation_reset(
+                        peer_id,
                         old_incarnation,
                         claimed_incarnation,
+                        "remote_incarnation_changed",
                     )
                     .await
-                } else {
-                    // The slot read guard prevents a replacement UDP transport
-                    // from publishing before the reset commit completes.
-                    peers
-                        .finish_claimed_remote_incarnation_reset(
-                            &peer_id,
-                            old_incarnation,
-                            claimed_incarnation,
-                            "remote_incarnation_changed",
-                        )
-                        .await
-                };
-                if changed {
-                    pending_handshakes
-                        .lock()
-                        .clear_peer_except_responder_owner(&peer_id);
-                }
-                drop(udp_slot);
-                Some(changed)
-            })
-            .await
-            {
-                Ok(changed) => changed,
-                Err(error) => {
-                    warn!(
-                        "Remote-incarnation responder reset task failed for {peer_id_for_error}: {error}"
-                    );
-                    Some(false)
-                }
+            };
+            if changed {
+                self.pending_handshakes
+                    .lock()
+                    .clear_peer_except_responder_owner(peer_id);
+            }
+            self.pending_handshakes
+                .lock()
+                .finish_remote_incarnation_reset(peer_id, claimed_incarnation);
+            drop(udp_slot);
+            return if changed {
+                RemoteIncarnationResetOutcome::Changed
+            } else {
+                RemoteIncarnationResetOutcome::RejectedLifecycle
             };
         }
 
@@ -403,10 +455,13 @@ impl Daemon {
                         "peer={peer_id} candidate_generation={candidate_generation}"
                     )),
                 );
-                return None;
+                return RemoteIncarnationResetOutcome::RejectedIdentity;
+            }
+            crate::peer::RemoteCandidateIncarnationClaim::RejectedLifecycle => {
+                return RemoteIncarnationResetOutcome::RejectedLifecycle;
             }
             crate::peer::RemoteCandidateIncarnationClaim::NoReset => {
-                return Some(false);
+                return RemoteIncarnationResetOutcome::Unchanged;
             }
             crate::peer::RemoteCandidateIncarnationClaim::Reset {
                 old_incarnation,
@@ -485,7 +540,11 @@ impl Daemon {
             }
         }
         drop(udp_slot);
-        Some(changed)
+        if changed {
+            RemoteIncarnationResetOutcome::Changed
+        } else {
+            RemoteIncarnationResetOutcome::RejectedLifecycle
+        }
     }
 
     /// Decide whether an offer may touch candidate-plane state.
@@ -687,7 +746,11 @@ impl Daemon {
     ) -> bool {
         let deadline = Instant::now() + UNKNOWN_PEER_OFFER_WAIT;
         loop {
-            if self.peers.get_connection(peer_id).await.is_some() {
+            if self
+                .peers
+                .peer_identity_public_key_sync(peer_id)
+                .is_some()
+            {
                 return true;
             }
             if self
@@ -1277,12 +1340,12 @@ impl Daemon {
 
     /// Handle one admitted responder offer with a bounded, idempotent retry.
     ///
-    /// The control signal receiver acknowledges after local enqueue, so a
-    /// transient failure after dequeue must be repaired by the worker itself.
+    /// The exact durable receipt remains attached to this worker until the
+    /// responder transaction commits or returns a typed retry/terminal result.
     /// `handle_event_peer_offer` uses the exact responder cache keyed by the
     /// WireGuard token, therefore retrying the same plaintext offer cannot
-    /// create a second response or a second session.  No encrypted data
-    /// packet is retained here; this is control-plane handshake material only.
+    /// create a second response or a second session. No encrypted data packet
+    /// is retained here; this is control-plane handshake material only.
     async fn handle_admitted_responder_offer(
         &self,
         offer: &PendingPeerOffer,
@@ -1511,11 +1574,10 @@ impl Daemon {
         offer.complete_delivery(control::SignalApplyOutcome::Retry);
     }
 
-    /// Finish an offer that arrived before PeerJoined.  Candidate/fresh
-    /// admission is deliberately repeated after registration, because the
-    /// first attempt would return `PeerMissing` and must not consume a fresh
-    /// prediction identity.  The same responder owner handles queued retries.
-    async fn run_deferred_peer_offer_worker(
+    /// Consume only the latency-critical responder half of an offer.  Remote
+    /// incarnation admission is non-queuing; bounded contention completes the
+    /// durable receipt as Retry so ordered server delivery can replay it.
+    async fn run_responder_offer_worker(
         &self,
         mut offer: PendingPeerOffer,
         mut reservation: ResponderWorkReservation,
@@ -1559,33 +1621,84 @@ impl Daemon {
                 offer = newest;
                 continue;
             }
-            let remote_incarnation_reset = match self
-                .reset_peer_for_remote_incarnation_if_needed_for_identity(
-                    &offer.from_node_id,
-                    offer.candidate_generation,
-                    offer.sender_public_key.as_deref(),
-                    RemoteIncarnationResetWork::PreserveResponder,
-                )
-                .await
-            {
-                Some(changed) => changed,
-                None => {
-                    // The queued signal belongs to a retired public-key
-                    // identity. Finish this exact owner turn normally so a
-                    // newer queued offer can run and the per-peer responder
-                    // lane cannot stay wedged.
-                    offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
-                    let Some(next) = self
-                        .pending_handshakes
-                        .lock()
-                        .finish_responder_work(&peer_id, reservation.owner)
-                    else {
-                        return;
-                    };
-                    offer = next;
-                    continue;
+            let mut reset_outcome = RemoteIncarnationResetOutcome::Unchanged;
+            for reset_attempt in 0..=RESPONDER_WORK_RETRY_LIMIT {
+                reset_outcome = self
+                    .reset_peer_for_remote_incarnation_if_needed_for_identity(
+                        &offer.from_node_id,
+                        offer.candidate_generation,
+                        offer.sender_public_key.as_deref(),
+                        RemoteIncarnationResetWork::PreserveResponder,
+                    )
+                    .await;
+                if !reset_outcome.retryable() {
+                    break;
                 }
-            };
+                if reset_attempt == RESPONDER_WORK_RETRY_LIMIT {
+                    break;
+                }
+                let delay = responder_offer_retry_delay(reset_attempt.saturating_add(1));
+                self.timeline.emit(
+                    "peer_offer_incarnation_retry",
+                    None,
+                    Some(reset_outcome.reason_code()),
+                    Some(format!(
+                        "peer={} owner={} retry_attempt={} delay_ms={}",
+                        peer_id,
+                        reservation.owner,
+                        reset_attempt.saturating_add(1),
+                        delay.as_millis()
+                    )),
+                );
+                tokio::select! {
+                    _ = sleep(delay) => {}
+                    changed = reservation.cancellation.changed() => {
+                        let _ = changed;
+                        offer.complete_delivery(control::SignalApplyOutcome::Retry);
+                        return;
+                    }
+                }
+            }
+            if reset_outcome == RemoteIncarnationResetOutcome::RejectedIdentity {
+                offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
+                let Some(next) = self
+                    .pending_handshakes
+                    .lock()
+                    .finish_responder_work(&peer_id, reservation.owner)
+                else {
+                    return;
+                };
+                offer = next;
+                continue;
+            }
+            if reset_outcome == RemoteIncarnationResetOutcome::RejectedLifecycle {
+                // The incarnation high-water mark has already advanced, but
+                // the claimed lifecycle was removed or superseded before its
+                // cleanup commit. This exact offer is stale; redelivery must
+                // not reinterpret a subsequent NoReset as a successful reset.
+                offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
+                let Some(next) = self
+                    .pending_handshakes
+                    .lock()
+                    .finish_responder_work(&peer_id, reservation.owner)
+                else {
+                    return;
+                };
+                offer = next;
+                continue;
+            }
+            if reset_outcome.retryable() {
+                offer.complete_delivery(control::SignalApplyOutcome::Retry);
+                let Some(next) = self
+                    .pending_handshakes
+                    .lock()
+                    .finish_responder_work(&peer_id, reservation.owner)
+                else {
+                    return;
+                };
+                offer = next;
+                continue;
+            }
             let Some(peer_session_generation) =
                 self.peers.peer_session_generation_sync(&offer.from_node_id)
             else {
@@ -1601,74 +1714,189 @@ impl Daemon {
                 continue;
             };
             offer.peer_session_generation = Some(peer_session_generation);
-            // The peer is now registered. Answer the encrypted initiation
-            // before candidate/fresh-prediction work, for the same reason as
-            // the normal known-peer path: a delayed candidate plane must not
-            // turn a delivered control signal into a silent handshake gap.
-            if !offer.handshake_init.is_empty() {
-                self.handle_admitted_responder_offer(
-                    &offer,
-                    reservation.owner,
-                    &mut reservation.cancellation,
-                )
-                .await;
-            }
+            self.handle_admitted_responder_offer(
+                &offer,
+                reservation.owner,
+                &mut reservation.cancellation,
+            )
+            .await;
             if *reservation.cancellation.borrow() {
-                if offer.handshake_init.is_empty() {
-                    offer.complete_delivery(control::SignalApplyOutcome::Retry);
-                }
                 return;
             }
-            // The offer-ingress verdict runs before any candidate-plane
-            // state: duplicates and rate-limited retransmissions never apply
-            // candidates, never run a fresh transaction and never trigger a
-            // punch — the handshake part below is still answered.
-            let (_fresh_verdict, candidate_apply_result, fresh_punch) = if self
-                .offer_ingress_verdict(
-                    &offer.from_node_id,
-                    &offer.candidates,
-                    &offer.candidate_sources,
-                    offer.candidates_expires_at_ms,
-                    offer.sender_public_key.as_deref(),
-                )
-                .await
-                == OfferIngressVerdict::Apply
+
+            let Some(next) = self
+                .pending_handshakes
+                .lock()
+                .finish_responder_work(&peer_id, reservation.owner)
+            else {
+                return;
+            };
+            offer = next;
+        }
+    }
+
+    /// Apply candidate/fresh-prediction work in its own bounded per-peer
+    /// owner.  Durable delivery was committed at enqueue, so contention is
+    /// repaired here without retaining a server receipt or blocking later
+    /// signals from the same sender.
+    async fn run_candidate_offer_worker(
+        &self,
+        mut offer: PendingPeerOffer,
+        mut reservation: CandidateOfferWorkReservation,
+    ) {
+        'work: loop {
+            let peer_id = offer.from_node_id.clone();
+            if *reservation.cancellation.borrow()
+                || !self
+                    .pending_handshakes
+                    .lock()
+                    .candidate_offer_work_is_current(&peer_id, reservation.owner)
             {
-                self.fresh_prediction_transaction(
-                    &offer.from_node_id,
-                    &offer.candidates,
-                    &offer.candidate_sources,
-                    offer.candidate_generation,
-                    offer.candidates_expires_at_ms,
-                    offer.sender_public_key.as_deref(),
-                )
+                return;
+            }
+            if !self
+                .wait_for_peer_offer_identity(&peer_id, &mut reservation.cancellation)
                 .await
-            } else {
-                self.peers
-                    .record_direct_event(
-                        &offer.from_node_id,
-                        "peer_offer_ingress_suppressed",
-                        None,
-                        Some(offer.candidates.len()),
-                        None,
-                        "offer suppressed by ingress verdict; candidate apply, fresh prediction and punch skipped; handshake still handled",
+            {
+                let Some(next) = self
+                    .pending_handshakes
+                    .lock()
+                    .finish_candidate_offer_work(&peer_id, reservation.owner)
+                else {
+                    return;
+                };
+                offer = next;
+                continue;
+            }
+            if let Some(newest) = self
+                .pending_handshakes
+                .lock()
+                .take_queued_candidate_offer_work(&peer_id, reservation.owner)
+            {
+                offer = newest;
+                continue;
+            }
+            if self.peers.current_network_generation_sync() != offer.network_generation {
+                let Some(next) = self
+                    .pending_handshakes
+                    .lock()
+                    .finish_candidate_offer_work(&peer_id, reservation.owner)
+                else {
+                    return;
+                };
+                offer = next;
+                continue;
+            }
+
+            let mut retry_attempt = 0u8;
+            let remote_incarnation_reset = loop {
+                let outcome = self
+                    .reset_peer_for_remote_incarnation_if_needed_for_identity(
+                        &peer_id,
+                        offer.candidate_generation,
+                        offer.sender_public_key.as_deref(),
+                        RemoteIncarnationResetWork::PreserveResponder,
                     )
                     .await;
-                (
-                    FreshSignalVerdict::None,
-                    CandidateSetApplyResult::IgnoredStale,
-                    FreshPunchDecision::None,
-                )
+                match outcome {
+                    RemoteIncarnationResetOutcome::Changed => break true,
+                    RemoteIncarnationResetOutcome::Unchanged => break false,
+                    RemoteIncarnationResetOutcome::RejectedIdentity
+                    | RemoteIncarnationResetOutcome::RejectedLifecycle => {
+                        let Some(next) = self
+                            .pending_handshakes
+                            .lock()
+                            .finish_candidate_offer_work(&peer_id, reservation.owner)
+                        else {
+                            return;
+                        };
+                        offer = next;
+                        continue 'work;
+                    }
+                    RemoteIncarnationResetOutcome::PendingCleanup
+                    | RemoteIncarnationResetOutcome::ContendedEpoch
+                    | RemoteIncarnationResetOutcome::ContendedConnections => {
+                        if let Some(newest) = self
+                            .pending_handshakes
+                            .lock()
+                            .take_queued_candidate_offer_work(&peer_id, reservation.owner)
+                        {
+                            offer = newest;
+                            continue 'work;
+                        }
+                        retry_attempt = retry_attempt.saturating_add(1);
+                        let delay = responder_offer_retry_delay(retry_attempt);
+                        self.timeline.emit(
+                            "peer_offer_candidate_retry",
+                            None,
+                            Some(outcome.reason_code()),
+                            Some(format!(
+                                "peer={} owner={} retry_attempt={} delay_ms={}",
+                                peer_id,
+                                reservation.owner,
+                                retry_attempt,
+                                delay.as_millis()
+                            )),
+                        );
+                        tokio::select! {
+                            _ = sleep(delay) => {}
+                            changed = reservation.cancellation.changed() => {
+                                let _ = changed;
+                                return;
+                            }
+                        }
+                    }
+                }
             };
+
+            offer.peer_session_generation = self.peers.peer_session_generation_sync(&peer_id);
+            let ingress = self
+                .offer_ingress_verdict(
+                    &peer_id,
+                    &offer.candidates,
+                    &offer.candidate_sources,
+                    offer.candidates_expires_at_ms,
+                    offer.sender_public_key.as_deref(),
+                )
+                .await;
+            let (_fresh_verdict, candidate_apply_result, fresh_punch) =
+                if ingress == OfferIngressVerdict::Apply {
+                    self.fresh_prediction_transaction(
+                        &peer_id,
+                        &offer.candidates,
+                        &offer.candidate_sources,
+                        offer.candidate_generation,
+                        offer.candidates_expires_at_ms,
+                        offer.sender_public_key.as_deref(),
+                    )
+                    .await
+                } else {
+                    self.peers
+                        .record_direct_event(
+                            &peer_id,
+                            "peer_offer_ingress_suppressed",
+                            None,
+                            Some(offer.candidates.len()),
+                            None,
+                            format!(
+                                "offer suppressed by ingress verdict={ingress:?}; candidate apply, fresh prediction and punch skipped"
+                            ),
+                        )
+                        .await;
+                    (
+                        FreshSignalVerdict::None,
+                        CandidateSetApplyResult::IgnoredStale,
+                        FreshPunchDecision::None,
+                    )
+                };
+            if !offer.handshake_init.is_empty() {
+                self.peers
+                    .recovery_reopen_on_evidence(&peer_id, "authenticated_peer_offer")
+                    .await;
+            }
             self.apply_deferred_peer_offer_punch(&offer, candidate_apply_result, fresh_punch)
                 .await;
-
             if remote_incarnation_reset && !*reservation.cancellation.borrow() {
-                // This is the critical Air-first recovery edge: the remote
-                // restart invalidated its stored copy of our candidates, while
-                // our local candidate hash may be unchanged. Replay it now so
-                // the two sides enter the same punch window without requiring
-                // a local daemon restart.
                 self.publish_current_candidates_to_peer(
                     &peer_id,
                     "remote incarnation candidate replay",
@@ -1676,23 +1904,10 @@ impl Daemon {
                 .await;
             }
 
-            if offer.handshake_init.is_empty() {
-                offer.complete_delivery(
-                    if self
-                        .peers
-                        .peer_session_is_current_sync(&peer_id, peer_session_generation)
-                    {
-                        control::SignalApplyOutcome::Applied
-                    } else {
-                        control::SignalApplyOutcome::TerminalRejected
-                    },
-                );
-            }
-
             let Some(next) = self
                 .pending_handshakes
                 .lock()
-                .finish_responder_work(&peer_id, reservation.owner)
+                .finish_candidate_offer_work(&peer_id, reservation.owner)
             else {
                 return;
             };
@@ -1753,21 +1968,13 @@ impl Daemon {
     /// are treated as stale.  Signals without a fingerprint (old server) or
     /// for a peer without a recorded public key are conservatively treated as
     /// matching (no identity information to contradict them).
-    async fn signal_sender_identity_matches_peer(
+    fn signal_sender_identity_matches_peer(
         &self,
         peer_id: &str,
         sender_public_key: Option<&str>,
     ) -> bool {
-        let Some(sender_public_key) = sender_public_key.map(str::trim) else {
-            return true;
-        };
-        if sender_public_key.is_empty() {
-            return false;
-        }
-        let Some(connection) = self.peers.get_connection(peer_id).await else {
-            return false;
-        };
-        connection.public_key.trim() == sender_public_key
+        self.peers
+            .signal_sender_identity_matches_peer_sync(peer_id, sender_public_key)
     }
 
     /// The prepare/apply/commit transaction for one fresh signal, shared by
@@ -1810,9 +2017,8 @@ impl Daemon {
             }
             Ok(None) => FreshSignalVerdict::None,
             Ok(Some(id)) => {
-                let signal_identity_matches = self
-                    .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
-                    .await;
+                let signal_identity_matches =
+                    self.signal_sender_identity_matches_peer(from_node_id, sender_public_key);
                 if !signal_identity_matches {
                     // The signal was bound by the control server to a sender
                     // identity fingerprint that is NOT the peer's current
@@ -2230,6 +2436,11 @@ impl Daemon {
         // blocked candidate refresh or peer-reflexive HTTP task must not
         // prevent a received WireGuard initiation from producing an answer.
         let mut responder_work: FuturesUnordered<ControlEventWork<'_>> = FuturesUnordered::new();
+        // Candidate application has independent per-peer owners and futures.
+        // Its durable receipt commits at bounded local enqueue, so neither a
+        // connection writer nor slow UDP work can head-of-line block the next
+        // signal from the same sender.
+        let mut candidate_work: FuturesUnordered<ControlEventWork<'_>> = FuturesUnordered::new();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let mut task_shutdown_rx = self.task_manager.shutdown_rx();
         let mut handshake_retry_kick_rx = self.handshake_retry_kick_tx.subscribe();
@@ -2266,6 +2477,14 @@ impl Daemon {
                         // completion can also free a pending initiator's
                         // reservation, so retry deferred roster work here even
                         // when the general slow-work lane is otherwise idle.
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            );
+                    }
+                    _ = candidate_work.next(), if !candidate_work.is_empty() => {
                         daemon.drain_initiator_retry_ledger(&mut slow_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
@@ -2853,19 +3072,17 @@ impl Daemon {
                             from_node_id,
                             candidates.len()
                         );
-                        self.peers
-                            .record_direct_event(
-                                &from_node_id,
-                                "peer_offer_received",
-                                None,
-                                Some(candidates.len()),
-                                None,
-                                format!(
-                                    "received offer handshake_bytes={} punch_at_ms={punch_at_ms:?}",
-                                    handshake_init.len()
-                                ),
-                            )
-                            .await;
+                        self.peers.record_direct_event_non_queuing(
+                            &from_node_id,
+                            "peer_offer_received",
+                            None,
+                            Some(candidates.len()),
+                            None,
+                            format!(
+                                "received offer handshake_bytes={} punch_at_ms={punch_at_ms:?}",
+                                handshake_init.len()
+                            ),
+                        );
                         self.timeline.emit(
                             "peer_offer_received",
                             None,
@@ -2878,112 +3095,67 @@ impl Daemon {
                                 candidates.len()
                             )),
                         );
-                        // Signal delivery can race the peer-list poll: an offer
-                        // may be received before PeerJoined has installed the
-                        // sender's static public key.  Do not run candidate
-                        // admission or consume the responder transaction in that
-                        // state.  Enqueue the complete newest offer under the
-                        // existing per-peer owner and replay it once registration
-                        // becomes visible.
-                        if !self.peers.peer_exists_sync(&from_node_id) {
-                            // Wake the peer poll immediately: the regular cadence
-                            // can be seconds away and a cold-start handshake must
-                            // not wait it out.
+                        let peer_known = self.peers.peer_exists_sync(&from_node_id);
+                        if !peer_known {
+                            // REST signal delivery can beat the independent roster poll.
+                            // Both bounded owners wait for identity publication; waking
+                            // the poll keeps that interval short without blocking this actor.
                             self.control.refresh_peers_now();
-                            self.peers
-                                .record_direct_event(
-                                    &from_node_id,
-                                    "peer_offer_deferred_unknown",
-                                    None,
-                                    Some(candidates.len()),
-                                    None,
-                                    "deferred offer until PeerJoined installs peer identity",
-                                )
-                                .await;
-                            let admitted = {
-                                let mut state = self.pending_handshakes.lock();
-                                state.enqueue_responder_work(PendingPeerOffer {
-                                    from_node_id: from_node_id.clone(),
-                                    candidates: candidates.clone(),
-                                    candidate_sources: candidate_sources.clone(),
-                                    candidate_generation,
-                                    network_generation,
-                                    peer_session_generation: None,
-                                    candidates_expires_at_ms,
-                                    sender_public_key: sender_public_key.clone(),
-                                    handshake_init: handshake_init.clone(),
-                                    punch_at_ms,
-                                    punch_at_server_ms,
-                                    session_id: session_id.clone(),
-                                    probe_ephemeral_public_key: probe_ephemeral_public_key.clone(),
-                                    delivery_receipt: delivery_receipt.clone(),
-                                })
-                            };
-                            if let Some((reservation, offer)) = admitted {
-                                self.timeline.emit(
-                                    "peer_offer_responder_work_admitted",
-                                    None,
-                                    None,
-                                    Some(format!(
-                                        "peer={} owner={} network_generation={} candidate_generation={} session_fp={} deferred_unknown=true",
-                                        from_node_id,
-                                        reservation.owner,
-                                        network_generation,
-                                        candidate_generation,
-                                        handshake_token_fingerprint(session_id.as_deref())
-                                    )),
-                                );
-                                responder_work.push(Box::pin(async move {
-                                    daemon
-                                        .run_deferred_peer_offer_worker(offer, reservation)
-                                        .await;
-                                }));
-                            } else {
-                                self.timeline.emit(
-                                    "peer_offer_responder_work_coalesced",
-                                    None,
-                                    Some("newest_wins_coalesced"),
-                                    Some(format!(
-                                        "peer={} network_generation={} candidate_generation={} session_fp={} deferred_unknown=true queued=true",
-                                        from_node_id,
-                                        network_generation,
-                                        candidate_generation,
-                                        handshake_token_fingerprint(session_id.as_deref())
-                                    )),
-                                );
+                        } else if !self.signal_sender_identity_matches_peer(
+                            &from_node_id,
+                            sender_public_key.as_deref(),
+                        ) {
+                            self.peers.record_direct_event_non_queuing(
+                                &from_node_id,
+                                "remote_signal_stale_identity",
+                                None,
+                                None,
+                                None,
+                                format!(
+                                    "ignored signal before incarnation/handshake/candidate mutation candidate_generation={candidate_generation}"
+                                ),
+                            );
+                            self.timeline.emit(
+                                "remote_signal_rejected",
+                                None,
+                                Some("stale_sender_identity"),
+                                Some(format!(
+                                    "peer={from_node_id} candidate_generation={candidate_generation}"
+                                )),
+                            );
+                            if let Some(receipt) = delivery_receipt.as_ref() {
+                                receipt.complete(control::SignalApplyOutcome::TerminalRejected);
                             }
                             continue;
                         }
-                        // Candidate-only offers have no latency-critical
-                        // WireGuard response to stage.  They still carry remote
-                        // candidate state and may need to wait behind the shared
-                        // epoch/UDP validation locks, so run them through the
-                        // existing per-peer newest-wins responder lane instead of
-                        // blocking the serial control receiver.  A later offer
-                        // for the same peer is coalesced by the same owner.
-                        if handshake_init.is_empty() {
-                            let admitted = {
-                                let mut state = self.pending_handshakes.lock();
-                                state.enqueue_responder_work(PendingPeerOffer {
-                                    from_node_id: from_node_id.clone(),
-                                    candidates: candidates.clone(),
-                                    candidate_sources: candidate_sources.clone(),
-                                    candidate_generation,
-                                    network_generation,
-                                    peer_session_generation: self
-                                        .peers
-                                        .peer_session_generation_sync(&from_node_id),
-                                    candidates_expires_at_ms,
-                                    sender_public_key: sender_public_key.clone(),
-                                    handshake_init: Vec::new(),
-                                    punch_at_ms,
-                                    punch_at_server_ms,
-                                    session_id: session_id.clone(),
-                                    probe_ephemeral_public_key: probe_ephemeral_public_key.clone(),
-                                    delivery_receipt: delivery_receipt.clone(),
-                                })
-                            };
-                            if let Some((reservation, offer)) = admitted {
+
+                        // Retain the candidate half first in its own bounded ledger.
+                        // No durable receipt enters this worker: successful local
+                        // admission is the application commit, and the owner repairs
+                        // connection/epoch contention independently.
+                        let candidate_admission = {
+                            let mut state = self.pending_handshakes.lock();
+                            state.enqueue_candidate_offer_work(PendingPeerOffer {
+                                from_node_id: from_node_id.clone(),
+                                candidates: candidates.clone(),
+                                candidate_sources: candidate_sources.clone(),
+                                candidate_generation,
+                                network_generation,
+                                peer_session_generation: self
+                                    .peers
+                                    .peer_session_generation_sync(&from_node_id),
+                                candidates_expires_at_ms,
+                                sender_public_key: sender_public_key.clone(),
+                                handshake_init: handshake_init.clone(),
+                                punch_at_ms,
+                                punch_at_server_ms,
+                                session_id: session_id.clone(),
+                                probe_ephemeral_public_key: probe_ephemeral_public_key.clone(),
+                                delivery_receipt: None,
+                            })
+                        };
+                        let candidate_signal_outcome = match candidate_admission {
+                            CandidateOfferWorkAdmission::Started(reservation, offer) => {
                                 self.timeline.emit(
                                     "peer_offer_candidate_work_admitted",
                                     None,
@@ -2997,12 +3169,14 @@ impl Daemon {
                                         candidates.len()
                                     )),
                                 );
-                                responder_work.push(Box::pin(async move {
+                                candidate_work.push(Box::pin(async move {
                                     daemon
-                                        .run_deferred_peer_offer_worker(offer, reservation)
+                                        .run_candidate_offer_worker(*offer, reservation)
                                         .await;
                                 }));
-                            } else {
+                                control::SignalApplyOutcome::Applied
+                            }
+                            CandidateOfferWorkAdmission::Coalesced => {
                                 self.timeline.emit(
                                     "peer_offer_candidate_work_coalesced",
                                     None,
@@ -3015,300 +3189,105 @@ impl Daemon {
                                         candidates.len()
                                     )),
                                 );
+                                control::SignalApplyOutcome::Applied
+                            }
+                            CandidateOfferWorkAdmission::RejectedIdentity => {
+                                control::SignalApplyOutcome::TerminalRejected
+                            }
+                            CandidateOfferWorkAdmission::Capacity => {
+                                self.timeline.emit(
+                                    "peer_offer_candidate_work_rejected",
+                                    None,
+                                    Some("candidate_owner_capacity"),
+                                    Some(format!(
+                                        "peer={} capacity={}",
+                                        from_node_id, MAX_CANDIDATE_OFFER_WORKERS
+                                    )),
+                                );
+                                control::SignalApplyOutcome::Retry
+                            }
+                        };
+
+                        if handshake_init.is_empty() {
+                            // The exact candidate payload is now owned locally. ACK its
+                            // durable row immediately so the sender's next independently
+                            // encrypted handshake signal is not head-of-line blocked.
+                            if let Some(receipt) = delivery_receipt.as_ref() {
+                                receipt.complete(candidate_signal_outcome);
                             }
                             continue;
                         }
 
-                        let remote_incarnation_reset = match self
-                            .reset_peer_for_remote_incarnation_if_needed_for_identity(
-                                &from_node_id,
-                                candidate_generation,
-                                sender_public_key.as_deref(),
-                                RemoteIncarnationResetWork::ClearAll,
-                            )
-                            .await
-                        {
-                            Some(changed) => changed,
-                            None => {
-                                debug!(
-                                    "Ignored peer offer from {from_node_id}: signal sender public key is stale"
-                                );
-                                if let Some(receipt) = delivery_receipt.as_ref() {
-                                    receipt.complete(control::SignalApplyOutcome::TerminalRejected);
-                                }
-                                continue;
+                        if candidate_signal_outcome != control::SignalApplyOutcome::Applied {
+                            // A combined offer is one durable transaction. If
+                            // its candidate half could not enter the bounded
+                            // local ledger, do not acknowledge only the
+                            // responder half and silently discard candidates.
+                            // Server redelivery replays the exact encrypted
+                            // offer once capacity or identity turnover clears.
+                            if let Some(receipt) = delivery_receipt.as_ref() {
+                                receipt.complete(candidate_signal_outcome);
                             }
-                        };
-                        if remote_incarnation_reset {
-                            // The peer's restart invalidated its copy of our
-                            // candidate snapshot. Replay our current set in a
-                            // separate worker; the responder admission below
-                            // remains latency-critical and is not delayed by
-                            // candidate publication.
-                            schedule_candidate_republication(
-                                daemon,
-                                &mut responder_work,
-                                from_node_id.clone(),
-                                "remote incarnation reset",
-                            );
-                        }
-                        // Admit the latency-critical responder before touching
-                        // candidate/fresh-prediction state.  A candidate refresh
-                        // may wait on STUN/HTTP or the general slow-work budget;
-                        // an already-delivered WireGuard initiation must not be
-                        // acknowledged locally and then wait behind that work.
-                        if !handshake_init.is_empty() {
-                            let admitted = {
-                                let mut state = self.pending_handshakes.lock();
-                                state.enqueue_responder_work(PendingPeerOffer {
-                                    from_node_id: from_node_id.clone(),
-                                    candidates: candidates.clone(),
-                                    candidate_sources: candidate_sources.clone(),
-                                    candidate_generation,
-                                    network_generation,
-                                    peer_session_generation: self
-                                        .peers
-                                        .peer_session_generation_sync(&from_node_id),
-                                    candidates_expires_at_ms,
-                                    sender_public_key: sender_public_key.clone(),
-                                    handshake_init: handshake_init.clone(),
-                                    punch_at_ms,
-                                    punch_at_server_ms,
-                                    session_id: session_id.clone(),
-                                    probe_ephemeral_public_key: probe_ephemeral_public_key.clone(),
-                                    delivery_receipt: delivery_receipt.clone(),
-                                })
-                            };
-                            if let Some((reservation, offer)) = admitted {
-                                self.peers
-                                    .record_direct_event(
-                                        &from_node_id,
-                                        "peer_offer_responder_work_admitted",
-                                        None,
-                                        Some(candidates.len()),
-                                        None,
-                                        format!(
-                                            "responder owner={} generation={} session_fp={} admitted before candidate-plane work",
-                                            reservation.owner,
-                                            offer.network_generation,
-                                            handshake_token_fingerprint(offer.session_id.as_deref())
-                                        ),
-                                    )
-                                    .await;
-                                debug!(
-                                    "Peer offer responder worker admitted: peer={} owner={} candidates={}",
-                                    from_node_id,
-                                    reservation.owner,
-                                    candidates.len()
-                                );
-                                daemon.timeline.emit(
-                                        "peer_offer_responder_work_admitted",
-                                    None,
-                                    None,
-                                        Some(format!(
-                                        "peer={} owner={} network_generation={} candidate_generation={} session_fp={} deferred_unknown=false",
-                                        from_node_id,
-                                        reservation.owner,
-                                        network_generation,
-                                        candidate_generation,
-                                        handshake_token_fingerprint(session_id.as_deref())
-                                    )),
-                                );
-                                responder_work.push(Box::pin(async move {
-                                    let mut offer = offer;
-                                    let mut reservation = reservation;
-                                    loop {
-                                        let peer_id = offer.from_node_id.clone();
-                                        daemon
-                                            .handle_admitted_responder_offer(
-                                                &offer,
-                                                reservation.owner,
-                                                &mut reservation.cancellation,
-                                            )
-                                            .await;
-                                        if *reservation.cancellation.borrow() {
-                                            return;
-                                        }
-                                        let Some(next) = daemon
-                                            .pending_handshakes
-                                            .lock()
-                                            .finish_responder_work(&peer_id, reservation.owner)
-                                        else {
-                                            break;
-                                        };
-                                        offer = next;
-                                    }
-                                }));
-                            } else {
-                                self.peers
-                                    .record_direct_event(
-                                        &from_node_id,
-                                        "peer_offer_responder_work_coalesced",
-                                        None,
-                                        Some(candidates.len()),
-                                        None,
-                                        "newest responder offer replaced the per-peer queued offer",
-                                    )
-                                    .await;
-                                debug!(
-                                    "Peer offer responder work coalesced: peer={} candidates={}",
-                                    from_node_id,
-                                    candidates.len()
-                                );
-                                self.timeline.emit(
-                                    "peer_offer_responder_work_coalesced",
-                                    None,
-                                    Some("newest_wins_coalesced"),
-                                    Some(format!(
-                                        "peer={} network_generation={} candidate_generation={} session_fp={} queued=true",
-                                        from_node_id,
-                                        network_generation,
-                                        candidate_generation,
-                                        handshake_token_fingerprint(session_id.as_deref())
-                                    )),
-                                );
-                            }
-                        }
-                        // Fresh-prediction verification happens BEFORE any
-                        // candidate state is touched: a superseded prediction
-                        // must not pollute the candidate set, while the handshake
-                        // itself is still handled below.  The prepare/apply/commit
-                        // transaction is shared with the answer path.
-                        //
-                        // The offer-ingress verdict runs even earlier: a duplicate
-                        // or rate-limited offer never touches the candidate plane
-                        // at all (no candidate apply, no fresh transaction, no
-                        // punch), while its handshake part is still answered.
-                        let ingress = self
-                            .offer_ingress_verdict(
-                                &from_node_id,
-                                &candidates,
-                                &candidate_sources,
-                                candidates_expires_at_ms,
-                                sender_public_key.as_deref(),
-                            )
-                            .await;
-                        let (_fresh_verdict, candidate_apply_result, fresh_punch) = if ingress
-                            == OfferIngressVerdict::Apply
-                        {
-                            self.fresh_prediction_transaction(
-                                &from_node_id,
-                                &candidates,
-                                &candidate_sources,
-                                candidate_generation,
-                                candidates_expires_at_ms,
-                                sender_public_key.as_deref(),
-                            )
-                            .await
-                        } else {
-                            self.peers
-                                .record_direct_event(
-                                    &from_node_id,
-                                    "peer_offer_ingress_suppressed",
-                                    None,
-                                    Some(candidates.len()),
-                                    None,
-                                    format!(
-                                        "offer suppressed by ingress verdict={ingress:?}; candidate apply, fresh prediction and punch skipped; handshake_bytes={}",
-                                        handshake_init.len()
-                                    ),
-                                )
-                                .await;
-                            (
-                                FreshSignalVerdict::None,
-                                CandidateSetApplyResult::IgnoredStale,
-                                FreshPunchDecision::None,
-                            )
-                        };
-                        if !handshake_init.is_empty() {
-                            // A successful authenticated offer is fresh
-                            // reachability evidence even when the candidate
-                            // list is byte-for-byte unchanged.  This is the
-                            // common rekey path for Android and must be able
-                            // to wake a frozen direct-recovery epoch before
-                            // the ordinary punch admission gate runs.
-                            self.peers
-                                .recovery_reopen_on_evidence(
-                                    &from_node_id,
-                                    "authenticated_peer_offer",
-                                )
-                                .await;
-                        }
-                        let hard_hard_handling = self
-                            .handle_hard_hard_fresh_offer(
-                                &from_node_id,
-                                session_id.as_deref(),
-                                punch_at_ms,
-                                fresh_punch.clone(),
-                            )
-                            .await;
-                        if candidate_apply_result == CandidateSetApplyResult::Applied
-                            && hard_hard_handling != HardHardOfferHandling::Started
-                        {
-                            self.peers
-                                .clear_hard_hard_sessions(Some(&from_node_id))
-                                .await;
-                        }
-                        if matches!(
-                            hard_hard_handling,
-                            HardHardOfferHandling::Rejected | HardHardOfferHandling::Started
-                        ) {
                             continue;
                         }
-                        match fresh_punch {
-                            // A valid fresh snapshot punches its frozen targets at
-                            // FRESH priority, always.
-                            FreshPunchDecision::Fresh(id, frozen_targets) => {
-                                self.start_hole_punch_at(
-                                    &from_node_id,
-                                    punch_at_ms,
-                                    Some(id),
-                                    Some(frozen_targets),
-                                )
-                                .await;
-                            }
-                            // An expired or empty committed snapshot must never
-                            // claim fresh priority or fall back to the shared
-                            // candidates as a fresh signal: only a handshake-
-                            // carrying offer degrades to an ordinary priority
-                            // punch; a candidate-only offer is ignored.
-                            FreshPunchDecision::Degraded => {
-                                if !handshake_init.is_empty() {
-                                    debug!(
-                                        "Degrading synchronized punch for {from_node_id}: the fresh snapshot is expired or empty; punching at ordinary priority"
-                                    );
-                                    self.start_hole_punch_at(
-                                        &from_node_id,
-                                        punch_at_ms,
-                                        None,
-                                        None,
-                                    )
-                                    .await;
-                                } else {
-                                    debug!(
-                                        "Skipping punch for candidate-only offer from {from_node_id}: its fresh snapshot is expired or empty"
-                                    );
-                                }
-                            }
-                            FreshPunchDecision::None => {
-                                if candidate_signal_starts_synchronized_punch(
-                                    &handshake_init,
-                                    candidate_apply_result,
-                                ) {
-                                    self.start_hole_punch_at(
-                                        &from_node_id,
-                                        punch_at_ms,
-                                        None,
-                                        None,
-                                    )
-                                    .await;
-                                } else {
-                                    debug!(
-                                        "Skipping synchronized punch for rejected candidate-only offer from {from_node_id}: {candidate_apply_result:?}"
-                                    );
-                                }
-                            }
+
+                        // Handshake material has a disjoint per-peer owner. It retains
+                        // the durable receipt until the exact responder transaction is
+                        // Applied/TerminalRejected; candidate work cannot occupy this slot.
+                        let admitted = {
+                            let mut state = self.pending_handshakes.lock();
+                            state.enqueue_responder_work(PendingPeerOffer {
+                                from_node_id: from_node_id.clone(),
+                                candidates,
+                                candidate_sources,
+                                candidate_generation,
+                                network_generation,
+                                peer_session_generation: self
+                                    .peers
+                                    .peer_session_generation_sync(&from_node_id),
+                                candidates_expires_at_ms,
+                                sender_public_key,
+                                handshake_init,
+                                punch_at_ms,
+                                punch_at_server_ms,
+                                session_id: session_id.clone(),
+                                probe_ephemeral_public_key,
+                                delivery_receipt: delivery_receipt.clone(),
+                            })
+                        };
+                        if let Some((reservation, offer)) = admitted {
+                            self.timeline.emit(
+                                "peer_offer_responder_work_admitted",
+                                None,
+                                None,
+                                Some(format!(
+                                    "peer={} owner={} network_generation={} candidate_generation={} session_fp={} deferred_unknown={}",
+                                    from_node_id,
+                                    reservation.owner,
+                                    network_generation,
+                                    candidate_generation,
+                                    handshake_token_fingerprint(session_id.as_deref()),
+                                    !peer_known
+                                )),
+                            );
+                            responder_work.push(Box::pin(async move {
+                                daemon.run_responder_offer_worker(offer, reservation).await;
+                            }));
+                        } else {
+                            self.timeline.emit(
+                                "peer_offer_responder_work_coalesced",
+                                None,
+                                Some("newest_wins_coalesced"),
+                                Some(format!(
+                                    "peer={} network_generation={} candidate_generation={} session_fp={} queued=true",
+                                    from_node_id,
+                                    network_generation,
+                                    candidate_generation,
+                                    handshake_token_fingerprint(session_id.as_deref())
+                                )),
+                            );
                         }
+                        continue;
                     }
 
                     ControlEvent::PeerAnswer {
@@ -3338,19 +3317,29 @@ impl Daemon {
                         if !self.peers.peer_exists_sync(&from_node_id) {
                             self.control.refresh_peers_now();
                         }
-                        self.peers
-                            .record_direct_event(
-                                &from_node_id,
-                                "peer_answer_received",
-                                None,
-                                Some(candidates.len()),
-                                None,
-                                format!(
-                                    "received answer handshake_bytes={} punch_at_ms={punch_at_ms:?}",
-                                    handshake_response.len()
-                                ),
-                            )
-                            .await;
+                        self.peers.record_direct_event_non_queuing(
+                            &from_node_id,
+                            "peer_answer_received",
+                            None,
+                            Some(candidates.len()),
+                            None,
+                            format!(
+                                "received answer handshake_bytes={} punch_at_ms={punch_at_ms:?}",
+                                handshake_response.len()
+                            ),
+                        );
+                        self.timeline.emit(
+                            "peer_answer_received",
+                            None,
+                            None,
+                            Some(format!(
+                                "peer={} candidate_generation={} handshake_bytes={} candidates={}",
+                                from_node_id,
+                                candidate_generation,
+                                handshake_response.len(),
+                                candidates.len()
+                            )),
+                        );
                         // The answer can be the first signal observed after the
                         // remote daemon restarted. Fence the retired transport but
                         // preserve the exact local initiator that this answer is
@@ -3368,8 +3357,9 @@ impl Daemon {
                             )
                             .await
                         {
-                            Some(changed) => changed,
-                            None => {
+                            RemoteIncarnationResetOutcome::Changed => true,
+                            RemoteIncarnationResetOutcome::Unchanged => false,
+                            RemoteIncarnationResetOutcome::RejectedIdentity => {
                                 debug!(
                                     "Ignored peer answer from {from_node_id}: signal sender public key is stale"
                                 );
@@ -3378,6 +3368,21 @@ impl Daemon {
                                 }
                                 continue;
                             }
+                            RemoteIncarnationResetOutcome::RejectedLifecycle => {
+                                if let Some(receipt) = answer_delivery_receipt.as_ref() {
+                                    receipt.complete(
+                                        control::SignalApplyOutcome::TerminalRejected,
+                                    );
+                                }
+                                continue;
+                            }
+                            outcome if outcome.retryable() => {
+                                if let Some(receipt) = answer_delivery_receipt.as_ref() {
+                                    receipt.complete(control::SignalApplyOutcome::Retry);
+                                }
+                                continue;
+                            }
+                            _ => false,
                         };
                         // Consume the WireGuard answer before candidate refresh or
                         // fresh-mapping work. Those paths may perform HTTP/STUN
@@ -3630,6 +3635,7 @@ impl Daemon {
         // daemon shutdown rather than leaving detached work behind.
         drop(slow_work);
         drop(responder_work);
+        drop(candidate_work);
         self.control_rx = control_rx;
     }
 }

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -211,6 +211,29 @@ impl RemoteIncarnationResetOutcome {
 }
 
 impl Daemon {
+    fn kick_handshake_after_remote_incarnation_rotation(
+        &self,
+        peer_id: &str,
+        claimed_incarnation: u64,
+    ) {
+        // Rotating PeerSessionGeneration correctly invalidates every starting
+        // initiator reservation stamped by the retired incarnation. Publish a
+        // separate commit-before-wake edge so the supervised maintenance
+        // owner immediately reserves a replacement under the new generation
+        // when this node is the deterministic initiator. The responder role
+        // observes the same edge and exits without claiming a reservation.
+        self.path_setup_kick_tx
+            .send_modify(|revision| *revision = revision.wrapping_add(1));
+        self.timeline.emit(
+            "remote_incarnation_handshake_restart_kicked",
+            None,
+            Some("peer_session_generation_rotated"),
+            Some(format!(
+                "peer={peer_id} incarnation={claimed_incarnation}"
+            )),
+        );
+    }
+
     fn clear_peer_handshake_lifecycle(&self, peer_id: &str, phase: &'static str) {
         let identity = HandshakeLeaseIdentity::new(
             peer_id,
@@ -418,6 +441,12 @@ impl Daemon {
                 .lock()
                 .finish_remote_incarnation_reset(peer_id, claimed_incarnation);
             drop(udp_slot);
+            if changed {
+                self.kick_handshake_after_remote_incarnation_rotation(
+                    peer_id,
+                    claimed_incarnation,
+                );
+            }
             return if changed {
                 RemoteIncarnationResetOutcome::Changed
             } else {
@@ -541,6 +570,10 @@ impl Daemon {
         }
         drop(udp_slot);
         if changed {
+            self.kick_handshake_after_remote_incarnation_rotation(
+                peer_id,
+                claimed_incarnation,
+            );
             RemoteIncarnationResetOutcome::Changed
         } else {
             RemoteIncarnationResetOutcome::RejectedLifecycle

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -82,6 +82,9 @@ fn responder_offer_error_is_retryable(error: &DaemonError) -> bool {
             error,
             DaemonError::Network(reason)
                 if reason == REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT
+                    || reason == REASON_RESPONDER_SESSION_STAGE_TIMEOUT
+                    || reason == REASON_RESPONDER_PROBE_BINDING_CONTENDED
+                    || reason == REASON_RESPONDER_COMMIT_CONTENDED
         )
 }
 
@@ -90,6 +93,15 @@ fn responder_offer_error_reason_code(error: &DaemonError) -> &'static str {
         DaemonError::ControlPlane(_) => "control_plane_error",
         DaemonError::Network(reason) if reason == REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT => {
             REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT
+        }
+        DaemonError::Network(reason) if reason == REASON_RESPONDER_SESSION_STAGE_TIMEOUT => {
+            REASON_RESPONDER_SESSION_STAGE_TIMEOUT
+        }
+        DaemonError::Network(reason) if reason == REASON_RESPONDER_PROBE_BINDING_CONTENDED => {
+            REASON_RESPONDER_PROBE_BINDING_CONTENDED
+        }
+        DaemonError::Network(reason) if reason == REASON_RESPONDER_COMMIT_CONTENDED => {
+            REASON_RESPONDER_COMMIT_CONTENDED
         }
         _ => "responder_offer_error",
     }

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -1861,15 +1861,97 @@ impl Daemon {
                 .await;
             let (_fresh_verdict, candidate_apply_result, fresh_punch) =
                 if ingress == OfferIngressVerdict::Apply {
-                    self.fresh_prediction_transaction(
-                        &peer_id,
-                        &offer.candidates,
-                        &offer.candidate_sources,
-                        offer.candidate_generation,
-                        offer.candidates_expires_at_ms,
-                        offer.sender_public_key.as_deref(),
-                    )
-                    .await
+                    if matches!(
+                        fresh_prediction_from_sources(&offer.candidate_sources),
+                        Ok(None)
+                    ) {
+                        // Ordinary candidate revisions are the common cold-start
+                        // path. Never hold the epoch while queueing a connection
+                        // writer: the bounded candidate owner already retains the
+                        // exact payload and can retry without blocking RelayReady,
+                        // confirmation, status, or the responder receipt.
+                        let mut apply_retry_attempt = 0u8;
+                        let apply_result = loop {
+                            match self
+                                .peers
+                                .try_add_candidates_with_metadata_for_identity(
+                                    &peer_id,
+                                    &offer.candidates,
+                                    &offer.candidate_sources,
+                                    offer.candidate_generation,
+                                    offer.candidates_expires_at_ms,
+                                    offer.sender_public_key.as_deref(),
+                                )
+                                .await
+                            {
+                                crate::peer::CandidateSetTryApplyOutcome::Completed(result) => {
+                                    break result;
+                                }
+                                outcome @ (crate::peer::CandidateSetTryApplyOutcome::ContendedEpoch
+                                | crate::peer::CandidateSetTryApplyOutcome::ContendedConnections) => {
+                                    if let Some(newest) = self
+                                        .pending_handshakes
+                                        .lock()
+                                        .take_queued_candidate_offer_work(
+                                            &peer_id,
+                                            reservation.owner,
+                                        )
+                                    {
+                                        offer = newest;
+                                        continue 'work;
+                                    }
+                                    apply_retry_attempt = apply_retry_attempt.saturating_add(1);
+                                    let delay =
+                                        responder_offer_retry_delay(apply_retry_attempt);
+                                    let reason_code = match outcome {
+                                        crate::peer::CandidateSetTryApplyOutcome::ContendedEpoch => {
+                                            "candidate_epoch_busy"
+                                        }
+                                        crate::peer::CandidateSetTryApplyOutcome::ContendedConnections => {
+                                            "candidate_connections_busy"
+                                        }
+                                        crate::peer::CandidateSetTryApplyOutcome::Completed(_) => {
+                                            unreachable!()
+                                        }
+                                    };
+                                    self.timeline.emit(
+                                        "peer_offer_candidate_retry",
+                                        None,
+                                        Some(reason_code),
+                                        Some(format!(
+                                            "peer={} owner={} retry_attempt={} delay_ms={}",
+                                            peer_id,
+                                            reservation.owner,
+                                            apply_retry_attempt,
+                                            delay.as_millis()
+                                        )),
+                                    );
+                                    tokio::select! {
+                                        _ = sleep(delay) => {}
+                                        changed = reservation.cancellation.changed() => {
+                                            let _ = changed;
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                        (
+                            FreshSignalVerdict::None,
+                            apply_result,
+                            FreshPunchDecision::None,
+                        )
+                    } else {
+                        self.fresh_prediction_transaction(
+                            &peer_id,
+                            &offer.candidates,
+                            &offer.candidate_sources,
+                            offer.candidate_generation,
+                            offer.candidates_expires_at_ms,
+                            offer.sender_public_key.as_deref(),
+                        )
+                        .await
+                    }
                 } else {
                     self.peers
                         .record_direct_event(

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -167,11 +167,53 @@ enum RemoteIncarnationResetWork {
 }
 
 impl Daemon {
+    fn clear_peer_handshake_lifecycle(&self, peer_id: &str, phase: &'static str) {
+        let identity = HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::Cleanup,
+            None,
+            self.peers.current_network_generation_sync(),
+            self.peers.peer_session_generation_sync(peer_id),
+            phase,
+        );
+        let lease = self.handshake_arbiter.try_acquire(identity);
+        match lease {
+            Ok(lease) => {
+                let cleared = self
+                    .pending_handshakes
+                    .try_with(|state| state.clear_peer(peer_id))
+                    .is_some();
+                drop(lease);
+                if !cleared {
+                    // Authoritative lifecycle cancellation may briefly wait
+                    // for another short pending-state transaction, but never
+                    // while owning the handshake mutation turn.
+                    self.pending_handshakes.lock().clear_peer(peer_id);
+                }
+            }
+            Err(contention) => {
+                self.pending_handshakes.lock().clear_peer(peer_id);
+                let holder = contention
+                    .holder
+                    .as_ref()
+                    .map(HandshakeHolderSnapshot::detail)
+                    .unwrap_or_else(|| "holder_kind=unknown holder_phase=unknown".to_string());
+                self.timeline.emit(
+                    "handshake_cleanup_turn_contended",
+                    None,
+                    Some("arbiter_contended"),
+                    Some(format!("peer={peer_id} phase={phase} {holder}")),
+                );
+            }
+        }
+    }
+
     /// A same-node remote restart is identified by the encoded candidate
     /// generation carried in its offer. Keep this narrow: endpoint metadata is
     /// also changed by ordinary NAT churn and is not safe as a lifecycle
-    /// signal. The arbiter covers the short state boundary; UDP cleanup then
-    /// invalidates late probes and dynamic socket adoption.
+    /// signal. PeerManager's claimed-incarnation transaction and the exact
+    /// peer-session generation provide the boundary; the handshake arbiter is
+    /// intentionally absent because this cleanup crosses actor awaits.
     #[cfg(test)]
     async fn reset_peer_for_remote_incarnation_if_needed(
         &self,
@@ -205,7 +247,6 @@ impl Daemon {
             // a lifecycle branch could wait for that arbiter and stop polling
             // its owner forever. Run the complete claim/cleanup/commit turn in
             // an independently scheduled task so the owner keeps progressing.
-            let handshake_arbiter = self.handshake_arbiter.clone();
             let transport = self.transport.clone();
             let punch_attempts = self.punch_attempts.clone();
             let udp_transport = self.udp_transport.clone();
@@ -216,7 +257,6 @@ impl Daemon {
             let peer_id_for_error = peer_id.clone();
             let sender_public_key = sender_public_key.map(str::to_string);
             return match tokio::spawn(async move {
-                let handshake_guard = handshake_arbiter.acquire(&peer_id).await;
                 let claim = peers
                     .claim_remote_candidate_incarnation_for_identity(
                         &peer_id,
@@ -226,7 +266,6 @@ impl Daemon {
                     .await;
                 let (old_incarnation, claimed_incarnation) = match claim {
                     crate::peer::RemoteCandidateIncarnationClaim::IdentityMismatch => {
-                        drop(handshake_guard);
                         peers
                             .record_direct_event(
                                 &peer_id,
@@ -250,7 +289,6 @@ impl Daemon {
                         return None;
                     }
                     crate::peer::RemoteCandidateIncarnationClaim::NoReset => {
-                        drop(handshake_guard);
                         return Some(false);
                     }
                     crate::peer::RemoteCandidateIncarnationClaim::Reset {
@@ -306,11 +344,9 @@ impl Daemon {
                 if changed {
                     pending_handshakes
                         .lock()
-                        .await
                         .clear_peer_except_responder_owner(&peer_id);
                 }
                 drop(udp_slot);
-                drop(handshake_guard);
                 Some(changed)
             })
             .await
@@ -325,7 +361,6 @@ impl Daemon {
             };
         }
 
-        let handshake_guard = self.handshake_arbiter.acquire(peer_id).await;
         let claim = self
             .peers
             .claim_remote_candidate_incarnation_for_identity(
@@ -336,7 +371,6 @@ impl Daemon {
             .await;
         let (old_incarnation, claimed_incarnation) = match claim {
             crate::peer::RemoteCandidateIncarnationClaim::IdentityMismatch => {
-                drop(handshake_guard);
                 self.peers
                     .record_direct_event(
                         peer_id,
@@ -360,7 +394,6 @@ impl Daemon {
                 return None;
             }
             crate::peer::RemoteCandidateIncarnationClaim::NoReset => {
-                drop(handshake_guard);
                 return Some(false);
             }
             crate::peer::RemoteCandidateIncarnationClaim::Reset {
@@ -415,7 +448,7 @@ impl Daemon {
                 .await
         };
         if changed {
-            let mut pending = self.pending_handshakes.lock().await;
+            let mut pending = self.pending_handshakes.lock();
             match pending_work {
                 RemoteIncarnationResetWork::ClearAll => pending.clear_peer(peer_id),
                 RemoteIncarnationResetWork::PreserveInitiator => {
@@ -440,7 +473,6 @@ impl Daemon {
             }
         }
         drop(udp_slot);
-        drop(handshake_guard);
         Some(changed)
     }
 
@@ -1223,7 +1255,6 @@ impl Daemon {
             let Some(next) = self
                 .pending_handshakes
                 .lock()
-                .await
                 .finish_peer_reflexive_work(&peer_id, reservation.owner)
             else {
                 return;
@@ -1494,7 +1525,6 @@ impl Daemon {
                 let Some(next) = self
                     .pending_handshakes
                     .lock()
-                    .await
                     .finish_responder_work(&peer_id, reservation.owner)
                 else {
                     offer.complete_delivery(control::SignalApplyOutcome::Retry);
@@ -1511,7 +1541,6 @@ impl Daemon {
             if let Some(newest) = self
                 .pending_handshakes
                 .lock()
-                .await
                 .take_queued_responder_work(&peer_id, reservation.owner)
             {
                 offer.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
@@ -1537,7 +1566,6 @@ impl Daemon {
                     let Some(next) = self
                         .pending_handshakes
                         .lock()
-                        .await
                         .finish_responder_work(&peer_id, reservation.owner)
                     else {
                         return;
@@ -1553,7 +1581,6 @@ impl Daemon {
                 let Some(next) = self
                     .pending_handshakes
                     .lock()
-                    .await
                     .finish_responder_work(&peer_id, reservation.owner)
                 else {
                     return;
@@ -1653,7 +1680,6 @@ impl Daemon {
             let Some(next) = self
                 .pending_handshakes
                 .lock()
-                .await
                 .finish_responder_work(&peer_id, reservation.owner)
             else {
                 return;
@@ -2009,7 +2035,7 @@ impl Daemon {
     /// after the global slow-work cap. This drain is newest-wins per peer,
     /// checks the current online state before starting, and leaves the
     /// per-peer reservation as the single-flight boundary for duplicates.
-    async fn drain_deferred_initiator_handshakes<'a>(
+    fn drain_deferred_initiator_handshakes<'a>(
         &'a self,
         slow_work: &mut FuturesUnordered<ControlEventWork<'a>>,
         deferred: &mut InitiatorQueue<control::PeerInfo>,
@@ -2027,22 +2053,8 @@ impl Daemon {
             };
             scanned = scanned.saturating_add(1);
             let peer_id = peer_info.node_id.clone();
-            let current_online = self
-                .peers
-                .get_connection(&peer_id)
-                .await
-                .is_some_and(|peer| peer.online);
+            let current_online = self.peers.peer_session_generation_sync(&peer_id).is_some();
             if !current_online {
-                self.peers
-                    .record_direct_event(
-                        &peer_id,
-                        "initiator_handshake_deferred_dropped",
-                        None,
-                        None,
-                        None,
-                        "reason_code=peer_offline_or_removed deferred control handshake was not started",
-                    )
-                    .await;
                 self.timeline.emit(
                     "initiator_handshake_deferred_dropped",
                     None,
@@ -2056,7 +2068,10 @@ impl Daemon {
                 continue;
             }
 
-            let Some(reservation) = self.reserve_event_initiator_handshake(&peer_id).await else {
+            let Some(reservation) = self
+                .reserve_event_initiator_handshake(&peer_id)
+                .into_reservation()
+            else {
                 // An existing pending handshake or starting worker owns this
                 // peer. Keep the newest roster update for the next completion
                 // pass; dropping it here would make endpoint/incarnation
@@ -2074,6 +2089,111 @@ impl Daemon {
             slow_work.push(Box::pin(async move {
                 daemon
                     .run_event_initiator_handshake(peer_info, reservation)
+                    .await;
+            }));
+        }
+    }
+
+    /// Validate one already-claimed retry inside the bounded slow-work lane.
+    /// In particular, the control roster snapshot may wait on its own actor;
+    /// it must never stall the serial control receiver which owns ledger
+    /// admission and wake processing.
+    async fn run_claimed_initiator_retry(
+        &self,
+        identity: HandshakeRetryIdentity,
+        mut reservation: HandshakeStartReservation,
+    ) {
+        let lifecycle_current = self.peers.current_network_generation_sync()
+            == identity.network_generation
+            && self
+                .peers
+                .peer_session_is_current_sync(&identity.peer_id, identity.peer_session_generation);
+        if !lifecycle_current {
+            self.pending_handshakes
+                .lock()
+                .cancel_reservation_if_current(&identity.peer_id, identity.reservation_owner);
+            self.timeline.emit(
+                "initiator_handshake_retry_cancelled",
+                None,
+                Some("stale_lifecycle"),
+                Some(format!(
+                    "peer={} owner={} generation={} peer_session_generation={} phase={} attempt={} cancellation_generation={}",
+                    identity.peer_id,
+                    identity.reservation_owner,
+                    identity.network_generation,
+                    identity.peer_session_generation.value(),
+                    identity.phase.as_str(),
+                    identity.attempt,
+                    identity.cancellation_generation,
+                )),
+            );
+            return;
+        }
+
+        let peer_info = self.control.peers().await.get(&identity.peer_id).cloned();
+        let Some(peer_info) = peer_info else {
+            if !self.schedule_initiator_retry(
+                &identity.peer_id,
+                &mut reservation,
+                identity.phase,
+                "control_snapshot_unavailable",
+            ) {
+                self.pending_handshakes
+                    .lock()
+                    .cancel_reservation_if_current(&identity.peer_id, identity.reservation_owner);
+            }
+            return;
+        };
+        if !peer_info.online || !self.should_start_initiator_handshake(&peer_info) {
+            self.pending_handshakes
+                .lock()
+                .cancel_reservation_if_current(&identity.peer_id, identity.reservation_owner);
+            return;
+        }
+
+        self.timeline.emit(
+            "initiator_handshake_retry_admitted",
+            None,
+            None,
+            Some(format!(
+                "peer={} owner={} generation={} peer_session_generation={} phase={} attempt={} cancellation_generation={}",
+                identity.peer_id,
+                identity.reservation_owner,
+                identity.network_generation,
+                identity.peer_session_generation.value(),
+                identity.phase.as_str(),
+                identity.attempt,
+                identity.cancellation_generation,
+            )),
+        );
+        self.run_event_initiator_handshake(peer_info, reservation)
+            .await;
+    }
+
+    /// Drain exact preparation/publication retries from the authoritative
+    /// per-peer ledger. Records are removed only when this supervised owner
+    /// claims them; a repeated watch kick merely causes another bounded scan.
+    /// This coordinator performs no await: all roster/session/control work is
+    /// polled as part of the existing bounded slow-work lane.
+    fn drain_initiator_retry_ledger<'a>(
+        &'a self,
+        slow_work: &mut FuturesUnordered<ControlEventWork<'a>>,
+    ) {
+        self.pending_handshakes
+            .lock()
+            .expire_initiator_retries(Instant::now());
+        while slow_work.len() < MAX_CONTROL_EVENT_SLOW_WORK {
+            let claimed = self
+                .pending_handshakes
+                .lock()
+                .claim_ready_initiator_retry(Instant::now());
+            let Some((identity, reservation)) = claimed else {
+                break;
+            };
+            let daemon = self;
+            slow_work.push(Box::pin(async move {
+                daemon
+                    .run_claimed_initiator_retry(identity, reservation)
                     .await;
             }));
         }
@@ -2100,6 +2220,9 @@ impl Daemon {
         let mut responder_work: FuturesUnordered<ControlEventWork<'_>> = FuturesUnordered::new();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let mut task_shutdown_rx = self.task_manager.shutdown_rx();
+        let mut handshake_retry_kick_rx = self.handshake_retry_kick_tx.subscribe();
+        let mut handshake_retry_tick = tokio::time::interval(Duration::from_millis(25));
+        handshake_retry_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                     _ = shutdown_rx.changed() => {
@@ -2118,12 +2241,12 @@ impl Daemon {
                         // Completion frees a bounded slot. Admit the oldest still
                         // live deferred peer immediately instead of waiting for a
                         // later control poll.
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
                                 &mut deferred_initiators,
-                            )
-                            .await;
+                            );
                     }
                     _ = responder_work.next(), if !responder_work.is_empty() => {
                         // Responder workers own their per-peer pending state and
@@ -2131,12 +2254,32 @@ impl Daemon {
                         // completion can also free a pending initiator's
                         // reservation, so retry deferred roster work here even
                         // when the general slow-work lane is otherwise idle.
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
                                 &mut deferred_initiators,
-                            )
-                            .await;
+                            );
+                    }
+                    changed = handshake_retry_kick_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                        handshake_retry_kick_rx.borrow_and_update();
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            );
+                    }
+                    _ = handshake_retry_tick.tick() => {
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            );
                     }
                     event = control_rx.recv() => {
                         let Some(event) = event else {
@@ -2319,7 +2462,7 @@ impl Daemon {
                             } else if should_start_initiator {
                                 if let Some(reservation) = self
                                     .reserve_event_initiator_handshake(&peer_info.node_id)
-                                    .await
+                                    .into_reservation()
                                 {
                                     debug!(
                                         "PeerJoined handshake reserved: peer={} elapsed_ms={}",
@@ -2379,13 +2522,11 @@ impl Daemon {
 
                     ControlEvent::PeerUpdated(peer_info) => {
                         // Public-key/offline publication and old-session removal
-                        // are one handshake lifecycle boundary. Offer/answer
-                        // workers re-check the server-bound sender key while they
-                        // own this same arbiter, so they can observe wholly before
-                        // or wholly after the update, never between `add_peer` and
-                        // the retired session cleanup.
-                        let peer_update_handshake_guard =
-                            self.handshake_arbiter.acquire(&peer_info.node_id).await;
+                        // are fenced by PeerSessionGeneration and exact pending
+                        // ownership.  This branch intentionally does not own the
+                        // handshake arbiter across connection/session/UDP actor
+                        // awaits; old work is cancelled synchronously in the
+                        // pending store before it can publish into the new life.
                         let previous = self.peers.get_connection(&peer_info.node_id).await;
                         let previous_peer_session_generation = self
                             .peers
@@ -2415,6 +2556,10 @@ impl Daemon {
                                 &mut deferred_initiators,
                                 &peer_info.node_id,
                             );
+                            self.clear_peer_handshake_lifecycle(
+                                &peer_info.node_id,
+                                "peer_offline",
+                            );
                             self.transport
                                 .remove_session_with_reason(
                                     &peer_info.node_id,
@@ -2422,11 +2567,6 @@ impl Daemon {
                                     "control_events.peer_updated_offline",
                                 )
                                 .await;
-                            self.pending_handshakes
-                                .lock()
-                                .await
-                                .clear_peer(&peer_info.node_id);
-                            drop(peer_update_handshake_guard);
                             if previous_peer_session_generation.is_none() {
                                 self.punch_attempts.cancel(&peer_info.node_id);
                             }
@@ -2468,6 +2608,10 @@ impl Daemon {
                                 &mut deferred_initiators,
                                 &peer_info.node_id,
                             );
+                            self.clear_peer_handshake_lifecycle(
+                                &peer_info.node_id,
+                                "public_key_changed",
+                            );
                             self.transport
                                 .remove_session_with_reason(
                                     &peer_info.node_id,
@@ -2475,11 +2619,6 @@ impl Daemon {
                                     "control_events.peer_updated_public_key",
                                 )
                                 .await;
-                            self.pending_handshakes
-                                .lock()
-                                .await
-                                .clear_peer(&peer_info.node_id);
-                            drop(peer_update_handshake_guard);
                             info!(
                                 "Peer {} public key changed; discarded the old WireGuard session",
                                 peer_info.node_id
@@ -2504,7 +2643,6 @@ impl Daemon {
                                 .await;
                             }
                         } else {
-                            drop(peer_update_handshake_guard);
                             if update.endpoint_changed {
                                 // Endpoint metadata changes are normal NAT/candidate
                                 // churn. They must not tear down a confirmed relay or
@@ -2592,7 +2730,7 @@ impl Daemon {
                         } else if should_start_initiator {
                             if let Some(reservation) = self
                                 .reserve_event_initiator_handshake(&peer_info.node_id)
-                                .await
+                                .into_reservation()
                             {
                                 let peer_info = peer_info.clone();
                                 slow_work.push(Box::pin(async move {
@@ -2639,20 +2777,17 @@ impl Daemon {
                                 self.dns.unregister(&previous.virtual_ip).await;
                             }
                         }
-                        {
-                            // PeerLeft shares the same short state boundary as
-                            // offer staging. It never holds the arbiter across the
-                            // subsequent UDP lifecycle cleanup.
-                            let _handshake_guard = self.handshake_arbiter.acquire(&node_id).await;
-                            self.transport
-                                .remove_session_with_reason(
-                                    &node_id,
-                                    "peer_left",
-                                    "control_events.peer_left",
-                                )
-                                .await;
-                            self.pending_handshakes.lock().await.clear_peer(&node_id);
-                        }
+                        // Cancel the exact reservation/retry first.  This is a
+                        // short in-memory transaction; the subsequent session
+                        // and UDP actor cleanup owns no handshake arbiter lease.
+                        self.clear_peer_handshake_lifecycle(&node_id, "peer_left");
+                        self.transport
+                            .remove_session_with_reason(
+                                &node_id,
+                                "peer_left",
+                                "control_events.peer_left",
+                            )
+                            .await;
                         // Keep the slot read guard through the selected cleanup.
                         // A UDP task cannot publish between observing `None` and
                         // structural removal (or replace a `Some` transport while
@@ -2754,7 +2889,7 @@ impl Daemon {
                                 )
                                 .await;
                             let admitted = {
-                                let mut state = self.pending_handshakes.lock().await;
+                                let mut state = self.pending_handshakes.lock();
                                 state.enqueue_responder_work(PendingPeerOffer {
                                     from_node_id: from_node_id.clone(),
                                     candidates: candidates.clone(),
@@ -2816,7 +2951,7 @@ impl Daemon {
                         // for the same peer is coalesced by the same owner.
                         if handshake_init.is_empty() {
                             let admitted = {
-                                let mut state = self.pending_handshakes.lock().await;
+                                let mut state = self.pending_handshakes.lock();
                                 state.enqueue_responder_work(PendingPeerOffer {
                                     from_node_id: from_node_id.clone(),
                                     candidates: candidates.clone(),
@@ -2912,7 +3047,7 @@ impl Daemon {
                         // acknowledged locally and then wait behind that work.
                         if !handshake_init.is_empty() {
                             let admitted = {
-                                let mut state = self.pending_handshakes.lock().await;
+                                let mut state = self.pending_handshakes.lock();
                                 state.enqueue_responder_work(PendingPeerOffer {
                                     from_node_id: from_node_id.clone(),
                                     candidates: candidates.clone(),
@@ -2985,7 +3120,6 @@ impl Daemon {
                                         let Some(next) = daemon
                                             .pending_handshakes
                                             .lock()
-                                            .await
                                             .finish_responder_work(&peer_id, reservation.owner)
                                         else {
                                             break;
@@ -3390,7 +3524,7 @@ impl Daemon {
                             delivery_receipt,
                         };
                         let admitted = {
-                            let mut state = self.pending_handshakes.lock().await;
+                            let mut state = self.pending_handshakes.lock();
                             if !state.has_peer_reflexive_worker(&from_node_id)
                                 && slow_work.len() >= MAX_CONTROL_EVENT_SLOW_WORK
                             {
@@ -3470,12 +3604,12 @@ impl Daemon {
                         // in either cooperative lane. Revisit the newest
                         // deferred roster edge before waiting for another
                         // unrelated event.
+                        daemon.drain_initiator_retry_ledger(&mut slow_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
                                 &mut deferred_initiators,
-                            )
-                            .await;
+                            );
                     }
                 }
         }

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -21,7 +21,7 @@ pub struct Daemon {
     /// business packets).
     outbound_rx: Option<mpsc::Receiver<OutboundPacket>>,
     /// In-flight initiator handshakes keyed by responder node ID (shared so timeout tasks can clean up).
-    pending_handshakes: Arc<tokio::sync::Mutex<PendingHandshakeState>>,
+    pending_handshakes: Arc<PendingHandshakeStore>,
     /// Serializes offer, answer, and maintenance mutations for one peer.
     handshake_arbiter: HandshakeArbiter,
     #[cfg(test)]
@@ -100,10 +100,13 @@ pub struct Daemon {
     /// polling at a fixed interval.
     relay_available_tx: watch::Sender<bool>,
     /// Shared event edge for forced Relay probing and encrypted-session
-    /// maintenance. A bounded initiator connection-writer timeout bumps this
-    /// edge after cancelling its reservation, so the failed setup is retried
-    /// by the normal maintenance owner instead of remaining silently lost.
+    /// maintenance. Relay availability and authenticated data-plane activity
+    /// bump this edge so a missing encrypted session is reconsidered promptly.
     path_setup_kick_tx: watch::Sender<u64>,
+    /// Commit-before-wake edge for exact initiator preparation/publication
+    /// retries.  The serial control owner consumes it; maintenance periodically
+    /// republishes the current revision as a lost-wakeup backstop.
+    handshake_retry_kick_tx: watch::Sender<u64>,
     /// Android's VpnService establishes the TUN before the Rust daemon starts.
     #[cfg(target_os = "android")]
     android_tun_fd: Option<std::os::fd::RawFd>,
@@ -183,6 +186,8 @@ impl Daemon {
         let udp_transport = Arc::new(RwLock::new(None));
         let (relay_available_tx, _relay_available_rx) = tokio::sync::watch::channel(false);
         let (path_setup_kick_tx, _path_setup_kick_rx) = tokio::sync::watch::channel(0u64);
+        let (handshake_retry_kick_tx, _handshake_retry_kick_rx) =
+            tokio::sync::watch::channel(0u64);
 
         // Register the punch-session canceller on the peer manager so a
         // stale/404 quarantined peer's in-flight recovery session is
@@ -190,6 +195,7 @@ impl Daemon {
         // the same deduplicator the daemon hands to the punch tasks).
         let punch_attempts = PunchAttemptDeduplicator::default();
         let peers = Arc::new(PeerManager::new(config.clone()));
+        let pending_handshakes = Arc::new(PendingHandshakeStore::default());
         peers.set_timeline(timeline.clone());
         transport.set_outbound_loss_context(&peers, timeline.clone());
         // Share ONE outbound-loss counter map between the peer manager (worker
@@ -207,6 +213,31 @@ impl Daemon {
                 punch_attempts.cancel(peer_id);
             }));
         }
+        {
+            let pending_handshakes = pending_handshakes.clone();
+            let timeline = timeline.clone();
+            peers.set_network_generation_handshake_cancel_hook(Arc::new(move |generation| {
+                let (cancelled_reservations, cancelled_pending, stale_probe_bindings) =
+                    pending_handshakes
+                    .lock()
+                    .cancel_before_network_generation(generation);
+                if cancelled_reservations > 0 || cancelled_pending > 0 {
+                    timeline.emit(
+                        "handshake_reservations_cancelled_for_generation",
+                        None,
+                        Some("network_generation_advanced"),
+                        Some(format!(
+                            "generation={generation} cancelled_reservations={cancelled_reservations} cancelled_pending={cancelled_pending}"
+                        )),
+                    );
+                }
+                (
+                    cancelled_reservations,
+                    cancelled_pending,
+                    stale_probe_bindings,
+                )
+            }));
+        }
 
         Self {
             config: Arc::new(config.clone()),
@@ -215,8 +246,8 @@ impl Daemon {
             peers,
             transport,
             outbound_rx: Some(outbound_rx),
-            pending_handshakes: Arc::new(tokio::sync::Mutex::new(PendingHandshakeState::default())),
-            handshake_arbiter: HandshakeArbiter::default(),
+            pending_handshakes,
+            handshake_arbiter: HandshakeArbiter::new(timeline.clone()),
             #[cfg(test)]
             responder_post_answer_test_gate: Arc::new(std::sync::Mutex::new(None)),
             local_candidates: Arc::new(RwLock::new(Vec::new())),
@@ -254,6 +285,7 @@ impl Daemon {
             status_events,
             relay_available_tx,
             path_setup_kick_tx,
+            handshake_retry_kick_tx,
             #[cfg(target_os = "android")]
             android_tun_fd: None,
             #[cfg(target_os = "android")]

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+type ResponderPostAnswerTestGateSlot =
+    Arc<std::sync::Mutex<Option<(String, Arc<ResponderPostAnswerTestGate>)>>>;
+
 /// The main daemon orchestrator.
 ///
 /// Holds all subsystems and coordinates their lifecycle.
@@ -20,6 +24,8 @@ pub struct Daemon {
     pending_handshakes: Arc<tokio::sync::Mutex<PendingHandshakeState>>,
     /// Serializes offer, answer, and maintenance mutations for one peer.
     handshake_arbiter: HandshakeArbiter,
+    #[cfg(test)]
+    responder_post_answer_test_gate: ResponderPostAnswerTestGateSlot,
     /// Local UDP candidate endpoints advertised in signaling messages.
     local_candidates: Arc<RwLock<Vec<String>>>,
     /// Local-only source metadata keyed by candidate endpoint string.
@@ -211,6 +217,8 @@ impl Daemon {
             outbound_rx: Some(outbound_rx),
             pending_handshakes: Arc::new(tokio::sync::Mutex::new(PendingHandshakeState::default())),
             handshake_arbiter: HandshakeArbiter::default(),
+            #[cfg(test)]
+            responder_post_answer_test_gate: Arc::new(std::sync::Mutex::new(None)),
             local_candidates: Arc::new(RwLock::new(Vec::new())),
             local_candidate_sources: Arc::new(RwLock::new(HashMap::new())),
             local_network_identity: Arc::new(RwLock::new(Vec::new())),

--- a/client/daemon/src/lib/daemon/handshake.rs
+++ b/client/daemon/src/lib/daemon/handshake.rs
@@ -1,36 +1,383 @@
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HandshakeOwnerKind {
+    EventInitiatorReserve,
+    EventInitiatorPrepare,
+    EventInitiatorPublish,
+    MaintenanceInitiator,
+    Responder,
+    InitiatorAnswer,
+    Cleanup,
+}
+
+impl HandshakeOwnerKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::EventInitiatorReserve => "event_initiator_reserve",
+            Self::EventInitiatorPrepare => "event_initiator_prepare",
+            Self::EventInitiatorPublish => "event_initiator_publish",
+            Self::MaintenanceInitiator => "maintenance_initiator",
+            Self::Responder => "responder",
+            Self::InitiatorAnswer => "initiator_answer",
+            Self::Cleanup => "cleanup",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HandshakeLeaseIdentity {
+    peer_id: String,
+    owner_kind: HandshakeOwnerKind,
+    reservation_owner: Option<u64>,
+    network_generation: u64,
+    peer_session_generation: Option<PeerSessionGeneration>,
+    phase: &'static str,
+}
+
+impl HandshakeLeaseIdentity {
+    fn new(
+        peer_id: &str,
+        owner_kind: HandshakeOwnerKind,
+        reservation_owner: Option<u64>,
+        network_generation: u64,
+        peer_session_generation: Option<PeerSessionGeneration>,
+        phase: &'static str,
+    ) -> Self {
+        Self {
+            peer_id: peer_id.to_string(),
+            owner_kind,
+            reservation_owner,
+            network_generation,
+            peer_session_generation,
+            phase,
+        }
+    }
+
+    fn detail(&self) -> String {
+        format!(
+            "peer={} owner_kind={} phase={} reservation_owner={} generation={} peer_session_generation={}",
+            self.peer_id,
+            self.owner_kind.as_str(),
+            self.phase,
+            self.reservation_owner
+                .map_or_else(|| "none".to_string(), |owner| owner.to_string()),
+            self.network_generation,
+            self.peer_session_generation
+                .map_or_else(|| "none".to_string(), |generation| generation.value().to_string()),
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HandshakeHolderSnapshot {
+    identity: HandshakeLeaseIdentity,
+    held_for: Duration,
+}
+
+impl HandshakeHolderSnapshot {
+    fn detail(&self) -> String {
+        format!(
+            "holder_kind={} holder_phase={} holder_reservation_owner={} holder_generation={} holder_peer_session_generation={} holder_held_ms={}",
+            self.identity.owner_kind.as_str(),
+            self.identity.phase,
+            self.identity
+                .reservation_owner
+                .map_or_else(|| "none".to_string(), |owner| owner.to_string()),
+            self.identity.network_generation,
+            self.identity
+                .peer_session_generation
+                .map_or_else(|| "none".to_string(), |generation| generation.value().to_string()),
+            self.held_for.as_millis(),
+        )
+    }
+}
+
+struct HandshakeHolderMetadata {
+    lease_id: u64,
+    identity: HandshakeLeaseIdentity,
+    acquired_at: Instant,
+}
+
+struct HandshakePeerTurn {
+    turn: Arc<Mutex<()>>,
+    holder: std::sync::Mutex<Option<HandshakeHolderMetadata>>,
+}
+
+impl HandshakePeerTurn {
+    fn new() -> Self {
+        Self {
+            turn: Arc::new(Mutex::new(())),
+            holder: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn holder_snapshot(&self) -> Option<HandshakeHolderSnapshot> {
+        self.holder
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .map(|holder| HandshakeHolderSnapshot {
+                identity: holder.identity.clone(),
+                held_for: holder.acquired_at.elapsed(),
+            })
+    }
+}
+
+#[derive(Clone)]
 struct HandshakeArbiter {
-    peer_locks: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
+    peer_locks: Arc<std::sync::Mutex<HashMap<String, Weak<HandshakePeerTurn>>>>,
+    next_lease_id: Arc<std::sync::atomic::AtomicU64>,
+    timeline: Option<Arc<ConnectionTimeline>>,
+}
+
+impl Default for HandshakeArbiter {
+    fn default() -> Self {
+        Self {
+            peer_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            next_lease_id: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            timeline: None,
+        }
+    }
+}
+
+struct HandshakeLease {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+    peer_turn: Arc<HandshakePeerTurn>,
+    identity: HandshakeLeaseIdentity,
+    lease_id: u64,
+    acquired_at: Instant,
+    timeline: Option<Arc<ConnectionTimeline>>,
+    /// Compile-time proof that a mutation turn cannot cross an `.await` in a
+    /// `Send` production future.  The underlying Tokio guard is Send; this
+    /// marker deliberately makes the higher-level lease non-Send.
+    _not_send: std::marker::PhantomData<std::rc::Rc<()>>,
+}
+
+impl Drop for HandshakeLease {
+    fn drop(&mut self) {
+        let held_for = self.acquired_at.elapsed();
+        let mut holder = self
+            .peer_turn
+            .holder
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if holder.as_ref().map(|holder| holder.lease_id) == Some(self.lease_id) {
+            holder.take();
+        }
+        drop(holder);
+        if let Some(timeline) = self.timeline.as_ref() {
+            timeline.emit(
+                "handshake_arbiter_released",
+                None,
+                None,
+                Some(format!(
+                    "{} held_us={}",
+                    self.identity.detail(),
+                    held_for.as_micros()
+                )),
+            );
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HandshakeAcquireContention {
+    holder: Option<HandshakeHolderSnapshot>,
+}
+
+struct HandshakeWaitTelemetry {
+    arbiter: HandshakeArbiter,
+    identity: HandshakeLeaseIdentity,
+    peer_turn: Arc<HandshakePeerTurn>,
+    started_at: Instant,
+    completed: bool,
+}
+
+impl HandshakeWaitTelemetry {
+    fn complete(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for HandshakeWaitTelemetry {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        self.arbiter.emit_wait_result(
+            "handshake_arbiter_cancelled",
+            &self.identity,
+            self.started_at.elapsed(),
+            self.peer_turn.holder_snapshot().as_ref(),
+            Some("acquisition_cancelled"),
+        );
+    }
 }
 
 impl HandshakeArbiter {
-    async fn acquire(&self, peer_id: &str) -> tokio::sync::OwnedMutexGuard<()> {
-        let peer_lock = {
-            let mut peer_locks = self.peer_locks.lock().await;
-            if let Some(peer_lock) = peer_locks.get(peer_id).and_then(Weak::upgrade) {
-                peer_lock
-            } else {
-                peer_locks.retain(|_, peer_lock| peer_lock.strong_count() > 0);
-                let peer_lock = Arc::new(Mutex::new(()));
-                peer_locks.insert(peer_id.to_string(), Arc::downgrade(&peer_lock));
-                peer_lock
-            }
-        };
-        peer_lock.lock_owned().await
+    fn new(timeline: Arc<ConnectionTimeline>) -> Self {
+        Self {
+            timeline: Some(timeline),
+            ..Self::default()
+        }
     }
 
-    /// Acquire a peer's handshake turn without allowing a stale lifecycle
-    /// worker to hold the responder lane forever.  Callers that need
-    /// cancellation should race this future with their cancellation watch;
-    /// this method supplies the independent hard upper bound.
+    fn peer_turn(&self, peer_id: &str) -> Arc<HandshakePeerTurn> {
+        let mut peer_locks = self
+            .peer_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(peer_lock) = peer_locks.get(peer_id).and_then(Weak::upgrade) {
+            return peer_lock;
+        }
+        peer_locks.retain(|_, peer_lock| peer_lock.strong_count() > 0);
+        let peer_lock = Arc::new(HandshakePeerTurn::new());
+        peer_locks.insert(peer_id.to_string(), Arc::downgrade(&peer_lock));
+        peer_lock
+    }
+
+    fn emit_wait_started(
+        &self,
+        identity: &HandshakeLeaseIdentity,
+        holder: Option<&HandshakeHolderSnapshot>,
+        wait_budget: Duration,
+    ) {
+        if let Some(timeline) = self.timeline.as_ref() {
+            let holder = holder
+                .map(HandshakeHolderSnapshot::detail)
+                .unwrap_or_else(|| "holder_kind=none holder_phase=none".to_string());
+            timeline.emit(
+                "handshake_arbiter_wait_started",
+                None,
+                None,
+                Some(format!(
+                    "{} wait_budget_us={} {holder}",
+                    identity.detail(),
+                    wait_budget.as_micros()
+                )),
+            );
+        }
+    }
+
+    fn emit_wait_result(
+        &self,
+        event: &'static str,
+        identity: &HandshakeLeaseIdentity,
+        waited: Duration,
+        holder: Option<&HandshakeHolderSnapshot>,
+        reason_code: Option<&'static str>,
+    ) {
+        if let Some(timeline) = self.timeline.as_ref() {
+            let holder = holder
+                .map(HandshakeHolderSnapshot::detail)
+                .unwrap_or_else(|| "holder_kind=none holder_phase=none".to_string());
+            timeline.emit(
+                event,
+                None,
+                reason_code,
+                Some(format!(
+                    "{} wait_us={} {holder}",
+                    identity.detail(),
+                    waited.as_micros()
+                )),
+            );
+        }
+    }
+
+    fn finish_acquire(
+        &self,
+        peer_turn: Arc<HandshakePeerTurn>,
+        guard: tokio::sync::OwnedMutexGuard<()>,
+        identity: HandshakeLeaseIdentity,
+        waited: Duration,
+    ) -> HandshakeLease {
+        let lease_id = self
+            .next_lease_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .wrapping_add(1);
+        let acquired_at = Instant::now();
+        *peer_turn
+            .holder
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(HandshakeHolderMetadata {
+            lease_id,
+            identity: identity.clone(),
+            acquired_at,
+        });
+        self.emit_wait_result("handshake_arbiter_acquired", &identity, waited, None, None);
+        HandshakeLease {
+            _guard: guard,
+            peer_turn,
+            identity,
+            lease_id,
+            acquired_at,
+            timeline: self.timeline.clone(),
+            _not_send: std::marker::PhantomData,
+        }
+    }
+
+    fn try_acquire(
+        &self,
+        identity: HandshakeLeaseIdentity,
+    ) -> std::result::Result<HandshakeLease, HandshakeAcquireContention> {
+        let peer_turn = self.peer_turn(&identity.peer_id);
+        let started_at = Instant::now();
+        let holder = peer_turn.holder_snapshot();
+        self.emit_wait_started(&identity, holder.as_ref(), Duration::ZERO);
+        match peer_turn.turn.clone().try_lock_owned() {
+            Ok(guard) => Ok(self.finish_acquire(peer_turn, guard, identity, started_at.elapsed())),
+            Err(_) => {
+                let holder = peer_turn.holder_snapshot();
+                self.emit_wait_result(
+                    "handshake_arbiter_contended",
+                    &identity,
+                    started_at.elapsed(),
+                    holder.as_ref(),
+                    Some("mutation_turn_contended"),
+                );
+                Err(HandshakeAcquireContention { holder })
+            }
+        }
+    }
+
+    /// Acquire one short mutation turn with a hard wait bound. External
+    /// cancellation drops the future and is recorded by `HandshakeWaitTelemetry`.
     async fn acquire_with_timeout(
         &self,
-        peer_id: &str,
-        timeout: Duration,
-    ) -> Option<tokio::sync::OwnedMutexGuard<()>> {
-        tokio::time::timeout(timeout, self.acquire(peer_id))
-            .await
-            .ok()
+        identity: HandshakeLeaseIdentity,
+        wait_budget: Duration,
+    ) -> Option<HandshakeLease> {
+        let peer_turn = self.peer_turn(&identity.peer_id);
+        let started_at = Instant::now();
+        self.emit_wait_started(&identity, peer_turn.holder_snapshot().as_ref(), wait_budget);
+        let mut telemetry = HandshakeWaitTelemetry {
+            arbiter: self.clone(),
+            identity: identity.clone(),
+            peer_turn: peer_turn.clone(),
+            started_at,
+            completed: false,
+        };
+        match tokio::time::timeout(wait_budget, peer_turn.turn.clone().lock_owned()).await {
+            Ok(guard) => {
+                telemetry.complete();
+                Some(self.finish_acquire(peer_turn, guard, identity, started_at.elapsed()))
+            }
+            Err(_) => {
+                telemetry.complete();
+                self.emit_wait_result(
+                    "handshake_arbiter_timeout",
+                    &identity,
+                    started_at.elapsed(),
+                    peer_turn.holder_snapshot().as_ref(),
+                    Some("mutation_turn_timeout"),
+                );
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn current_holder(&self, peer_id: &str) -> Option<HandshakeHolderSnapshot> {
+        self.peer_turn(peer_id).holder_snapshot()
     }
 }
 
@@ -39,22 +386,19 @@ impl HandshakeArbiter {
 /// network/handshake timeout: the responder worker retries the same idempotent
 /// offer when this bound is hit.
 const RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: Duration = Duration::from_millis(750);
-const REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: &str =
-    "responder_handshake_arbiter_timeout";
-/// A transient connection snapshot may make the initiator's atomic Probe
-/// binding stage contend. This bound is deliberately shorter than the normal
-/// handshake retry cadence: its purpose is to remove the queued writer and
-/// reschedule, not to hide a wedged connection map behind a longer timeout.
-const INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT: Duration = Duration::from_millis(250);
-const REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT: &str =
-    "initiator_probe_binding_writer_timeout";
-
+const REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: &str = "responder_handshake_arbiter_timeout";
+const INITIATOR_ANSWER_HANDSHAKE_ARBITER_TIMEOUT: Duration = Duration::from_millis(100);
 /// Correlate one control-plane session without writing the raw session token
 /// to logs. This uses the existing local diagnostic fingerprint only; it is
 /// not an authentication or identity value.
 fn handshake_token_fingerprint(token: Option<&str>) -> String {
     token
-        .map(|token| format!("{:016x}", crate::transport::wire_fingerprint(token.as_bytes())))
+        .map(|token| {
+            format!(
+                "{:016x}",
+                crate::transport::wire_fingerprint(token.as_bytes())
+            )
+        })
         .unwrap_or_else(|| "legacy".to_string())
 }
 
@@ -89,7 +433,10 @@ fn local_is_designated_handshake_initiator(
 /// this daemon to start an initiator transaction.  Equal keys are invalid
 /// configuration and intentionally return true so the normal handshake path
 /// emits its explicit identity error instead of silently suppressing it.
-fn should_start_initiator_for_keys(local_public_key: &[u8; 32], peer_public_key: &[u8; 32]) -> bool {
+fn should_start_initiator_for_keys(
+    local_public_key: &[u8; 32],
+    peer_public_key: &[u8; 32],
+) -> bool {
     local_public_key == peer_public_key
         || local_is_designated_handshake_initiator(local_public_key, peer_public_key)
 }
@@ -118,16 +465,14 @@ impl Daemon {
     /// path can report the precise configuration error instead of silently
     /// suppressing it.
     fn should_start_initiator_handshake(&self, peer_info: &control::PeerInfo) -> bool {
-        let local_public_fingerprint = decode_x25519_key(
-            &self.config.node.private_key,
-            "node private key",
-        )
-        .ok()
-        .map(|private_key| {
-            let identity = NodeIdentity::from_private_key(private_key);
-            handshake_public_key_fingerprint(&identity.public_key())
-        })
-        .unwrap_or_else(|| "invalid".to_string());
+        let local_public_fingerprint =
+            decode_x25519_key(&self.config.node.private_key, "node private key")
+                .ok()
+                .map(|private_key| {
+                    let identity = NodeIdentity::from_private_key(private_key);
+                    handshake_public_key_fingerprint(&identity.public_key())
+                })
+                .unwrap_or_else(|| "invalid".to_string());
         let peer_public_fingerprint = decode_x25519_key(&peer_info.public_key, "peer public key")
             .ok()
             .map(|public_key| handshake_public_key_fingerprint(&public_key))
@@ -154,7 +499,11 @@ impl Daemon {
             Some(format!(
                 "peer={} role={} local_public_fp={} peer_public_fp={}",
                 peer_info.node_id,
-                if should_start { "initiator" } else { "responder" },
+                if should_start {
+                    "initiator"
+                } else {
+                    "responder"
+                },
                 local_public_fingerprint,
                 peer_public_fingerprint,
             )),
@@ -164,10 +513,7 @@ impl Daemon {
                 "initiator_handshake_suppressed",
                 None,
                 Some("deterministic_responder_role"),
-                Some(format!(
-                    "peer={} local_role=responder",
-                    peer_info.node_id
-                )),
+                Some(format!("peer={} local_role=responder", peer_info.node_id)),
             );
         }
         should_start

--- a/client/daemon/src/lib/daemon/handshake.rs
+++ b/client/daemon/src/lib/daemon/handshake.rs
@@ -387,6 +387,11 @@ impl HandshakeArbiter {
 /// offer when this bound is hit.
 const RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: Duration = Duration::from_millis(750);
 const REASON_RESPONDER_HANDSHAKE_ARBITER_TIMEOUT: &str = "responder_handshake_arbiter_timeout";
+const RESPONDER_SESSION_STAGE_TIMEOUT: Duration = Duration::from_millis(750);
+const REASON_RESPONDER_SESSION_STAGE_TIMEOUT: &str = "responder_session_stage_timeout";
+const REASON_RESPONDER_PROBE_BINDING_CONTENDED: &str =
+    "responder_probe_binding_connections_contended";
+const REASON_RESPONDER_COMMIT_CONTENDED: &str = "responder_answer_commit_contended";
 const INITIATOR_ANSWER_HANDSHAKE_ARBITER_TIMEOUT: Duration = Duration::from_millis(100);
 /// Correlate one control-plane session without writing the raw session token
 /// to logs. This uses the existing local diagnostic fingerprint only; it is

--- a/client/daemon/src/lib/daemon/handshake.rs
+++ b/client/daemon/src/lib/daemon/handshake.rs
@@ -58,6 +58,26 @@ fn handshake_token_fingerprint(token: Option<&str>) -> String {
         .unwrap_or_else(|| "legacy".to_string())
 }
 
+/// Deterministic pause after responder transport-grace refresh and before the
+/// non-queuing Probe-binding connection transaction. Tests use this exact
+/// production boundary to inject startup contention without timing sleeps.
+#[cfg(test)]
+#[derive(Debug)]
+struct ResponderPostAnswerTestGate {
+    reached: tokio::sync::Notify,
+    release: tokio::sync::Barrier,
+}
+
+#[cfg(test)]
+impl ResponderPostAnswerTestGate {
+    fn new() -> Self {
+        Self {
+            reached: tokio::sync::Notify::new(),
+            release: tokio::sync::Barrier::new(2),
+        }
+    }
+}
+
 fn local_is_designated_handshake_initiator(
     local_public_key: &[u8; 32],
     peer_public_key: &[u8; 32],

--- a/client/daemon/src/lib/daemon/handshake/answer.rs
+++ b/client/daemon/src/lib/daemon/handshake/answer.rs
@@ -46,18 +46,46 @@ impl Daemon {
                 handshake_token_fingerprint(session_id.as_deref())
             )),
         );
-        let _handshake_guard = self.handshake_arbiter.acquire(from_node_id).await;
-        self.timeline.emit(
-            "initiator_answer_lock_acquired",
+        let identity = HandshakeLeaseIdentity::new(
+            from_node_id,
+            HandshakeOwnerKind::InitiatorAnswer,
             None,
-            None,
-            Some(format!(
-                "peer={from_node_id} generation={} wait_ms={} session_fp={}",
-                self.peers.current_network_generation_sync(),
-                lock_wait_started.elapsed().as_millis(),
-                handshake_token_fingerprint(session_id.as_deref())
-            )),
+            ingress_generation,
+            self.peers.peer_session_generation_sync(from_node_id),
+            "answer_admission",
         );
+        {
+            let handshake_guard = self
+                .handshake_arbiter
+                .acquire_with_timeout(identity, INITIATOR_ANSWER_HANDSHAKE_ARBITER_TIMEOUT)
+                .await;
+            if handshake_guard.is_none() {
+                self.timeline.emit(
+                    "initiator_answer_lock_timeout",
+                    None,
+                    Some("mutation_turn_timeout"),
+                    Some(format!(
+                        "peer={from_node_id} generation={ingress_generation} session_fp={}",
+                        handshake_token_fingerprint(session_id.as_deref())
+                    )),
+                );
+            } else {
+                self.timeline.emit(
+                    "initiator_answer_lock_acquired",
+                    None,
+                    None,
+                    Some(format!(
+                        "peer={from_node_id} generation={} wait_ms={} session_fp={}",
+                        self.peers.current_network_generation_sync(),
+                        lock_wait_started.elapsed().as_millis(),
+                        handshake_token_fingerprint(session_id.as_deref())
+                    )),
+                );
+            }
+            // The answer's exact pending-id and lifecycle stamps own the slow
+            // identity/session commit below.  The arbiter protects only this
+            // admission observation and is never carried through an await.
+        }
         if !self
             .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
             .await
@@ -105,7 +133,7 @@ impl Daemon {
         let epoch_guard = epoch_gate.lock().await;
         let current_generation = self.peers.current_network_generation_sync();
         let (keys, expected_session_id, probe_ephemeral_shared, peer_session_generation) = {
-            let mut state = self.pending_handshakes.lock().await;
+            let mut state = self.pending_handshakes.lock();
             let expected_session_id = state.session_id(from_node_id).map(str::to_string);
             let Some(peer_session_generation) = state.peer_session_generation(from_node_id) else {
                 warn!("Ignoring WireGuard answer from {from_node_id}: no lifecycle-bound pending handshake");

--- a/client/daemon/src/lib/daemon/handshake/answer.rs
+++ b/client/daemon/src/lib/daemon/handshake/answer.rs
@@ -88,7 +88,6 @@ impl Daemon {
         }
         if !self
             .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
-            .await
         {
             self.timeline.emit(
                 "peer_answer_rejected",

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -35,183 +35,167 @@ where
     }
 }
 
+enum EventInitiatorReservationOutcome {
+    Reserved(HandshakeStartReservation),
+    Busy,
+    Contended,
+    RejectedLifecycle,
+}
+
+impl EventInitiatorReservationOutcome {
+    fn into_reservation(self) -> Option<HandshakeStartReservation> {
+        match self {
+            Self::Reserved(reservation) => Some(reservation),
+            Self::Busy | Self::Contended | Self::RejectedLifecycle => None,
+        }
+    }
+
+    #[cfg(test)]
+    fn expect(self, message: &str) -> HandshakeStartReservation {
+        match self {
+            Self::Reserved(reservation) => reservation,
+            Self::Busy => panic!("{message}: reservation busy"),
+            Self::Contended => panic!("{message}: arbiter contended"),
+            Self::RejectedLifecycle => panic!("{message}: lifecycle rejected"),
+        }
+    }
+}
+
 impl Daemon {
     /// Fast admission used by the serial control event loop before it puts
     /// potentially slow initiator work into its bounded work set.
-    async fn reserve_event_initiator_handshake(
-        &self,
-        peer_id: &str,
-    ) -> Option<HandshakeStartReservation> {
-        // Serialize replacement cleanup with offer/answer processing.  Without
-        // this short arbiter boundary a new-generation trigger could remove a
-        // stale pending initiator while the responder path was simultaneously
-        // staging its Probe binding for the same peer.
-        let _handshake_guard = self.handshake_arbiter.acquire(peer_id).await;
+    fn reserve_event_initiator_handshake(&self, peer_id: &str) -> EventInitiatorReservationOutcome {
         let network_generation = self.peers.current_network_generation_sync();
-        let peer_session_generation = self.peers.peer_session_generation_sync(peer_id)?;
-        let stale_session_id = self
-            .pending_handshakes
-            .lock()
-            .await
-            .remove_stale_pending_for_generation(
+        let Some(peer_session_generation) = self.peers.peer_session_generation_sync(peer_id) else {
+            return EventInitiatorReservationOutcome::RejectedLifecycle;
+        };
+        let identity = HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::EventInitiatorReserve,
+            None,
+            network_generation,
+            Some(peer_session_generation),
+            "reserve",
+        );
+        let handshake_guard = match self.handshake_arbiter.try_acquire(identity) {
+            Ok(handshake_guard) => handshake_guard,
+            Err(contention) => {
+                let holder = contention
+                    .holder
+                    .as_ref()
+                    .map(HandshakeHolderSnapshot::detail)
+                    .unwrap_or_else(|| "holder_kind=unknown holder_phase=unknown".to_string());
+                self.timeline.emit(
+                    "initiator_reservation_contended",
+                    None,
+                    Some("arbiter_contended"),
+                    Some(format!(
+                        "peer={peer_id} generation={network_generation} peer_session_generation={} {holder}",
+                        peer_session_generation.value()
+                    )),
+                );
+                return EventInitiatorReservationOutcome::Contended;
+            }
+        };
+        let transaction = self.pending_handshakes.try_with(|state| {
+            let stale_session_id = state.remove_stale_pending_for_generation(
                 peer_id,
                 network_generation,
                 peer_session_generation,
             );
-        if let Some(session_id) = stale_session_id {
-            self.peers
-                .discard_pending_probe_session_binding(peer_id, &session_id)
-                .await;
-        }
-        let mut state = self.pending_handshakes.lock().await;
-        let reservation = state.reserve_start_with_owner_at_generation(
-            peer_id,
-            network_generation,
-            peer_session_generation,
-        )?;
-        if state.attempts.get(peer_id).copied().unwrap_or(0) >= MAX_HANDSHAKE_ATTEMPTS {
-            state.attempts.remove(peer_id);
-        }
+            let reservation = state.reserve_start_with_owner_at_generation_and_kind(
+                peer_id,
+                network_generation,
+                peer_session_generation,
+                HandshakeOwnerKind::EventInitiatorReserve,
+            );
+            if reservation.is_some()
+                && state.attempts.get(peer_id).copied().unwrap_or(0) >= MAX_HANDSHAKE_ATTEMPTS
+            {
+                state.attempts.remove(peer_id);
+            }
+            (stale_session_id, reservation)
+        });
+        let Some((stale_session_id, reservation)) = transaction else {
+            drop(handshake_guard);
+            return EventInitiatorReservationOutcome::Contended;
+        };
+        drop(handshake_guard);
+        let Some(mut reservation) = reservation else {
+            return EventInitiatorReservationOutcome::Busy;
+        };
+        reservation.stale_session_id = stale_session_id;
         self.timeline.emit(
             "initiator_handshake_reserved",
             None,
             None,
             Some(format!(
-                "peer={peer_id} owner={} generation={network_generation}",
-                reservation.owner
+                "peer={peer_id} owner={} owner_kind={} generation={network_generation}",
+                reservation.owner,
+                reservation.owner_kind.as_str(),
             )),
         );
-        Some(reservation)
+        EventInitiatorReservationOutcome::Reserved(reservation)
     }
 
-    /// Transfer a contended Probe-binding publication out of the cooperative
-    /// control-event work set. The control loop contains branches that await
-    /// connection-map readers and writers; keeping the first fair writer
-    /// waiter inside that same loop can therefore prevent both the waiter and
-    /// its timeout from ever being polled. This independently scheduled task
-    /// owns no emit, network-epoch, handshake-arbiter, or connection guard.
-    fn defer_initiator_probe_binding_writer_retry(
+    /// Commit one exact retry identity before publishing its wake edge.  The
+    /// per-peer map coalesces duplicate contention, the reservation remains
+    /// the cross-await owner, and the supervised control loop plus maintenance
+    /// scan jointly provide progress without detached tasks.
+    fn schedule_initiator_retry(
         &self,
-        peer_id: String,
-        owner: u64,
-        network_generation: u64,
-        retry: u32,
-        mut cancellation: tokio::sync::watch::Receiver<bool>,
-    ) {
-        let peers = self.peers.clone();
-        let pending_handshakes = self.pending_handshakes.clone();
-        let path_setup_kick_tx = self.path_setup_kick_tx.clone();
-        let timeline = self.timeline.clone();
-
-        timeline.emit(
-            "initiator_publish_probe_binding_writer_wait",
-            None,
-            Some("connection_writer_contended"),
-            Some(format!(
-                "peer={peer_id} owner={owner} generation={network_generation} retry={retry} timeout_ms={}",
-                INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
-            )),
+        peer_id: &str,
+        reservation: &mut HandshakeStartReservation,
+        phase: InitiatorRetryPhase,
+        reason_code: &'static str,
+    ) -> bool {
+        let scheduled = self.pending_handshakes.lock().schedule_initiator_retry(
+            peer_id,
+            reservation,
+            phase,
+            Instant::now(),
         );
-
-        // The task is intrinsically bounded by the writer timeout. Dropping
-        // the JoinHandle deliberately detaches it from the serial control
-        // loop whose cooperative polling is the condition being avoided.
-        tokio::spawn(async move {
-            if *cancellation.borrow() || cancellation.has_changed().is_err() {
-                return;
-            }
-
-            let writer_wait_started = Instant::now();
-            timeline.emit(
-                "initiator_publish_probe_binding_writer_wait_started",
+        let Some((identity, revision)) = scheduled else {
+            // Capacity, TTL, or an ownership mismatch cannot leave a prepared
+            // reservation with no progress edge.  Cancel only the exact owner;
+            // a replacement lifecycle remains untouched.
+            let cancelled = self
+                .pending_handshakes
+                .lock()
+                .cancel_reservation_if_current(peer_id, reservation.owner);
+            self.timeline.emit(
+                "initiator_handshake_retry_rejected",
                 None,
-                Some("connection_writer_contended"),
+                Some("retry_not_admitted"),
                 Some(format!(
-                    "peer={peer_id} owner={owner} generation={network_generation} retry={retry} timeout_ms={}",
-                    INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
+                    "peer={peer_id} owner={} generation={} peer_session_generation={} phase={} cancellation_generation={} cancelled_exact_owner={cancelled}",
+                    reservation.owner,
+                    reservation.network_generation,
+                    reservation.peer_session_generation.value(),
+                    phase.as_str(),
+                    reservation.cancellation_generation,
                 )),
             );
-            let writer_available = tokio::select! {
-                biased;
-                changed = cancellation.changed() => {
-                    let _ = changed;
-                    timeline.emit(
-                        "initiator_publish_probe_binding_writer_wait_cancelled",
-                        None,
-                        Some("initiator_reservation_cancelled"),
-                        Some(format!(
-                            "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={}",
-                            writer_wait_started.elapsed().as_millis()
-                        )),
-                    );
-                    return;
-                }
-                available = peers.wait_for_probe_session_binding_writer(
-                    INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT,
-                ) => available
-            };
-            let wait_ms = writer_wait_started.elapsed().as_millis();
-
-            // Re-check cancellation while obtaining the short reservation
-            // mutex. PeerLeft/network-generation cleanup wins over this old
-            // retry and therefore cannot be followed by a stale kick.
-            let cancelled_current = tokio::select! {
-                biased;
-                changed = cancellation.changed() => {
-                    let _ = changed;
-                    false
-                }
-                mut state = pending_handshakes.lock() => {
-                    state.cancel_reservation_if_current(&peer_id, owner)
-                }
-            };
-            if !cancelled_current {
-                timeline.emit(
-                    "initiator_publish_probe_binding_writer_wait_stale",
-                    None,
-                    Some("initiator_reservation_replaced"),
-                    Some(format!(
-                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} writer_available={writer_available}"
-                    )),
-                );
-                return;
-            }
-
-            let next_kick = (*path_setup_kick_tx.borrow()).wrapping_add(1);
-            path_setup_kick_tx.send_replace(next_kick);
-            if writer_available {
-                timeline.emit(
-                    "initiator_publish_probe_binding_writer_available",
-                    None,
-                    None,
-                    Some(format!(
-                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} reschedule_kick={next_kick}"
-                    )),
-                );
-            } else {
-                timeline.emit(
-                    "initiator_publish_probe_binding_writer_timeout",
-                    None,
-                    Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT),
-                    Some(format!(
-                        "peer={peer_id} owner={owner} generation={network_generation} retry={retry} wait_ms={wait_ms} timeout_ms={} reschedule_kick={next_kick}",
-                        INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis()
-                    )),
-                );
-                warn!(
-                    event = "initiator_publish_probe_binding_writer_timeout",
-                    reason_code = REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT,
-                    peer_id = %peer_id,
-                    owner,
-                    network_generation,
-                    retry,
-                    wait_ms,
-                    timeout_ms = INITIATOR_PROBE_BINDING_WRITER_WAIT_TIMEOUT.as_millis(),
-                    reschedule_kick = next_kick,
-                    "Probe binding connection writer remained contended; reservation cancelled and path setup rescheduled"
-                );
-            }
-        });
+            return false;
+        };
+        reservation.disposition = HandshakeStartDisposition::RetryScheduled;
+        self.timeline.emit(
+            "initiator_handshake_retry_scheduled",
+            None,
+            Some(reason_code),
+            Some(format!(
+                "peer={} owner={} generation={} peer_session_generation={} phase={} attempt={} cancellation_generation={} retry_revision={revision}",
+                identity.peer_id,
+                identity.reservation_owner,
+                identity.network_generation,
+                identity.peer_session_generation.value(),
+                identity.phase.as_str(),
+                identity.attempt,
+                identity.cancellation_generation,
+            )),
+        );
+        self.handshake_retry_kick_tx.send_replace(revision);
+        true
     }
 
     /// Complete an initiator handshake after the control event loop has
@@ -226,6 +210,11 @@ impl Daemon {
         peer_info: &control::PeerInfo,
         reservation: &mut HandshakeStartReservation,
     ) -> Result<Option<u64>> {
+        if let Some(stale_session_id) = reservation.stale_session_id.take() {
+            self.peers
+                .discard_pending_probe_session_binding(&peer_info.node_id, &stale_session_id)
+                .await;
+        }
         if *reservation.cancellation.borrow() {
             return Ok(None);
         }
@@ -243,165 +232,116 @@ impl Daemon {
         {
             self.pending_handshakes
                 .lock()
-                .await
                 .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
             return Ok(None);
         }
-        let lock_wait_started = Instant::now();
-        self.timeline.emit(
-            "initiator_handshake_lock_wait",
-            None,
-            None,
-            Some(format!(
-                "peer={} owner={} generation={} phase=preparation",
-                peer_info.node_id, reservation.owner, handshake_generation
-            )),
-        );
-        let handshake_guard = self.handshake_arbiter.acquire(&peer_info.node_id).await;
-        self.timeline.emit(
-            "initiator_handshake_lock_acquired",
-            None,
-            None,
-            Some(format!(
-                "peer={} owner={} generation={} phase=preparation wait_ms={}",
-                peer_info.node_id,
-                reservation.owner,
+        let peer_id = peer_info.node_id.clone();
+        let prepared_already = self
+            .pending_handshakes
+            .lock()
+            .has_prepared_for_reservation(&peer_id, reservation);
+        if !prepared_already {
+            let identity = HandshakeLeaseIdentity::new(
+                &peer_id,
+                HandshakeOwnerKind::EventInitiatorPrepare,
+                Some(reservation.owner),
                 handshake_generation,
-                lock_wait_started.elapsed().as_millis()
-            )),
-        );
-        if !self.peers.peer_session_is_current_sync(
-            &peer_info.node_id,
-            reservation.peer_session_generation,
-        ) {
+                Some(reservation.peer_session_generation),
+                "preparation",
+            );
+            let Ok(handshake_guard) = self.handshake_arbiter.try_acquire(identity) else {
+                self.schedule_initiator_retry(
+                    &peer_id,
+                    reservation,
+                    InitiatorRetryPhase::Preparation,
+                    "arbiter_contended",
+                );
+                return Ok(None);
+            };
+            let current = self
+                .pending_handshakes
+                .try_with(|state| state.starting_reservation_is_current(&peer_id, reservation));
             drop(handshake_guard);
-            self.pending_handshakes
-                .lock()
-                .await
-                .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-            return Ok(None);
-        }
-        // This worker is cooperatively polled by the serial control loop. The
-        // arbiter is an admission boundary only: keeping it across the actor
-        // status await would self-deadlock if PeerLeft/offline entered the
-        // serial branch, waited for this guard, and thereby stopped polling the
-        // worker which owns it. The reservation/lifecycle stamp is revalidated
-        // at the later publish transaction.
-        drop(handshake_guard);
-        let status = self.transport.session_status(&peer_info.node_id).await;
-        if status.has_active || status.has_pending_responder {
-            self.pending_handshakes
-                .lock()
-                .await
-                .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-            return Ok(None);
-        }
-
-        let identity = match self.local_identity() {
-            Ok(identity) => identity,
-            Err(error) => {
-                self.pending_handshakes
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-                return Err(error);
-            }
-        };
-        let peer_public = match decode_x25519_key(&peer_info.public_key, "peer public key") {
-            Ok(peer_public) => peer_public,
-            Err(error) => {
-                self.pending_handshakes
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-                return Err(error);
-            }
-        };
-        if !local_is_designated_handshake_initiator(&identity.public_key(), &peer_public) {
-            self.pending_handshakes
-                .lock()
-                .await
-                .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-            return Ok(None);
-        }
-
-        let mut initiator = HandshakeInitiator::new(identity, peer_public, None);
-        let initiation = match initiator.create_initiation() {
-            Ok(initiation) => initiation,
-            Err(error) => {
-                self.pending_handshakes
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
-                return Err(DaemonError::Peer(format!(
-                    "WireGuard initiation failed: {error}"
-                )));
-            }
-        };
-        let initiation_bytes = initiation.to_bytes();
-
-        // Candidate gathering may wait on a live STUN fan-out. Keep the owner
-        // reservation; the arbiter was already released before actor I/O.
-        // Host candidates are published before that gather completes, so a
-        // provisional non-empty snapshot must not immediately win the first
-        // offer. Give the full startup snapshot a bounded opportunity while
-        // preserving the relay-first fast path.
-        let (candidates, candidate_sources) = {
-            let initial_snapshot = self.initial_candidate_set_if_ready().await;
-            let mut relay_available = self.relay_available_tx.subscribe();
-            let relay_is_available = *relay_available.borrow();
-            if let Some(initial_snapshot) = initial_snapshot {
-                if let Some(snapshot) = relay_first_candidate_shortcut(
-                    initial_snapshot.0,
-                    initial_snapshot.1,
-                    relay_is_available,
-                ) {
-                    if snapshot.0.is_empty() {
-                        self.peers
-                            .record_direct_event(
-                                &peer_info.node_id,
-                                "relay_first_empty_candidate_offer",
-                                None,
-                                Some(0),
-                                None,
-                                "relay transport is available; encrypted handshake is not gated on STUN candidates",
-                            )
-                            .await;
-                    }
-                    snapshot
-                } else {
-                    self.wait_for_local_candidate_set().await
+            match current {
+                Some(true) => {}
+                Some(false) => return Ok(None),
+                None => {
+                    self.schedule_initiator_retry(
+                        &peer_id,
+                        reservation,
+                        InitiatorRetryPhase::Preparation,
+                        "pending_state_contended",
+                    );
+                    return Ok(None);
                 }
-            } else if relay_is_available {
-                // The relay is already usable, so do not hold the encrypted
-                // session behind a slow first STUN gather. The full candidate
-                // snapshot is still published independently by UDP startup.
-                self.peers
-                    .record_direct_event(
-                        &peer_info.node_id,
-                        "relay_first_empty_candidate_offer",
-                        None,
-                        Some(0),
-                        None,
-                        "relay transport is available before the initial UDP candidate snapshot; encrypted handshake is not gated on STUN candidates",
-                    )
-                    .await;
-                (Vec::new(), HashMap::new())
-            } else {
-                // Once the relay transport is up, an empty candidate list is
-                // intentional: the control-plane handshake still establishes
-                // the encrypted session, and the forced relay probe can then
-                // prove the relay path.  Waiting for STUN here recreated the
-                // old "relay TCP is ready but the first business packet waits
-                // for candidate gathering" failure.  Direct candidates are
-                // refreshed and signaled independently after this point.
-                // Relay selection and candidate gathering run in parallel.
-                // Whichever becomes usable first wins; a cancellation is
-                // fail-closed and releases the reservation immediately.
-                tokio::select! {
-                    biased;
-                    changed = relay_available.changed() => {
-                        if changed.is_ok() && *relay_available.borrow() {
+            }
+
+            // Every actor/control/candidate await below is owned by the exact
+            // reservation, never by the mutation-turn lease.
+            let status = self.transport.session_status(&peer_info.node_id).await;
+            if status.has_active || status.has_pending_responder {
+                self.pending_handshakes
+                    .lock()
+                    .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
+                return Ok(None);
+            }
+
+            let identity = match self.local_identity() {
+                Ok(identity) => identity,
+                Err(error) => {
+                    self.pending_handshakes
+                        .lock()
+                        .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
+                    return Err(error);
+                }
+            };
+            let peer_public = match decode_x25519_key(&peer_info.public_key, "peer public key") {
+                Ok(peer_public) => peer_public,
+                Err(error) => {
+                    self.pending_handshakes
+                        .lock()
+                        .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
+                    return Err(error);
+                }
+            };
+            if !local_is_designated_handshake_initiator(&identity.public_key(), &peer_public) {
+                self.pending_handshakes
+                    .lock()
+                    .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
+                return Ok(None);
+            }
+
+            let mut initiator = HandshakeInitiator::new(identity, peer_public, None);
+            let initiation = match initiator.create_initiation() {
+                Ok(initiation) => initiation,
+                Err(error) => {
+                    self.pending_handshakes
+                        .lock()
+                        .cancel_reservation_if_current(&peer_info.node_id, reservation.owner);
+                    return Err(DaemonError::Peer(format!(
+                        "WireGuard initiation failed: {error}"
+                    )));
+                }
+            };
+            let initiation_bytes = initiation.to_bytes();
+
+            // Candidate gathering may wait on a live STUN fan-out. Keep the owner
+            // reservation; the arbiter was already released before actor I/O.
+            // Host candidates are published before that gather completes, so a
+            // provisional non-empty snapshot must not immediately win the first
+            // offer. Give the full startup snapshot a bounded opportunity while
+            // preserving the relay-first fast path.
+            let (candidates, candidate_sources) = {
+                let initial_snapshot = self.initial_candidate_set_if_ready().await;
+                let mut relay_available = self.relay_available_tx.subscribe();
+                let relay_is_available = *relay_available.borrow();
+                if let Some(initial_snapshot) = initial_snapshot {
+                    if let Some(snapshot) = relay_first_candidate_shortcut(
+                        initial_snapshot.0,
+                        initial_snapshot.1,
+                        relay_is_available,
+                    ) {
+                        if snapshot.0.is_empty() {
                             self.peers
                                 .record_direct_event(
                                     &peer_info.node_id,
@@ -409,69 +349,151 @@ impl Daemon {
                                     None,
                                     Some(0),
                                     None,
-                                    "relay became available before STUN candidates; encrypted handshake is not gated on candidates",
+                                    "relay transport is available; encrypted handshake is not gated on STUN candidates",
                                 )
                                 .await;
-                            (Vec::new(), HashMap::new())
-                        } else {
-                            self.wait_for_initial_candidate_set().await
                         }
+                        snapshot
+                    } else {
+                        self.wait_for_local_candidate_set().await
                     }
-                    candidates = self.wait_for_initial_candidate_set() => candidates,
-                    changed = reservation.cancellation.changed() => {
-                        if changed.is_err() || *reservation.cancellation.borrow() {
+                } else if relay_is_available {
+                    // The relay is already usable, so do not hold the encrypted
+                    // session behind a slow first STUN gather. The full candidate
+                    // snapshot is still published independently by UDP startup.
+                    self.peers
+                        .record_direct_event(
+                            &peer_info.node_id,
+                            "relay_first_empty_candidate_offer",
+                            None,
+                            Some(0),
+                            None,
+                            "relay transport is available before the initial UDP candidate snapshot; encrypted handshake is not gated on STUN candidates",
+                        )
+                        .await;
+                    (Vec::new(), HashMap::new())
+                } else {
+                    // Once the relay transport is up, an empty candidate list is
+                    // intentional: the control-plane handshake still establishes
+                    // the encrypted session, and the forced relay probe can then
+                    // prove the relay path.  Waiting for STUN here recreated the
+                    // old "relay TCP is ready but the first business packet waits
+                    // for candidate gathering" failure.  Direct candidates are
+                    // refreshed and signaled independently after this point.
+                    // Relay selection and candidate gathering run in parallel.
+                    // Whichever becomes usable first wins; a cancellation is
+                    // fail-closed and releases the reservation immediately.
+                    tokio::select! {
+                        biased;
+                        changed = relay_available.changed() => {
+                            if changed.is_ok() && *relay_available.borrow() {
+                                self.peers
+                                    .record_direct_event(
+                                        &peer_info.node_id,
+                                        "relay_first_empty_candidate_offer",
+                                        None,
+                                        Some(0),
+                                        None,
+                                        "relay became available before STUN candidates; encrypted handshake is not gated on candidates",
+                                    )
+                                    .await;
+                                (Vec::new(), HashMap::new())
+                            } else {
+                                self.wait_for_initial_candidate_set().await
+                            }
+                        }
+                        candidates = self.wait_for_initial_candidate_set() => candidates,
+                        changed = reservation.cancellation.changed() => {
+                            if changed.is_err() || *reservation.cancellation.borrow() {
+                                return Ok(None);
+                            }
                             return Ok(None);
                         }
-                        return Ok(None);
                     }
                 }
+            };
+            if *reservation.cancellation.borrow() {
+                return Ok(None);
             }
-        };
-        if *reservation.cancellation.borrow() {
-            return Ok(None);
+
+            let session_id = new_probe_session_id();
+            let (probe_ephemeral, probe_ephemeral_public_key) = new_probe_ephemeral_keypair();
+            let prepared = PreparedInitiatorHandshake {
+                initiator,
+                initiation_bytes,
+                candidates,
+                candidate_sources,
+                session_id,
+                probe_ephemeral,
+                probe_ephemeral_public_key,
+            };
+            if !self.pending_handshakes.lock().store_prepared_if_current(
+                &peer_id,
+                reservation,
+                prepared,
+            ) {
+                return Ok(None);
+            }
         }
 
         // Re-enter the short mutation boundary.  A responder may have won
         // while gathering candidates; only the owner that is still current may
         // turn its reservation into a pending initiator transaction.
-        let lock_wait_started = Instant::now();
-        self.timeline.emit(
-            "initiator_handshake_lock_wait",
-            None,
-            None,
-            Some(format!(
-                "peer={} owner={} generation={} phase=publish",
-                peer_info.node_id, reservation.owner, handshake_generation
-            )),
+        let identity = HandshakeLeaseIdentity::new(
+            &peer_id,
+            HandshakeOwnerKind::EventInitiatorPublish,
+            Some(reservation.owner),
+            handshake_generation,
+            Some(reservation.peer_session_generation),
+            "publish",
         );
-        let handshake_guard = self.handshake_arbiter.acquire(&peer_info.node_id).await;
-        self.timeline.emit(
-            "initiator_handshake_lock_acquired",
-            None,
-            None,
-            Some(format!(
-                "peer={} owner={} generation={} phase=publish wait_ms={}",
-                peer_info.node_id,
-                reservation.owner,
-                handshake_generation,
-                lock_wait_started.elapsed().as_millis()
-            )),
-        );
-        // As above, never let a cooperatively-polled worker own the arbiter
-        // while awaiting the emit/session actors. Exact reservation, network
-        // generation and peer lifecycle checks below form the commit fence.
+        let Ok(handshake_guard) = self.handshake_arbiter.try_acquire(identity) else {
+            self.schedule_initiator_retry(
+                &peer_id,
+                reservation,
+                InitiatorRetryPhase::Publish,
+                "arbiter_contended",
+            );
+            return Ok(None);
+        };
+        let prepared = self
+            .pending_handshakes
+            .try_with(|state| state.take_prepared_if_current(&peer_id, reservation));
         drop(handshake_guard);
-        let peer_id = peer_info.node_id.clone();
-        let session_id = new_probe_session_id();
-        let (probe_ephemeral, probe_ephemeral_public_key) = new_probe_ephemeral_keypair();
+        let prepared = match prepared {
+            Some(Some(prepared)) => prepared,
+            Some(None) => {
+                self.pending_handshakes
+                    .lock()
+                    .cancel_reservation_if_current(&peer_id, reservation.owner);
+                return Ok(None);
+            }
+            None => {
+                self.schedule_initiator_retry(
+                    &peer_id,
+                    reservation,
+                    InitiatorRetryPhase::Publish,
+                    "pending_state_contended",
+                );
+                return Ok(None);
+            }
+        };
+        let PreparedInitiatorHandshake {
+            initiator,
+            initiation_bytes,
+            candidates,
+            candidate_sources,
+            session_id,
+            probe_ephemeral,
+            probe_ephemeral_public_key,
+        } = prepared;
         let binding_contentions = 0u32;
         let (attempt_no, pending_id) = {
             // The outbound worker establishes the canonical lifecycle order
             // `emit -> generation -> session/connection`. The connection
             // mutation itself is non-blocking while these outer guards are
-            // held; on contention we release both and transfer a bounded
-            // writer wait to an independent task. Normal maintenance starts a
-            // fresh transaction after that task publishes its retry edge.
+            // held; contention restores the exact prepared initiation into
+            // the bounded retry ledger before waking its supervised owner.
             let emit_wait_started = Instant::now();
             self.timeline.emit(
                 "initiator_publish_emit_lock_wait",
@@ -518,16 +540,14 @@ impl Daemon {
             if *reservation.cancellation.borrow()
                 || reservation.cancellation.has_changed().is_err()
                 || self.peers.current_network_generation_sync() != handshake_generation
-                || !self.peers.peer_session_is_current_sync(
-                    &peer_id,
-                    reservation.peer_session_generation,
-                )
+                || !self
+                    .peers
+                    .peer_session_is_current_sync(&peer_id, reservation.peer_session_generation)
             {
                 drop(epoch_guard);
                 drop(emit_guard);
                 self.pending_handshakes
                     .lock()
-                    .await
                     .cancel_reservation_if_current(&peer_id, reservation.owner);
                 return Ok(None);
             }
@@ -546,7 +566,6 @@ impl Daemon {
                 drop(emit_guard);
                 self.pending_handshakes
                     .lock()
-                    .await
                     .cancel_reservation_if_current(&peer_id, reservation.owner);
                 return Ok(None);
             }
@@ -572,27 +591,40 @@ impl Daemon {
                     );
                     drop(epoch_guard);
                     drop(emit_guard);
-                    reservation.disposition =
-                        HandshakeStartDisposition::ProbeBindingRetryDeferred;
-                    self.defer_initiator_probe_binding_writer_retry(
-                        peer_id.clone(),
-                        reservation.owner,
-                        handshake_generation,
-                        binding_contentions,
-                        reservation.cancellation.clone(),
-                    );
+                    let prepared = PreparedInitiatorHandshake {
+                        initiator,
+                        initiation_bytes,
+                        candidates,
+                        candidate_sources,
+                        session_id,
+                        probe_ephemeral,
+                        probe_ephemeral_public_key,
+                    };
+                    if self.pending_handshakes.lock().store_prepared_if_current(
+                        &peer_id,
+                        reservation,
+                        prepared,
+                    ) {
+                        self.schedule_initiator_retry(
+                            &peer_id,
+                            reservation,
+                            InitiatorRetryPhase::Publish,
+                            "connection_writer_contended",
+                        );
+                    }
                     return Ok(None);
                 }
                 Some(ProbeBindingStage::Staged) => {
-                    let inserted = {
-                        let mut state = self.pending_handshakes.lock().await;
+                    let mut initiator = Some(initiator);
+                    let mut probe_ephemeral = Some(probe_ephemeral);
+                    let insert_transaction = self.pending_handshakes.try_with(|state| {
                         state
                             .insert_reserved_if_current_with_generation(
                                 peer_id.clone(),
                                 reservation.owner,
-                                initiator,
+                                initiator.take().expect("prepared initiator"),
                                 Some(session_id.clone()),
-                                Some(probe_ephemeral),
+                                probe_ephemeral.take(),
                                 handshake_generation,
                                 reservation.peer_session_generation,
                             )
@@ -601,6 +633,35 @@ impl Daemon {
                                 *attempts = attempts.saturating_add(1);
                                 (*attempts, pending_id)
                             })
+                    });
+                    let Some(inserted) = insert_transaction else {
+                        drop(epoch_guard);
+                        drop(emit_guard);
+                        self.peers
+                            .discard_pending_probe_session_binding(&peer_id, &session_id)
+                            .await;
+                        let prepared = PreparedInitiatorHandshake {
+                            initiator: initiator.take().expect("unconsumed initiator"),
+                            initiation_bytes,
+                            candidates,
+                            candidate_sources,
+                            session_id,
+                            probe_ephemeral: probe_ephemeral.take().expect("unconsumed Probe key"),
+                            probe_ephemeral_public_key,
+                        };
+                        if self.pending_handshakes.lock().store_prepared_if_current(
+                            &peer_id,
+                            reservation,
+                            prepared,
+                        ) {
+                            self.schedule_initiator_retry(
+                                &peer_id,
+                                reservation,
+                                InitiatorRetryPhase::Publish,
+                                "pending_state_contended",
+                            );
+                        }
+                        return Ok(None);
                     };
                     let Some((attempt_no, pending_id)) = inserted else {
                         drop(epoch_guard);
@@ -647,7 +708,6 @@ impl Daemon {
                     drop(emit_guard);
                     self.pending_handshakes
                         .lock()
-                        .await
                         .cancel_reservation_if_current(&peer_id, reservation.owner);
                     return Err(DaemonError::Peer(format!(
                         "failed to stage Probe v2 handshake binding for {peer_id}: {stage:?}"
@@ -685,6 +745,9 @@ impl Daemon {
                     handshake_token_fingerprint(Some(&session_id))
                 )),
             );
+            self.peers
+                .discard_pending_probe_session_binding(&peer_id, &session_id)
+                .await;
             return Ok(None);
         };
 
@@ -745,7 +808,7 @@ impl Daemon {
             // old timer must not publish a failure into the replacement
             // lifecycle (same-node ABA).
             let removed = {
-                let mut state = pending.lock().await;
+                let mut state = pending.lock();
                 if state.is_current(&timeout_peer, pending_id)
                     && state.peer_session_generation(&timeout_peer)
                         == Some(timeout_peer_session_generation)
@@ -763,14 +826,10 @@ impl Daemon {
                 return;
             }
 
-            if peers.peer_session_is_current_sync(
-                &timeout_peer,
-                timeout_peer_session_generation,
-            ) && !transport.has_session(&timeout_peer).await
-                && peers.peer_session_is_current_sync(
-                    &timeout_peer,
-                    timeout_peer_session_generation,
-                )
+            if peers.peer_session_is_current_sync(&timeout_peer, timeout_peer_session_generation)
+                && !transport.has_session(&timeout_peer).await
+                && peers
+                    .peer_session_is_current_sync(&timeout_peer, timeout_peer_session_generation)
             {
                 warn!("Handshake timeout for peer {timeout_peer}");
                 let failed = peers
@@ -819,9 +878,7 @@ impl Daemon {
                 self.start_hole_punch_at(&peer_id, Some(punch_at_ms), None, None)
                     .await;
             }
-            Ok(None)
-                if reservation.disposition
-                    == HandshakeStartDisposition::ProbeBindingRetryDeferred => {}
+            Ok(None) if reservation.disposition == HandshakeStartDisposition::RetryScheduled => {}
             Ok(None) if !*reservation.cancellation.borrow() => {
                 self.publish_current_candidates_to_peer(&peer_id, "peer event")
                     .await;

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -198,6 +198,31 @@ impl Daemon {
         true
     }
 
+    /// Put an exact prepared initiation back under its reservation before
+    /// publishing the retry edge. Every publish-side contention path uses
+    /// this helper so taking the prepared value out of the short state turn
+    /// can never create a lost wake or regenerate Noise/Probe key material.
+    fn retain_prepared_initiator_publish_retry(
+        &self,
+        peer_id: &str,
+        reservation: &mut HandshakeStartReservation,
+        prepared: PreparedInitiatorHandshake,
+        reason_code: &'static str,
+    ) {
+        if self
+            .pending_handshakes
+            .lock()
+            .store_prepared_if_current(peer_id, reservation, prepared)
+        {
+            self.schedule_initiator_retry(
+                peer_id,
+                reservation,
+                InitiatorRetryPhase::Publish,
+                reason_code,
+            );
+        }
+    }
+
     /// Complete an initiator handshake after the control event loop has
     /// atomically admitted a reservation for this peer.
     ///
@@ -487,54 +512,102 @@ impl Daemon {
             probe_ephemeral,
             probe_ephemeral_public_key,
         } = prepared;
-        let binding_contentions = 0u32;
+        let publish_attempt = reservation.retry_attempt;
         let (attempt_no, pending_id) = {
             // The outbound worker establishes the canonical lifecycle order
-            // `emit -> generation -> session/connection`. The connection
-            // mutation itself is non-blocking while these outer guards are
-            // held; contention restores the exact prepared initiation into
-            // the bounded retry ledger before waking its supervised owner.
-            let emit_wait_started = Instant::now();
+            // `emit -> generation -> session/connection`. Every acquisition
+            // after the short emit-registry lookup is try-only. Contention
+            // restores the exact prepared initiation before waking the
+            // supervised retry owner, so the emit fence can never be held
+            // while waiting for epoch/session/connection state.
             self.timeline.emit(
                 "initiator_publish_emit_lock_wait",
                 None,
                 None,
                 Some(format!(
-                    "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions}",
+                    "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} wait_budget_us=0",
                     reservation.owner
                 )),
             );
-            let emit_guard = self.transport.acquire_outbound_emit_guard(&peer_id).await;
+            let Some(emit_guard) = self.transport.try_acquire_outbound_emit_guard(&peer_id) else {
+                self.timeline.emit(
+                    "initiator_publish_emit_lock_contended",
+                    None,
+                    Some("emit_guard_contended"),
+                    Some(format!(
+                        "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} queued=false",
+                        reservation.owner
+                    )),
+                );
+                self.retain_prepared_initiator_publish_retry(
+                    &peer_id,
+                    reservation,
+                    PreparedInitiatorHandshake {
+                        initiator,
+                        initiation_bytes,
+                        candidates,
+                        candidate_sources,
+                        session_id,
+                        probe_ephemeral,
+                        probe_ephemeral_public_key,
+                    },
+                    "emit_guard_contended",
+                );
+                return Ok(None);
+            };
             self.timeline.emit(
                 "initiator_publish_emit_lock_acquired",
                 None,
                 None,
                 Some(format!(
-                    "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={}",
-                    reservation.owner,
-                    emit_wait_started.elapsed().as_millis()
+                    "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} wait_us=0",
+                    reservation.owner
                 )),
             );
             let epoch_gate = self.peers.network_epoch_gate();
-            let epoch_wait_started = Instant::now();
             self.timeline.emit(
                 "initiator_publish_epoch_gate_wait",
                 None,
                 None,
                 Some(format!(
-                    "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions}",
+                    "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} wait_budget_us=0",
                     reservation.owner
                 )),
             );
-            let epoch_guard = epoch_gate.lock().await;
+            let Ok(epoch_guard) = epoch_gate.try_lock() else {
+                self.timeline.emit(
+                    "initiator_publish_epoch_gate_contended",
+                    None,
+                    Some("network_epoch_contended"),
+                    Some(format!(
+                        "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} queued=false",
+                        reservation.owner
+                    )),
+                );
+                drop(emit_guard);
+                self.retain_prepared_initiator_publish_retry(
+                    &peer_id,
+                    reservation,
+                    PreparedInitiatorHandshake {
+                        initiator,
+                        initiation_bytes,
+                        candidates,
+                        candidate_sources,
+                        session_id,
+                        probe_ephemeral,
+                        probe_ephemeral_public_key,
+                    },
+                    "network_epoch_contended",
+                );
+                return Ok(None);
+            };
             self.timeline.emit(
                 "initiator_publish_epoch_gate_acquired",
                 None,
                 None,
                 Some(format!(
-                    "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} wait_ms={}",
-                    reservation.owner,
-                    epoch_wait_started.elapsed().as_millis()
+                    "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} wait_us=0",
+                    reservation.owner
                 )),
             );
             if *reservation.cancellation.borrow()
@@ -551,13 +624,40 @@ impl Daemon {
                     .cancel_reservation_if_current(&peer_id, reservation.owner);
                 return Ok(None);
             }
-            let status = self.transport.session_status(&peer_id).await;
+            let Some(status) = self.transport.try_session_status(&peer_id) else {
+                self.timeline.emit(
+                    "initiator_publish_session_status_contended",
+                    None,
+                    Some("transport_sessions_contended"),
+                    Some(format!(
+                        "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} queued=false",
+                        reservation.owner
+                    )),
+                );
+                drop(epoch_guard);
+                drop(emit_guard);
+                self.retain_prepared_initiator_publish_retry(
+                    &peer_id,
+                    reservation,
+                    PreparedInitiatorHandshake {
+                        initiator,
+                        initiation_bytes,
+                        candidates,
+                        candidate_sources,
+                        session_id,
+                        probe_ephemeral,
+                        probe_ephemeral_public_key,
+                    },
+                    "transport_sessions_contended",
+                );
+                return Ok(None);
+            };
             self.timeline.emit(
                 "initiator_publish_session_status_ready",
                 None,
                 None,
                 Some(format!(
-                    "peer={peer_id} owner={} generation={handshake_generation} retry={binding_contentions} has_active={} has_pending_responder={}",
+                    "peer={peer_id} owner={} generation={handshake_generation} retry={publish_attempt} has_active={} has_pending_responder={}",
                     reservation.owner, status.has_active, status.has_pending_responder
                 )),
             );
@@ -579,7 +679,7 @@ impl Daemon {
             );
             match stage {
                 None => {
-                    let binding_contentions = binding_contentions.saturating_add(1);
+                    let binding_contentions = publish_attempt.saturating_add(1);
                     self.timeline.emit(
                         "initiator_publish_probe_binding_contended",
                         None,
@@ -591,30 +691,23 @@ impl Daemon {
                     );
                     drop(epoch_guard);
                     drop(emit_guard);
-                    let prepared = PreparedInitiatorHandshake {
-                        initiator,
-                        initiation_bytes,
-                        candidates,
-                        candidate_sources,
-                        session_id,
-                        probe_ephemeral,
-                        probe_ephemeral_public_key,
-                    };
-                    if self.pending_handshakes.lock().store_prepared_if_current(
+                    self.retain_prepared_initiator_publish_retry(
                         &peer_id,
                         reservation,
-                        prepared,
-                    ) {
-                        self.schedule_initiator_retry(
-                            &peer_id,
-                            reservation,
-                            InitiatorRetryPhase::Publish,
-                            "connection_writer_contended",
-                        );
-                    }
+                        PreparedInitiatorHandshake {
+                            initiator,
+                            initiation_bytes,
+                            candidates,
+                            candidate_sources,
+                            session_id,
+                            probe_ephemeral,
+                            probe_ephemeral_public_key,
+                        },
+                        "connection_writer_contended",
+                    );
                     return Ok(None);
                 }
-                Some(ProbeBindingStage::Staged) => {
+                Some(ProbeBindingStage::Staged | ProbeBindingStage::ReplayableDuplicate) => {
                     let mut initiator = Some(initiator);
                     let mut probe_ephemeral = Some(probe_ephemeral);
                     let insert_transaction = self.pending_handshakes.try_with(|state| {
@@ -637,38 +730,27 @@ impl Daemon {
                     let Some(inserted) = insert_transaction else {
                         drop(epoch_guard);
                         drop(emit_guard);
-                        self.peers
-                            .discard_pending_probe_session_binding(&peer_id, &session_id)
-                            .await;
-                        let prepared = PreparedInitiatorHandshake {
-                            initiator: initiator.take().expect("unconsumed initiator"),
-                            initiation_bytes,
-                            candidates,
-                            candidate_sources,
-                            session_id,
-                            probe_ephemeral: probe_ephemeral.take().expect("unconsumed Probe key"),
-                            probe_ephemeral_public_key,
-                        };
-                        if self.pending_handshakes.lock().store_prepared_if_current(
+                        self.retain_prepared_initiator_publish_retry(
                             &peer_id,
                             reservation,
-                            prepared,
-                        ) {
-                            self.schedule_initiator_retry(
-                                &peer_id,
-                                reservation,
-                                InitiatorRetryPhase::Publish,
-                                "pending_state_contended",
-                            );
-                        }
+                            PreparedInitiatorHandshake {
+                                initiator: initiator.take().expect("unconsumed initiator"),
+                                initiation_bytes,
+                                candidates,
+                                candidate_sources,
+                                session_id,
+                                probe_ephemeral: probe_ephemeral
+                                    .take()
+                                    .expect("unconsumed Probe key"),
+                                probe_ephemeral_public_key,
+                            },
+                            "pending_state_contended",
+                        );
                         return Ok(None);
                     };
                     let Some((attempt_no, pending_id)) = inserted else {
                         drop(epoch_guard);
                         drop(emit_guard);
-                        self.peers
-                            .discard_pending_probe_session_binding(&peer_id, &session_id)
-                            .await;
                         return Ok(None);
                     };
                     self.timeline.emit(
@@ -676,7 +758,7 @@ impl Daemon {
                         None,
                         None,
                         Some(format!(
-                            "peer={peer_id} owner={} generation={handshake_generation} pending_id={pending_id} retries={binding_contentions}",
+                            "peer={peer_id} owner={} generation={handshake_generation} pending_id={pending_id} retries={publish_attempt}",
                             reservation.owner
                         )),
                     );

--- a/client/daemon/src/lib/daemon/handshake/offer.rs
+++ b/client/daemon/src/lib/daemon/handshake/offer.rs
@@ -8,8 +8,7 @@ impl Daemon {
         *self
             .responder_post_answer_test_gate
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-            Some((peer_id.to_string(), gate));
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((peer_id.to_string(), gate));
     }
 
     #[cfg(test)]
@@ -42,7 +41,7 @@ impl Daemon {
         &self,
         from_node_id: &str,
         cancellation: Option<&mut tokio::sync::watch::Receiver<bool>>,
-    ) -> Result<Option<tokio::sync::OwnedMutexGuard<()>>> {
+    ) -> Result<Option<HandshakeLease>> {
         let wait_started = Instant::now();
         let generation = self.peers.current_network_generation_sync();
         self.timeline.emit(
@@ -53,6 +52,14 @@ impl Daemon {
                 "peer={from_node_id} generation={generation} wait_budget_ms={}",
                 RESPONDER_HANDSHAKE_ARBITER_TIMEOUT.as_millis()
             )),
+        );
+        let identity = HandshakeLeaseIdentity::new(
+            from_node_id,
+            HandshakeOwnerKind::Responder,
+            None,
+            generation,
+            self.peers.peer_session_generation_sync(from_node_id),
+            "responder_admission",
         );
         let guard = match cancellation {
             Some(cancellation) => {
@@ -72,14 +79,14 @@ impl Daemon {
                         return Ok(None);
                     }
                     guard = self.handshake_arbiter.acquire_with_timeout(
-                        from_node_id,
+                        identity.clone(),
                         RESPONDER_HANDSHAKE_ARBITER_TIMEOUT,
                     ) => guard,
                 }
             }
             None => {
                 self.handshake_arbiter
-                    .acquire_with_timeout(from_node_id, RESPONDER_HANDSHAKE_ARBITER_TIMEOUT)
+                    .acquire_with_timeout(identity, RESPONDER_HANDSHAKE_ARBITER_TIMEOUT)
                     .await
             }
         };
@@ -241,7 +248,6 @@ impl Daemon {
             let current = self
                 .pending_handshakes
                 .lock()
-                .await
                 .responder_work_is_current(from_node_id, owner);
             if !current {
                 return Ok(());
@@ -283,7 +289,6 @@ impl Daemon {
             let current = self
                 .pending_handshakes
                 .lock()
-                .await
                 .responder_work_is_current(from_node_id, owner);
             if !current {
                 return Ok(());
@@ -386,7 +391,7 @@ impl Daemon {
             .clone()
             .unwrap_or_else(|| format!("legacy-wg-{}", initiation.sender_index));
         let cached = {
-            self.pending_handshakes.lock().await.responder_cache_lookup(
+            self.pending_handshakes.lock().responder_cache_lookup(
                 from_node_id,
                 &handshake_token,
                 handshake_init,
@@ -448,7 +453,6 @@ impl Daemon {
                 let timestamp_floor = self
                     .pending_handshakes
                     .lock()
-                    .await
                     .responder_timestamp_floor(from_node_id, &expected_peer_public);
                 self.timeline.emit(
                     "peer_offer_responder_timestamp_floor_acquired",
@@ -513,11 +517,8 @@ impl Daemon {
                         handshake_token_fingerprint(Some(&handshake_token))
                     )),
                 );
-                let timestamp_committed = self
-                    .pending_handshakes
-                    .lock()
-                    .await
-                    .commit_responder_timestamp(
+                let timestamp_committed =
+                    self.pending_handshakes.lock().commit_responder_timestamp(
                         from_node_id,
                         expected_peer_public,
                         authenticated_timestamp,
@@ -591,7 +592,7 @@ impl Daemon {
             return Ok(());
         }
         let superseded_initiator_token = {
-            let mut state = self.pending_handshakes.lock().await;
+            let mut state = self.pending_handshakes.lock();
             let token = state.session_id(from_node_id).map(str::to_string);
             state.remove(from_node_id);
             state.cancel_reservation(from_node_id);
@@ -752,10 +753,11 @@ impl Daemon {
         // an old-generation offer must not leave a cache entry that can be
         // replayed into a later session.
         if let Some(cache_entry) = cache_entry_to_commit {
-            self.pending_handshakes
-                .lock()
-                .await
-                .cache_responder_handshake(from_node_id, &handshake_token, cache_entry);
+            self.pending_handshakes.lock().cache_responder_handshake(
+                from_node_id,
+                &handshake_token,
+                cache_entry,
+            );
         }
 
         // All state required to replay/validate the response is now staged.
@@ -880,7 +882,6 @@ impl Daemon {
             let current = self
                 .pending_handshakes
                 .lock()
-                .await
                 .responder_work_is_current(from_node_id, owner);
             if !current {
                 return Ok(());
@@ -935,10 +936,7 @@ impl Daemon {
             let connection_refresh_started = Instant::now();
             let outcome = self
                 .peers
-                .try_refresh_pending_probe_session_binding_grace(
-                    from_node_id,
-                    &handshake_token,
-                );
+                .try_refresh_pending_probe_session_binding_grace(from_node_id, &handshake_token);
             self.timeline.emit(
                 "peer_answer_probe_binding_grace_result",
                 None,

--- a/client/daemon/src/lib/daemon/handshake/offer.rs
+++ b/client/daemon/src/lib/daemon/handshake/offer.rs
@@ -390,10 +390,24 @@ impl Daemon {
         let handshake_token = session_id
             .clone()
             .unwrap_or_else(|| format!("legacy-wg-{}", initiation.sender_index));
+        let responder_network_generation = expected_network_generation
+            .unwrap_or_else(|| self.peers.current_network_generation_sync());
+        let responder_peer_session_generation = expected_peer_session_generation
+            .or_else(|| self.peers.peer_session_generation_sync(from_node_id))
+            .ok_or_else(|| {
+                DaemonError::Peer(format!(
+                    "refusing WireGuard offer from {from_node_id}: peer lifecycle is not registered"
+                ))
+            })?;
+        let responder_lifecycle = ResponderHandshakeLifecycle {
+            network_generation: responder_network_generation,
+            peer_session_generation: responder_peer_session_generation,
+        };
         let cached = {
             self.pending_handshakes.lock().responder_cache_lookup(
                 from_node_id,
                 &handshake_token,
+                responder_lifecycle,
                 handshake_init,
                 modern_probe_public_key.as_deref(),
                 &expected_peer_public,
@@ -403,6 +417,7 @@ impl Daemon {
             ResponderHandshakeCacheLookup::Hit(_) => "hit",
             ResponderHandshakeCacheLookup::Miss => "miss",
             ResponderHandshakeCacheLookup::FingerprintMismatch => "fingerprint_mismatch",
+            ResponderHandshakeCacheLookup::StaleLifecycle => "stale_lifecycle",
         };
         self.timeline.emit(
             "peer_offer_responder_cache_lookup",
@@ -434,6 +449,11 @@ impl Daemon {
             ResponderHandshakeCacheLookup::FingerprintMismatch => {
                 return Err(DaemonError::Peer(format!(
                     "refusing WireGuard offer from {from_node_id}: reused session token has different handshake or Probe key material"
+                )));
+            }
+            ResponderHandshakeCacheLookup::StaleLifecycle => {
+                return Err(DaemonError::Peer(format!(
+                    "refusing WireGuard offer from {from_node_id}: cached responder transaction belongs to a retired lifecycle"
                 )));
             }
             ResponderHandshakeCacheLookup::Miss => {
@@ -557,6 +577,7 @@ impl Daemon {
                     };
                 let response_bytes = response.to_bytes();
                 let cache_entry = CachedResponderHandshake {
+                    lifecycle: responder_lifecycle,
                     handshake_init: handshake_init.to_vec(),
                     initiator_static_public_key: expected_peer_public,
                     request_probe_ephemeral_public_key: modern_probe_public_key.clone(),
@@ -591,6 +612,22 @@ impl Daemon {
         {
             return Ok(());
         }
+
+        // Commit the exact authenticated response before any try-only
+        // transport/connection mutation. A connection writer can be
+        // temporarily unavailable after the Noise timestamp is consumed;
+        // retaining these exact bytes and keys makes that outcome retryable
+        // instead of turning the next copy into a replay rejection. The cache
+        // carries both local lifecycle generations, so a stale retry cannot
+        // cross a handover or same-node leave/rejoin.
+        if let Some(cache_entry) = cache_entry_to_commit {
+            self.pending_handshakes.lock().cache_responder_handshake(
+                from_node_id,
+                &handshake_token,
+                cache_entry,
+            );
+        }
+
         let superseded_initiator_token = {
             let mut state = self.pending_handshakes.lock();
             let token = state.session_id(from_node_id).map(str::to_string);
@@ -600,9 +637,20 @@ impl Daemon {
             token
         };
         if let Some(token) = superseded_initiator_token {
-            self.peers
-                .discard_pending_probe_session_binding(from_node_id, &token)
-                .await;
+            let cleanup = self
+                .peers
+                .try_discard_pending_probe_session_binding(from_node_id, &token);
+            self.timeline.emit(
+                "peer_offer_superseded_probe_binding_cleanup",
+                None,
+                cleanup
+                    .is_none()
+                    .then_some("connection_writer_contended"),
+                Some(format!(
+                    "peer={from_node_id} generation={responder_network_generation} cleaned={} queued_writer=false",
+                    cleanup.unwrap_or(false)
+                )),
+            );
         }
 
         // Stage the responder key and its Probe binding as short per-peer
@@ -629,31 +677,44 @@ impl Daemon {
                     self.peers.current_network_generation_sync()
                 )),
             );
+            if !cached_replay {
+                self.pending_handshakes
+                    .lock()
+                    .discard_responder_handshake_cache(from_node_id, &handshake_token);
+            }
             return Ok(());
         }
         let responder_transport_session = TransportSession::new(keys.clone());
-        let initial_stage = self
-            .transport
-            .stage_responder_session(
+        let initial_stage = tokio::time::timeout(
+            RESPONDER_SESSION_STAGE_TIMEOUT,
+            self.transport.stage_responder_session(
                 from_node_id.to_string(),
                 handshake_token.clone(),
                 responder_transport_session,
-            )
-            .await;
+            ),
+        )
+        .await
+        .map_err(|_| {
+            DaemonError::Network(REASON_RESPONDER_SESSION_STAGE_TIMEOUT.to_string())
+        })?;
         let (had_active, responder_staged_new) = match initial_stage {
             ResponderSessionStage::Staged { had_active } => (had_active, true),
             ResponderSessionStage::ReplayableDuplicate { had_active } if cached_replay => {
                 (had_active, false)
             }
             ResponderSessionStage::StaleDuplicate if cached_replay => {
-                match self
-                    .transport
-                    .restage_cached_responder_session(
+                match tokio::time::timeout(
+                    RESPONDER_SESSION_STAGE_TIMEOUT,
+                    self.transport.restage_cached_responder_session(
                         from_node_id.to_string(),
                         handshake_token.clone(),
                         TransportSession::new(keys.clone()),
-                    )
-                    .await
+                    ),
+                )
+                .await
+                .map_err(|_| {
+                    DaemonError::Network(REASON_RESPONDER_SESSION_STAGE_TIMEOUT.to_string())
+                })?
                 {
                     ResponderSessionStage::Staged { had_active } => (had_active, true),
                     ResponderSessionStage::ReplayableDuplicate { had_active } => {
@@ -669,6 +730,11 @@ impl Daemon {
             ResponderSessionStage::ReplayableDuplicate { .. }
             | ResponderSessionStage::StaleDuplicate
             | ResponderSessionStage::Busy => {
+                if !cached_replay {
+                    self.pending_handshakes
+                        .lock()
+                        .discard_responder_handshake_cache(from_node_id, &handshake_token);
+                }
                 return Err(DaemonError::Peer(format!(
                     "refusing duplicate WireGuard offer token from {from_node_id}; exact cached answer is unavailable"
                 )));
@@ -676,27 +742,44 @@ impl Daemon {
         };
         let staged_probe_binding = session_id.is_some() || probe_ephemeral_shared.is_some();
         if staged_probe_binding {
-            match self
-                .peers
-                .stage_probe_session_binding(
-                    from_node_id,
-                    handshake_token.clone(),
-                    session_id.clone(),
-                    probe_ephemeral_shared,
-                    true,
-                )
-                .await
-            {
-                ProbeBindingStage::Staged => {}
-                ProbeBindingStage::ReplayableDuplicate if cached_replay => {}
-                ProbeBindingStage::StaleDuplicate
-                | ProbeBindingStage::Busy
-                | ProbeBindingStage::ReplayableDuplicate
-                | ProbeBindingStage::PeerMissing => {
+            match self.peers.try_stage_probe_session_binding(
+                from_node_id,
+                handshake_token.clone(),
+                session_id.clone(),
+                probe_ephemeral_shared,
+                true,
+            ) {
+                None => {
+                    self.timeline.emit(
+                        "peer_offer_responder_probe_binding_contended",
+                        None,
+                        Some(REASON_RESPONDER_PROBE_BINDING_CONTENDED),
+                        Some(format!(
+                            "peer={from_node_id} generation={responder_network_generation} session_fp={} queued_writer=false exact_response_retained=true",
+                            handshake_token_fingerprint(Some(&handshake_token))
+                        )),
+                    );
+                    return Err(DaemonError::Network(
+                        REASON_RESPONDER_PROBE_BINDING_CONTENDED.to_string(),
+                    ));
+                }
+                Some(ProbeBindingStage::Staged) => {}
+                Some(ProbeBindingStage::ReplayableDuplicate) if cached_replay => {}
+                Some(
+                    ProbeBindingStage::StaleDuplicate
+                    | ProbeBindingStage::Busy
+                    | ProbeBindingStage::ReplayableDuplicate
+                    | ProbeBindingStage::PeerMissing,
+                ) => {
                     if responder_staged_new {
                         self.transport
                             .discard_responder_session(from_node_id, &handshake_token)
                             .await;
+                    }
+                    if !cached_replay {
+                        self.pending_handshakes
+                            .lock()
+                            .discard_responder_handshake_cache(from_node_id, &handshake_token);
                     }
                     return Err(DaemonError::Peer(format!(
                         "failed to stage Probe v2 responder binding for {from_node_id}"
@@ -746,18 +829,6 @@ impl Daemon {
                     .await;
             }
             return Ok(());
-        }
-
-        // Publish newly generated responder bytes only after both transport
-        // layers and the generation check accepted the offer. In particular,
-        // an old-generation offer must not leave a cache entry that can be
-        // replayed into a later session.
-        if let Some(cache_entry) = cache_entry_to_commit {
-            self.pending_handshakes.lock().cache_responder_handshake(
-                from_node_id,
-                &handshake_token,
-                cache_entry,
-            );
         }
 
         // All state required to replay/validate the response is now staged.
@@ -986,10 +1057,22 @@ impl Daemon {
                 self.peers.current_network_generation_sync()
             )),
         );
-        let emit_guard = self
+        let Some(emit_guard) = self
             .transport
-            .acquire_outbound_emit_guard(from_node_id)
-            .await;
+            .try_acquire_outbound_emit_guard(from_node_id)
+        else {
+            self.timeline.emit(
+                "peer_answer_commit_contended",
+                None,
+                Some(REASON_RESPONDER_COMMIT_CONTENDED),
+                Some(format!(
+                    "peer={from_node_id} generation={responder_network_generation} phase=emit queued=false exact_response_retained=true"
+                )),
+            );
+            return Err(DaemonError::Network(
+                REASON_RESPONDER_COMMIT_CONTENDED.to_string(),
+            ));
+        };
         self.timeline.emit(
             "peer_answer_commit_emit_lock_acquired",
             None,
@@ -1001,7 +1084,20 @@ impl Daemon {
             )),
         );
         let epoch_gate = self.peers.network_epoch_gate();
-        let epoch_guard = epoch_gate.lock().await;
+        let Ok(epoch_guard) = epoch_gate.try_lock() else {
+            drop(emit_guard);
+            self.timeline.emit(
+                "peer_answer_commit_contended",
+                None,
+                Some(REASON_RESPONDER_COMMIT_CONTENDED),
+                Some(format!(
+                    "peer={from_node_id} generation={responder_network_generation} phase=network_epoch queued=false exact_response_retained=true"
+                )),
+            );
+            return Err(DaemonError::Network(
+                REASON_RESPONDER_COMMIT_CONTENDED.to_string(),
+            ));
+        };
         if expected_network_generation
             .is_some_and(|generation| self.peers.current_network_generation_sync() != generation)
             || expected_peer_session_generation.is_some_and(|expected| {
@@ -1044,10 +1140,24 @@ impl Daemon {
                 handshake_token_fingerprint(Some(&handshake_token))
             )),
         );
-        let commit = self
+        let Some(commit) = self
             .transport
-            .commit_responder_session_locked(from_node_id, &handshake_token)
-            .await;
+            .try_commit_responder_session_locked(from_node_id, &handshake_token)
+        else {
+            drop(epoch_guard);
+            drop(emit_guard);
+            self.timeline.emit(
+                "peer_answer_commit_contended",
+                None,
+                Some(REASON_RESPONDER_COMMIT_CONTENDED),
+                Some(format!(
+                    "peer={from_node_id} generation={responder_network_generation} phase=transport_sessions queued=false exact_response_retained=true"
+                )),
+            );
+            return Err(DaemonError::Network(
+                REASON_RESPONDER_COMMIT_CONTENDED.to_string(),
+            ));
+        };
         drop(epoch_guard);
         drop(emit_guard);
         if commit == ResponderSessionCommit::ActivatedInitial {

--- a/client/daemon/src/lib/daemon/handshake/offer.rs
+++ b/client/daemon/src/lib/daemon/handshake/offer.rs
@@ -1,4 +1,39 @@
 impl Daemon {
+    #[cfg(test)]
+    fn install_responder_post_answer_gate_for_test(
+        &self,
+        peer_id: &str,
+        gate: Arc<ResponderPostAnswerTestGate>,
+    ) {
+        *self
+            .responder_post_answer_test_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some((peer_id.to_string(), gate));
+    }
+
+    #[cfg(test)]
+    async fn pause_responder_post_answer_for_test(&self, peer_id: &str) {
+        let gate = {
+            let mut installed = self
+                .responder_post_answer_test_gate
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if installed
+                .as_ref()
+                .is_some_and(|(installed_peer, _)| installed_peer == peer_id)
+            {
+                installed.take().map(|(_, gate)| gate)
+            } else {
+                None
+            }
+        };
+        if let Some(gate) = gate {
+            gate.reached.notify_one();
+            gate.release.wait().await;
+        }
+    }
+
     /// Acquire the responder's short mutation turn with both cancellation and
     /// a hard lock-wait bound.  A control signal is already acknowledged when
     /// it enters the responder worker, so an unbounded arbiter wait would turn
@@ -864,17 +899,63 @@ impl Daemon {
             return Ok(());
         }
         drop(handshake_guard);
+        self.timeline.emit(
+            "peer_answer_post_delivery_responder_lock_released",
+            None,
+            None,
+            Some(format!(
+                "peer={from_node_id} generation={} session_fp={}",
+                self.peers.current_network_generation_sync(),
+                handshake_token_fingerprint(Some(&handshake_token))
+            )),
+        );
         // Refresh both pending slots after the HTTP attempt. This separates
         // potentially slow control-plane delivery from the wide direct
         // adoption window; an ambiguous error intentionally leaves both
         // staged so a retry can still authenticate the exact token.
-        self.transport
+        let transport_grace_started = Instant::now();
+        let transport_grace_refreshed = self
+            .transport
             .refresh_responder_session_grace(from_node_id, &handshake_token)
             .await;
+        self.timeline.emit(
+            "peer_answer_responder_session_grace_result",
+            None,
+            (!transport_grace_refreshed).then_some("pending_session_missing"),
+            Some(format!(
+                "peer={from_node_id} generation={} refreshed={transport_grace_refreshed} elapsed_us={}",
+                self.peers.current_network_generation_sync(),
+                transport_grace_started.elapsed().as_micros()
+            )),
+        );
+        #[cfg(test)]
+        self.pause_responder_post_answer_for_test(from_node_id)
+            .await;
         if staged_probe_binding {
-            self.peers
-                .refresh_pending_probe_session_binding_grace(from_node_id, &handshake_token)
-                .await;
+            let connection_refresh_started = Instant::now();
+            let outcome = self
+                .peers
+                .try_refresh_pending_probe_session_binding_grace(
+                    from_node_id,
+                    &handshake_token,
+                );
+            self.timeline.emit(
+                "peer_answer_probe_binding_grace_result",
+                None,
+                match outcome {
+                    PendingProbeBindingCommitOutcome::ContendedConnections => {
+                        Some("fair_rwlock_writer_unavailable")
+                    }
+                    PendingProbeBindingCommitOutcome::Missing => Some("pending_binding_missing"),
+                    PendingProbeBindingCommitOutcome::Committed
+                    | PendingProbeBindingCommitOutcome::AlreadyCurrent => None,
+                },
+                Some(format!(
+                    "peer={from_node_id} generation={} outcome={outcome:?} connections_wait_us={} queued_writer=false",
+                    self.peers.current_network_generation_sync(),
+                    connection_refresh_started.elapsed().as_micros()
+                )),
+            );
         }
         // A transport error is delivery-ambiguous: the control server or peer
         // may already have received the answer. The `?` intentionally leaves

--- a/client/daemon/src/lib/daemon/handshake/offer.rs
+++ b/client/daemon/src/lib/daemon/handshake/offer.rs
@@ -34,9 +34,10 @@ impl Daemon {
     }
 
     /// Acquire the responder's short mutation turn with both cancellation and
-    /// a hard lock-wait bound.  A control signal is already acknowledged when
-    /// it enters the responder worker, so an unbounded arbiter wait would turn
-    /// one stale initiator/lifecycle task into a permanent session blackout.
+    /// a hard lock-wait bound. The responder worker retains the exact durable
+    /// receipt, so an unbounded arbiter wait would head-of-line block every
+    /// later signal from this sender and turn one stale lifecycle task into a
+    /// permanent session blackout.
     async fn acquire_responder_handshake_guard(
         &self,
         from_node_id: &str,
@@ -253,13 +254,11 @@ impl Daemon {
                 return Ok(());
             }
         }
-        // Identity lookup may wait behind control/connection state. Never hold
-        // the per-peer arbiter across it: this responder future is cooperatively
-        // polled by the serial control loop, whose lifecycle branch may itself
-        // be waiting to acquire the same arbiter.
+        // Identity comes from the synchronous lifecycle mirror, so this
+        // admission check cannot queue behind control or connection state.
+        // The per-peer arbiter still remains a short mutation turn only.
         if !self
             .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
-            .await
         {
             self.timeline.emit(
                 "peer_offer_rejected",
@@ -330,20 +329,7 @@ impl Daemon {
         // rule on inbound offers prevents crossing rekeys from staging a
         // second responder transaction after this node already claimed the
         // initiator side.
-        let known_peer_public_key = self
-            .control
-            .peers()
-            .await
-            .get(from_node_id)
-            .map(|peer| peer.public_key.clone());
-        let known_peer_public_key = match known_peer_public_key {
-            Some(public_key) => Some(public_key),
-            None => self
-                .peers
-                .get_connection(from_node_id)
-                .await
-                .map(|peer| peer.public_key),
-        };
+        let known_peer_public_key = self.peers.peer_identity_public_key_sync(from_node_id);
         let expected_peer_public = known_peer_public_key
             .as_deref()
             .map(|public_key| decode_x25519_key(public_key, "peer public key"))

--- a/client/daemon/src/lib/daemon/handshake_maintenance.rs
+++ b/client/daemon/src/lib/daemon/handshake_maintenance.rs
@@ -1,7 +1,7 @@
 struct HandshakeMaintenanceContext {
     peers: Arc<PeerManager>,
     transport: WireGuardTransport,
-    pending: Arc<tokio::sync::Mutex<PendingHandshakeState>>,
+    pending: Arc<PendingHandshakeStore>,
     handshake_arbiter: HandshakeArbiter,
     control: ControlClient,
     local_candidates: Arc<RwLock<Vec<String>>>,
@@ -19,6 +19,71 @@ struct HandshakeMaintenanceContext {
     /// immediately. The ten-second tick remains the recovery backstop, but it
     /// must not be the first chance to recreate a missing encrypted session.
     kick_rx: tokio::sync::watch::Receiver<u64>,
+    handshake_retry_kick_tx: tokio::sync::watch::Sender<u64>,
+}
+
+enum MaintenanceInitiatorReservationOutcome {
+    Reserved {
+        reservation: HandshakeStartReservation,
+        stale_session_id: Option<String>,
+        retry_budget_reset: bool,
+    },
+    Busy,
+    Contended,
+}
+
+/// Claim the maintenance producer's long-lived reservation in one short,
+/// zero-wait mutation turn. All actor/control/candidate snapshots happen
+/// before this function and every slow continuation happens after it.
+fn try_reserve_maintenance_initiator(
+    pending: &PendingHandshakeStore,
+    handshake_arbiter: &HandshakeArbiter,
+    peer_id: &str,
+    network_generation: u64,
+    peer_session_generation: PeerSessionGeneration,
+) -> MaintenanceInitiatorReservationOutcome {
+    let identity = HandshakeLeaseIdentity::new(
+        peer_id,
+        HandshakeOwnerKind::MaintenanceInitiator,
+        None,
+        network_generation,
+        Some(peer_session_generation),
+        "reserve",
+    );
+    let Ok(handshake_guard) = handshake_arbiter.try_acquire(identity) else {
+        return MaintenanceInitiatorReservationOutcome::Contended;
+    };
+    let transaction = pending.try_with(|state| {
+        let stale_session_id = state.remove_stale_pending_for_generation(
+            peer_id,
+            network_generation,
+            peer_session_generation,
+        );
+        let reservation = state.reserve_start_with_owner_at_generation_and_kind(
+            peer_id,
+            network_generation,
+            peer_session_generation,
+            HandshakeOwnerKind::MaintenanceInitiator,
+        );
+        let retry_budget_reset = reservation.is_some()
+            && state.attempts.get(peer_id).copied().unwrap_or(0) >= MAX_HANDSHAKE_ATTEMPTS;
+        if retry_budget_reset {
+            state.attempts.remove(peer_id);
+        }
+        (stale_session_id, reservation, retry_budget_reset)
+    });
+    drop(handshake_guard);
+    let Some((stale_session_id, reservation, retry_budget_reset)) = transaction else {
+        return MaintenanceInitiatorReservationOutcome::Contended;
+    };
+    match reservation {
+        Some(reservation) => MaintenanceInitiatorReservationOutcome::Reserved {
+            reservation,
+            stale_session_id,
+            retry_budget_reset,
+        },
+        None => MaintenanceInitiatorReservationOutcome::Busy,
+    }
 }
 
 async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
@@ -40,6 +105,7 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
         udp_advertise,
         node_private_key,
         mut kick_rx,
+        handshake_retry_kick_tx,
     } = ctx;
 
     let mut tick = tokio::time::interval(Duration::from_secs(10));
@@ -52,6 +118,19 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 }
                 kick_rx.borrow_and_update();
             }
+        }
+        // The exact retry record is committed before its wake.  Republishing
+        // the current revision from the supervised maintenance owner makes a
+        // receiver replacement or coalesced watch notification harmless: the
+        // control coordinator always scans the authoritative ledger.
+        let retry_revision = {
+            let state = pending.lock();
+            state
+                .has_initiator_retries()
+                .then(|| state.retry_revision())
+        };
+        if let Some(retry_revision) = retry_revision {
+            handshake_retry_kick_tx.send_replace(retry_revision);
         }
         let conns = peers.all_connections().await;
         for conn in conns {
@@ -72,13 +151,13 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 );
                 continue;
             }
-            let handshake_guard = handshake_arbiter.acquire(&conn.node_id).await;
-            let Some(peer_session_generation) =
-                peers.peer_session_generation_sync(&conn.node_id)
+            let Some(peer_session_generation) = peers.peer_session_generation_sync(&conn.node_id)
             else {
                 continue;
             };
-            // Establish missing sessions and refresh sessions that need rekey.
+            // Maintenance is a low-priority producer.  Snapshot every actor or
+            // control-plane dependency before attempting the zero-wait mutation
+            // turn; an Event/Responder owner must never queue behind this scan.
             let status = transport.session_status(&conn.node_id).await;
             if status.has_pending_responder {
                 debug!(
@@ -108,102 +187,60 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 );
             }
             let handshake_generation = peers.current_network_generation_sync();
+            let control_peers = control.peers().await;
+            let Some(peer_info) = control_peers.get(&conn.node_id) else {
+                debug!("No control peer info for handshake with {}", conn.node_id);
+                continue;
+            };
+            let Ok(private_key) = decode_x25519_key(&node_private_key, "node private key") else {
+                continue;
+            };
+            let Ok(peer_public) = decode_x25519_key(&peer_info.public_key, "peer public key")
+            else {
+                continue;
+            };
+            let identity = NodeIdentity::from_private_key(private_key);
+            if !local_is_designated_handshake_initiator(&identity.public_key(), &peer_public) {
+                continue;
+            }
+            let mut initiator = HandshakeInitiator::new(identity, peer_public, None);
+            let Ok(initiation) = initiator.create_initiation() else {
+                continue;
+            };
+            let initiation_bytes = initiation.to_bytes();
 
-            // Reserve before any further awaits.  The peer-join path can run at
-            // the same time as this maintenance loop; without this reservation,
-            // both paths could create an initiator and the later one would
-            // overwrite the former pending handshake.
-            let stale_session_id = pending
-                .lock()
-                .await
-                .remove_stale_pending_for_generation(
+            let (mut reservation, stale_session_id, retry_budget_reset) =
+                match try_reserve_maintenance_initiator(
+                    &pending,
+                    &handshake_arbiter,
                     &conn.node_id,
                     handshake_generation,
                     peer_session_generation,
+                ) {
+                    MaintenanceInitiatorReservationOutcome::Reserved {
+                        reservation,
+                        stale_session_id,
+                        retry_budget_reset,
+                    } => (reservation, stale_session_id, retry_budget_reset),
+                    MaintenanceInitiatorReservationOutcome::Busy
+                    | MaintenanceInitiatorReservationOutcome::Contended => {
+                        // A high-priority Event/Responder turn owns the peer, or
+                        // the short state store is momentarily busy. Never join
+                        // either wait queue; a kick/tick reevaluates lifecycle.
+                        continue;
+                    }
+                };
+            if retry_budget_reset {
+                warn!(
+                    "Handshake for {} reached max attempts; resetting retry budget",
+                    conn.node_id
                 );
+            }
             if let Some(session_id) = stale_session_id {
                 peers
                     .discard_pending_probe_session_binding(&conn.node_id, &session_id)
                     .await;
             }
-            let Some(reservation) = ({
-                let mut state = pending.lock().await;
-                let reservation = state.reserve_start_with_owner_at_generation(
-                    &conn.node_id,
-                    handshake_generation,
-                    peer_session_generation,
-                );
-                if reservation.is_some()
-                    && state.attempts.get(&conn.node_id).copied().unwrap_or(0)
-                        >= MAX_HANDSHAKE_ATTEMPTS
-                {
-                    warn!(
-                        "Handshake for {} reached max attempts; resetting retry budget",
-                        conn.node_id
-                    );
-                    state.attempts.remove(&conn.node_id);
-                }
-                reservation
-            }) else {
-                continue;
-            };
-
-            // PeerConnection doesn't store public key; look up from control.
-            // Best-effort: if control has the peer, use it.
-            // (control.peers is async)
-            // We intentionally skip initiation if we can't get the key —
-            // the peer may also rekey from its side.
-            let control_peers = control.peers().await;
-            let Some(peer_info) = control_peers.get(&conn.node_id) else {
-                pending
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
-                debug!("No control peer info for handshake with {}", conn.node_id);
-                continue;
-            };
-            let Ok(private_key) = decode_x25519_key(&node_private_key, "node private key") else {
-                pending
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
-                continue;
-            };
-            let Ok(peer_public) = decode_x25519_key(&peer_info.public_key, "peer public key")
-            else {
-                pending
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
-                continue;
-            };
-            let identity = NodeIdentity::from_private_key(private_key);
-            if !local_is_designated_handshake_initiator(&identity.public_key(), &peer_public) {
-                // Let the deterministically selected peer initiate.
-                pending
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
-                continue;
-            }
-            let mut initiator = HandshakeInitiator::new(identity, peer_public, None);
-            let Ok(initiation) = initiator.create_initiation() else {
-                pending
-                    .lock()
-                    .await
-                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
-                continue;
-            };
-            let initiation_bytes = initiation.to_bytes();
-            // The per-peer handshake reservation above is the actual
-            // mutual-exclusion primitive.  The arbiter guard must NOT be held
-            // across the slow steps below (STUN candidate refresh, control
-            // plane offer POST): a crossing inbound offer/answer handler
-            // waits on the same arbiter, and holding it through a multi-second
-            // refresh or POST stalls (or effectively deadlocks) the responder
-            // path — the peer never answers, the session never forms, and
-            // direct validation can never promote.
-            drop(handshake_guard);
             // Rekey defaults to the cached candidate snapshot: a live STUN
             // gather is only run when no snapshot exists yet (first boot), so
             // a healthy Direct peer's rekey never re-triggers traversal churn.
@@ -212,7 +249,12 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 let snapshot_state = candidate_snapshot.read().await.clone();
                 let leased = snapshot_state.as_ref().and_then(|snapshot| {
                     (snapshot.initial_gather_complete && !snapshot.candidates.is_empty()).then(
-                        || (snapshot.candidates.clone(), snapshot.candidate_sources.clone()),
+                        || {
+                            (
+                                snapshot.candidates.clone(),
+                                snapshot.candidate_sources.clone(),
+                            )
+                        },
                     )
                 });
                 let startup_snapshot_is_provisional = snapshot_state
@@ -271,54 +313,82 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                     reservation.peer_session_generation,
                 )
                 || should_cancel_maintenance_offer(
-                is_rekey,
-                current_status.has_active,
-                current_status.needs_rekey,
-                current_status.expired,
-                current_status.has_pending_responder,
-            )
+                    is_rekey,
+                    current_status.has_active,
+                    current_status.needs_rekey,
+                    current_status.expired,
+                    current_status.has_pending_responder,
+                )
             {
                 pending
                     .lock()
-                    .await
                     .cancel_reservation_if_current(&conn.node_id, reservation.owner);
                 continue;
             }
 
             let session_id = new_probe_session_id();
             let (probe_ephemeral, probe_ephemeral_public_key) = new_probe_ephemeral_keypair();
+            let publish_identity = HandshakeLeaseIdentity::new(
+                &conn.node_id,
+                HandshakeOwnerKind::MaintenanceInitiator,
+                Some(reservation.owner),
+                handshake_generation,
+                Some(reservation.peer_session_generation),
+                "publish",
+            );
+            let Ok(publish_guard) = handshake_arbiter.try_acquire(publish_identity) else {
+                pending
+                    .lock()
+                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
+                continue;
+            };
             let Some((attempt_no, pending_id)) = ({
                 let epoch_gate = peers.network_epoch_gate();
-                let _epoch_guard = epoch_gate.lock().await;
-                if peers.current_network_generation_sync() != handshake_generation
+                let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+                    drop(publish_guard);
+                    pending
+                        .lock()
+                        .cancel_reservation_if_current(&conn.node_id, reservation.owner);
+                    continue;
+                };
+                if *reservation.cancellation.borrow()
+                    || peers.current_network_generation_sync() != handshake_generation
                     || !peers.peer_session_is_current_sync(
                         &conn.node_id,
                         reservation.peer_session_generation,
                     )
                 {
+                    drop(_epoch_guard);
+                    drop(publish_guard);
                     pending
                         .lock()
-                        .await
                         .cancel_reservation_if_current(&conn.node_id, reservation.owner);
                     continue;
                 }
-                let mut state = pending.lock().await;
-                state
-                    .insert_reserved_if_current_with_generation(
-                        conn.node_id.clone(),
-                        reservation.owner,
-                        initiator,
-                        Some(session_id.clone()),
-                        Some(probe_ephemeral),
-                        handshake_generation,
-                        reservation.peer_session_generation,
-                    )
-                    .map(|pending_id| {
-                        let attempts = state.attempts.entry(conn.node_id.clone()).or_insert(0);
-                        *attempts = attempts.saturating_add(1);
-                        (*attempts, pending_id)
-                    })
+                let inserted = pending.try_with(|state| {
+                    state
+                        .insert_reserved_if_current_with_generation(
+                            conn.node_id.clone(),
+                            reservation.owner,
+                            initiator,
+                            Some(session_id.clone()),
+                            Some(probe_ephemeral),
+                            handshake_generation,
+                            reservation.peer_session_generation,
+                        )
+                        .map(|pending_id| {
+                            let attempts = state.attempts.entry(conn.node_id.clone()).or_insert(0);
+                            *attempts = attempts.saturating_add(1);
+                            (*attempts, pending_id)
+                        })
+                });
+                drop(_epoch_guard);
+                drop(publish_guard);
+                inserted.flatten()
             }) else {
+                pending
+                    .lock()
+                    .cancel_reservation_if_current(&conn.node_id, reservation.owner);
                 continue;
             };
             // An inbound responder rekey can be staged after the candidate
@@ -326,28 +396,56 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
             // staged. Re-check at the mutation boundary so the crossing
             // initiator never overwrites the responder's pending binding.
             let pre_probe_status = transport.session_status(&conn.node_id).await;
-            if should_cancel_maintenance_offer(
-                is_rekey,
-                pre_probe_status.has_active,
-                pre_probe_status.needs_rekey,
-                pre_probe_status.expired,
-                pre_probe_status.has_pending_responder,
-            ) {
-                pending.lock().await.remove(&conn.node_id);
+            if *reservation.cancellation.borrow()
+                || peers.current_network_generation_sync() != handshake_generation
+                || !peers.peer_session_is_current_sync(
+                    &conn.node_id,
+                    reservation.peer_session_generation,
+                )
+                || should_cancel_maintenance_offer(
+                    is_rekey,
+                    pre_probe_status.has_active,
+                    pre_probe_status.needs_rekey,
+                    pre_probe_status.expired,
+                    pre_probe_status.has_pending_responder,
+                )
+            {
+                pending.lock().remove_if_current(&conn.node_id, pending_id);
                 continue;
             }
-            if peers
-                .stage_probe_session_binding(
-                    &conn.node_id,
-                    session_id.clone(),
-                    Some(session_id.clone()),
-                    None,
-                    false,
-                )
-                .await
-                != ProbeBindingStage::Staged
-            {
-                pending.lock().await.remove(&conn.node_id);
+            // Stage the Probe binding in the same generation transaction and
+            // never queue a connection writer. Maintenance is the low-priority
+            // producer: contention cancels this exact pending owner and the
+            // next kick/tick takes a fresh snapshot.
+            let binding_stage = {
+                let epoch_gate = peers.network_epoch_gate();
+                let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+                    pending.lock().remove_if_current(&conn.node_id, pending_id);
+                    continue;
+                };
+                if *reservation.cancellation.borrow()
+                    || peers.current_network_generation_sync() != handshake_generation
+                    || !peers.peer_session_is_current_sync(
+                        &conn.node_id,
+                        reservation.peer_session_generation,
+                    )
+                {
+                    None
+                } else {
+                    peers.try_stage_probe_session_binding(
+                        &conn.node_id,
+                        session_id.clone(),
+                        Some(session_id.clone()),
+                        None,
+                        false,
+                    )
+                }
+            };
+            if binding_stage != Some(ProbeBindingStage::Staged) {
+                pending.lock().remove_if_current(&conn.node_id, pending_id);
+                peers
+                    .discard_pending_probe_session_binding(&conn.node_id, &session_id)
+                    .await;
                 warn!(
                     "Failed to stage Probe v2 binding for handshake with {}",
                     conn.node_id
@@ -356,8 +454,8 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
             }
 
             let punch_at_ms = Some(relay_assisted_punch_at_ms());
-            let offer_result = control
-                .send_peer_offer_with_sources_punch_and_session(
+            let Some(offer_result) = await_initiator_offer_or_cancellation(
+                control.send_peer_offer_with_sources_punch_and_session(
                     &conn.node_id,
                     &candidates,
                     &candidate_sources,
@@ -365,8 +463,16 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                     punch_at_ms,
                     Some(session_id.clone()),
                     Some(probe_ephemeral_public_key.clone()),
-                )
-                .await;
+                ),
+                &mut reservation.cancellation,
+            )
+            .await
+            else {
+                peers
+                    .discard_pending_probe_session_binding(&conn.node_id, &session_id)
+                    .await;
+                continue;
+            };
             if offer_result.is_ok() {
                 if is_rekey {
                     info!(
@@ -412,7 +518,7 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 // an answer/retry/rejoin that replaced it makes this task a
                 // no-op. The stored lifecycle stamp closes the same-node ABA.
                 let removed = {
-                    let mut state = pending2.lock().await;
+                    let mut state = pending2.lock();
                     if state.is_current(&timeout_peer, pending_id)
                         && state.peer_session_generation(&timeout_peer)
                             == Some(timeout_peer_session_generation)
@@ -430,10 +536,9 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                     return;
                 }
 
-                if peers2.peer_session_is_current_sync(
-                    &timeout_peer,
-                    timeout_peer_session_generation,
-                ) {
+                if peers2
+                    .peer_session_is_current_sync(&timeout_peer, timeout_peer_session_generation)
+                {
                     let status = transport2.session_status(&timeout_peer).await;
                     if !is_rekey
                         && !status.has_active

--- a/client/daemon/src/lib/daemon/run.rs
+++ b/client/daemon/src/lib/daemon/run.rs
@@ -553,6 +553,7 @@ impl Daemon {
                     udp_advertise: self.config.network.udp_advertise.clone(),
                     node_private_key: self.config.node.private_key.clone(),
                     kick_rx: handshake_kick_rx,
+                    handshake_retry_kick_tx: self.handshake_retry_kick_tx.clone(),
                 }),
             )
             .await;

--- a/client/daemon/src/lib/pending_handshake.rs
+++ b/client/daemon/src/lib/pending_handshake.rs
@@ -1,5 +1,15 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ResponderHandshakeLifecycle {
+    network_generation: u64,
+    peer_session_generation: PeerSessionGeneration,
+}
+
 #[derive(Clone)]
 struct CachedResponderHandshake {
+    /// Exact local lifecycle which authenticated and prepared this response.
+    /// A token replay after a network handover or same-node leave/rejoin must
+    /// not reuse receive keys from the retired responder transaction.
+    lifecycle: ResponderHandshakeLifecycle,
     handshake_init: Vec<u8>,
     /// Static Noise/WireGuard public key authenticated by this initiation.
     /// Cache replay is valid only while the node ID still maps to this key.
@@ -19,6 +29,7 @@ enum ResponderHandshakeCacheLookup {
     Miss,
     Hit(Box<CachedResponderHandshake>),
     FingerprintMismatch,
+    StaleLifecycle,
 }
 
 /// A peer offer admitted to the single responder worker for that peer.
@@ -970,6 +981,7 @@ impl PendingHandshakeState {
         &mut self,
         peer_id: &str,
         token: &str,
+        lifecycle: ResponderHandshakeLifecycle,
         handshake_init: &[u8],
         request_probe_ephemeral_public_key: Option<&str>,
         expected_initiator_static_public_key: &[u8; 32],
@@ -981,6 +993,10 @@ impl PendingHandshakeState {
         let Some(cached) = self.responder_cache.get(&key) else {
             return ResponderHandshakeCacheLookup::Miss;
         };
+        if cached.lifecycle != lifecycle {
+            self.responder_cache.remove(&key);
+            return ResponderHandshakeCacheLookup::StaleLifecycle;
+        }
         let request_probe_ephemeral_public_key =
             normalize_probe_ephemeral_public_key(request_probe_ephemeral_public_key);
         if cached.handshake_init != handshake_init
@@ -1003,6 +1019,11 @@ impl PendingHandshakeState {
         );
         self.responder_cache
             .insert((peer_id.to_string(), token.to_string()), cached);
+    }
+
+    fn discard_responder_handshake_cache(&mut self, peer_id: &str, token: &str) {
+        self.responder_cache
+            .remove(&(peer_id.to_string(), token.to_string()));
     }
 
     fn responder_timestamp_floor(

--- a/client/daemon/src/lib/pending_handshake.rs
+++ b/client/daemon/src/lib/pending_handshake.rs
@@ -92,16 +92,81 @@ impl PendingPeerReflexive {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum HandshakeStartDisposition {
     Active,
-    ProbeBindingRetryDeferred,
+    RetryScheduled,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InitiatorRetryPhase {
+    Preparation,
+    Publish,
+}
+
+impl InitiatorRetryPhase {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Preparation => "preparation",
+            Self::Publish => "publish",
+        }
+    }
 }
 
 struct HandshakeStartReservation {
     owner: u64,
+    owner_kind: HandshakeOwnerKind,
     network_generation: u64,
     peer_session_generation: PeerSessionGeneration,
+    cancellation_generation: u64,
     cancellation: tokio::sync::watch::Receiver<bool>,
     disposition: HandshakeStartDisposition,
+    /// Retry lineage survives a claim/remove cycle so repeated contention
+    /// cannot reset backoff or extend the phase TTL indefinitely.
+    retry_phase: Option<InitiatorRetryPhase>,
+    retry_attempt: u32,
+    retry_expires_at: Option<Instant>,
+    /// Exact old-generation Probe binding removed from pending-handshake
+    /// state by admission. The bounded worker, never the serial coordinator,
+    /// performs the actor cleanup before preparing the replacement.
+    stale_session_id: Option<String>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HandshakeRetryIdentity {
+    peer_id: String,
+    network_generation: u64,
+    peer_session_generation: PeerSessionGeneration,
+    reservation_owner: u64,
+    phase: InitiatorRetryPhase,
+    attempt: u32,
+    cancellation_generation: u64,
+}
+
+struct PendingInitiatorRetry {
+    identity: HandshakeRetryIdentity,
+    not_before: Instant,
+    expires_at: Instant,
+}
+
+struct PreparedInitiatorHandshake {
+    initiator: HandshakeInitiator,
+    initiation_bytes: Vec<u8>,
+    candidates: Vec<String>,
+    candidate_sources: HashMap<String, String>,
+    session_id: String,
+    probe_ephemeral: DhKeyPair,
+    probe_ephemeral_public_key: String,
+}
+
+const MAX_PENDING_INITIATOR_RETRIES: usize = 1024;
+const INITIATOR_RETRY_TTL: Duration = Duration::from_secs(30);
+const INITIATOR_RETRY_BACKOFF: [Duration; 7] = [
+    Duration::ZERO,
+    Duration::from_millis(10),
+    Duration::from_millis(25),
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+];
 
 /// Owner token for the one responder worker admitted for a peer.
 struct ResponderWorkReservation {
@@ -170,6 +235,9 @@ struct PendingHandshakeState {
     /// before a new-generation attempt is admitted.
     starting_network_generations: HashMap<String, u64>,
     starting_peer_session_generations: HashMap<String, PeerSessionGeneration>,
+    starting_owner_kinds: HashMap<String, HandshakeOwnerKind>,
+    starting_cancellation_generations: HashMap<String, u64>,
+    starting_prepared: HashMap<String, PreparedInitiatorHandshake>,
     /// Owner token for every `starting` reservation.  This is deliberately
     /// separate from `pending_ids`: a preparation has no WireGuard session ID
     /// yet, but it still must not be allowed to clean up a newer reservation.
@@ -177,12 +245,15 @@ struct PendingHandshakeState {
     /// Cancellation handles for slow event-triggered preparation work. A peer
     /// leave or identity replacement wakes a pre-commit STUN wait immediately.
     starting_cancellations: HashMap<String, tokio::sync::watch::Sender<bool>>,
+    initiator_retries: HashMap<String, PendingInitiatorRetry>,
     /// Cancellation handles transferred from `starting` when an event
     /// initiator commits its pending transaction.  Keeping this sender alive
     /// makes the subsequent control-plane offer wait cancellable by a
     /// PeerLeft, crossing offer, or matching answer.
     pending_cancellations: HashMap<String, tokio::sync::watch::Sender<bool>>,
     next_start_id: u64,
+    next_cancellation_generation: u64,
+    retry_revision: u64,
     pending_ids: HashMap<String, u64>,
     next_id: u64,
     /// Number of initiation attempts per peer (bounded retries).
@@ -206,6 +277,36 @@ struct PendingHandshakeState {
     next_peer_reflexive_worker_id: u64,
 }
 
+/// All pending-handshake mutations are short, in-memory transactions.  A
+/// synchronous store makes that contract explicit: an arbiter lease can use
+/// `try_lock` without introducing an async lock edge, and the compiler rejects
+/// any attempt to carry the guard through a `Send` future's `.await`.
+#[derive(Default)]
+struct PendingHandshakeStore {
+    state: std::sync::Mutex<PendingHandshakeState>,
+}
+
+impl PendingHandshakeStore {
+    fn lock(&self) -> std::sync::MutexGuard<'_, PendingHandshakeState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn try_lock(&self) -> Option<std::sync::MutexGuard<'_, PendingHandshakeState>> {
+        match self.state.try_lock() {
+            Ok(guard) => Some(guard),
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+            Err(std::sync::TryLockError::WouldBlock) => None,
+        }
+    }
+
+    fn try_with<R>(&self, operation: impl FnOnce(&mut PendingHandshakeState) -> R) -> Option<R> {
+        let mut state = self.try_lock()?;
+        Some(operation(&mut state))
+    }
+}
+
 impl PendingHandshakeState {
     /// Atomically claim the right to prepare a new initiator for `peer_id`.
     ///
@@ -221,11 +322,27 @@ impl PendingHandshakeState {
         self.reserve_start_with_owner_at_generation(peer_id, 0, PeerSessionGeneration::for_test(1))
     }
 
+    #[cfg(test)]
     fn reserve_start_with_owner_at_generation(
         &mut self,
         peer_id: &str,
         network_generation: u64,
         peer_session_generation: PeerSessionGeneration,
+    ) -> Option<HandshakeStartReservation> {
+        self.reserve_start_with_owner_at_generation_and_kind(
+            peer_id,
+            network_generation,
+            peer_session_generation,
+            HandshakeOwnerKind::EventInitiatorReserve,
+        )
+    }
+
+    fn reserve_start_with_owner_at_generation_and_kind(
+        &mut self,
+        peer_id: &str,
+        network_generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        owner_kind: HandshakeOwnerKind,
     ) -> Option<HandshakeStartReservation> {
         if self.pending.contains_key(peer_id) {
             // A pending transaction from an older network incarnation can no
@@ -246,6 +363,15 @@ impl PendingHandshakeState {
                     != Some(&peer_session_generation)
             {
                 self.cancel_reservation(peer_id);
+            } else if owner_kind == HandshakeOwnerKind::EventInitiatorReserve
+                && self.starting_owner_kinds.get(peer_id)
+                    == Some(&HandshakeOwnerKind::MaintenanceInitiator)
+            {
+                // Event-triggered initiation is latency-critical.  A
+                // maintenance owner is allowed to finish only until the next
+                // short mutation turn; after that its cancellation receiver
+                // makes every slow continuation fail closed.
+                self.cancel_reservation(peer_id);
             } else {
                 return None;
             }
@@ -255,21 +381,33 @@ impl PendingHandshakeState {
         }
         self.next_start_id = self.next_start_id.saturating_add(1);
         let owner = self.next_start_id;
+        self.next_cancellation_generation = self.next_cancellation_generation.saturating_add(1);
+        let cancellation_generation = self.next_cancellation_generation;
         let (cancellation_tx, cancellation) = tokio::sync::watch::channel(false);
         self.starting.insert(peer_id.to_string());
         self.starting_network_generations
             .insert(peer_id.to_string(), network_generation);
         self.starting_peer_session_generations
             .insert(peer_id.to_string(), peer_session_generation);
+        self.starting_owner_kinds
+            .insert(peer_id.to_string(), owner_kind);
+        self.starting_cancellation_generations
+            .insert(peer_id.to_string(), cancellation_generation);
         self.starting_ids.insert(peer_id.to_string(), owner);
         self.starting_cancellations
             .insert(peer_id.to_string(), cancellation_tx);
         Some(HandshakeStartReservation {
             owner,
+            owner_kind,
             network_generation,
             peer_session_generation,
+            cancellation_generation,
             cancellation,
             disposition: HandshakeStartDisposition::Active,
+            retry_phase: None,
+            retry_attempt: 0,
+            retry_expires_at: None,
+            stale_session_id: None,
         })
     }
 
@@ -277,6 +415,10 @@ impl PendingHandshakeState {
         self.starting.remove(peer_id);
         self.starting_network_generations.remove(peer_id);
         self.starting_peer_session_generations.remove(peer_id);
+        self.starting_owner_kinds.remove(peer_id);
+        self.starting_cancellation_generations.remove(peer_id);
+        self.starting_prepared.remove(peer_id);
+        self.initiator_retries.remove(peer_id);
         self.starting_ids.remove(peer_id);
         if let Some(cancellation) = self.starting_cancellations.remove(peer_id) {
             cancellation.send_replace(true);
@@ -289,6 +431,287 @@ impl PendingHandshakeState {
         }
         self.cancel_reservation(peer_id);
         true
+    }
+
+    /// Cancel every initiator owner stamped before `generation` and return the
+    /// exact staged Probe bindings which the peer manager must remove while it
+    /// owns the same generation/connection transaction.
+    fn cancel_before_network_generation(
+        &mut self,
+        generation: u64,
+    ) -> (usize, usize, Vec<(String, String)>) {
+        let stale_peers = self
+            .starting_network_generations
+            .iter()
+            .filter(|(_, reserved_generation)| **reserved_generation < generation)
+            .map(|(peer_id, _)| peer_id.clone())
+            .collect::<Vec<_>>();
+        let cancelled_reservations = stale_peers.len();
+        for peer_id in stale_peers {
+            self.cancel_reservation(&peer_id);
+        }
+
+        let stale_pending_peers = self
+            .pending_network_generations
+            .iter()
+            .filter(|(_, pending_generation)| **pending_generation < generation)
+            .map(|(peer_id, _)| peer_id.clone())
+            .collect::<Vec<_>>();
+        let cancelled_pending = stale_pending_peers.len();
+        let mut stale_probe_bindings = Vec::with_capacity(cancelled_pending);
+        for peer_id in stale_pending_peers {
+            if let Some(session_id) = self.session_id(&peer_id).map(str::to_string) {
+                stale_probe_bindings.push((peer_id.clone(), session_id));
+            }
+            // `remove` wakes a control POST which inherited the exact starting
+            // reservation cancellation sender. A request that was not yet
+            // delivered therefore cannot publish after the generation edge.
+            self.remove(&peer_id);
+        }
+        (
+            cancelled_reservations,
+            cancelled_pending,
+            stale_probe_bindings,
+        )
+    }
+
+    fn reservation_for_retry(
+        &self,
+        identity: &HandshakeRetryIdentity,
+    ) -> Option<HandshakeStartReservation> {
+        if self.starting_ids.get(&identity.peer_id).copied() != Some(identity.reservation_owner)
+            || self.starting_network_generations.get(&identity.peer_id)
+                != Some(&identity.network_generation)
+            || self
+                .starting_peer_session_generations
+                .get(&identity.peer_id)
+                != Some(&identity.peer_session_generation)
+            || self
+                .starting_cancellation_generations
+                .get(&identity.peer_id)
+                .copied()
+                != Some(identity.cancellation_generation)
+        {
+            return None;
+        }
+        let cancellation = self
+            .starting_cancellations
+            .get(&identity.peer_id)?
+            .subscribe();
+        Some(HandshakeStartReservation {
+            owner: identity.reservation_owner,
+            owner_kind: *self.starting_owner_kinds.get(&identity.peer_id)?,
+            network_generation: identity.network_generation,
+            peer_session_generation: identity.peer_session_generation,
+            cancellation_generation: identity.cancellation_generation,
+            cancellation,
+            disposition: HandshakeStartDisposition::Active,
+            retry_phase: None,
+            retry_attempt: 0,
+            retry_expires_at: None,
+            stale_session_id: None,
+        })
+    }
+
+    fn store_prepared_if_current(
+        &mut self,
+        peer_id: &str,
+        reservation: &HandshakeStartReservation,
+        prepared: PreparedInitiatorHandshake,
+    ) -> bool {
+        if self.starting_ids.get(peer_id).copied() != Some(reservation.owner)
+            || self.starting_network_generations.get(peer_id)
+                != Some(&reservation.network_generation)
+            || self.starting_peer_session_generations.get(peer_id)
+                != Some(&reservation.peer_session_generation)
+            || self.starting_cancellation_generations.get(peer_id).copied()
+                != Some(reservation.cancellation_generation)
+        {
+            return false;
+        }
+        self.starting_prepared.insert(peer_id.to_string(), prepared);
+        true
+    }
+
+    fn take_prepared_if_current(
+        &mut self,
+        peer_id: &str,
+        reservation: &HandshakeStartReservation,
+    ) -> Option<PreparedInitiatorHandshake> {
+        if self.starting_ids.get(peer_id).copied() != Some(reservation.owner)
+            || self.starting_cancellation_generations.get(peer_id).copied()
+                != Some(reservation.cancellation_generation)
+        {
+            return None;
+        }
+        self.starting_prepared.remove(peer_id)
+    }
+
+    fn starting_reservation_is_current(
+        &self,
+        peer_id: &str,
+        reservation: &HandshakeStartReservation,
+    ) -> bool {
+        self.starting_ids.get(peer_id).copied() == Some(reservation.owner)
+            && self.starting_network_generations.get(peer_id)
+                == Some(&reservation.network_generation)
+            && self.starting_peer_session_generations.get(peer_id)
+                == Some(&reservation.peer_session_generation)
+            && self.starting_cancellation_generations.get(peer_id).copied()
+                == Some(reservation.cancellation_generation)
+    }
+
+    fn has_prepared_for_reservation(
+        &self,
+        peer_id: &str,
+        reservation: &HandshakeStartReservation,
+    ) -> bool {
+        self.starting_ids.get(peer_id).copied() == Some(reservation.owner)
+            && self.starting_cancellation_generations.get(peer_id).copied()
+                == Some(reservation.cancellation_generation)
+            && self.starting_prepared.contains_key(peer_id)
+    }
+
+    fn schedule_initiator_retry(
+        &mut self,
+        peer_id: &str,
+        reservation: &HandshakeStartReservation,
+        phase: InitiatorRetryPhase,
+        now: Instant,
+    ) -> Option<(HandshakeRetryIdentity, u64)> {
+        if self.starting_ids.get(peer_id).copied() != Some(reservation.owner)
+            || self.starting_network_generations.get(peer_id)
+                != Some(&reservation.network_generation)
+            || self.starting_peer_session_generations.get(peer_id)
+                != Some(&reservation.peer_session_generation)
+            || self.starting_cancellation_generations.get(peer_id).copied()
+                != Some(reservation.cancellation_generation)
+            || (phase == InitiatorRetryPhase::Publish
+                && !self.starting_prepared.contains_key(peer_id))
+        {
+            return None;
+        }
+        if !self.initiator_retries.contains_key(peer_id)
+            && self.initiator_retries.len() >= MAX_PENDING_INITIATOR_RETRIES
+        {
+            return None;
+        }
+        let matching_retry = self.initiator_retries.get(peer_id).filter(|retry| {
+            retry.identity.reservation_owner == reservation.owner
+                && retry.identity.phase == phase
+                && retry.identity.cancellation_generation == reservation.cancellation_generation
+        });
+        let claimed_attempt = if reservation.retry_phase == Some(phase) {
+            reservation.retry_attempt
+        } else {
+            0
+        };
+        let previous_attempt = matching_retry
+            .map(|retry| retry.identity.attempt)
+            .unwrap_or(0)
+            .max(claimed_attempt);
+        let attempt = previous_attempt.saturating_add(1);
+        // Repeated contention for the same exact phase may increase backoff,
+        // but it must not extend the record forever.  A phase transition is
+        // meaningful progress and receives its own bounded TTL.
+        let expires_at = matching_retry
+            .map(|retry| retry.expires_at)
+            .or_else(|| {
+                (reservation.retry_phase == Some(phase))
+                    .then_some(reservation.retry_expires_at)
+                    .flatten()
+            })
+            .unwrap_or(now + INITIATOR_RETRY_TTL);
+        if expires_at <= now {
+            self.cancel_reservation_if_current(peer_id, reservation.owner);
+            return None;
+        }
+        let backoff_index = (attempt as usize).saturating_sub(1);
+        let backoff = INITIATOR_RETRY_BACKOFF
+            .get(backoff_index)
+            .copied()
+            .unwrap_or(*INITIATOR_RETRY_BACKOFF.last().expect("retry backoff"));
+        let identity = HandshakeRetryIdentity {
+            peer_id: peer_id.to_string(),
+            network_generation: reservation.network_generation,
+            peer_session_generation: reservation.peer_session_generation,
+            reservation_owner: reservation.owner,
+            phase,
+            attempt,
+            cancellation_generation: reservation.cancellation_generation,
+        };
+        self.initiator_retries.insert(
+            peer_id.to_string(),
+            PendingInitiatorRetry {
+                identity: identity.clone(),
+                not_before: now + backoff,
+                expires_at,
+            },
+        );
+        self.retry_revision = self.retry_revision.wrapping_add(1);
+        Some((identity, self.retry_revision))
+    }
+
+    fn expire_initiator_retries(&mut self, now: Instant) {
+        // Expiration is terminal for the exact reservation.  Purge before
+        // selecting ready work so a delayed maintenance scan can never run a
+        // retry after its strict TTL, and so an expired owner cannot leak its
+        // prepared initiation indefinitely.
+        let expired = self
+            .initiator_retries
+            .iter()
+            .filter(|(_, retry)| retry.expires_at <= now)
+            .map(|(peer_id, retry)| {
+                (
+                    peer_id.clone(),
+                    retry.identity.reservation_owner,
+                    retry.identity.cancellation_generation,
+                )
+            })
+            .collect::<Vec<_>>();
+        for (peer_id, reservation_owner, cancellation_generation) in expired {
+            let still_exact = self.starting_ids.get(&peer_id).copied() == Some(reservation_owner)
+                && self
+                    .starting_cancellation_generations
+                    .get(&peer_id)
+                    .copied()
+                    == Some(cancellation_generation);
+            if still_exact {
+                self.cancel_reservation(&peer_id);
+            } else {
+                self.initiator_retries.remove(&peer_id);
+            }
+        }
+    }
+
+    fn claim_ready_initiator_retry(
+        &mut self,
+        now: Instant,
+    ) -> Option<(HandshakeRetryIdentity, HandshakeStartReservation)> {
+        self.expire_initiator_retries(now);
+        let peer_id = self
+            .initiator_retries
+            .iter()
+            .filter(|(_, retry)| retry.not_before <= now && retry.expires_at > now)
+            .min_by_key(|(_, retry)| (retry.expires_at, retry.not_before))
+            .map(|(peer_id, _)| peer_id.clone())?;
+        let retry = self.initiator_retries.remove(&peer_id)?;
+        let Some(mut reservation) = self.reservation_for_retry(&retry.identity) else {
+            self.cancel_reservation_if_current(&peer_id, retry.identity.reservation_owner);
+            return None;
+        };
+        reservation.retry_phase = Some(retry.identity.phase);
+        reservation.retry_attempt = retry.identity.attempt;
+        reservation.retry_expires_at = Some(retry.expires_at);
+        Some((retry.identity, reservation))
+    }
+
+    fn has_initiator_retries(&self) -> bool {
+        !self.initiator_retries.is_empty()
+    }
+
+    fn retry_revision(&self) -> u64 {
+        self.retry_revision
     }
 
     #[cfg(test)]
@@ -332,6 +755,10 @@ impl PendingHandshakeState {
         self.starting.remove(&peer_id);
         self.starting_network_generations.remove(&peer_id);
         self.starting_peer_session_generations.remove(&peer_id);
+        self.starting_owner_kinds.remove(&peer_id);
+        self.starting_cancellation_generations.remove(&peer_id);
+        self.starting_prepared.remove(&peer_id);
+        self.initiator_retries.remove(&peer_id);
         self.starting_ids.remove(&peer_id);
         let cancellation = self.starting_cancellations.remove(&peer_id);
         Some(self.insert_with_generation(
@@ -529,6 +956,14 @@ impl PendingHandshakeState {
 
     fn is_current(&self, peer_id: &str, pending_id: u64) -> bool {
         self.pending_ids.get(peer_id).copied() == Some(pending_id)
+    }
+
+    fn remove_if_current(&mut self, peer_id: &str, pending_id: u64) -> bool {
+        if !self.is_current(peer_id, pending_id) {
+            return false;
+        }
+        self.remove(peer_id);
+        true
     }
 
     fn responder_cache_lookup(

--- a/client/daemon/src/lib/pending_handshake.rs
+++ b/client/daemon/src/lib/pending_handshake.rs
@@ -204,6 +204,36 @@ fn same_responder_sender_identity(left: Option<&str>, right: Option<&str>) -> bo
     }
 }
 
+/// Owner token for one independently polled candidate-offer worker.
+///
+/// Candidate application may wait on the network epoch, the connection map,
+/// STUN or UDP actors.  It therefore has a separate owner from the responder
+/// transaction: a candidate-only signal can never occupy the peer's
+/// latency-critical WireGuard responder slot.
+struct CandidateOfferWorkReservation {
+    owner: u64,
+    cancellation: tokio::sync::watch::Receiver<bool>,
+}
+
+struct CandidateOfferWorkOwner {
+    owner: u64,
+    cancellation: tokio::sync::watch::Sender<bool>,
+    active_sender_public_key: Option<String>,
+    queued: Option<PendingPeerOffer>,
+}
+
+enum CandidateOfferWorkAdmission {
+    Started(CandidateOfferWorkReservation, Box<PendingPeerOffer>),
+    Coalesced,
+    RejectedIdentity,
+    Capacity,
+}
+
+/// A corrupt or hostile control stream must not turn the per-peer candidate
+/// ledger into an unbounded process allocation.  The active value plus one
+/// newest-wins queued value per admitted peer are the complete retained set.
+const MAX_CANDIDATE_OFFER_WORKERS: usize = 1024;
+
 /// Owner token for the one peer-reflexive worker admitted for a peer.
 struct PeerReflexiveWorkReservation {
     owner: u64,
@@ -282,6 +312,15 @@ struct PendingHandshakeState {
     /// a peer. Later offers coalesce into a single newest-wins queue slot.
     responder_workers: HashMap<String, ResponderWorkOwner>,
     next_responder_worker_id: u64,
+    /// Candidate application is intentionally disjoint from responder work.
+    /// Each peer owns at most one active and one newest-wins queued value.
+    candidate_offer_workers: HashMap<String, CandidateOfferWorkOwner>,
+    next_candidate_offer_worker_id: u64,
+    /// A claimed remote incarnation is not current until its old transport
+    /// cleanup and peer-session rotation commit. Candidate and responder
+    /// owners consult this one-entry-per-peer fence before interpreting the
+    /// synchronous incarnation high-water as `NoReset`.
+    remote_incarnation_resets: HashMap<String, u64>,
     /// Exactly one slow peer-reflexive worker may wait on candidate refresh
     /// or HTTP for a peer. Later observations replace its one queued value.
     peer_reflexive_workers: HashMap<String, PeerReflexiveWorkOwner>,
@@ -921,6 +960,9 @@ impl PendingHandshakeState {
             }
             worker.cancellation.send_replace(true);
         }
+        if let Some(worker) = self.candidate_offer_workers.remove(peer_id) {
+            worker.cancellation.send_replace(true);
+        }
         if let Some(worker) = self.peer_reflexive_workers.remove(peer_id) {
             if let Some(queued) = worker.queued.as_ref() {
                 queued.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
@@ -939,6 +981,9 @@ impl PendingHandshakeState {
             if let Some(queued) = worker.queued.as_ref() {
                 queued.complete_delivery(control::SignalApplyOutcome::TerminalRejected);
             }
+            worker.cancellation.send_replace(true);
+        }
+        if let Some(worker) = self.candidate_offer_workers.remove(peer_id) {
             worker.cancellation.send_replace(true);
         }
         if let Some(worker) = self.peer_reflexive_workers.remove(peer_id) {
@@ -1166,6 +1211,127 @@ impl PendingHandshakeState {
         self.responder_workers
             .get(peer_id)
             .is_some_and(|worker| worker.owner == owner && !*worker.cancellation.borrow())
+    }
+
+    /// Retain one bounded candidate transaction per peer, with one
+    /// newest-wins successor.  The durable signal receipt is deliberately not
+    /// stored here: admission itself is the application commit, after which
+    /// this owner is responsible for transient retries.
+    fn enqueue_candidate_offer_work(
+        &mut self,
+        offer: PendingPeerOffer,
+    ) -> CandidateOfferWorkAdmission {
+        debug_assert!(offer.delivery_receipt.is_none());
+        let cancelled = self
+            .candidate_offer_workers
+            .get(&offer.from_node_id)
+            .is_some_and(|worker| *worker.cancellation.borrow());
+        if cancelled {
+            self.candidate_offer_workers.remove(&offer.from_node_id);
+        }
+        if let Some(worker) = self.candidate_offer_workers.get_mut(&offer.from_node_id) {
+            let incoming_matches_active = same_responder_sender_identity(
+                worker.active_sender_public_key.as_deref(),
+                offer.sender_public_key.as_deref(),
+            );
+            let queued_has_different_identity = worker.queued.as_ref().is_some_and(|queued| {
+                !same_responder_sender_identity(
+                    queued.sender_public_key.as_deref(),
+                    offer.sender_public_key.as_deref(),
+                )
+            });
+            if incoming_matches_active && queued_has_different_identity {
+                return CandidateOfferWorkAdmission::RejectedIdentity;
+            }
+            worker.queued = Some(offer);
+            return CandidateOfferWorkAdmission::Coalesced;
+        }
+        if self.candidate_offer_workers.len() >= MAX_CANDIDATE_OFFER_WORKERS {
+            return CandidateOfferWorkAdmission::Capacity;
+        }
+
+        self.next_candidate_offer_worker_id =
+            self.next_candidate_offer_worker_id.saturating_add(1);
+        let owner = self.next_candidate_offer_worker_id;
+        let peer_id = offer.from_node_id.clone();
+        let active_sender_public_key = offer.sender_public_key.clone();
+        let (cancellation_tx, cancellation) = tokio::sync::watch::channel(false);
+        self.candidate_offer_workers.insert(
+            peer_id,
+            CandidateOfferWorkOwner {
+                owner,
+                cancellation: cancellation_tx,
+                active_sender_public_key,
+                queued: None,
+            },
+        );
+        CandidateOfferWorkAdmission::Started(
+            CandidateOfferWorkReservation {
+                owner,
+                cancellation,
+            },
+            Box::new(offer),
+        )
+    }
+
+    fn finish_candidate_offer_work(
+        &mut self,
+        peer_id: &str,
+        owner: u64,
+    ) -> Option<PendingPeerOffer> {
+        let worker = self.candidate_offer_workers.get_mut(peer_id)?;
+        if worker.owner != owner || *worker.cancellation.borrow() {
+            return None;
+        }
+        if let Some(next) = worker.queued.take() {
+            worker.active_sender_public_key = next.sender_public_key.clone();
+            return Some(next);
+        }
+        self.candidate_offer_workers.remove(peer_id);
+        None
+    }
+
+    fn take_queued_candidate_offer_work(
+        &mut self,
+        peer_id: &str,
+        owner: u64,
+    ) -> Option<PendingPeerOffer> {
+        let worker = self.candidate_offer_workers.get_mut(peer_id)?;
+        if worker.owner != owner || *worker.cancellation.borrow() {
+            return None;
+        }
+        let next = worker.queued.take()?;
+        worker.active_sender_public_key = next.sender_public_key.clone();
+        Some(next)
+    }
+
+    fn candidate_offer_work_is_current(&self, peer_id: &str, owner: u64) -> bool {
+        self.candidate_offer_workers
+            .get(peer_id)
+            .is_some_and(|worker| worker.owner == owner && !*worker.cancellation.borrow())
+    }
+
+    fn remote_incarnation_reset_in_progress(&self, peer_id: &str) -> Option<u64> {
+        self.remote_incarnation_resets.get(peer_id).copied()
+    }
+
+    fn begin_remote_incarnation_reset(&mut self, peer_id: &str, incarnation: u64) -> bool {
+        if self.remote_incarnation_resets.contains_key(peer_id) {
+            return false;
+        }
+        self.remote_incarnation_resets
+            .insert(peer_id.to_string(), incarnation);
+        true
+    }
+
+    fn finish_remote_incarnation_reset(&mut self, peer_id: &str, incarnation: u64) {
+        if self
+            .remote_incarnation_resets
+            .get(peer_id)
+            .is_some_and(|pending| *pending == incarnation)
+        {
+            self.remote_incarnation_resets.remove(peer_id);
+        }
     }
 
     /// Coalesce slow peer-reflexive work to one active worker per peer.

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -2221,6 +2221,236 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initiator_publish_epoch_contention_releases_emit_and_retries_exact_offer() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "initiator-epoch-contention").unwrap();
+    config.control.auth_token = "initiator-epoch-contention-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must complete before epoch contention");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "peer-initiator-epoch-contention".to_string(),
+        public_key: hex::encode(remote_identity.public_key()),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        ..control::PeerInfo::default()
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.relay_available_tx.send_replace(true);
+
+    let epoch_gate = daemon.peers.network_epoch_gate();
+    let epoch_guard = epoch_gate.lock().await;
+    let mut reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .expect("event initiator reservation must be admitted");
+    let reservation_owner = reservation.owner;
+    let worker = {
+        let daemon = daemon.clone();
+        let peer_info = peer_info.clone();
+        tokio::spawn(async move {
+            daemon
+                .run_reserved_initiator_handshake(&peer_info, &mut reservation)
+                .await
+        })
+    };
+    let first = timeout(Duration::from_secs(1), worker)
+        .await
+        .expect("epoch contention must not block the initiator worker")
+        .expect("initiator worker panicked")
+        .expect("epoch contention is a non-fatal publish outcome");
+    assert_eq!(first, None);
+
+    let emit_guard = daemon
+        .transport
+        .try_acquire_outbound_emit_guard(&peer_info.node_id)
+        .expect("publish retained the emit guard while the epoch was contended");
+    drop(emit_guard);
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(state.starting_prepared.contains_key(&peer_info.node_id));
+        let retry = state
+            .initiator_retries
+            .get(&peer_info.node_id)
+            .expect("exact prepared publish retry was not retained");
+        assert_eq!(retry.identity.reservation_owner, reservation_owner);
+        assert_eq!(retry.identity.phase, InitiatorRetryPhase::Publish);
+    }
+    assert!(daemon.timeline.snapshot().events.iter().any(|event| {
+        event.event == "initiator_publish_epoch_gate_contended"
+            && event
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("queued=false"))
+    }));
+
+    drop(epoch_guard);
+    let (identity, mut retry_reservation) = daemon
+        .pending_handshakes
+        .lock()
+        .claim_ready_initiator_retry(Instant::now())
+        .expect("exact epoch-contention retry must be ready");
+    assert_eq!(identity.reservation_owner, reservation_owner);
+    let published = timeout(
+        Duration::from_secs(2),
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut retry_reservation),
+    )
+    .await
+    .expect("exact publish retry stalled after epoch release")
+    .expect("exact publish retry failed");
+    assert!(published.is_some());
+    timeout(
+        Duration::from_secs(1),
+        control_capture.wait_for_signal_count(1),
+    )
+    .await
+    .expect("mock control did not receive the retried Offer");
+    let offers = control_capture
+        .signal_bodies()
+        .iter()
+        .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|body| body.get("type").and_then(serde_json::Value::as_str) == Some("peer_offer"))
+        .count();
+    assert_eq!(offers, 1, "the exact reservation may publish one Offer");
+
+    let session_id = {
+        let mut state = daemon.pending_handshakes.lock();
+        let session_id = state.pending_session_ids.get(&peer_info.node_id).cloned();
+        state.clear_peer(&peer_info.node_id);
+        session_id
+    };
+    if let Some(session_id) = session_id {
+        daemon
+            .peers
+            .discard_pending_probe_session_binding(&peer_info.node_id, &session_id)
+            .await;
+    }
+    control_capture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responder_probe_binding_contention_retains_exact_answer_without_queued_writer() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "responder-binding-contention")
+            .unwrap();
+    config.control.auth_token = "responder-binding-contention-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must complete before responder contention");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if identity.public_key() < local_public {
+            break identity;
+        }
+    };
+    let peer_id = "peer-responder-binding-contention";
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: hex::encode(remote_identity.public_key()),
+            virtual_ip: "10.20.0.3".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+    daemon.relay_available_tx.send_replace(true);
+
+    let mut remote_initiator = HandshakeInitiator::new(remote_identity, local_public, None);
+    let initiation = remote_initiator.create_initiation().unwrap().to_bytes();
+    let session_id = "responder-binding-contention-session".to_string();
+    let request_probe_public_key = hex::encode(DhKeyPair::generate().public_key());
+    let connection_guard = daemon
+        .peers
+        .connection_map_for_test()
+        .read_owned()
+        .await;
+
+    let first_error = timeout(
+        Duration::from_secs(1),
+        daemon.handle_peer_offer(
+            peer_id,
+            &[],
+            &initiation,
+            None,
+            None,
+            Some(session_id.clone()),
+            Some(request_probe_public_key.clone()),
+        ),
+    )
+    .await
+    .expect("responder queued behind the held connection reader")
+    .expect_err("connection contention must be a typed retry outcome");
+    assert!(matches!(
+        first_error,
+        DaemonError::Network(ref reason)
+            if reason == REASON_RESPONDER_PROBE_BINDING_CONTENDED
+    ));
+    assert!(
+        timeout(Duration::from_millis(100), daemon.peers.get_connection(peer_id))
+            .await
+            .expect("responder contention queued a writer and blocked a later reader")
+            .is_some()
+    );
+    assert!(
+        daemon
+            .pending_handshakes
+            .lock()
+            .responder_cache
+            .contains_key(&(peer_id.to_string(), session_id.clone())),
+        "the authenticated exact Answer must be retained before try-write contention"
+    );
+    assert!(daemon.transport.session_status(peer_id).await.has_pending_responder);
+
+    drop(connection_guard);
+    timeout(
+        Duration::from_secs(2),
+        daemon.handle_peer_offer(
+            peer_id,
+            &[],
+            &initiation,
+            None,
+            None,
+            Some(session_id),
+            Some(request_probe_public_key),
+        ),
+    )
+    .await
+    .expect("exact cached responder retry stalled after reader release")
+    .expect("exact cached responder retry failed");
+    timeout(
+        Duration::from_secs(1),
+        control_capture.wait_for_signal_count(1),
+    )
+    .await
+    .expect("mock control did not receive the retained exact Answer");
+    let answers = control_capture
+        .signal_bodies()
+        .iter()
+        .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|body| body.get("type").and_then(serde_json::Value::as_str) == Some("peer_answer"))
+        .count();
+    assert_eq!(answers, 1, "contention retry may publish one exact Answer");
+    assert!(daemon.transport.has_session(peer_id).await);
+    control_capture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn relay_probe_snapshot_contention_preserves_exact_publish_retry_without_queued_writer() {
     let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
     let daemon = Arc::new(Daemon::new(config));
@@ -3601,6 +3831,10 @@ fn responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse() {
         "peer-cache",
         "session-cache",
         CachedResponderHandshake {
+            lifecycle: ResponderHandshakeLifecycle {
+                network_generation: 0,
+                peer_session_generation: PeerSessionGeneration::for_test(1),
+            },
             handshake_init: initiation_bytes.clone(),
             initiator_static_public_key: initiator_public,
             request_probe_ephemeral_public_key: Some(differently_cased_probe_public_key),
@@ -3615,6 +3849,10 @@ fn responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse() {
     let ResponderHandshakeCacheLookup::Hit(cached) = state.responder_cache_lookup(
         "peer-cache",
         "session-cache",
+        ResponderHandshakeLifecycle {
+            network_generation: 0,
+            peer_session_generation: PeerSessionGeneration::for_test(1),
+        },
         &initiation_bytes,
         Some(&request_probe_public_key),
         &initiator_public,
@@ -3633,6 +3871,10 @@ fn responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse() {
         state.responder_cache_lookup(
             "peer-cache",
             "session-cache",
+            ResponderHandshakeLifecycle {
+                network_generation: 0,
+                peer_session_generation: PeerSessionGeneration::for_test(1),
+            },
             &mismatched,
             Some(&request_probe_public_key),
             &initiator_public,
@@ -3644,6 +3886,10 @@ fn responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse() {
         state.responder_cache_lookup(
             "peer-cache",
             "session-cache",
+            ResponderHandshakeLifecycle {
+                network_generation: 0,
+                peer_session_generation: PeerSessionGeneration::for_test(1),
+            },
             &initiation.to_bytes(),
             Some(&hex::encode([0xcdu8; 32])),
             &initiator_public,
@@ -3655,12 +3901,53 @@ fn responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse() {
         state.responder_cache_lookup(
             "peer-cache",
             "session-cache",
+            ResponderHandshakeLifecycle {
+                network_generation: 0,
+                peer_session_generation: PeerSessionGeneration::for_test(1),
+            },
             &initiation.to_bytes(),
             Some(&request_probe_public_key),
             &[0xee; 32],
         ),
         ResponderHandshakeCacheLookup::FingerprintMismatch
     ));
+
+    assert!(matches!(
+        state.responder_cache_lookup(
+            "peer-cache",
+            "session-cache",
+            ResponderHandshakeLifecycle {
+                network_generation: 1,
+                peer_session_generation: PeerSessionGeneration::for_test(1),
+            },
+            &initiation.to_bytes(),
+            Some(&request_probe_public_key),
+            &initiator_public,
+        ),
+        ResponderHandshakeCacheLookup::StaleLifecycle
+    ));
+    assert!(!state
+        .responder_cache
+        .contains_key(&("peer-cache".to_string(), "session-cache".to_string())));
+
+    state.cache_responder_handshake("peer-cache", "session-cache", (*cached).clone());
+    assert!(matches!(
+        state.responder_cache_lookup(
+            "peer-cache",
+            "session-cache",
+            ResponderHandshakeLifecycle {
+                network_generation: 0,
+                peer_session_generation: PeerSessionGeneration::for_test(2),
+            },
+            &initiation.to_bytes(),
+            Some(&request_probe_public_key),
+            &initiator_public,
+        ),
+        ResponderHandshakeCacheLookup::StaleLifecycle
+    ));
+    assert!(!state
+        .responder_cache
+        .contains_key(&("peer-cache".to_string(), "session-cache".to_string())));
 }
 
 #[test]
@@ -3723,6 +4010,10 @@ async fn responder_cache_rejects_offer_after_peer_static_key_rotation() {
             peer_id,
             token,
             CachedResponderHandshake {
+                lifecycle: ResponderHandshakeLifecycle {
+                    network_generation: 0,
+                    peer_session_generation: PeerSessionGeneration::for_test(1),
+                },
                 handshake_init: initiation_bytes.clone(),
                 initiator_static_public_key: old_public,
                 request_probe_ephemeral_public_key: Some(request_probe_public_key.clone()),
@@ -3843,6 +4134,10 @@ async fn expired_responder_cache_conflict_does_not_poison_active_token() {
             peer_id,
             token,
             CachedResponderHandshake {
+                lifecycle: ResponderHandshakeLifecycle {
+                    network_generation: 0,
+                    peer_session_generation: PeerSessionGeneration::for_test(1),
+                },
                 handshake_init: offer_bytes.clone(),
                 initiator_static_public_key: offer_public,
                 request_probe_ephemeral_public_key: Some(request_probe_public_key.clone()),
@@ -4877,7 +5172,7 @@ async fn relay_first_packet_liveness_crosses_responder_status_and_writer_content
         tokio::task::yield_now().await;
     }
     assert!(daemon.peers.try_all_connections().is_none());
-    let contended_status = timeout(Duration::from_millis(250), fetch_status(diag_address))
+    let contended_status = timeout(Duration::from_secs(1), fetch_status(diag_address))
         .await
         .expect("/status waited behind the fairly queued connection writer");
     assert!(contended_status.starts_with("HTTP/1.1 200 OK"));

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -2160,6 +2160,220 @@ async fn blocking_candidate_apply_releases_epoch_before_waiting_for_writer_turn(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_incarnation_claim_and_finish_never_queue_writer_with_epoch() {
+    fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
+        0x4000_0000_0000_0000 | (incarnation << 21) | counter
+    }
+
+    let config = Config::generate_default("http://127.0.0.1:1", "incarnation-lock-order")
+        .unwrap();
+    let daemon = Daemon::new(config);
+    let peer_id = "peer-incarnation-lock-order";
+    let peer_identity = NodeIdentity::generate();
+    let sender_public_key = hex::encode(peer_identity.public_key());
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: sender_public_key.clone(),
+            virtual_ip: "10.20.0.2".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+
+    let peers = daemon.peers.clone();
+    let reader = peers.connection_map_for_test().read_owned().await;
+    let claim_start = Arc::new(tokio::sync::Barrier::new(2));
+    let worker_start = claim_start.clone();
+    let worker_peers = peers.clone();
+    let claim = tokio::spawn(async move {
+        worker_start.wait().await;
+        worker_peers
+            .claim_remote_candidate_incarnation_for_identity(
+                peer_id,
+                encoded_generation(9_000, 1),
+                Some(&sender_public_key),
+            )
+            .await
+    });
+    claim_start.wait().await;
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if peers.connection_map_for_test().try_read().is_err() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("remote-incarnation claim never entered the fair writer queue");
+    assert!(
+        peers.network_epoch_gate().try_lock().is_ok(),
+        "remote-incarnation claim queued the writer while retaining the epoch"
+    );
+    drop(reader);
+    assert_eq!(
+        timeout(Duration::from_secs(1), claim)
+            .await
+            .expect("remote-incarnation claim did not finish after reader release")
+            .expect("remote-incarnation claim task panicked"),
+        crate::peer::RemoteCandidateIncarnationClaim::NoReset
+    );
+
+    let (old_incarnation, claimed_incarnation) = match peers
+        .claim_remote_candidate_incarnation_for_identity(
+            peer_id,
+            encoded_generation(9_001, 1),
+            None,
+        )
+        .await
+    {
+        crate::peer::RemoteCandidateIncarnationClaim::Reset {
+            old_incarnation,
+            new_incarnation,
+        } => (old_incarnation, new_incarnation),
+        outcome => panic!("new incarnation was not claimed: {outcome:?}"),
+    };
+    let retired_peer_session = peers.peer_session_generation_sync(peer_id).unwrap();
+    let reader = peers.connection_map_for_test().read_owned().await;
+    let finish_start = Arc::new(tokio::sync::Barrier::new(2));
+    let worker_start = finish_start.clone();
+    let worker_peers = peers.clone();
+    let finish = tokio::spawn(async move {
+        worker_start.wait().await;
+        worker_peers
+            .finish_claimed_remote_incarnation_reset(
+                peer_id,
+                old_incarnation,
+                claimed_incarnation,
+                "test_incarnation_lock_order",
+            )
+            .await
+    });
+    finish_start.wait().await;
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if peers.connection_map_for_test().try_read().is_err() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("remote-incarnation finish never entered the fair writer queue");
+    assert!(
+        peers.network_epoch_gate().try_lock().is_ok(),
+        "remote-incarnation finish queued the writer while retaining the epoch"
+    );
+    drop(reader);
+    assert!(
+        timeout(Duration::from_secs(1), finish)
+            .await
+            .expect("remote-incarnation finish did not complete after reader release")
+            .expect("remote-incarnation finish task panicked")
+    );
+    assert_ne!(
+        peers.peer_session_generation_sync(peer_id),
+        Some(retired_peer_session),
+        "remote-incarnation finish must rotate the peer lifecycle"
+    );
+}
+
+#[tokio::test]
+async fn remote_incarnation_rotation_cancels_retry_and_kicks_replacement() {
+    fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
+        0x4000_0000_0000_0000 | (incarnation << 21) | counter
+    }
+
+    let config = Config::generate_default("http://127.0.0.1:1", "incarnation-retry-kick")
+        .unwrap();
+    let daemon = Daemon::new(config);
+    let peer_id = "peer-incarnation-retry-kick";
+    let peer_identity = NodeIdentity::generate();
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: hex::encode(peer_identity.public_key()),
+            virtual_ip: "10.20.0.2".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+    assert_eq!(
+        daemon
+            .peers
+            .claim_remote_candidate_incarnation_for_identity(
+                peer_id,
+                encoded_generation(9_100, 1),
+                None,
+            )
+            .await,
+        crate::peer::RemoteCandidateIncarnationClaim::NoReset
+    );
+
+    let network_generation = daemon.peers.current_network_generation_sync();
+    let retired_peer_session = daemon.peers.peer_session_generation_sync(peer_id).unwrap();
+    let reservation = {
+        let mut pending = daemon.pending_handshakes.lock();
+        let reservation = pending
+            .reserve_start_with_owner_at_generation_and_kind(
+                peer_id,
+                network_generation,
+                retired_peer_session,
+                HandshakeOwnerKind::EventInitiatorReserve,
+            )
+            .expect("the exact initiator reservation must be available");
+        assert!(
+            pending
+                .schedule_initiator_retry(
+                    peer_id,
+                    &reservation,
+                    InitiatorRetryPhase::Preparation,
+                    Instant::now(),
+                )
+                .is_some(),
+            "the exact retry must commit before the incarnation edge"
+        );
+        reservation
+    };
+    let mut restart_kick = daemon.path_setup_kick_tx.subscribe();
+
+    assert!(
+        daemon
+            .reset_peer_for_remote_incarnation_if_needed(
+                peer_id,
+                encoded_generation(9_101, 1),
+                RemoteIncarnationResetWork::PreserveResponder,
+            )
+            .await,
+        "the newer remote incarnation must rotate the peer lifecycle"
+    );
+    timeout(Duration::from_secs(1), restart_kick.changed())
+        .await
+        .expect("the committed lifecycle rotation did not wake handshake maintenance")
+        .expect("the handshake-maintenance kick sender closed");
+
+    let pending = daemon.pending_handshakes.lock();
+    assert!(
+        !pending.starting.contains(peer_id) && !pending.initiator_retries.contains_key(peer_id),
+        "the retired generation's reservation and retry must be cancelled together"
+    );
+    assert!(
+        *reservation.cancellation.borrow(),
+        "the retired exact owner must observe terminal cancellation"
+    );
+    assert_ne!(
+        daemon.peers.peer_session_generation_sync(peer_id),
+        Some(retired_peer_session),
+        "the replacement wake is valid only after PeerSessionGeneration rotates"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_offer() {
     fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
         0x4000_0000_0000_0000 | (incarnation << 21) | counter
@@ -2295,10 +2509,21 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
         peers.connection_map_for_test().try_read().is_ok(),
         "candidate admission queued a connection writer behind the held reader"
     );
-    assert!(
-        peers.network_epoch_gate().try_lock().is_ok(),
-        "candidate apply retained the network epoch after try-write contention"
-    );
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if let Ok(epoch) = peers.network_epoch_gate().try_lock() {
+                drop(epoch);
+                break;
+            }
+            // The bounded owner may be inside its next legitimate try-only
+            // transaction at the exact instant the receipt is observed. It
+            // must nevertheless expose an epoch-free retry boundary while
+            // the connection reader remains held.
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("candidate apply retained the network epoch across connection contention");
 
     let responder_receipt = control::SignalDeliveryReceipt::pending();
     control

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -33,6 +33,152 @@ async fn part03_outbound_transport(
     (transport, outbound_rx, remote_session)
 }
 
+struct HandshakeControlCapture {
+    base_url: String,
+    registered_rx: watch::Receiver<bool>,
+    signal_revision_rx: watch::Receiver<u64>,
+    signal_bodies: Arc<std::sync::Mutex<Vec<String>>>,
+    shutdown_tx: watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl HandshakeControlCapture {
+    async fn wait_registered(&mut self) {
+        while !*self.registered_rx.borrow() {
+            self.registered_rx
+                .changed()
+                .await
+                .expect("handshake control capture stopped before registration");
+        }
+    }
+
+    async fn wait_for_signal_count(&mut self, expected: usize) {
+        while self
+            .signal_bodies
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+            < expected
+        {
+            self.signal_revision_rx
+                .changed()
+                .await
+                .expect("handshake control capture stopped before signal delivery");
+        }
+    }
+
+    fn signal_bodies(&self) -> Vec<String> {
+        self.signal_bodies
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    async fn stop(self) {
+        self.shutdown_tx.send_replace(true);
+        self.task
+            .await
+            .expect("handshake control capture task panicked");
+    }
+}
+
+async fn start_handshake_control_capture() -> HandshakeControlCapture {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let (registered_tx, registered_rx) = watch::channel(false);
+    let (signal_revision_tx, signal_revision_rx) = watch::channel(0u64);
+    let signal_bodies = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+    let server_bodies = signal_bodies.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            let accepted = tokio::select! {
+                biased;
+                changed = shutdown_rx.changed() => {
+                    let _ = changed;
+                    return;
+                }
+                accepted = listener.accept() => accepted,
+            };
+            let Ok((mut stream, _)) = accepted else {
+                return;
+            };
+            let mut request = Vec::new();
+            let mut chunk = [0u8; 4096];
+            let header_end = loop {
+                let Ok(read) = stream.read(&mut chunk).await else {
+                    break None;
+                };
+                if read == 0 {
+                    break None;
+                }
+                request.extend_from_slice(&chunk[..read]);
+                if let Some(position) = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                {
+                    break Some(position + 4);
+                }
+            };
+            let Some(header_end) = header_end else {
+                continue;
+            };
+            let head = String::from_utf8_lossy(&request[..header_end]).into_owned();
+            let content_length = head
+                .lines()
+                .find_map(|line| {
+                    line.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                })
+                .unwrap_or(0);
+            while request.len() < header_end + content_length {
+                let Ok(read) = stream.read(&mut chunk).await else {
+                    break;
+                };
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let body = String::from_utf8_lossy(
+                &request[header_end..request.len().min(header_end + content_length)],
+            )
+            .into_owned();
+            let response_body = if head.contains("/api/v1/devices") {
+                registered_tx.send_replace(true);
+                r#"{"success":true,"node_id":"node-local","virtual_ip":"10.20.0.1","cidr":"10.20.0.0/16","relay_servers":[]}"#
+            } else if head.starts_with("POST") && head.contains("/api/v1/signals") {
+                let revision = {
+                    let mut bodies = server_bodies
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    bodies.push(body);
+                    bodies.len() as u64
+                };
+                signal_revision_tx.send_replace(revision);
+                r#"{"success":true,"protocol_version":1}"#
+            } else {
+                r#"{"signals":[],"server_time_ms":0}"#
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        }
+    });
+    HandshakeControlCapture {
+        base_url,
+        registered_rx,
+        signal_revision_rx,
+        signal_bodies,
+        shutdown_tx,
+        task,
+    }
+}
+
 #[tokio::test]
 async fn relay_supervisor_reconnects_after_stream_closes() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -333,7 +479,7 @@ async fn initiator_rekey_keeps_peer_in_direct_state() {
         .consume_initiation_and_respond(&initiation)
         .unwrap();
     {
-        let mut state = daemon.pending_handshakes.lock().await;
+        let mut state = daemon.pending_handshakes.lock();
         state.insert(peer_id.to_string(), initiator, None, None);
     }
 
@@ -414,7 +560,6 @@ async fn peer_answer_from_new_remote_incarnation_rebinds_pending_initiator() {
     daemon
         .pending_handshakes
         .lock()
-        .await
         .insert_with_generation(
             peer_id.to_string(),
             initiator,
@@ -437,7 +582,7 @@ async fn peer_answer_from_new_remote_incarnation_rebinds_pending_initiator() {
     let new_peer_session_generation = daemon.peers.peer_session_generation_sync(peer_id).unwrap();
     assert_ne!(new_peer_session_generation, old_peer_session_generation);
     {
-        let pending = daemon.pending_handshakes.lock().await;
+        let pending = daemon.pending_handshakes.lock();
         assert!(pending.pending.contains_key(peer_id));
         assert_eq!(
             pending.peer_session_generation(peer_id),
@@ -557,10 +702,21 @@ async fn responder_remote_incarnation_reset_does_not_self_lock_lifecycle_arbiter
 
     let lifecycle_guard = timeout(
         Duration::from_millis(500),
-        daemon.handshake_arbiter.acquire(peer_id),
+        daemon.handshake_arbiter.acquire_with_timeout(
+            HandshakeLeaseIdentity::new(
+                peer_id,
+                HandshakeOwnerKind::Cleanup,
+                None,
+                daemon.peers.current_network_generation_sync(),
+                daemon.peers.peer_session_generation_sync(peer_id),
+                "test_reset_probe",
+            ),
+            Duration::from_millis(100),
+        ),
     )
     .await
-    .expect("responder reset retained an unpolled lifecycle-arbiter owner");
+    .expect("responder reset retained an unpolled lifecycle-arbiter owner")
+    .expect("lifecycle mutation turn remained contended");
     drop(lifecycle_guard);
     assert!(timeout(Duration::from_millis(500), &mut reset)
         .await
@@ -700,7 +856,7 @@ async fn stale_wireguard_answer_does_not_clear_pending_handshake() {
     let initiation = initiator.create_initiation().unwrap();
 
     {
-        let mut state = daemon.pending_handshakes.lock().await;
+        let mut state = daemon.pending_handshakes.lock();
         state.insert(peer_id.to_string(), initiator, None, None);
         state.attempts.insert(peer_id.to_string(), 1);
     }
@@ -716,7 +872,7 @@ async fn stale_wireguard_answer_does_not_clear_pending_handshake() {
         .await
         .unwrap();
 
-    let state = daemon.pending_handshakes.lock().await;
+    let state = daemon.pending_handshakes.lock();
     assert!(state.pending.contains_key(peer_id));
     assert_eq!(state.attempts.get(peer_id), Some(&1));
 }
@@ -753,24 +909,34 @@ async fn wireguard_answer_from_previous_network_generation_cannot_install_sessio
         .consume_initiation_and_respond(&initiation)
         .unwrap();
 
+    let (pending_cancellation_tx, mut pending_cancellation) = watch::channel(false);
     {
-        let mut state = daemon.pending_handshakes.lock().await;
+        let mut state = daemon.pending_handshakes.lock();
         state.insert_with_generation(
             peer_id.to_string(),
             initiator,
             None,
             None,
-            None,
+            Some(pending_cancellation_tx),
             0,
-            PeerSessionGeneration::for_test(1),
+            daemon.peers.peer_session_generation_sync(peer_id).unwrap(),
         );
     }
     assert_eq!(
         daemon
             .peers
             .advance_network_generation("late handshake answer test")
-            .await,
+        .await,
         1
+    );
+    assert!(*pending_cancellation.borrow_and_update());
+    assert!(
+        !daemon
+            .pending_handshakes
+            .lock()
+            .pending
+            .contains_key(peer_id),
+        "the generation transaction must synchronously cancel the old pending owner"
     );
 
     daemon
@@ -779,13 +945,12 @@ async fn wireguard_answer_from_previous_network_generation_cannot_install_sessio
         .unwrap();
 
     assert!(
-        daemon
+        !daemon
             .pending_handshakes
             .lock()
-            .await
             .pending
             .contains_key(peer_id),
-        "a stale answer must not consume the pending transaction"
+        "a stale answer must not recreate the cancelled pending transaction"
     );
     assert!(
         !daemon.transport.has_session(peer_id).await,
@@ -817,7 +982,6 @@ async fn responder_offer_from_previous_network_generation_cannot_stage_session()
     let (reservation, offer) = daemon
         .pending_handshakes
         .lock()
-        .await
         .enqueue_responder_work(offer)
         .expect("the offer must acquire a responder worker");
 
@@ -889,7 +1053,7 @@ async fn incomplete_modern_answer_preserves_pending_handshake_and_old_session() 
         .unwrap();
     let session_id = "modern-session".to_string();
     {
-        let mut state = daemon.pending_handshakes.lock().await;
+        let mut state = daemon.pending_handshakes.lock();
         state.insert(
             peer_id.to_string(),
             new_initiator,
@@ -910,7 +1074,7 @@ async fn incomplete_modern_answer_preserves_pending_handshake_and_old_session() 
             .await
             .unwrap();
 
-        let state = daemon.pending_handshakes.lock().await;
+        let state = daemon.pending_handshakes.lock();
         assert!(state.pending.contains_key(peer_id));
         assert!(state.pending_probe_ephemeral.contains_key(peer_id));
         assert_eq!(state.attempts.get(peer_id), Some(&2));
@@ -1006,7 +1170,6 @@ async fn modern_offer_rejects_missing_or_malformed_probe_ephemeral_key() {
     assert!(daemon
         .pending_handshakes
         .lock()
-        .await
         .responder_cache
         .is_empty());
     let status = daemon.transport.session_status(peer_id).await;
@@ -1085,6 +1248,47 @@ fn handshake_reservation_commit_requires_exact_peer_lifecycle() {
         "a failed stale commit must not consume or rewrite the live reservation"
     );
     assert!(!state.pending.contains_key(peer_id));
+}
+
+#[test]
+fn stale_handshake_pending_owner_cannot_remove_replacement_transaction() {
+    let mut state = PendingHandshakeState::default();
+    let peer_id = "peer-pending-owner-replacement";
+    let remote_identity = NodeIdentity::generate();
+    let old_reservation = state.reserve_start_with_owner(peer_id).unwrap();
+    let old_pending_id = state
+        .insert_reserved_if_current(
+            peer_id.to_string(),
+            old_reservation.owner,
+            HandshakeInitiator::new(
+                NodeIdentity::generate(),
+                remote_identity.public_key(),
+                None,
+            ),
+            Some("old-pending-token".to_string()),
+            None,
+        )
+        .unwrap();
+    state.remove(peer_id);
+
+    let replacement_reservation = state.reserve_start_with_owner(peer_id).unwrap();
+    let replacement_pending_id = state
+        .insert_reserved_if_current(
+            peer_id.to_string(),
+            replacement_reservation.owner,
+            HandshakeInitiator::new(
+                NodeIdentity::generate(),
+                remote_identity.public_key(),
+                None,
+            ),
+            Some("replacement-pending-token".to_string()),
+            None,
+        )
+        .unwrap();
+
+    assert!(!state.remove_if_current(peer_id, old_pending_id));
+    assert!(state.is_current(peer_id, replacement_pending_id));
+    assert_eq!(state.session_id(peer_id), Some("replacement-pending-token"));
 }
 
 #[test]
@@ -1342,7 +1546,6 @@ async fn deferred_unknown_peer_offer_replays_candidate_admission_after_peer_join
     let (reservation, offer) = daemon
         .pending_handshakes
         .lock()
-        .await
         .enqueue_responder_work(offer)
         .expect("unknown offer must acquire one deferred owner");
 
@@ -1377,7 +1580,6 @@ async fn deferred_unknown_peer_offer_replays_candidate_admission_after_peer_join
     assert!(!daemon
         .pending_handshakes
         .lock()
-        .await
         .responder_workers
         .contains_key(peer_id));
 }
@@ -1522,11 +1724,12 @@ async fn last_seen_only_peer_update_refreshes_diagnostics_without_handshake_rese
     // worker. The fixed branch returns immediately after `add_peer`.
     sleep(Duration::from_millis(25)).await;
 
-    let state = pending.lock().await;
-    assert!(!state.starting.contains(peer_id));
-    assert!(!state.pending.contains_key(peer_id));
-    assert!(!state.attempts.contains_key(peer_id));
-    drop(state);
+    {
+        let state = pending.lock();
+        assert!(!state.starting.contains(peer_id));
+        assert!(!state.pending.contains_key(peer_id));
+        assert!(!state.attempts.contains_key(peer_id));
+    }
     assert_eq!(
         peers.peer_session_generation_sync(peer_id),
         Some(lifecycle),
@@ -1579,7 +1782,6 @@ async fn control_event_loop_processes_peer_answer_while_peer_reflexive_work_wait
     daemon
         .pending_handshakes
         .lock()
-        .await
         .insert(peer_id.to_string(), initiator, None, None);
 
     let candidate_refresh_lock = daemon.candidate_refresh_lock.clone();
@@ -1851,7 +2053,6 @@ async fn initiator_arbiter_is_released_before_candidate_refresh_wait() {
     let candidate_guard = candidate_refresh_lock.lock().await;
     let mut reservation = daemon
         .reserve_event_initiator_handshake(&peer_info.node_id)
-        .await
         .expect("event initiator reservation must be admitted");
     let mut worker =
         Box::pin(daemon.run_reserved_initiator_handshake(&peer_info, &mut reservation));
@@ -1866,18 +2067,24 @@ async fn initiator_arbiter_is_released_before_candidate_refresh_wait() {
         }
     })
     .await;
-    let guard = tokio::time::timeout(
-        Duration::from_millis(100),
-        daemon.handshake_arbiter.acquire(&peer_info.node_id),
-    )
-    .await
-    .expect("arbiter must be free while candidate gathering waits");
+    let guard = daemon
+        .handshake_arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            &peer_info.node_id,
+            HandshakeOwnerKind::Responder,
+            None,
+            daemon.peers.current_network_generation_sync(),
+            daemon
+                .peers
+                .peer_session_generation_sync(&peer_info.node_id),
+            "candidate_wait_probe",
+        ))
+        .expect("arbiter must be free while candidate gathering waits");
     drop(guard);
 
     daemon
         .pending_handshakes
         .lock()
-        .await
         .clear_peer(&peer_info.node_id);
     drop(candidate_guard);
     tokio::time::timeout(Duration::from_secs(1), &mut worker)
@@ -1889,7 +2096,7 @@ async fn initiator_arbiter_is_released_before_candidate_refresh_wait() {
 #[tokio::test]
 async fn initiator_publish_releases_epoch_while_connection_writer_is_contended() {
     let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
-    let daemon = Daemon::new(config);
+    let daemon = Arc::new(Daemon::new(config));
     let local_public = daemon.local_identity().unwrap().public_key();
     let peer_identity = loop {
         let identity = NodeIdentity::generate();
@@ -1914,13 +2121,13 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
 
     let mut reservation = daemon
         .reserve_event_initiator_handshake(&peer_info.node_id)
-        .await
         .expect("event initiator reservation must be admitted");
     let peers = daemon.peers.clone();
     let pending = daemon.pending_handshakes.clone();
     let timeline = daemon.timeline.clone();
     let peer_id = peer_info.node_id.clone();
-    let mut reschedule_rx = daemon.path_setup_kick_tx.subscribe();
+    let mut retry_rx = daemon.handshake_retry_kick_tx.subscribe();
+    let reservation_owner = reservation.owner;
 
     // A candidate/connection reader is sufficient to make Probe-binding
     // staging need the connection writer. The old publish path inserted its
@@ -1928,9 +2135,11 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
     // emit and network-epoch guards, completing an ABBA cycle with lifecycle
     // work that needed the epoch before it could release the connection map.
     let connection_guard = peers.connection_map_for_test().read_owned().await;
+    let worker_daemon = daemon.clone();
+    let worker_peer = peer_info.clone();
     let worker = tokio::spawn(async move {
-        daemon
-            .run_reserved_initiator_handshake(&peer_info, &mut reservation)
+        worker_daemon
+            .run_reserved_initiator_handshake(&worker_peer, &mut reservation)
             .await
     });
 
@@ -1951,7 +2160,7 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
     .expect("initiator must report connection-writer contention");
 
     assert!(
-        !pending.lock().await.pending.contains_key(&peer_id),
+        !pending.lock().pending.contains_key(&peer_id),
         "an initiator must not become pending before its Probe binding is staged"
     );
     let epoch_gate = peers.network_epoch_gate();
@@ -1967,29 +2176,52 @@ async fn initiator_publish_releases_epoch_while_connection_writer_is_contended()
         .expect("connection contention is a non-fatal initiator outcome");
     assert_eq!(result, None);
 
+    {
+        let state = pending.lock();
+        assert!(state.starting.contains(&peer_id));
+        assert!(state.starting_prepared.contains_key(&peer_id));
+        assert!(state.initiator_retries.contains_key(&peer_id));
+    }
+
     drop(connection_guard);
-    tokio::time::timeout(Duration::from_secs(1), reschedule_rx.changed())
+    tokio::time::timeout(Duration::from_secs(1), retry_rx.changed())
         .await
-        .expect("writer availability must publish a maintenance reschedule edge")
-        .expect("path-setup reschedule sender must stay live");
+        .expect("contention must publish an exact retry edge")
+        .expect("handshake retry sender must stay live");
     assert!(timeline.snapshot().events.iter().any(|event| {
-        event.event == "initiator_publish_probe_binding_writer_available"
+        event.event == "initiator_handshake_retry_scheduled"
             && event
                 .detail
                 .as_deref()
-                .is_some_and(|detail| detail.contains("reschedule_kick="))
+                .is_some_and(|detail| detail.contains("phase=publish"))
     }));
-    let state = pending.lock().await;
-    assert!(!state.pending.contains_key(&peer_id));
-    assert!(!state.starting.contains(&peer_id));
+    let (identity, mut retry_reservation) = pending
+        .lock()
+        .claim_ready_initiator_retry(Instant::now())
+        .expect("exact retry must be ready after contention");
+    assert_eq!(identity.reservation_owner, reservation_owner);
+    let _ = tokio::time::timeout(
+        Duration::from_secs(2),
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut retry_reservation),
+    )
+    .await
+    .expect("exact prepared initiation retry must not stall");
+    let session_id = {
+        let mut state = pending.lock();
+        let session_id = state.pending_session_ids.get(&peer_id).cloned();
+        state.clear_peer(&peer_id);
+        session_id
+    };
+    if let Some(session_id) = session_id {
+        daemon
+            .peers
+            .discard_pending_probe_session_binding(&peer_id, &session_id)
+            .await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_and_reschedules_initiator(
-) {
-    use std::future::Future;
-    use std::task::Poll;
-
+async fn relay_probe_snapshot_contention_preserves_exact_publish_retry_without_queued_writer() {
     let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
     let daemon = Arc::new(Daemon::new(config));
     let local_public = daemon.local_identity().unwrap().public_key();
@@ -2014,9 +2246,6 @@ async fn relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_a
     daemon.peers.add_peer(&peer_info).await;
     daemon.relay_available_tx.send_replace(true);
 
-    // Reproduce the production startup actor, not a synthetic lock owner: the
-    // forced-Relay target scan has acquired its real connection snapshot when
-    // the initiator reaches atomic Probe-binding publication.
     let relay_snapshot_gate = Arc::new(crate::peer::RelayProbeSnapshotTestGate::new());
     daemon.peers.install_relay_probe_snapshot_gate_for_test(
         &peer_info.node_id,
@@ -2031,190 +2260,99 @@ async fn relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_a
     .await
     .expect("the real relay target snapshot must own the connection reader");
 
-    let mut reschedule_rx = daemon.path_setup_kick_tx.subscribe();
+    let mut retry_rx = daemon.handshake_retry_kick_tx.subscribe();
     let mut reservation = daemon
         .reserve_event_initiator_handshake(&peer_info.node_id)
-        .await
         .expect("event initiator reservation must be admitted");
-    let mut worker = Box::pin(
+    let reservation_owner = reservation.owner;
+    let cancellation_generation = reservation.cancellation_generation;
+    let first_result = tokio::time::timeout(
+        Duration::from_secs(1),
         daemon.run_reserved_initiator_handshake(&peer_info, &mut reservation),
-    );
-
-    // Poll the cooperative slow-work future only until it queues the writer.
-    // The production failure kept the writer and its timeout inside this
-    // future, so its first Pending at this point let a later control-loop
-    // branch wait behind that same writer forever. The fixed future transfers
-    // ownership to an independently scheduled bounded task and is Ready in
-    // the very poll that records contention.
-    let first_result = tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            let polled = std::future::poll_fn(|context| {
-                Poll::Ready(worker.as_mut().poll(context))
-            })
-            .await;
-            let writer_scheduled = daemon
-                .timeline
-                .snapshot()
-                .events
-                .iter()
-                .any(|event| event.event == "initiator_publish_probe_binding_writer_wait");
-            match polled {
-                Poll::Ready(result) => {
-                    assert!(
-                        writer_scheduled,
-                        "initiator completed before exercising writer contention"
-                    );
-                    break result;
-                }
-                Poll::Pending if writer_scheduled => {
-                    panic!(
-                        "cooperative initiator retained the queued writer waiter and its timeout"
-                    );
-                }
-                Poll::Pending => tokio::task::yield_now().await,
-            }
-        }
-    })
+    )
     .await
-    .expect("initiator must reach writer contention")
+    .expect("initiator must return immediately on connection contention")
     .expect("connection contention is a non-fatal initiator outcome");
     assert_eq!(first_result, None);
-    drop(worker);
     assert_eq!(
         reservation.disposition,
-        HandshakeStartDisposition::ProbeBindingRetryDeferred
+        HandshakeStartDisposition::RetryScheduled
     );
 
-    tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            if daemon.timeline.snapshot().events.iter().any(|event| {
-                event.event == "initiator_publish_probe_binding_writer_wait_started"
-            }) {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("detached writer waiter must start independently");
-
-    // The writer barrier must own no upper guard while queued.
-    let epoch_gate = daemon.peers.network_epoch_gate();
-    let epoch_guard = tokio::time::timeout(Duration::from_millis(100), epoch_gate.lock())
-        .await
-        .expect("writer wait must not retain the network epoch guard");
-    drop(epoch_guard);
-    let emit_guard = tokio::time::timeout(
+    // A try-write must never enter Tokio's writer queue.  A later reader can
+    // therefore complete while the original Relay snapshot is still held.
+    assert!(tokio::time::timeout(
         Duration::from_millis(100),
-        daemon
-            .transport
-            .acquire_outbound_emit_guard(&peer_info.node_id),
+        daemon.peers.get_connection(&peer_info.node_id),
     )
-        .await
-        .expect("writer wait must not retain the outbound emit guard");
-    drop(emit_guard);
+    .await
+    .expect("connection contention queued a writer and blocked a later reader")
+    .is_some());
 
-    // Tokio queues this real status read behind the waiting writer. The old
-    // unbounded barrier left it there until /status returned 503.
-    let mut status_read = {
-        let queue_deadline = Instant::now() + Duration::from_millis(100);
-        loop {
-            let status_peers = daemon.peers.clone();
-            let status_peer_id = peer_info.node_id.clone();
-            let mut candidate = tokio::spawn(async move {
-                status_peers.get_connection(&status_peer_id).await
-            });
-            if tokio::time::timeout(Duration::from_millis(10), &mut candidate)
-                .await
-                .is_err()
-            {
-                break candidate;
-            }
-            assert!(
-                Instant::now() < queue_deadline,
-                "the detached connection writer never entered Tokio's fair queue"
-            );
-            tokio::task::yield_now().await;
-        }
-    };
-
-    tokio::time::timeout(Duration::from_secs(1), reschedule_rx.changed())
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.pending.contains_key(&peer_info.node_id));
+        assert!(state.starting.contains(&peer_info.node_id));
+        assert!(state.starting_prepared.contains_key(&peer_info.node_id));
+        assert_eq!(state.initiator_retries.len(), 1);
+        let retry = state
+            .initiator_retries
+            .get(&peer_info.node_id)
+            .expect("exact publish retry must be retained");
+        assert_eq!(retry.identity.reservation_owner, reservation_owner);
+        assert_eq!(
+            retry.identity.cancellation_generation,
+            cancellation_generation
+        );
+        assert_eq!(retry.identity.phase, InitiatorRetryPhase::Publish);
+    }
+    tokio::time::timeout(Duration::from_secs(1), retry_rx.changed())
         .await
-        .expect("bounded writer timeout must publish a maintenance reschedule edge")
-        .expect("path-setup reschedule sender must stay live");
-    // Cancellation of the timed-out writer removes it from the fair queue;
-    // readers can progress even while the original Relay snapshot is still
-    // deliberately alive.
-    assert!(
-        tokio::time::timeout(Duration::from_millis(100), &mut status_read)
-            .await
-            .expect("status read must resume when the timed-out writer is removed")
-            .expect("status task must not panic")
-            .is_some()
-    );
-    let state = daemon.pending_handshakes.lock().await;
-    assert!(
-        !state.pending.contains_key(&peer_info.node_id),
-        "timed-out publication must not publish a pending initiator"
-    );
-    assert!(
-        !state.starting.contains(&peer_info.node_id),
-        "timed-out publication must cancel its reservation atomically"
-    );
-    drop(state);
-    let timeout_event = daemon
-        .timeline
-        .snapshot()
-        .events
-        .into_iter()
-        .find(|event| event.event == "initiator_publish_probe_binding_writer_timeout")
-        .expect("timeout must have a structured timeline diagnostic");
-    assert_eq!(
-        timeout_event.reason_code.as_deref(),
-        Some(REASON_INITIATOR_PROBE_BINDING_WRITER_TIMEOUT)
-    );
-    assert!(timeout_event
-        .detail
-        .as_deref()
-        .is_some_and(|detail| detail.contains("timeout_ms=250")
-            && detail.contains("reschedule_kick=")));
+        .expect("exact retry wake must be published after the state commit")
+        .expect("retry coordinator must stay live");
 
     relay_snapshot_gate.release.notify_one();
-    let targets = tokio::time::timeout(Duration::from_secs(1), relay_targets)
+    tokio::time::timeout(Duration::from_secs(1), relay_targets)
         .await
         .expect("relay target scan must resume")
         .expect("relay target task must not panic");
-    assert!(targets
-        .iter()
-        .any(|(peer_id, _, _)| peer_id == &peer_info.node_id));
 
-    // Consume the reschedule edge the same way maintenance does: a fresh
-    // reservation succeeds once the real Relay reader has left the map.
-    let mut retry_reservation = daemon
-        .reserve_event_initiator_handshake(&peer_info.node_id)
-        .await
-        .expect("rescheduled initiator must obtain a fresh reservation");
+    let (retry_identity, mut retry_reservation) = daemon
+        .pending_handshakes
+        .lock()
+        .claim_ready_initiator_retry(Instant::now())
+        .expect("the exact retry must be claimable");
+    assert_eq!(retry_identity.reservation_owner, reservation_owner);
+    assert_eq!(
+        retry_identity.cancellation_generation,
+        cancellation_generation
+    );
     let _retry_result = tokio::time::timeout(
         Duration::from_secs(2),
         daemon.run_reserved_initiator_handshake(&peer_info, &mut retry_reservation),
     )
     .await
-    .expect("rescheduled initiator must not stall");
-    assert!(daemon.timeline.snapshot().events.iter().any(|event| {
-        event.event == "initiator_publish_probe_binding_staged"
-            && event
-                .detail
-                .as_deref()
-                .is_some_and(|detail| detail.contains(&peer_info.node_id))
-    }));
+    .expect("exact prepared publication retry must not stall");
+
+    let staged_count = daemon
+        .timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|event| {
+            event.event == "initiator_session_staged"
+                && event
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains(&peer_info.node_id))
+        })
+        .count();
+    assert_eq!(staged_count, 1, "the exact owner may stage only one Offer");
 
     let session_id = {
-        let mut state = daemon.pending_handshakes.lock().await;
-        let session_id = state
-            .pending_session_ids
-            .get(&peer_info.node_id)
-            .cloned();
-        state.remove(&peer_info.node_id);
+        let mut state = daemon.pending_handshakes.lock();
+        let session_id = state.pending_session_ids.get(&peer_info.node_id).cloned();
+        state.clear_peer(&peer_info.node_id);
         session_id
     };
     if let Some(session_id) = session_id {
@@ -2224,14 +2362,13 @@ async fn relay_probe_snapshot_contention_detaches_writer_wait_unblocks_readers_a
             .await;
     }
 }
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn detached_probe_binding_writer_wait_cancels_without_stale_reschedule() {
+#[tokio::test]
+async fn exact_handshake_retry_cancellation_is_merged_and_stale_wake_is_harmless() {
     let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
-    let daemon = Arc::new(Daemon::new(config));
+    let daemon = Daemon::new(config);
     let peer_identity = NodeIdentity::generate();
     let peer_info = control::PeerInfo {
-        node_id: "peer-cancelled-detached-writer".to_string(),
+        node_id: "peer-cancelled-exact-retry".to_string(),
         device_name: String::new(),
         app_version: String::new(),
         public_key: hex::encode(peer_identity.public_key()),
@@ -2244,91 +2381,60 @@ async fn detached_probe_binding_writer_wait_cancels_without_stale_reschedule() {
     };
     daemon.peers.add_peer(&peer_info).await;
 
-    let reservation = daemon
+    let mut retry_rx = daemon.handshake_retry_kick_tx.subscribe();
+    let mut reservation = daemon
         .reserve_event_initiator_handshake(&peer_info.node_id)
-        .await
         .expect("event initiator reservation must be admitted");
-    let connection_guard = daemon
-        .peers
-        .connection_map_for_test()
-        .read_owned()
-        .await;
-    let reschedule_rx = daemon.path_setup_kick_tx.subscribe();
-    daemon.defer_initiator_probe_binding_writer_retry(
-        peer_info.node_id.clone(),
-        reservation.owner,
-        reservation.network_generation,
-        1,
-        reservation.cancellation.clone(),
-    );
+    let mut cancellation = reservation.cancellation.clone();
+    assert!(daemon.schedule_initiator_retry(
+        &peer_info.node_id,
+        &mut reservation,
+        InitiatorRetryPhase::Preparation,
+        "test_contention",
+    ));
+    assert!(daemon.schedule_initiator_retry(
+        &peer_info.node_id,
+        &mut reservation,
+        InitiatorRetryPhase::Preparation,
+        "duplicate_test_contention",
+    ));
+    tokio::time::timeout(Duration::from_secs(1), retry_rx.changed())
+        .await
+        .expect("commit-before-wake retry edge was lost")
+        .expect("retry coordinator must stay live");
 
-    tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            if daemon.timeline.snapshot().events.iter().any(|event| {
-                event.event == "initiator_publish_probe_binding_writer_wait_started"
-            }) {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("detached writer waiter must start");
-
-    let mut status_read = {
-        let queue_deadline = Instant::now() + Duration::from_millis(100);
-        loop {
-            let status_peers = daemon.peers.clone();
-            let status_peer_id = peer_info.node_id.clone();
-            let mut candidate = tokio::spawn(async move {
-                status_peers.get_connection(&status_peer_id).await
-            });
-            if tokio::time::timeout(Duration::from_millis(10), &mut candidate)
-                .await
-                .is_err()
-            {
-                break candidate;
-            }
-            assert!(
-                Instant::now() < queue_deadline,
-                "the detached connection writer never entered Tokio's fair queue"
-            );
-            tokio::task::yield_now().await;
-        }
+    let retry_revision = {
+        let state = daemon.pending_handshakes.lock();
+        assert_eq!(state.initiator_retries.len(), 1);
+        let retry = state
+            .initiator_retries
+            .get(&peer_info.node_id)
+            .expect("newest exact retry must remain");
+        assert_eq!(retry.identity.reservation_owner, reservation.owner);
+        assert_eq!(retry.identity.attempt, 2);
+        state.retry_revision()
     };
 
+    daemon.clear_peer_handshake_lifecycle(&peer_info.node_id, "test_peer_left");
+    assert!(*cancellation.borrow_and_update());
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.starting.contains(&peer_info.node_id));
+        assert!(!state.starting_prepared.contains_key(&peer_info.node_id));
+        assert!(!state.initiator_retries.contains_key(&peer_info.node_id));
+    }
+
+    // A coalesced/late watch value is only a hint.  The authoritative ledger
+    // is empty after cancellation, so it cannot resurrect the retired owner.
     daemon
+        .handshake_retry_kick_tx
+        .send_replace(retry_revision);
+    assert!(daemon
         .pending_handshakes
         .lock()
-        .await
-        .clear_peer(&peer_info.node_id);
-    tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            if daemon.timeline.snapshot().events.iter().any(|event| {
-                event.event == "initiator_publish_probe_binding_writer_wait_cancelled"
-            }) {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("reservation cancellation must wake the detached writer waiter");
-
-    assert!(
-        tokio::time::timeout(Duration::from_millis(100), &mut status_read)
-            .await
-            .expect("status read must resume after cancellation removes the writer")
-            .expect("status task must not panic")
-            .is_some()
-    );
-    assert!(
-        matches!(reschedule_rx.has_changed(), Ok(false)),
-        "a cancelled old owner must not publish a path-setup retry"
-    );
-    drop(connection_guard);
+        .claim_ready_initiator_retry(Instant::now())
+        .is_none());
 }
-
 #[tokio::test]
 async fn committed_initiator_offer_wait_is_cancelled_when_pending_is_removed() {
     let peer_id = "peer-cancelled-initiator-offer";
@@ -2381,6 +2487,997 @@ async fn committed_initiator_offer_wait_is_cancelled_when_pending_is_removed() {
     assert!(outcome.is_none());
 }
 
+#[tokio::test(start_paused = true)]
+async fn handshake_arbiter_telemetry_pairs_holder_release_timeout_and_cancellation() {
+    use std::task::Poll;
+
+    let timeline = ConnectionTimeline::new("arbiter-telemetry", 0);
+    let arbiter = HandshakeArbiter::new(timeline.clone());
+    let peer_id = "peer-arbiter-telemetry";
+    let owner = arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::MaintenanceInitiator,
+            Some(77),
+            9,
+            Some(PeerSessionGeneration::for_test(11)),
+            "maintenance_snapshot_commit",
+        ))
+        .expect("maintenance mutation turn must be acquired");
+    let holder = arbiter
+        .current_holder(peer_id)
+        .expect("current holder metadata must be visible without an async lock");
+    assert_eq!(
+        holder.identity.owner_kind,
+        HandshakeOwnerKind::MaintenanceInitiator
+    );
+    assert_eq!(holder.identity.phase, "maintenance_snapshot_commit");
+    assert_eq!(holder.identity.reservation_owner, Some(77));
+    assert_eq!(holder.identity.network_generation, 9);
+    assert_eq!(
+        holder.identity.peer_session_generation,
+        Some(PeerSessionGeneration::for_test(11))
+    );
+    assert!(holder.held_for < Duration::from_secs(1));
+
+    let contention = match arbiter.try_acquire(HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::EventInitiatorPrepare,
+            Some(78),
+            9,
+            Some(PeerSessionGeneration::for_test(11)),
+            "preparation",
+        )) {
+        Ok(_) => panic!("the maintenance holder unexpectedly admitted a second turn"),
+        Err(contention) => contention,
+    };
+    assert_eq!(
+        contention.holder.unwrap().identity,
+        holder.identity,
+        "contention diagnostics must identify the actual maintenance holder"
+    );
+
+    let mut timed = Box::pin(arbiter.acquire_with_timeout(
+        HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::Responder,
+            None,
+            9,
+            Some(PeerSessionGeneration::for_test(11)),
+            "responder_admission",
+        ),
+        Duration::from_millis(10),
+    ));
+    std::future::poll_fn(|context| match std::future::Future::poll(timed.as_mut(), context) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!("bounded waiter completed before paused time advanced"),
+    })
+    .await;
+    tokio::time::advance(Duration::from_millis(11)).await;
+    assert!(timed.await.is_none());
+
+    let mut cancelled = Box::pin(arbiter.acquire_with_timeout(
+        HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::Cleanup,
+            None,
+            9,
+            Some(PeerSessionGeneration::for_test(11)),
+            "peer_left",
+        ),
+        Duration::from_secs(1),
+    ));
+    std::future::poll_fn(|context| {
+        match std::future::Future::poll(cancelled.as_mut(), context) {
+            Poll::Pending => Poll::Ready(()),
+            Poll::Ready(_) => panic!("cancellation waiter unexpectedly acquired the turn"),
+        }
+    })
+    .await;
+    drop(cancelled);
+    drop(owner);
+    assert!(arbiter.current_holder(peer_id).is_none());
+
+    let events = timeline.snapshot().events;
+    let count = |name: &str| events.iter().filter(|event| event.event == name).count();
+    assert_eq!(count("handshake_arbiter_wait_started"), 4);
+    assert_eq!(count("handshake_arbiter_acquired"), 1);
+    assert_eq!(count("handshake_arbiter_contended"), 1);
+    assert_eq!(count("handshake_arbiter_timeout"), 1);
+    assert_eq!(count("handshake_arbiter_cancelled"), 1);
+    assert_eq!(count("handshake_arbiter_released"), 1);
+    assert!(events.iter().any(|event| {
+        event.event == "handshake_arbiter_released"
+            && event.detail.as_deref().is_some_and(|detail| {
+                detail.contains("owner_kind=maintenance_initiator")
+                    && detail.contains("phase=maintenance_snapshot_commit")
+                    && detail.contains("reservation_owner=77")
+                    && detail.contains("held_us=")
+            })
+    }));
+    let diagnostic_text = events
+        .iter()
+        .filter_map(|event| event.detail.as_deref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    for forbidden in [
+        "do-not-log-private-key",
+        "do-not-log-session-secret",
+        "do-not-log-raw-handshake-token",
+    ] {
+        assert!(!diagnostic_text.contains(forbidden));
+    }
+}
+
+#[tokio::test]
+async fn peer_scoped_handshake_arbiter_contention_does_not_block_another_peer_session() {
+    let arbiter = HandshakeArbiter::default();
+    let peer_a = "peer-arbiter-a";
+    let peer_b = "peer-arbiter-b";
+    let peer_a_owner = arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            peer_a,
+            HandshakeOwnerKind::MaintenanceInitiator,
+            Some(1),
+            0,
+            Some(PeerSessionGeneration::for_test(1)),
+            "maintenance_reserve",
+        ))
+        .unwrap();
+    let peer_b_turn = arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            peer_b,
+            HandshakeOwnerKind::Responder,
+            None,
+            0,
+            Some(PeerSessionGeneration::for_test(1)),
+            "responder_admission",
+        ))
+        .expect("peer A's turn must not serialize peer B");
+    drop(peer_b_turn);
+
+    let (transport, _outbound_rx) = WireGuardTransport::new();
+    let (peer_b_session, _) = part03_establish_sessions();
+    transport.add_session(peer_b, peer_b_session).await;
+    assert!(transport.has_session(peer_b).await);
+    assert_eq!(
+        arbiter.current_holder(peer_a).unwrap().identity.owner_kind,
+        HandshakeOwnerKind::MaintenanceInitiator
+    );
+    drop(peer_a_owner);
+}
+
+#[test]
+fn exact_handshake_retry_has_strict_ttl_and_all_lifecycle_cancellations_are_terminal() {
+    fn reserve_retry(
+        state: &mut PendingHandshakeState,
+        peer_id: &str,
+        network_generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        now: Instant,
+    ) -> (HandshakeStartReservation, watch::Receiver<bool>) {
+        let reservation = state
+            .reserve_start_with_owner_at_generation(
+                peer_id,
+                network_generation,
+                peer_session_generation,
+            )
+            .expect("test lifecycle must reserve an initiator");
+        let cancellation = reservation.cancellation.clone();
+        state
+            .schedule_initiator_retry(
+                peer_id,
+                &reservation,
+                InitiatorRetryPhase::Preparation,
+                now,
+            )
+            .expect("test lifecycle must retain one exact retry");
+        (reservation, cancellation)
+    }
+
+    let now = Instant::now();
+    let peer_generation = PeerSessionGeneration::for_test(1);
+    let mut ttl_state = PendingHandshakeState::default();
+    let (ttl_reservation, mut ttl_cancellation) =
+        reserve_retry(&mut ttl_state, "peer-retry-ttl", 4, peer_generation, now);
+    let original_expiry = ttl_state
+        .initiator_retries
+        .get("peer-retry-ttl")
+        .unwrap()
+        .expires_at;
+    ttl_state
+        .schedule_initiator_retry(
+            "peer-retry-ttl",
+            &ttl_reservation,
+            InitiatorRetryPhase::Preparation,
+            now + Duration::from_millis(1),
+        )
+        .expect("duplicate retry must merge before TTL");
+    assert_eq!(
+        ttl_state
+            .initiator_retries
+            .get("peer-retry-ttl")
+            .unwrap()
+            .expires_at,
+        original_expiry,
+        "duplicate kicks must not extend the strict phase TTL"
+    );
+    let (claimed_identity, claimed_reservation) = ttl_state
+        .claim_ready_initiator_retry(now + Duration::from_millis(12))
+        .expect("the merged retry must become ready deterministically");
+    assert_eq!(claimed_identity.attempt, 2);
+    let (rescheduled_identity, _) = ttl_state
+        .schedule_initiator_retry(
+            "peer-retry-ttl",
+            &claimed_reservation,
+            InitiatorRetryPhase::Preparation,
+            now + Duration::from_millis(12),
+        )
+        .expect("claimed contention must preserve its retry lineage");
+    assert_eq!(rescheduled_identity.attempt, 3);
+    assert_eq!(
+        ttl_state
+            .initiator_retries
+            .get("peer-retry-ttl")
+            .unwrap()
+            .expires_at,
+        original_expiry,
+        "claim and reschedule must not reset the strict phase TTL"
+    );
+    assert!(ttl_state
+        .claim_ready_initiator_retry(original_expiry)
+        .is_none());
+    assert!(*ttl_cancellation.borrow_and_update());
+    assert!(!ttl_state.starting.contains("peer-retry-ttl"));
+    assert!(!ttl_state
+        .initiator_retries
+        .contains_key("peer-retry-ttl"));
+
+    let mut full_lane_expiry = PendingHandshakeState::default();
+    let (_, mut full_lane_cancellation) = reserve_retry(
+        &mut full_lane_expiry,
+        "peer-full-lane-expiry",
+        4,
+        peer_generation,
+        now,
+    );
+    full_lane_expiry.expire_initiator_retries(now + INITIATOR_RETRY_TTL);
+    assert!(*full_lane_cancellation.borrow_and_update());
+    assert!(full_lane_expiry.initiator_retries.is_empty());
+    assert!(!full_lane_expiry.starting.contains("peer-full-lane-expiry"));
+
+    let mut peer_left = PendingHandshakeState::default();
+    let (_, mut peer_left_cancel) =
+        reserve_retry(&mut peer_left, "peer-left-retry", 1, peer_generation, now);
+    peer_left.clear_peer("peer-left-retry");
+    assert!(*peer_left_cancel.borrow_and_update());
+    assert!(peer_left.initiator_retries.is_empty());
+
+    let mut offline = PendingHandshakeState::default();
+    let (_, mut offline_cancel) =
+        reserve_retry(&mut offline, "peer-offline-retry", 1, peer_generation, now);
+    offline.clear_peer("peer-offline-retry");
+    assert!(*offline_cancel.borrow_and_update());
+    assert!(offline.initiator_retries.is_empty());
+
+    let mut generation = PendingHandshakeState::default();
+    let (_, mut generation_cancel) =
+        reserve_retry(&mut generation, "peer-generation-retry", 1, peer_generation, now);
+    let replacement = generation
+        .reserve_start_with_owner_at_generation(
+            "peer-generation-retry",
+            2,
+            peer_generation,
+        )
+        .expect("a new network generation must replace the stale retry owner");
+    assert!(*generation_cancel.borrow_and_update());
+    assert_eq!(generation.initiator_retries.len(), 0);
+    generation.cancel_reservation_if_current("peer-generation-retry", replacement.owner);
+
+    let mut rejoin = PendingHandshakeState::default();
+    let (_, mut rejoin_cancel) =
+        reserve_retry(&mut rejoin, "peer-rejoin-retry", 1, peer_generation, now);
+    rejoin.clear_peer("peer-rejoin-retry");
+    let replacement_generation = PeerSessionGeneration::for_test(2);
+    let replacement = rejoin
+        .reserve_start_with_owner_at_generation(
+            "peer-rejoin-retry",
+            1,
+            replacement_generation,
+        )
+        .expect("same-node rejoin must create a new exact lifecycle owner");
+    assert!(*rejoin_cancel.borrow_and_update());
+    assert_eq!(
+        replacement.peer_session_generation,
+        replacement_generation
+    );
+    rejoin.cancel_reservation_if_current("peer-rejoin-retry", replacement.owner);
+
+    let mut responder = PendingHandshakeState::default();
+    let (reservation, mut responder_cancel) = reserve_retry(
+        &mut responder,
+        "peer-responder-retry",
+        1,
+        peer_generation,
+        now,
+    );
+    assert!(responder.cancel_reservation_if_current(
+        "peer-responder-retry",
+        reservation.owner
+    ));
+    assert!(*responder_cancel.borrow_and_update());
+    assert!(responder.initiator_retries.is_empty());
+
+    let mut bounded = PendingHandshakeState::default();
+    for index in 0..MAX_PENDING_INITIATOR_RETRIES {
+        let peer_id = format!("bounded-retry-{index}");
+        let reservation = bounded
+            .reserve_start_with_owner_at_generation(&peer_id, 1, peer_generation)
+            .unwrap();
+        assert!(bounded
+            .schedule_initiator_retry(
+                &peer_id,
+                &reservation,
+                InitiatorRetryPhase::Preparation,
+                now,
+            )
+            .is_some());
+    }
+    let overflow_peer = "bounded-retry-overflow";
+    let overflow = bounded
+        .reserve_start_with_owner_at_generation(overflow_peer, 1, peer_generation)
+        .unwrap();
+    assert!(bounded
+        .schedule_initiator_retry(
+            overflow_peer,
+            &overflow,
+            InitiatorRetryPhase::Preparation,
+            now,
+        )
+        .is_none());
+    assert_eq!(
+        bounded.initiator_retries.len(),
+        MAX_PENDING_INITIATOR_RETRIES
+    );
+}
+
+#[tokio::test]
+async fn network_generation_advance_synchronously_cancels_exact_handshake_retry_and_pending_offer()
+{
+    let daemon = Daemon::new(
+        Config::generate_default("http://127.0.0.1:1", "generation-cancel-network").unwrap(),
+    );
+    let peer_id = "peer-generation-hook-cancel";
+    let peer_identity = NodeIdentity::generate();
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: hex::encode(peer_identity.public_key()),
+            virtual_ip: "10.20.0.9".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+    let mut reservation = daemon
+        .pending_handshakes
+        .lock()
+        .reserve_start_with_owner_at_generation(
+            peer_id,
+            0,
+            daemon.peers.peer_session_generation_sync(peer_id).unwrap(),
+        )
+        .unwrap();
+    let mut cancellation = reservation.cancellation.clone();
+    assert!(daemon.schedule_initiator_retry(
+        peer_id,
+        &mut reservation,
+        InitiatorRetryPhase::Preparation,
+        "test_generation_advance",
+    ));
+
+    let pending_peer_id = "peer-generation-hook-pending";
+    let pending_peer_identity = NodeIdentity::generate();
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: pending_peer_id.to_string(),
+            public_key: hex::encode(pending_peer_identity.public_key()),
+            virtual_ip: "10.20.0.10".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+    let pending_peer_session = daemon
+        .peers
+        .peer_session_generation_sync(pending_peer_id)
+        .unwrap();
+    let pending_token = "generation-bound-pending-token".to_string();
+    let (pending_id, mut pending_cancellation) = {
+        let mut state = daemon.pending_handshakes.lock();
+        let pending_reservation = state
+            .reserve_start_with_owner_at_generation(pending_peer_id, 0, pending_peer_session)
+            .unwrap();
+        let cancellation = pending_reservation.cancellation.clone();
+        let initiator = HandshakeInitiator::new(
+            daemon.local_identity().unwrap(),
+            pending_peer_identity.public_key(),
+            None,
+        );
+        let pending_id = state
+            .insert_reserved_if_current_with_generation(
+                pending_peer_id.to_string(),
+                pending_reservation.owner,
+                initiator,
+                Some(pending_token.clone()),
+                None,
+                0,
+                pending_peer_session,
+            )
+            .unwrap();
+        (pending_id, cancellation)
+    };
+    assert_eq!(
+        daemon
+            .peers
+            .stage_probe_session_binding(
+                pending_peer_id,
+                pending_token.clone(),
+                Some(pending_token.clone()),
+                None,
+                false,
+            )
+            .await,
+        ProbeBindingStage::Staged
+    );
+    assert!(daemon
+        .pending_handshakes
+        .lock()
+        .is_current(pending_peer_id, pending_id));
+
+    assert_eq!(
+        daemon
+            .peers
+            .advance_network_generation("test exact handshake retry cancellation")
+            .await,
+        1
+    );
+    assert!(*cancellation.borrow_and_update());
+    assert!(*pending_cancellation.borrow_and_update());
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.starting.contains(peer_id));
+        assert!(!state.initiator_retries.contains_key(peer_id));
+        assert!(!state.pending.contains_key(pending_peer_id));
+    }
+    assert_eq!(
+        daemon
+            .peers
+            .try_confirm_pending_probe_session_binding(pending_peer_id, &pending_token),
+        PendingProbeBindingCommitOutcome::Missing,
+        "the generation transaction must remove the exact staged Probe binding"
+    );
+
+    // Candidate refresh is a second network-generation transition, not a
+    // weaker lifecycle. It must execute the same synchronous handshake fence.
+    let current_generation = daemon.peers.current_network_generation_sync();
+    let peer_session = daemon.peers.peer_session_generation_sync(peer_id).unwrap();
+    let mut refresh_reservation = daemon
+        .pending_handshakes
+        .lock()
+        .reserve_start_with_owner_at_generation(peer_id, current_generation, peer_session)
+        .unwrap();
+    let mut refresh_cancellation = refresh_reservation.cancellation.clone();
+    assert!(daemon.schedule_initiator_retry(
+        peer_id,
+        &mut refresh_reservation,
+        InitiatorRetryPhase::Preparation,
+        "test_candidate_refresh_generation_advance",
+    ));
+
+    let pending_peer_session = daemon
+        .peers
+        .peer_session_generation_sync(pending_peer_id)
+        .unwrap();
+    let refresh_pending_token = "candidate-refresh-bound-pending-token".to_string();
+    let mut refresh_pending_cancellation = {
+        let mut state = daemon.pending_handshakes.lock();
+        let reservation = state
+            .reserve_start_with_owner_at_generation(
+                pending_peer_id,
+                current_generation,
+                pending_peer_session,
+            )
+            .unwrap();
+        let cancellation = reservation.cancellation.clone();
+        state
+            .insert_reserved_if_current_with_generation(
+                pending_peer_id.to_string(),
+                reservation.owner,
+                HandshakeInitiator::new(
+                    daemon.local_identity().unwrap(),
+                    pending_peer_identity.public_key(),
+                    None,
+                ),
+                Some(refresh_pending_token.clone()),
+                None,
+                current_generation,
+                pending_peer_session,
+            )
+            .unwrap();
+        cancellation
+    };
+    assert_eq!(
+        daemon
+            .peers
+            .stage_probe_session_binding(
+                pending_peer_id,
+                refresh_pending_token.clone(),
+                Some(refresh_pending_token.clone()),
+                None,
+                false,
+            )
+            .await,
+        ProbeBindingStage::Staged
+    );
+
+    assert_eq!(
+        daemon
+            .peers
+            .advance_candidate_refresh_generation(
+                "test candidate-refresh handshake cancellation",
+            )
+            .await,
+        current_generation + 1
+    );
+    assert!(*refresh_cancellation.borrow_and_update());
+    assert!(*refresh_pending_cancellation.borrow_and_update());
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.starting.contains(peer_id));
+        assert!(!state.initiator_retries.contains_key(peer_id));
+        assert!(!state.pending.contains_key(pending_peer_id));
+    }
+    assert_eq!(
+        daemon.peers.try_confirm_pending_probe_session_binding(
+            pending_peer_id,
+            &refresh_pending_token,
+        ),
+        PendingProbeBindingCommitOutcome::Missing,
+        "candidate refresh must remove the exact staged Probe binding"
+    );
+}
+
+#[test]
+fn handshake_lifecycle_model_checks_first_1000_deterministic_interleavings() {
+    fn next_permutation(values: &mut [u8]) -> bool {
+        let Some(pivot) = (0..values.len().saturating_sub(1))
+            .rev()
+            .find(|&index| values[index] < values[index + 1])
+        else {
+            return false;
+        };
+        let swap = (pivot + 1..values.len())
+            .rev()
+            .find(|&index| values[pivot] < values[index])
+            .unwrap();
+        values.swap(pivot, swap);
+        values[pivot + 1..].reverse();
+        true
+    }
+
+    const MAINTENANCE_SNAPSHOT: u8 = 0;
+    const EVENT_RESERVE: u8 = 1;
+    const MAINTENANCE_RESERVE: u8 = 2;
+    const EVENT_PREPARE: u8 = 3;
+    const RESPONDER_OFFER: u8 = 4;
+    const PUBLISH: u8 = 5;
+    const GENERATION_ADVANCE: u8 = 6;
+
+    let peer_id = "peer-interleaving-model";
+    let peer_generation = PeerSessionGeneration::for_test(1);
+    let mut order = [0, 1, 2, 3, 4, 5, 6];
+    let mut checked = 0usize;
+    loop {
+        let mut state = PendingHandshakeState::default();
+        let mut network_generation = 1u64;
+        let mut event_owner: Option<HandshakeStartReservation> = None;
+        let mut prepared_owner: Option<(u64, u64, u64)> = None;
+        let mut responder_session = false;
+        let mut valid_offers = 0usize;
+        let stale_owner_commits = 0usize;
+
+        for action in order {
+            match action {
+                MAINTENANCE_SNAPSHOT => {
+                    // Snapshot-only work has no mutation ownership.
+                }
+                EVENT_RESERVE if !responder_session => {
+                    if let Some(reservation) = state
+                        .reserve_start_with_owner_at_generation_and_kind(
+                            peer_id,
+                            network_generation,
+                            peer_generation,
+                            HandshakeOwnerKind::EventInitiatorReserve,
+                        )
+                    {
+                        event_owner = Some(reservation);
+                    }
+                }
+                MAINTENANCE_RESERVE if !responder_session => {
+                    let _ = state.reserve_start_with_owner_at_generation_and_kind(
+                        peer_id,
+                        network_generation,
+                        peer_generation,
+                        HandshakeOwnerKind::MaintenanceInitiator,
+                    );
+                }
+                EVENT_PREPARE => {
+                    if let Some(reservation) = event_owner.as_ref().filter(|reservation| {
+                        state.starting_reservation_is_current(peer_id, reservation)
+                    }) {
+                        prepared_owner = Some((
+                            reservation.owner,
+                            reservation.network_generation,
+                            reservation.cancellation_generation,
+                        ));
+                    }
+                }
+                RESPONDER_OFFER => {
+                    state.cancel_reservation(peer_id);
+                    responder_session = true;
+                }
+                PUBLISH => {
+                    if let (Some(reservation), Some(prepared)) =
+                        (event_owner.as_ref(), prepared_owner)
+                    {
+                        let current = state.starting_reservation_is_current(peer_id, reservation)
+                            && prepared
+                                == (
+                                    reservation.owner,
+                                    network_generation,
+                                    reservation.cancellation_generation,
+                                )
+                            && !responder_session;
+                        if current {
+                            valid_offers += 1;
+                            state.cancel_reservation(peer_id);
+                        }
+                    }
+                }
+                GENERATION_ADVANCE => {
+                    network_generation = network_generation.saturating_add(1);
+                    state.clear_peer(peer_id);
+                    prepared_owner = None;
+                }
+                _ => {}
+            }
+            assert!(state.starting.len() <= 1);
+            assert!(state.initiator_retries.len() <= 1);
+            assert!(valid_offers <= 1);
+            assert_eq!(stale_owner_commits, 0);
+        }
+        state.clear_peer(peer_id);
+        assert!(state.starting.is_empty());
+        assert!(state.initiator_retries.is_empty());
+        checked += 1;
+        if checked == 1000 || !next_permutation(&mut order) {
+            break;
+        }
+    }
+    assert_eq!(checked, 1000);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn maintenance_snapshot_race_yields_to_event_single_offer_and_one_session() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "handshake-race-network").unwrap();
+    config.control.auth_token = "handshake-race-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must not stall the deterministic race");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "peer-maintenance-event-race".to_string(),
+        public_key: hex::encode(remote_identity.public_key()),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        ..control::PeerInfo::default()
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.relay_available_tx.send_replace(true);
+    let network_generation = daemon.peers.current_network_generation_sync();
+    let peer_session_generation = daemon
+        .peers
+        .peer_session_generation_sync(&peer_info.node_id)
+        .unwrap();
+
+    // Pause maintenance after its actor/control snapshots and immediately
+    // before its zero-wait mutation turn: this is the exact boundary where the
+    // old implementation held the arbiter across session/control awaits.
+    let snapshot_ready = Arc::new(tokio::sync::Barrier::new(2));
+    let allow_reserve = Arc::new(tokio::sync::Barrier::new(2));
+    let maintenance = tokio::spawn({
+        let transport = daemon.transport.clone();
+        let pending = daemon.pending_handshakes.clone();
+        let arbiter = daemon.handshake_arbiter.clone();
+        let peer_id = peer_info.node_id.clone();
+        let snapshot_ready = snapshot_ready.clone();
+        let allow_reserve = allow_reserve.clone();
+        async move {
+            let status = transport.session_status(&peer_id).await;
+            assert!(!status.has_active);
+            snapshot_ready.wait().await;
+            allow_reserve.wait().await;
+            try_reserve_maintenance_initiator(
+                &pending,
+                &arbiter,
+                &peer_id,
+                network_generation,
+                peer_session_generation,
+            )
+        }
+    });
+    snapshot_ready.wait().await;
+    assert!(
+        daemon
+            .handshake_arbiter
+            .current_holder(&peer_info.node_id)
+            .is_none(),
+        "maintenance snapshots must not own a mutation turn"
+    );
+    let mut event_reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .expect("PeerJoined must reserve while maintenance is paused at its old await boundary");
+    let event_owner = event_reservation.owner;
+    allow_reserve.wait().await;
+    let maintenance_outcome = timeout(Duration::from_secs(1), maintenance)
+        .await
+        .expect("maintenance zero-wait admission did not terminate")
+        .expect("maintenance snapshot task panicked");
+    assert!(matches!(
+        maintenance_outcome,
+        MaintenanceInitiatorReservationOutcome::Busy
+    ));
+
+    let punch_at = timeout(
+        Duration::from_secs(2),
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut event_reservation),
+    )
+    .await
+    .expect("event preparation/publish must not wait on the retired maintenance producer")
+    .expect("event initiator failed")
+    .expect("event initiator did not publish its one Offer");
+    assert!(punch_at > 0);
+    timeout(
+        Duration::from_secs(1),
+        control_capture.wait_for_signal_count(1),
+    )
+    .await
+    .expect("mock control did not receive the event Offer");
+    let bodies = control_capture.signal_bodies();
+    let offers = bodies
+        .iter()
+        .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|body| body.get("type").and_then(serde_json::Value::as_str) == Some("peer_offer"))
+        .collect::<Vec<_>>();
+    assert_eq!(offers.len(), 1, "the lifecycle may publish one valid Offer");
+    let offer = &offers[0];
+    let initiation = hex::decode(
+        offer
+            .get("handshake")
+            .and_then(serde_json::Value::as_str)
+            .expect("captured Offer omitted its WireGuard initiation"),
+    )
+    .unwrap();
+    let session_id = offer
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("captured Offer omitted its exact session id")
+        .to_string();
+    let initiation = MessageInitiation::from_bytes(&initiation).unwrap();
+    let mut remote_responder = HandshakeResponder::new(remote_identity, None);
+    let (response, _) = remote_responder
+        .consume_initiation_and_respond(&initiation)
+        .unwrap();
+    let remote_probe_public = hex::encode(DhKeyPair::generate().public_key());
+    assert!(
+        daemon
+            .handle_peer_answer(
+                &peer_info.node_id,
+                &response.to_bytes(),
+                Some(session_id),
+                Some(remote_probe_public),
+            )
+            .await
+            .unwrap()
+    );
+    assert!(daemon.transport.has_session(&peer_info.node_id).await);
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.pending.contains_key(&peer_info.node_id));
+        assert!(!state.starting.contains(&peer_info.node_id));
+        assert!(!state.initiator_retries.contains_key(&peer_info.node_id));
+    }
+    let staged = daemon
+        .timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|event| {
+            event.event == "initiator_session_staged"
+                && event.detail.as_deref().is_some_and(|detail| {
+                    detail.contains(&format!("owner={event_owner}"))
+                })
+        })
+        .count();
+    assert_eq!(staged, 1);
+    control_capture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responder_preempts_contended_initiator_retry_with_bounded_turn_and_no_stale_offer() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "responder-preemption-network")
+            .unwrap();
+    config.control.auth_token = "responder-preemption-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must complete before responder preemption");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if identity.public_key() < local_public {
+            break identity;
+        }
+    };
+    let peer_id = "peer-responder-preempts-initiator";
+    let peer_info = control::PeerInfo {
+        node_id: peer_id.to_string(),
+        public_key: hex::encode(remote_identity.public_key()),
+        virtual_ip: "10.20.0.3".to_string(),
+        online: true,
+        ..control::PeerInfo::default()
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.relay_available_tx.send_replace(true);
+    let network_generation = daemon.peers.current_network_generation_sync();
+    let peer_session_generation = daemon
+        .peers
+        .peer_session_generation_sync(peer_id)
+        .unwrap();
+    let mut stale_reservation = daemon
+        .pending_handshakes
+        .lock()
+        .reserve_start_with_owner_at_generation(peer_id, network_generation, peer_session_generation)
+        .expect("stale event initiator must own the setup transaction");
+    let stale_owner = stale_reservation.owner;
+    let mut stale_cancellation = stale_reservation.cancellation.clone();
+
+    let blocking_turn = daemon
+        .handshake_arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            peer_id,
+            HandshakeOwnerKind::EventInitiatorPrepare,
+            Some(stale_owner),
+            network_generation,
+            Some(peer_session_generation),
+            "preparation",
+        ))
+        .unwrap();
+    let preparation_result = timeout(
+        Duration::from_millis(100),
+        daemon.run_reserved_initiator_handshake(&peer_info, &mut stale_reservation),
+    )
+    .await
+    .expect("preparation contention must return without waiting for the held turn")
+    .expect("preparation contention is non-fatal");
+    assert_eq!(preparation_result, None);
+    assert_eq!(
+        stale_reservation.disposition,
+        HandshakeStartDisposition::RetryScheduled
+    );
+    assert_eq!(
+        daemon
+            .pending_handshakes
+            .lock()
+            .initiator_retries
+            .get(peer_id)
+            .unwrap()
+            .identity
+            .phase,
+        InitiatorRetryPhase::Preparation
+    );
+    let mut remote_initiator = HandshakeInitiator::new(remote_identity, local_public, None);
+    let initiation = remote_initiator.create_initiation().unwrap().to_bytes();
+    let responder = {
+        let daemon = daemon.clone();
+        let peer_id = peer_id.to_string();
+        tokio::spawn(async move {
+            daemon
+                .handle_peer_offer(&peer_id, &[], &initiation, None, None, None, None)
+                .await
+        })
+    };
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if daemon.timeline.snapshot().events.iter().any(|event| {
+                event.event == "handshake_arbiter_wait_started"
+                    && event.detail.as_deref().is_some_and(|detail| {
+                        detail.contains(peer_id)
+                            && detail.contains("owner_kind=responder")
+                            && detail.contains("holder_kind=event_initiator_prepare")
+                            && detail.contains(&format!(
+                                "holder_reservation_owner={stale_owner}"
+                            ))
+                    })
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("responder did not expose the exact contending initiator holder");
+    drop(blocking_turn);
+    timeout(Duration::from_secs(2), responder)
+        .await
+        .expect("responder exceeded its bounded mutation-turn/control budget")
+        .expect("responder task panicked")
+        .expect("legal responder offer failed");
+    assert!(*stale_cancellation.borrow_and_update());
+    assert!(daemon.transport.has_session(peer_id).await);
+    {
+        let state = daemon.pending_handshakes.lock();
+        assert!(!state.starting.contains(peer_id));
+        assert!(!state.initiator_retries.contains_key(peer_id));
+        assert!(!state.pending.contains_key(peer_id));
+    }
+    timeout(
+        Duration::from_secs(1),
+        control_capture.wait_for_signal_count(1),
+    )
+    .await
+    .expect("responder answer was not delivered");
+    let bodies = control_capture.signal_bodies();
+    assert_eq!(
+        bodies
+            .iter()
+            .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+            .filter(|body| {
+                body.get("type").and_then(serde_json::Value::as_str) == Some("peer_answer")
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        bodies
+            .iter()
+            .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+            .filter(|body| {
+                body.get("type").and_then(serde_json::Value::as_str) == Some("peer_offer")
+            })
+            .count(),
+        0,
+        "the cancelled initiator retry must not publish a stale Offer"
+    );
+    control_capture.stop().await;
+}
+
 #[test]
 fn handshake_role_is_deterministic_from_decoded_static_public_keys() {
     let lower = [0x11; 32];
@@ -2400,22 +3497,62 @@ fn handshake_role_is_deterministic_from_decoded_static_public_keys() {
 #[tokio::test]
 async fn handshake_arbiter_prunes_dead_peer_locks_on_churn() {
     let arbiter = HandshakeArbiter::default();
-    let first = arbiter.acquire("peer-old").await;
+    let first = arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            "peer-old",
+            HandshakeOwnerKind::MaintenanceInitiator,
+            None,
+            1,
+            Some(PeerSessionGeneration::for_test(1)),
+            "test_owner",
+        ))
+        .unwrap();
     drop(first);
-    let second = arbiter.acquire("peer-new").await;
+    let second = arbiter
+        .try_acquire(HandshakeLeaseIdentity::new(
+            "peer-new",
+            HandshakeOwnerKind::MaintenanceInitiator,
+            None,
+            1,
+            Some(PeerSessionGeneration::for_test(1)),
+            "test_owner",
+        ))
+        .unwrap();
     drop(second);
 
-    assert!(!arbiter.peer_locks.lock().await.contains_key("peer-old"));
+    assert!(!arbiter
+        .peer_locks
+        .lock()
+        .unwrap()
+        .contains_key("peer-old"));
 }
 
 #[tokio::test]
 async fn handshake_arbiter_wait_is_bounded_and_recovers_after_owner_release() {
     let arbiter = HandshakeArbiter::default();
-    let owner = arbiter.acquire("peer-lock-timeout").await;
+    let owner_identity = HandshakeLeaseIdentity::new(
+        "peer-lock-timeout",
+        HandshakeOwnerKind::MaintenanceInitiator,
+        Some(7),
+        3,
+        Some(PeerSessionGeneration::for_test(4)),
+        "maintenance_reserve",
+    );
+    let owner = arbiter.try_acquire(owner_identity).unwrap();
 
     assert!(
         arbiter
-            .acquire_with_timeout("peer-lock-timeout", Duration::from_millis(10))
+            .acquire_with_timeout(
+                HandshakeLeaseIdentity::new(
+                    "peer-lock-timeout",
+                    HandshakeOwnerKind::Responder,
+                    None,
+                    3,
+                    Some(PeerSessionGeneration::for_test(4)),
+                    "responder_admission",
+                ),
+                Duration::from_millis(10),
+            )
             .await
             .is_none(),
         "a responder must not wait forever behind a stale handshake owner"
@@ -2424,7 +3561,17 @@ async fn handshake_arbiter_wait_is_bounded_and_recovers_after_owner_release() {
     drop(owner);
     assert!(
         arbiter
-            .acquire_with_timeout("peer-lock-timeout", Duration::from_millis(100))
+            .acquire_with_timeout(
+                HandshakeLeaseIdentity::new(
+                    "peer-lock-timeout",
+                    HandshakeOwnerKind::Responder,
+                    None,
+                    3,
+                    Some(PeerSessionGeneration::for_test(4)),
+                    "responder_admission",
+                ),
+                Duration::from_millis(100),
+            )
             .await
             .is_some(),
         "the same peer must recover immediately after the owner releases"
@@ -2572,7 +3719,6 @@ async fn responder_cache_rejects_offer_after_peer_static_key_rotation() {
     daemon
         .pending_handshakes
         .lock()
-        .await
         .cache_responder_handshake(
             peer_id,
             token,
@@ -2693,7 +3839,6 @@ async fn expired_responder_cache_conflict_does_not_poison_active_token() {
     daemon
         .pending_handshakes
         .lock()
-        .await
         .cache_responder_handshake(
             peer_id,
             token,
@@ -2740,7 +3885,6 @@ async fn expired_responder_cache_conflict_does_not_poison_active_token() {
         assert!(!daemon
             .pending_handshakes
             .lock()
-            .await
             .responder_cache
             .contains_key(&(peer_id.to_string(), token.to_string())));
     }
@@ -6007,7 +7151,6 @@ async fn peer_answer_from_new_remote_incarnation_preserves_pending_initiator() {
     daemon
         .pending_handshakes
         .lock()
-        .await
         .insert_with_generation(
             peer_id.to_string(),
             initiator,
@@ -6032,7 +7175,6 @@ async fn peer_answer_from_new_remote_incarnation_preserves_pending_initiator() {
     assert!(daemon
         .pending_handshakes
         .lock()
-        .await
         .pending
         .contains_key(peer_id));
     assert!(!daemon.transport.has_session(peer_id).await);
@@ -6119,7 +7261,7 @@ async fn stale_sender_known_offer_cannot_reset_current_identity_or_apply_candida
     let original_session_generation = daemon.peers.peer_session_generation_sync(peer_id).unwrap();
     let (active_session, _) = part03_establish_sessions();
     daemon.transport.add_session(peer_id, active_session).await;
-    daemon.pending_handshakes.lock().await.insert(
+    daemon.pending_handshakes.lock().insert(
         peer_id.to_string(),
         HandshakeInitiator::new(
             daemon.local_identity().unwrap(),
@@ -6188,7 +7330,7 @@ async fn stale_sender_known_offer_cannot_reset_current_identity_or_apply_candida
         peers.get_connection(peer_id).await.unwrap().candidates,
         vec![baseline_candidate]
     );
-    assert!(pending.lock().await.pending.contains_key(peer_id));
+    assert!(pending.lock().pending.contains_key(peer_id));
 
     let _ = shutdown.send(true);
     timeout(Duration::from_secs(1), loop_task)
@@ -6256,7 +7398,6 @@ async fn stale_sender_answer_cannot_reset_or_consume_current_initiator() {
     daemon
         .pending_handshakes
         .lock()
-        .await
         .insert(peer_id.to_string(), initiator, None, None);
 
     let peers = daemon.peers.clone();
@@ -6315,7 +7456,7 @@ async fn stale_sender_answer_cannot_reset_or_consume_current_initiator() {
         peers.get_connection(peer_id).await.unwrap().candidates,
         vec![baseline_candidate]
     );
-    assert!(pending.lock().await.pending.contains_key(peer_id));
+    assert!(pending.lock().pending.contains_key(peer_id));
 
     let _ = shutdown.send(true);
     timeout(Duration::from_secs(1), loop_task)
@@ -6366,7 +7507,7 @@ async fn stale_sender_deferred_offer_releases_owner_without_mutating_peer() {
     let original_session_generation = daemon.peers.peer_session_generation_sync(peer_id).unwrap();
     let (active_session, _) = part03_establish_sessions();
     daemon.transport.add_session(peer_id, active_session).await;
-    daemon.pending_handshakes.lock().await.insert(
+    daemon.pending_handshakes.lock().insert(
         peer_id.to_string(),
         HandshakeInitiator::new(
             daemon.local_identity().unwrap(),
@@ -6395,7 +7536,6 @@ async fn stale_sender_deferred_offer_releases_owner_without_mutating_peer() {
     let (reservation, offer) = daemon
         .pending_handshakes
         .lock()
-        .await
         .enqueue_responder_work(offer)
         .expect("the deferred offer must acquire an owner");
 
@@ -6420,7 +7560,7 @@ async fn stale_sender_deferred_offer_releases_owner_without_mutating_peer() {
             .candidates,
         vec![baseline_candidate]
     );
-    let pending = daemon.pending_handshakes.lock().await;
+    let pending = daemon.pending_handshakes.lock();
     assert!(pending.pending.contains_key(peer_id));
     assert!(!pending.responder_workers.contains_key(peer_id));
 }

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -2094,6 +2094,72 @@ async fn control_event_loop_queues_candidate_offer_while_connection_writer_is_bl
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_candidate_apply_releases_epoch_before_waiting_for_writer_turn() {
+    let config = Config::generate_default("http://127.0.0.1:1", "candidate-lock-order").unwrap();
+    let daemon = Daemon::new(config);
+    let peer_id = "peer-candidate-lock-order";
+    let peer_identity = NodeIdentity::generate();
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: hex::encode(peer_identity.public_key()),
+            virtual_ip: "10.20.0.2".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+
+    let peers = daemon.peers.clone();
+    let reader = peers.connection_map_for_test().read_owned().await;
+    let start = Arc::new(tokio::sync::Barrier::new(2));
+    let worker_start = start.clone();
+    let worker_peers = peers.clone();
+    let sender_public_key = hex::encode(peer_identity.public_key());
+    let worker = tokio::spawn(async move {
+        worker_start.wait().await;
+        worker_peers
+            .add_candidates_with_metadata_for_identity(
+                peer_id,
+                &["198.51.100.81:48100".to_string()],
+                &HashMap::from([(
+                    "198.51.100.81:48100".to_string(),
+                    "stun".to_string(),
+                )]),
+                1,
+                None,
+                Some(&sender_public_key),
+            )
+            .await
+    });
+    start.wait().await;
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if peers.connection_map_for_test().try_read().is_err() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("blocking candidate apply never entered the fair writer queue");
+    assert!(
+        peers.network_epoch_gate().try_lock().is_ok(),
+        "candidate apply queued the connection writer while retaining the epoch"
+    );
+
+    drop(reader);
+    assert_eq!(
+        timeout(Duration::from_secs(1), worker)
+            .await
+            .expect("candidate apply did not finish after the reader released")
+            .expect("candidate apply task panicked"),
+        CandidateSetApplyResult::Applied
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_offer() {
     fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
         0x4000_0000_0000_0000 | (incarnation << 21) | counter
@@ -2161,6 +2227,35 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
     .await
     .expect("peer lifecycle must be published before the contention edge");
 
+    // Publish the remote incarnation first so the two delivered offers take
+    // the synchronous same-incarnation fast path. The contention below then
+    // occurs at candidate apply itself, not at incarnation preflight.
+    let initial_incarnation = timeout(Duration::from_secs(1), async {
+        loop {
+            let outcome = peers.try_claim_remote_candidate_incarnation_for_identity(
+                peer_id,
+                encoded_generation(733, 1),
+                Some(&hex::encode(remote_identity.public_key())),
+            );
+            if !matches!(
+                outcome,
+                crate::peer::RemoteCandidateIncarnationTryClaim::ContendedEpoch
+                    | crate::peer::RemoteCandidateIncarnationTryClaim::ContendedConnections
+            ) {
+                break outcome;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("peer-join lifecycle transaction did not release its canonical locks");
+    assert_eq!(
+        initial_incarnation,
+        crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+            crate::peer::RemoteCandidateIncarnationClaim::NoReset,
+        )
+    );
+
     // A read guard makes candidate mutation need the connection writer. The
     // candidate owner must use try-write, retain the exact payload locally,
     // and ACK its durable row without joining Tokio's fair writer queue.
@@ -2180,7 +2275,7 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
                     "198.51.100.80:48000".to_string(),
                     "stun".to_string(),
                 )]),
-                candidate_generation: encoded_generation(733, 1),
+                candidate_generation: encoded_generation(733, 2),
                 candidates_expires_at_ms: None,
                 handshake_init: Vec::new(),
                 punch_at_ms: None,
@@ -2200,6 +2295,10 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
         peers.connection_map_for_test().try_read().is_ok(),
         "candidate admission queued a connection writer behind the held reader"
     );
+    assert!(
+        peers.network_epoch_gate().try_lock().is_ok(),
+        "candidate apply retained the network epoch after try-write contention"
+    );
 
     let responder_receipt = control::SignalDeliveryReceipt::pending();
     control
@@ -2216,7 +2315,7 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
                     "198.51.100.80:48000".to_string(),
                     "stun".to_string(),
                 )]),
-                candidate_generation: encoded_generation(733, 2),
+                candidate_generation: encoded_generation(733, 3),
                 candidates_expires_at_ms: None,
                 handshake_init: initiation,
                 punch_at_ms: None,
@@ -2285,6 +2384,35 @@ async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_off
         "candidate contention may produce only one exact Answer"
     );
     assert!(transport.has_session(peer_id).await);
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let candidate_committed = peers
+                .get_connection(peer_id)
+                .await
+                .is_some_and(|connection| {
+                    connection
+                        .candidates
+                        .iter()
+                        .any(|candidate| candidate == "198.51.100.80:48000")
+                });
+            let candidate_owner_finished = !pending
+                .lock()
+                .candidate_offer_workers
+                .contains_key(peer_id);
+            if candidate_committed && candidate_owner_finished {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect(
+        "candidate owner must retry, finish its handover transaction, and release the epoch",
+    );
+    assert!(
+        peers.network_epoch_gate().try_lock().is_ok(),
+        "candidate follow-up leaked the network epoch guard"
+    );
 
     let _ = shutdown.send(true);
     timeout(Duration::from_secs(1), loop_task)

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -1483,6 +1483,75 @@ fn cancelled_responder_owner_cannot_consume_a_new_offer() {
 }
 
 #[test]
+fn candidate_offer_work_is_newest_wins_owner_scoped_and_capacity_bounded() {
+    fn offer(peer_id: &str, generation: u64) -> PendingPeerOffer {
+        PendingPeerOffer {
+            from_node_id: peer_id.to_string(),
+            candidates: vec![format!("198.51.100.10:{}", 41_000 + generation)],
+            candidate_sources: HashMap::new(),
+            candidate_generation: generation,
+            network_generation: 0,
+            peer_session_generation: None,
+            candidates_expires_at_ms: None,
+            sender_public_key: Some("candidate-owner-key".to_string()),
+            handshake_init: Vec::new(),
+            punch_at_ms: None,
+            punch_at_server_ms: None,
+            session_id: None,
+            probe_ephemeral_public_key: None,
+            delivery_receipt: None,
+        }
+    }
+
+    let mut state = PendingHandshakeState::default();
+    let CandidateOfferWorkAdmission::Started(reservation, first) =
+        state.enqueue_candidate_offer_work(offer("peer-candidate-owner", 1))
+    else {
+        panic!("first candidate payload must acquire an owner");
+    };
+    assert!(matches!(
+        state.enqueue_candidate_offer_work(offer("peer-candidate-owner", 2)),
+        CandidateOfferWorkAdmission::Coalesced,
+    ));
+    assert!(matches!(
+        state.enqueue_candidate_offer_work(offer("peer-candidate-owner", 3)),
+        CandidateOfferWorkAdmission::Coalesced,
+    ));
+    assert_eq!(first.candidate_generation, 1);
+    let newest = state
+        .take_queued_candidate_offer_work("peer-candidate-owner", reservation.owner)
+        .expect("one newest-wins successor must be retained");
+    assert_eq!(newest.candidate_generation, 3);
+    assert!(state
+        .finish_candidate_offer_work("peer-candidate-owner", reservation.owner)
+        .is_none());
+
+    state.clear_peer("peer-candidate-owner");
+    let CandidateOfferWorkAdmission::Started(replacement, _) =
+        state.enqueue_candidate_offer_work(offer("peer-candidate-owner", 4))
+    else {
+        panic!("a cleared lifecycle must admit a replacement owner");
+    };
+    assert_ne!(replacement.owner, reservation.owner);
+
+    let mut full = PendingHandshakeState::default();
+    for index in 0..MAX_CANDIDATE_OFFER_WORKERS {
+        assert!(matches!(
+            full.enqueue_candidate_offer_work(offer(&format!("peer-capacity-{index}"), 1)),
+            CandidateOfferWorkAdmission::Started(_, _),
+        ));
+    }
+    assert!(matches!(
+        full.enqueue_candidate_offer_work(offer("peer-over-capacity", 1)),
+        CandidateOfferWorkAdmission::Capacity,
+    ));
+    assert_eq!(
+        full.candidate_offer_workers.len(),
+        MAX_CANDIDATE_OFFER_WORKERS
+    );
+}
+
+#[test]
 fn peer_reflexive_work_is_newest_wins_and_owner_scoped() {
     fn observation(peer_id: &str, endpoint: &str) -> PendingPeerReflexive {
         PendingPeerReflexive {
@@ -1543,11 +1612,13 @@ async fn deferred_unknown_peer_offer_replays_candidate_admission_after_peer_join
         probe_ephemeral_public_key: None,
         delivery_receipt: None,
     };
-    let (reservation, offer) = daemon
+    let CandidateOfferWorkAdmission::Started(reservation, offer) = daemon
         .pending_handshakes
         .lock()
-        .enqueue_responder_work(offer)
-        .expect("unknown offer must acquire one deferred owner");
+        .enqueue_candidate_offer_work(offer)
+    else {
+        panic!("unknown offer must acquire one deferred candidate owner");
+    };
 
     let join = async {
         sleep(Duration::from_millis(25)).await;
@@ -1568,7 +1639,7 @@ async fn deferred_unknown_peer_offer_replays_candidate_admission_after_peer_join
             .await;
     };
     tokio::join!(
-        daemon.run_deferred_peer_offer_worker(offer, reservation),
+        daemon.run_candidate_offer_worker(*offer, reservation),
         join
     );
 
@@ -1580,7 +1651,7 @@ async fn deferred_unknown_peer_offer_replays_candidate_admission_after_peer_join
     assert!(!daemon
         .pending_handshakes
         .lock()
-        .responder_workers
+        .candidate_offer_workers
         .contains_key(peer_id));
 }
 
@@ -2020,6 +2091,304 @@ async fn control_event_loop_queues_candidate_offer_while_connection_writer_is_bl
         .await
         .expect("control event loop did not stop")
         .expect("control event loop task panicked");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_offer() {
+    fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
+        0x4000_0000_0000_0000 | (incarnation << 21) | counter
+    }
+
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "candidate-hol-responder").unwrap();
+    config.control.auth_token = "candidate-hol-responder-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Daemon::new(config);
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must complete before the HOL regression");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if identity.public_key() < local_public {
+            break identity;
+        }
+    };
+    let peer_id = "peer-candidate-hol-responder";
+    let peer_info = control::PeerInfo {
+        node_id: peer_id.to_string(),
+        public_key: hex::encode(remote_identity.public_key()),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        ..control::PeerInfo::default()
+    };
+    let mut remote_initiator =
+        HandshakeInitiator::new(remote_identity.clone(), local_public, None);
+    let initiation = remote_initiator.create_initiation().unwrap().to_bytes();
+    let session_id = "candidate-hol-responder-session".to_string();
+    let probe_public_key = hex::encode(DhKeyPair::generate().public_key());
+
+    daemon.relay_available_tx.send_replace(true);
+    let control = daemon.control.clone();
+    let peers = daemon.peers.clone();
+    let pending = daemon.pending_handshakes.clone();
+    let transport = daemon.transport.clone();
+    let shutdown = daemon.shutdown_sender();
+    let start = Arc::new(tokio::sync::Barrier::new(2));
+    let loop_start = start.clone();
+    let (network_tx, _network_rx) = mpsc::channel(8);
+    let mut relay_started = false;
+    let mut daemon_task = daemon;
+    let loop_task = tokio::spawn(async move {
+        loop_start.wait().await;
+        daemon_task
+            .run_control_event_loop(&mut relay_started, network_tx)
+            .await;
+    });
+    start.wait().await;
+
+    control
+        .event_sender()
+        .send(ControlEvent::PeerJoined(peer_info))
+        .unwrap();
+    timeout(Duration::from_secs(1), async {
+        while !peers.peer_exists_sync(peer_id) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("peer lifecycle must be published before the contention edge");
+
+    // A read guard makes candidate mutation need the connection writer. The
+    // candidate owner must use try-write, retain the exact payload locally,
+    // and ACK its durable row without joining Tokio's fair writer queue.
+    let connection_reader = peers.hold_connections_reader_for_test().await;
+    let candidate_receipt = control::SignalDeliveryReceipt::pending();
+    control
+        .event_sender()
+        .send(ControlEvent::DeliveredSignal {
+            signal_id: "candidate-before-handshake".to_string(),
+            signal_seq: Some(1),
+            event: Box::new(ControlEvent::PeerOffer {
+                from_node_id: peer_id.to_string(),
+                candidates: vec!["198.51.100.80:48000".to_string()],
+                session_id: None,
+                probe_ephemeral_public_key: None,
+                candidate_sources: HashMap::from([(
+                    "198.51.100.80:48000".to_string(),
+                    "stun".to_string(),
+                )]),
+                candidate_generation: encoded_generation(733, 1),
+                candidates_expires_at_ms: None,
+                handshake_init: Vec::new(),
+                punch_at_ms: None,
+                punch_at_server_ms: None,
+                sender_public_key: Some(hex::encode(remote_identity.public_key())),
+            }),
+            receipt: candidate_receipt.clone(),
+        })
+        .unwrap();
+    assert_eq!(
+        timeout(Duration::from_secs(1), candidate_receipt.wait())
+            .await
+            .expect("candidate enqueue must commit while the reader is held"),
+        control::SignalApplyOutcome::Applied
+    );
+    assert!(
+        peers.connection_map_for_test().try_read().is_ok(),
+        "candidate admission queued a connection writer behind the held reader"
+    );
+
+    let responder_receipt = control::SignalDeliveryReceipt::pending();
+    control
+        .event_sender()
+        .send(ControlEvent::DeliveredSignal {
+            signal_id: "handshake-after-candidate".to_string(),
+            signal_seq: Some(2),
+            event: Box::new(ControlEvent::PeerOffer {
+                from_node_id: peer_id.to_string(),
+                candidates: vec!["198.51.100.80:48000".to_string()],
+                session_id: Some(session_id),
+                probe_ephemeral_public_key: Some(probe_public_key),
+                candidate_sources: HashMap::from([(
+                    "198.51.100.80:48000".to_string(),
+                    "stun".to_string(),
+                )]),
+                candidate_generation: encoded_generation(733, 2),
+                candidates_expires_at_ms: None,
+                handshake_init: initiation,
+                punch_at_ms: None,
+                punch_at_server_ms: None,
+                sender_public_key: Some(hex::encode(remote_identity.public_key())),
+            }),
+            receipt: responder_receipt.clone(),
+        })
+        .unwrap();
+
+    timeout(Duration::from_secs(1), async {
+        while !pending.lock().responder_workers.contains_key(peer_id) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("handshake must enter its independent responder owner");
+    assert_eq!(
+        responder_receipt.current(),
+        control::SignalApplyOutcome::Pending,
+        "the handshake receipt must remain exact until responder commit"
+    );
+
+    // A following marker proves the serial actor is still consuming events
+    // while both bounded workers observe connection contention.
+    let marker_receipt = control::SignalDeliveryReceipt::pending();
+    control
+        .event_sender()
+        .send(ControlEvent::DeliveredSignal {
+            signal_id: "post-handshake-marker".to_string(),
+            signal_seq: Some(3),
+            event: Box::new(ControlEvent::ServerError {
+                code: 4999,
+                message: "candidate HOL regression marker".to_string(),
+            }),
+            receipt: marker_receipt.clone(),
+        })
+        .unwrap();
+    assert_eq!(
+        timeout(Duration::from_secs(1), marker_receipt.wait())
+            .await
+            .expect("serial actor stopped behind candidate/responder contention"),
+        control::SignalApplyOutcome::Applied
+    );
+
+    drop(connection_reader);
+    assert_eq!(
+        timeout(Duration::from_secs(2), responder_receipt.wait())
+            .await
+            .expect("responder did not commit after connection contention cleared"),
+        control::SignalApplyOutcome::Applied
+    );
+    timeout(Duration::from_secs(1), control_capture.wait_for_signal_count(1))
+        .await
+        .expect("mock control did not receive the responder Answer");
+    assert_eq!(
+        control_capture
+            .signal_bodies()
+            .iter()
+            .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+            .filter(|body| {
+                body.get("type").and_then(serde_json::Value::as_str) == Some("peer_answer")
+            })
+            .count(),
+        1,
+        "candidate contention may produce only one exact Answer"
+    );
+    assert!(transport.has_session(peer_id).await);
+
+    let _ = shutdown.send(true);
+    timeout(Duration::from_secs(1), loop_task)
+        .await
+        .expect("control event loop did not stop")
+        .expect("control event loop task panicked");
+    control_capture.stop().await;
+}
+
+#[tokio::test]
+async fn remote_incarnation_cleanup_fence_prevents_no_reset_race() {
+    fn encoded_generation(incarnation: u64, counter: u64) -> u64 {
+        0x4000_0000_0000_0000 | (incarnation << 21) | counter
+    }
+
+    let config = Config::generate_default("http://127.0.0.1:1", "reset-fence").unwrap();
+    let daemon = Daemon::new(config);
+    let remote_identity = NodeIdentity::generate();
+    let peer_id = "peer-reset-fence";
+    let peer_info = control::PeerInfo {
+        node_id: peer_id.to_string(),
+        public_key: hex::encode(remote_identity.public_key()),
+        virtual_ip: "10.20.0.2".to_string(),
+        online: true,
+        ..control::PeerInfo::default()
+    };
+    daemon.peers.add_peer(&peer_info).await;
+
+    let first = encoded_generation(8_000, 1);
+    assert_eq!(
+        daemon
+            .peers
+            .try_claim_remote_candidate_incarnation_for_identity(
+                peer_id,
+                first,
+                Some(&peer_info.public_key),
+            ),
+        crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+            crate::peer::RemoteCandidateIncarnationClaim::NoReset,
+        )
+    );
+    let restart = encoded_generation(8_001, 1);
+    let (old_incarnation, claimed_incarnation) = match daemon
+        .peers
+        .try_claim_remote_candidate_incarnation_for_identity(
+            peer_id,
+            restart,
+            Some(&peer_info.public_key),
+        ) {
+        crate::peer::RemoteCandidateIncarnationTryClaim::Committed(
+            crate::peer::RemoteCandidateIncarnationClaim::Reset {
+                old_incarnation,
+                new_incarnation,
+            },
+        ) => (old_incarnation, new_incarnation),
+        outcome => panic!("restart claim was not admitted: {outcome:?}"),
+    };
+    assert!(
+        daemon
+            .pending_handshakes
+            .lock()
+            .begin_remote_incarnation_reset(peer_id, claimed_incarnation)
+    );
+
+    assert_eq!(
+        daemon
+            .reset_peer_for_remote_incarnation_if_needed_for_identity(
+                peer_id,
+                restart,
+                Some(&peer_info.public_key),
+                RemoteIncarnationResetWork::PreserveResponder,
+            )
+            .await,
+        RemoteIncarnationResetOutcome::PendingCleanup,
+        "a parallel worker must not mistake a claimed high-water for committed cleanup",
+    );
+
+    assert!(
+        daemon
+            .peers
+            .finish_claimed_remote_incarnation_reset(
+                peer_id,
+                old_incarnation,
+                claimed_incarnation,
+                "test_reset_fence",
+            )
+            .await
+    );
+    daemon
+        .pending_handshakes
+        .lock()
+        .finish_remote_incarnation_reset(peer_id, claimed_incarnation);
+    assert_eq!(
+        daemon
+            .reset_peer_for_remote_incarnation_if_needed_for_identity(
+                peer_id,
+                restart,
+                Some(&peer_info.public_key),
+                RemoteIncarnationResetWork::PreserveResponder,
+            )
+            .await,
+        RemoteIncarnationResetOutcome::Unchanged,
+        "NoReset is admissible only after the claimed cleanup commits",
+    );
 }
 
 #[tokio::test]
@@ -7828,15 +8197,17 @@ async fn stale_sender_deferred_offer_releases_owner_without_mutating_peer() {
         probe_ephemeral_public_key: None,
         delivery_receipt: None,
     };
-    let (reservation, offer) = daemon
+    let CandidateOfferWorkAdmission::Started(reservation, offer) = daemon
         .pending_handshakes
         .lock()
-        .enqueue_responder_work(offer)
-        .expect("the deferred offer must acquire an owner");
+        .enqueue_candidate_offer_work(offer)
+    else {
+        panic!("the deferred offer must acquire a candidate owner");
+    };
 
     timeout(
         Duration::from_secs(1),
-        daemon.run_deferred_peer_offer_worker(offer, reservation),
+        daemon.run_candidate_offer_worker(*offer, reservation),
     )
     .await
     .expect("the stale deferred owner must finish instead of wedging the lane");
@@ -7857,7 +8228,7 @@ async fn stale_sender_deferred_offer_releases_owner_without_mutating_peer() {
     );
     let pending = daemon.pending_handshakes.lock();
     assert!(pending.pending.contains_key(peer_id));
-    assert!(!pending.responder_workers.contains_key(peer_id));
+    assert!(!pending.candidate_offer_workers.contains_key(peer_id));
 }
 
 #[tokio::test]

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -3351,6 +3351,694 @@ async fn responder_answer_uses_cached_candidates_while_refresh_is_blocked() {
     server.abort();
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_first_packet_liveness_crosses_responder_status_and_writer_contention() {
+    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn fetch_status(address: SocketAddr) -> String {
+        let mut stream = TcpStream::connect(address).await.unwrap();
+        stream
+            .write_all(
+                b"GET /status HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer relay-liveness-test\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await.unwrap();
+        response
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap().to_string();
+    let registered = Arc::new(AtomicBool::new(false));
+    let answer_delivered = Arc::new(AtomicBool::new(false));
+    let answer_payload = Arc::new(std::sync::Mutex::new(None::<String>));
+    let server = {
+        let registered = registered.clone();
+        let answer_delivered = answer_delivered.clone();
+        let answer_payload = answer_payload.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let registered = registered.clone();
+                let answer_delivered = answer_delivered.clone();
+                let answer_payload = answer_payload.clone();
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut chunk = [0u8; 4096];
+                    let header_end = loop {
+                        let Ok(read) = stream.read(&mut chunk).await else {
+                            return;
+                        };
+                        if read == 0 {
+                            return;
+                        }
+                        request.extend_from_slice(&chunk[..read]);
+                        if let Some(position) = request
+                            .windows(4)
+                            .position(|window| window == b"\r\n\r\n")
+                        {
+                            break position + 4;
+                        }
+                    };
+                    let head = String::from_utf8_lossy(&request[..header_end]).into_owned();
+                    let content_length = head
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length:")
+                                .and_then(|value| value.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    while request.len() < header_end + content_length {
+                        let Ok(read) = stream.read(&mut chunk).await else {
+                            return;
+                        };
+                        if read == 0 {
+                            break;
+                        }
+                        request.extend_from_slice(&chunk[..read]);
+                    }
+                    let body = String::from_utf8_lossy(
+                        &request[header_end..request.len().min(header_end + content_length)],
+                    );
+                    let (status_body, registration) = if head.contains("/api/v1/devices") {
+                        (
+                            r#"{"success":true,"node_id":"node-local","virtual_ip":"10.20.0.1","cidr":"10.20.0.0/16","relay_servers":[]}"#,
+                            true,
+                        )
+                    } else if head.contains("/api/v1/signals") && head.starts_with("POST") {
+                        if body.contains("\"type\":\"peer_answer\"") {
+                            answer_delivered.store(true, AtomicOrdering::SeqCst);
+                            *answer_payload
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                                Some(body.into_owned());
+                        }
+                        (r#"{"success":true,"protocol_version":1}"#, false)
+                    } else {
+                        (r#"{"signals":[],"server_time_ms":0}"#, false)
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        status_body.len(),
+                        status_body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    if registration {
+                        registered.store(true, AtomicOrdering::SeqCst);
+                    }
+                });
+            }
+        })
+    };
+
+    let mut config = Config::generate_default(&format!("http://{address}"), "net1").unwrap();
+    config.control.auth_token = "test-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(3), async {
+        while !registered.load(AtomicOrdering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("daemon did not register with mock control");
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let remote_identity = loop {
+        let identity = NodeIdentity::generate();
+        if identity.public_key() < local_public {
+            break identity;
+        }
+    };
+    let peer_id = "node-remote";
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: peer_id.to_string(),
+            public_key: hex::encode(remote_identity.public_key()),
+            virtual_ip: "10.20.0.2".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+    daemon.relay_available_tx.send_replace(true);
+
+    let relay_server = p2pnet_relay::RelayServer::start_random().await.unwrap();
+    let relay_endpoint = relay_server.addr.to_string();
+    let (local_relay, local_relay_rx) = RelayTransport::connect(
+        &relay_endpoint,
+        "node-local",
+        daemon.peers.clone(),
+    )
+    .await
+    .unwrap();
+    let local_relay_connection_id = local_relay.connection_id();
+    let relay_slot = Arc::new(RwLock::new(Some(local_relay.clone())));
+    let (remote_relay, mut remote_relay_rx) =
+        p2pnet_relay::RelayClient::connect(&relay_endpoint, peer_id)
+            .await
+            .unwrap();
+    let remote_peers = Arc::new(PeerManager::new(
+        Config::generate_default("https://ctrl.test", "net1").unwrap(),
+    ));
+    remote_peers
+        .add_peer(&control::PeerInfo {
+            node_id: "node-local".to_string(),
+            public_key: hex::encode(local_public),
+            virtual_ip: "10.20.0.1".to_string(),
+            online: true,
+            ..control::PeerInfo::default()
+        })
+        .await;
+
+    // Serve the real diagnostics endpoint against this daemon state and prime
+    // its validated snapshot before introducing a fair-queue writer.
+    let diag_probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let diag_address = diag_probe.local_addr().unwrap();
+    drop(diag_probe);
+    let (diag_shutdown_tx, diag_shutdown_rx) = tokio::sync::watch::channel(false);
+    let diagnostics_context = DiagnosticsContext::new(
+        daemon.config.clone(),
+        daemon.peers.clone(),
+        daemon.udp_transport.clone(),
+        daemon.candidate_snapshot.clone(),
+        daemon.nat_profile.clone(),
+        daemon.gateway_mapping_diagnostics.clone(),
+        relay_slot.clone(),
+        daemon.relay_selection.clone(),
+        daemon.health.clone(),
+        daemon.task_manager.clone(),
+        daemon.route_manager.clone(),
+        diag_shutdown_tx.clone(),
+        daemon.timeline.clone(),
+        daemon.status_events.clone(),
+        None,
+        Some("relay-liveness-test".to_string()),
+    );
+    let (diag_ready_tx, diag_ready_rx) = tokio::sync::oneshot::channel();
+    let diagnostics_worker = tokio::spawn(run_diagnostics_server_with_retry_ready(
+        diag_address.to_string(),
+        diagnostics_context,
+        diag_shutdown_rx,
+        Some(diag_ready_tx),
+    ));
+    timeout(Duration::from_secs(1), diag_ready_rx)
+        .await
+        .expect("diagnostics listener did not bind")
+        .expect("diagnostics listener dropped readiness");
+    let initial_status = fetch_status(diag_address).await;
+    assert!(initial_status.starts_with("HTTP/1.1 200 OK"));
+
+    let mut remote_initiator =
+        HandshakeInitiator::new(remote_identity, local_public, None);
+    let initiation = remote_initiator.create_initiation().unwrap().to_bytes();
+    let session_id = "post-answer-contention-owner".to_string();
+    let probe_public = hex::encode(DhKeyPair::generate().public_key());
+    let gate = Arc::new(ResponderPostAnswerTestGate::new());
+    daemon.install_responder_post_answer_gate_for_test(peer_id, gate.clone());
+
+    let offer_worker = tokio::spawn({
+        let daemon = daemon.clone();
+        let peer_id = peer_id.to_string();
+        let session_id = session_id.clone();
+        async move {
+            daemon
+                .handle_peer_offer(
+                    &peer_id,
+                    &[],
+                    &initiation,
+                    None,
+                    None,
+                    Some(session_id),
+                    Some(probe_public),
+                )
+                .await
+        }
+    });
+
+    timeout(Duration::from_secs(3), gate.reached.notified())
+        .await
+        .expect("responder did not reach the post-answer grace boundary");
+    assert!(
+        answer_delivered.load(AtomicOrdering::SeqCst),
+        "the controlled pause must occur only after answer delivery succeeded"
+    );
+    let status = daemon.transport.session_status(peer_id).await;
+    assert!(status.has_pending_responder);
+    assert!(!status.has_active);
+
+    let answer_json = answer_payload
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .expect("mock control did not retain the delivered answer");
+    let answer_json: serde_json::Value = serde_json::from_str(&answer_json).unwrap();
+    let response_wire = hex::decode(
+        answer_json
+            .get("handshake")
+            .and_then(serde_json::Value::as_str)
+            .expect("answer did not contain the WireGuard response"),
+    )
+    .unwrap();
+    let response = MessageResponse::from_bytes(&response_wire).unwrap();
+    let mut remote_session =
+        TransportSession::new(remote_initiator.consume_response(&response).unwrap());
+
+    let (encrypted_tx, encrypted_rx) = mpsc::channel(8);
+    let relay_reader = tokio::spawn(local_relay.clone().run_inbound(
+        local_relay_rx,
+        encrypted_tx,
+        None,
+    ));
+    let (inbound_tx, mut inbound_rx) = mpsc::channel(8);
+    let (_udp_tx, udp_updates) = watch::channel(None);
+    let inbound_worker = tokio::spawn({
+        let transport = daemon.transport.clone();
+        let peers = daemon.peers.clone();
+        let evidence = InboundEvidenceFeed {
+            relay_transport: relay_slot.clone(),
+            timeline: Some(daemon.timeline.clone()),
+            overlay_ingress_tx: None,
+        };
+        async move {
+            transport
+                .run_inbound_with_peers_live_udp_and_relay(
+                    encrypted_rx,
+                    inbound_tx,
+                    Some(peers),
+                    udp_updates,
+                    Some(evidence),
+                )
+                .await
+        }
+    });
+    let build_probe = |kind, generation, request_id, owner_token| {
+        Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 2),
+            Ipv4Addr::new(10, 20, 0, 1),
+            request_id,
+            1,
+            &crate::relay_probe::build_relay_probe_payload(
+                kind,
+                generation,
+                request_id,
+                owner_token,
+            ),
+        )
+    };
+
+    // The Answer has been delivered but its responder owner is paused. Hold a
+    // production connection snapshot and send the first encrypted Probe over
+    // an actual relay client/server/reader chain. The pending receive key must
+    // promote and ACK even though every connection transaction contends.
+    let connection_reader = daemon.peers.connection_map_for_test().read_owned().await;
+    let first_request = build_probe(crate::relay_probe::RelayProbeKind::Request, 0, 1, 0x11);
+    remote_relay
+        .send_data(
+            "node-local",
+            &remote_session.encrypt_to_bytes(&first_request).unwrap(),
+        )
+        .await
+        .unwrap();
+    let first_ack = timeout(Duration::from_secs(1), remote_relay_rx.recv())
+        .await
+        .expect("first Relay Probe ACK stalled behind the connection reader")
+        .expect("remote relay registration closed");
+    let first_ack_wire = match first_ack {
+        p2pnet_relay::RelayMessage::Data { from_node, data } => {
+            assert_eq!(from_node, "node-local");
+            data
+        }
+        other => panic!("expected encrypted Relay Probe ACK, got {other:?}"),
+    };
+    let first_ack_packet = remote_session
+        .decrypt_from_bytes(&first_ack_wire)
+        .expect("first Relay Probe ACK did not use the promoted responder key");
+    let first_ack_token = crate::relay_probe::parse_relay_probe_token(&first_ack_packet)
+        .expect("first Relay response was not a typed Probe ACK");
+    assert_eq!(
+        first_ack_token.kind,
+        crate::relay_probe::RelayProbeKind::Ack
+    );
+    let status = daemon.transport.session_status(peer_id).await;
+    assert!(status.has_active, "first Probe did not promote pending session");
+    assert!(!status.has_pending_responder);
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let events = daemon.timeline.snapshot().events;
+            if events
+                .iter()
+                .any(|event| event.event == "relay_probe_ack_sent")
+                && events.iter().any(|event| {
+                    event.event == "relay_ready_connections_contended"
+                        && event.reason_code.as_deref()
+                            == Some("fair_rwlock_writer_unavailable")
+                })
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first Relay Probe did not finish its non-queuing ACK path");
+    assert!(
+        daemon.peers.try_all_connections().is_some(),
+        "first-packet handling queued a connection writer"
+    );
+
+    // Add a real queued writer behind the retained reader. Tokio's fair RwLock
+    // now rejects every new reader; /status must serve its validated cache as
+    // HTTP 200, and the responder must still reach its session commit after
+    // its controlled gate is released.
+    let writer_started = Arc::new(tokio::sync::Notify::new());
+    let queued_writer = tokio::spawn({
+        let peers = daemon.peers.clone();
+        let writer_started = writer_started.clone();
+        async move {
+            writer_started.notify_one();
+            let _writer = peers.hold_connections_writer_for_test().await;
+        }
+    });
+    writer_started.notified().await;
+    for _ in 0..64 {
+        if daemon.peers.try_all_connections().is_none() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(daemon.peers.try_all_connections().is_none());
+    let contended_status = timeout(Duration::from_millis(250), fetch_status(diag_address))
+        .await
+        .expect("/status waited behind the fairly queued connection writer");
+    assert!(contended_status.starts_with("HTTP/1.1 200 OK"));
+    let contended_status_json: serde_json::Value = serde_json::from_str(
+        contended_status
+            .split("\r\n\r\n")
+            .nth(1)
+            .expect("status response had no body"),
+    )
+    .unwrap();
+    assert_eq!(
+        contended_status_json
+            .get("peer_snapshot_stale")
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+
+    gate.release.wait().await;
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let events = daemon.timeline.snapshot().events;
+            let contended = events.iter().any(|event| {
+                event.event == "peer_answer_probe_binding_grace_result"
+                    && event.reason_code.as_deref()
+                        == Some("fair_rwlock_writer_unavailable")
+            });
+            let committed = events
+                .iter()
+                .any(|event| event.event == "peer_answer_commit_result");
+            if contended && committed {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("responder commit stalled behind connection contention");
+    let status = daemon.transport.session_status(peer_id).await;
+    assert!(status.has_active);
+    assert!(!status.has_pending_responder);
+
+    drop(connection_reader);
+    timeout(Duration::from_secs(1), queued_writer)
+        .await
+        .expect("connection writer remained queued after reader release")
+        .expect("connection writer task panicked");
+    timeout(Duration::from_secs(1), offer_worker)
+        .await
+        .expect("responder did not finish after controlled reader release")
+        .expect("responder task panicked")
+        .expect("responder failed");
+    let events = daemon.timeline.snapshot().events;
+    assert!(events
+        .iter()
+        .any(|event| event.event == "peer_answer_control_accepted"));
+    assert!(events
+        .iter()
+        .any(|event| event.event == "peer_answer_committed"));
+
+    // A later independently encrypted Probe retries the contended ready and
+    // Probe-binding transactions after the reader exits.
+    let second_request = build_probe(crate::relay_probe::RelayProbeKind::Request, 0, 2, 0x22);
+    remote_relay
+        .send_data(
+            "node-local",
+            &remote_session.encrypt_to_bytes(&second_request).unwrap(),
+        )
+        .await
+        .unwrap();
+    let second_ack = timeout(Duration::from_secs(1), remote_relay_rx.recv())
+        .await
+        .expect("retry Relay Probe did not receive an ACK")
+        .expect("remote relay registration closed during retry");
+    match second_ack {
+        p2pnet_relay::RelayMessage::Data { data, .. } => {
+            remote_session
+                .decrypt_from_bytes(&data)
+                .expect("retry Relay Probe ACK did not decrypt");
+        }
+        other => panic!("expected retry Relay Probe ACK, got {other:?}"),
+    }
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let connection = daemon.peers.get_connection(peer_id).await.unwrap();
+            if connection.relay_ready_connection_id == Some(local_relay_connection_id)
+                && daemon.peers.probe_key_for_peer(peer_id).await.is_some()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("retry Probe did not commit ready and Probe binding");
+    let local_connection = daemon.peers.get_connection(peer_id).await.unwrap();
+    assert_eq!(
+        local_connection.relay_ready_connection_id,
+        Some(local_relay_connection_id)
+    );
+    assert!(daemon.peers.probe_key_for_peer(peer_id).await.is_some());
+
+    // The first real ACK confirms the opposite endpoint, and a matching ACK
+    // delivered back through the same local Relay incarnation confirms this
+    // endpoint. Both selectors must remain Relay (never Direct).
+    let remote_connection_id = 0x7001;
+    remote_peers
+        .mark_relay_transport_ready_with_transport(
+            "node-local",
+            &relay_endpoint,
+            0,
+            Some(remote_connection_id),
+        )
+        .await;
+    remote_peers.register_relay_probe_expectation_for_transport(
+        "node-local",
+        0,
+        1,
+        0x11,
+        &relay_endpoint,
+        remote_connection_id,
+    );
+    assert!(
+        remote_peers
+            .consume_relay_probe_ack_with_transport(
+                "node-local",
+                first_ack_token,
+                &relay_endpoint,
+                Some(remote_connection_id),
+            )
+            .await
+    );
+    assert!(
+        daemon
+            .peers
+            .register_relay_probe_expectation_for_transport(
+            peer_id,
+            0,
+            3,
+            0x33,
+            &relay_endpoint,
+            local_relay_connection_id,
+        )
+    );
+    let local_ack = build_probe(crate::relay_probe::RelayProbeKind::Ack, 0, 3, 0x33);
+    let local_confirmation = timeout(Duration::from_secs(1), async {
+        // Contention is retryable, not rejection: production's forced Probe
+        // loop emits independently encrypted ACKs. Exercise that exact rule
+        // without sleeping until one short transaction wins the map.
+        for _ in 0..32 {
+            if daemon.peers.is_relay_peer_confirmed(peer_id).await {
+                return;
+            }
+            remote_relay
+                .send_data(
+                    "node-local",
+                    &remote_session.encrypt_to_bytes(&local_ack).unwrap(),
+                )
+                .await
+                .unwrap();
+            for _ in 0..64 {
+                if daemon.peers.is_relay_peer_confirmed(peer_id).await {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+        loop {
+            if daemon.peers.is_relay_peer_confirmed(peer_id).await {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        local_confirmation.is_ok(),
+        "matching Relay ACK did not confirm the local endpoint; events={:?} connection={:?} expectation_present={}",
+        daemon
+            .timeline
+            .snapshot()
+            .events
+            .iter()
+            .map(|event| (
+                event.event.as_str(),
+                event.reason_code.as_deref(),
+                event.detail.as_deref()
+            ))
+            .collect::<Vec<_>>(),
+        daemon.peers.get_connection(peer_id).await,
+        daemon.peers.relay_probe_expectation_present(peer_id),
+    );
+    assert!(daemon.peers.is_relay_peer_confirmed(peer_id).await);
+    assert!(remote_peers.is_relay_peer_confirmed("node-local").await);
+    assert!(!daemon.peers.is_direct(peer_id).await);
+    assert!(!remote_peers.is_direct("node-local").await);
+    assert_eq!(
+        daemon
+            .peers
+            .get_connection(peer_id)
+            .await
+            .unwrap()
+            .active_path(),
+        Some(NetworkPath::Relay)
+    );
+    assert_eq!(
+        remote_peers
+            .get_connection("node-local")
+            .await
+            .unwrap()
+            .active_path(),
+        Some(NetworkPath::Relay)
+    );
+
+    // A normal business packet follows the same real Relay reader and reaches
+    // the inbound business queue; control Probe frames never leak there.
+    let business_packet = Ipv4Packet::build_icmp_echo_request(
+        Ipv4Addr::new(10, 20, 0, 2),
+        Ipv4Addr::new(10, 20, 0, 1),
+        9,
+        1,
+        b"relay-business-after-confirmation",
+    );
+    remote_relay
+        .send_data(
+            "node-local",
+            &remote_session.encrypt_to_bytes(&business_packet).unwrap(),
+        )
+        .await
+        .unwrap();
+    let business_ingress = timeout(Duration::from_secs(1), inbound_rx.recv())
+        .await
+        .expect("business Relay frame accumulated in the inbound actor")
+        .expect("business inbound queue closed");
+    assert_eq!(business_ingress.peer_id, peer_id);
+    assert_eq!(business_ingress.packet, business_packet);
+    assert!(inbound_rx.try_recv().is_err(), "control Probe leaked to TUN");
+
+    // Generation retirement revokes the current proof. A subsequently
+    // decrypted old-generation request is drained and answered idempotently,
+    // but cannot recreate RelayPeerConfirmed in the new generation.
+    assert_eq!(
+        daemon
+            .peers
+            .advance_network_generation("relay first-packet stale-event fence")
+            .await,
+        1
+    );
+    let stale_request = build_probe(crate::relay_probe::RelayProbeKind::Request, 0, 4, 0x44);
+    remote_relay
+        .send_data(
+            "node-local",
+            &remote_session.encrypt_to_bytes(&stale_request).unwrap(),
+        )
+        .await
+        .unwrap();
+    let stale_response = timeout(Duration::from_secs(1), remote_relay_rx.recv())
+        .await
+        .expect("old-generation request accumulated in the inbound actor")
+        .expect("remote relay registration closed during stale-event fence");
+    let stale_response = match stale_response {
+        p2pnet_relay::RelayMessage::Data { data, .. } => remote_session
+            .decrypt_from_bytes(&data)
+            .expect("old-generation idempotent ACK did not decrypt"),
+        other => panic!("expected old-generation idempotent ACK, got {other:?}"),
+    };
+    let stale_response = crate::relay_probe::parse_relay_probe_token(&stale_response)
+        .expect("old-generation response was not a Probe ACK");
+    assert_eq!(stale_response.kind, crate::relay_probe::RelayProbeKind::Ack);
+    assert_eq!(stale_response.generation, 0);
+    assert!(
+        !daemon.peers.is_relay_peer_confirmed(peer_id).await,
+        "old-generation request recreated RelayPeerConfirmed"
+    );
+
+    let final_status = timeout(Duration::from_millis(250), fetch_status(diag_address))
+        .await
+        .expect("/status did not recover after connection contention");
+    assert!(final_status.starts_with("HTTP/1.1 200 OK"));
+    let session_status = daemon.transport.session_status(peer_id).await;
+    assert!(session_status.has_active);
+    assert!(!session_status.has_pending_responder);
+
+    remote_relay.close().await.unwrap();
+    local_relay.abort_writer();
+    let _ = timeout(Duration::from_secs(1), relay_reader)
+        .await
+        .expect("Relay reader task leaked")
+        .expect("Relay reader task panicked");
+    timeout(Duration::from_secs(1), inbound_worker)
+        .await
+        .expect("WireGuard inbound actor leaked")
+        .expect("WireGuard inbound actor panicked")
+        .expect("WireGuard inbound actor failed");
+    diag_shutdown_tx.send_replace(true);
+    timeout(Duration::from_secs(1), diagnostics_worker)
+        .await
+        .expect("diagnostics task leaked")
+        .expect("diagnostics task panicked")
+        .expect("diagnostics task failed");
+
+    server.abort();
+    let _ = server.await;
+    relay_server.shutdown().await;
+}
+
 #[tokio::test]
 async fn test_network_outbound_relay_wait_timeout_emits_reason_and_never_delivers() {
     let server = p2pnet_relay::RelayServer::start_random().await.unwrap();

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -403,6 +403,17 @@ pub enum CandidateSetApplyResult {
     PeerMissing,
 }
 
+/// Non-queuing candidate-set transaction used by bounded control workers.
+/// The worker retains the exact newest-wins payload on contention instead of
+/// joining the writer-preferred connection-map queue while owning the network
+/// epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CandidateSetTryApplyOutcome {
+    Completed(CandidateSetApplyResult),
+    ContendedEpoch,
+    ContendedConnections,
+}
+
 /// Admission result for the identity-bound remote-incarnation preflight.
 ///
 /// A signal whose server-bound sender key no longer matches the peer's current

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -58,6 +58,12 @@ pub const DIRECT_RETRY_BASE_INTERVAL: Duration = Duration::from_secs(1);
 /// running during this window; if the relay peer ACK does not arrive, a
 /// genuinely encrypted-confirmed Direct path is the bounded fallback.
 pub(crate) const RELAY_FIRST_CONFIRMATION_GRACE: Duration = Duration::from_secs(3);
+/// A decrypted Relay business packet has already crossed WireGuard's replay
+/// window, so lock contention cannot be allowed to discard its evidence.  The
+/// ledger is deliberately short-lived and process-bounded: later authenticated
+/// frames retry the exact lifecycle transaction, while stale entries expire.
+const PENDING_RELAY_BUSINESS_EVIDENCE_TTL: Duration = Duration::from_secs(3);
+const MAX_PENDING_RELAY_BUSINESS_EVIDENCE: usize = 1024;
 const DIRECT_RETRY_BACKOFF_MAX_EXPONENT: u32 = 3;
 const DIRECT_TO_RELAY_HYSTERESIS_MARGIN: i32 = 15;
 const DIRECT_CONFIRMED_MIN_SCORE: i32 = 60;
@@ -333,6 +339,45 @@ pub(crate) enum RelayReadyCommitOutcome {
     ContendedEpoch,
     ContendedConnections,
     Rejected,
+}
+
+/// Result of atomically committing authenticated Relay business evidence from
+/// the serial WireGuard inbound actor.  Contention outcomes retain the exact
+/// packet evidence in the bounded manager ledger and never join an async lock
+/// queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayBusinessEvidenceCommitOutcome {
+    Committed,
+    AlreadyCurrent,
+    PendingConfirmation,
+    ContendedEpoch,
+    ContendedConnections,
+    RejectedLifecycle,
+}
+
+/// Result of committing a matched path-commit ACK without queuing behind the
+/// network epoch or connection map.  The expectation is consumed only for the
+/// two successful outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathCommitCommitOutcome {
+    Committed,
+    AlreadyCurrent,
+    ContendedEpoch,
+    ContendedConnections,
+    RejectedLifecycle,
+}
+
+/// Exact authenticated Relay business evidence retained across a contended
+/// connection transaction.  There is at most one newest-wins entry per peer.
+#[derive(Debug, Clone)]
+struct PendingRelayBusinessEvidence {
+    peer_id: String,
+    network_generation: u64,
+    peer_session_generation: PeerSessionGeneration,
+    wireguard_session_instance: u64,
+    relay_endpoint: String,
+    relay_connection_id: Option<u64>,
+    received_at: Instant,
 }
 
 /// Result of mutating a staged responder Probe-v2 binding without joining

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -322,6 +322,29 @@ pub(crate) enum ProbeBindingStage {
     PeerMissing,
 }
 
+/// Result of a relay-ready commit attempted from the serial WireGuard
+/// ingress actor.  Contention is deliberately distinct from rejection: the
+/// relay probe loop or a later authenticated frame may retry a contended
+/// transaction, while a rejected lifecycle must never be resurrected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayReadyCommitOutcome {
+    Committed,
+    AlreadyCurrent,
+    ContendedEpoch,
+    ContendedConnections,
+    Rejected,
+}
+
+/// Result of mutating a staged responder Probe-v2 binding without joining
+/// the writer-preferred connection-map wait queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PendingProbeBindingCommitOutcome {
+    Committed,
+    AlreadyCurrent,
+    ContendedConnections,
+    Missing,
+}
+
 /// Outcome of applying a versioned candidate signal from the control plane.
 ///
 /// Callers use this to avoid starting a synchronized punch for a signal whose

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -412,11 +412,23 @@ pub enum CandidateSetApplyResult {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteCandidateIncarnationClaim {
     IdentityMismatch,
+    RejectedLifecycle,
     NoReset,
     Reset {
         old_incarnation: u64,
         new_incarnation: u64,
     },
+}
+
+/// Non-queuing form of the remote-incarnation preflight used by inbound
+/// control workers.  Contention is explicit: callers retain their bounded
+/// owner and retry instead of joining the fair connection-writer queue and
+/// blocking later handshake signals behind it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteCandidateIncarnationTryClaim {
+    Committed(RemoteCandidateIncarnationClaim),
+    ContendedEpoch,
+    ContendedConnections,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/client/daemon/src/peer/connection/core.rs
+++ b/client/daemon/src/peer/connection/core.rs
@@ -22,18 +22,6 @@ struct PendingProbeSessionBinding {
     promote_on_match: bool,
 }
 
-/// A real decrypted relay business packet can arrive a few milliseconds
-/// before this daemon receives the matching encrypted relay-probe ACK.  Keep
-/// only that bounded evidence tuple so the later confirmation can complete
-/// the proof without replaying the WireGuard ciphertext.
-#[derive(Debug, Clone)]
-pub(crate) struct PendingRelayBusinessEvidence {
-    pub generation: u64,
-    pub relay_endpoint: String,
-    pub relay_connection_id: Option<u64>,
-    pub received_at: Instant,
-}
-
 /// The relay-first business gate state for one peer connection.
 ///
 /// This is the set of fields that describe relay-first startup/fallback
@@ -82,11 +70,6 @@ pub(crate) struct RelayFirstBusinessState {
     /// already-established Direct path must not be demoted and forced to
     /// repeat the initial relay-first gate.
     pub business_gate_completed_generation: Option<u64>,
-    /// Real relay business ingress observed before local RelayPeerConfirmed.
-    /// It is promoted only when the later confirmation matches generation,
-    /// endpoint and transport incarnation; relay transport renewal clears the
-    /// pending tuple, while a generation/session reset clears all gate state.
-    pub(crate) preconfirmation: Option<PendingRelayBusinessEvidence>,
 }
 
 /// No-await, generation-bound projection of one peer's committed business

--- a/client/daemon/src/peer/connection/health.rs
+++ b/client/daemon/src/peer/connection/health.rs
@@ -436,7 +436,6 @@ impl PeerConnection {
             self.relay_first.business_received_generation = None;
             self.relay_first.business_exchange_generation = None;
             self.relay_first.business_pathcommit_generation = None;
-            self.relay_first.preconfirmation = None;
         }
         if self.relay_first.gate_generation != Some(local_generation) {
             self.relay_first.gate_generation = None;
@@ -451,7 +450,6 @@ impl PeerConnection {
             self.relay_first.business_received_generation = None;
             self.relay_first.business_exchange_generation = None;
             self.relay_first.business_pathcommit_generation = None;
-            self.relay_first.preconfirmation = None;
             self.relay_confirm_seq = self.relay_confirm_seq.wrapping_add(1);
         }
         self.candidate_pairs
@@ -684,7 +682,6 @@ impl PeerConnection {
             self.relay_first.business_received_generation = None;
             self.relay_first.business_exchange_generation = None;
             self.relay_first.business_pathcommit_generation = None;
-            self.relay_first.preconfirmation = None;
             self.relay_first.gate_generation = None;
             self.relay_first.gate_started_at = None;
         } else {
@@ -696,7 +693,6 @@ impl PeerConnection {
             self.relay_first.business_received_generation = None;
             self.relay_first.business_exchange_generation = None;
             self.relay_first.business_pathcommit_generation = None;
-            self.relay_first.preconfirmation = None;
             self.relay_first.gate_generation = None;
             self.relay_first.gate_started_at = None;
         }

--- a/client/daemon/src/peer/manager/candidates/signaled.rs
+++ b/client/daemon/src/peer/manager/candidates/signaled.rs
@@ -35,16 +35,25 @@ impl PeerManager {
         candidate_generation: u64,
         candidates_expires_at_ms: Option<u64>,
     ) -> CandidateSetApplyResult {
-        self.add_candidates_with_metadata_for_identity_with_hard_hard_retire(
-            node_id,
-            candidates,
-            candidate_sources,
-            candidate_generation,
-            candidates_expires_at_ms,
-            None,
-            true,
-        )
-        .await
+        match self
+            .add_candidates_with_metadata_for_identity_with_hard_hard_retire(
+                node_id,
+                candidates,
+                candidate_sources,
+                candidate_generation,
+                candidates_expires_at_ms,
+                None,
+                true,
+                false,
+            )
+            .await
+        {
+            CandidateSetTryApplyOutcome::Completed(result) => result,
+            CandidateSetTryApplyOutcome::ContendedEpoch
+            | CandidateSetTryApplyOutcome::ContendedConnections => {
+                unreachable!("blocking candidate transaction returned contention")
+            }
+        }
     }
 
     /// Identity-bound candidate apply used by control-plane signals.
@@ -62,6 +71,42 @@ impl PeerManager {
         candidates_expires_at_ms: Option<u64>,
         sender_public_key: Option<&str>,
     ) -> CandidateSetApplyResult {
+        match self
+            .add_candidates_with_metadata_for_identity_with_hard_hard_retire(
+                node_id,
+                candidates,
+                candidate_sources,
+                candidate_generation,
+                candidates_expires_at_ms,
+                sender_public_key,
+                false,
+                false,
+            )
+            .await
+        {
+            CandidateSetTryApplyOutcome::Completed(result) => result,
+            CandidateSetTryApplyOutcome::ContendedEpoch
+            | CandidateSetTryApplyOutcome::ContendedConnections => {
+                unreachable!("blocking candidate transaction returned contention")
+            }
+        }
+    }
+
+    /// Apply one identity-bound control-plane candidate revision without
+    /// queueing on either canonical lifecycle lock. The caller owns the
+    /// bounded newest-wins retry ledger. Once both guards are acquired, the
+    /// existing epoch fence remains held through the post-commit cancellation
+    /// transaction, but connection-lock contention is never awaited while
+    /// that epoch fence is owned.
+    pub(crate) async fn try_add_candidates_with_metadata_for_identity(
+        &self,
+        node_id: &str,
+        candidates: &[String],
+        candidate_sources: &HashMap<String, String>,
+        candidate_generation: u64,
+        candidates_expires_at_ms: Option<u64>,
+        sender_public_key: Option<&str>,
+    ) -> CandidateSetTryApplyOutcome {
         self.add_candidates_with_metadata_for_identity_with_hard_hard_retire(
             node_id,
             candidates,
@@ -70,6 +115,7 @@ impl PeerManager {
             candidates_expires_at_ms,
             sender_public_key,
             false,
+            true,
         )
         .await
     }
@@ -84,16 +130,40 @@ impl PeerManager {
         candidates_expires_at_ms: Option<u64>,
         sender_public_key: Option<&str>,
         retire_hard_hard: bool,
-    ) -> CandidateSetApplyResult {
+        non_queuing: bool,
+    ) -> CandidateSetTryApplyOutcome {
         let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
+        let (_epoch_guard, mut connections) = loop {
+            let epoch_guard = if non_queuing {
+                let Ok(guard) = epoch_gate.try_lock() else {
+                    return CandidateSetTryApplyOutcome::ContendedEpoch;
+                };
+                guard
+            } else {
+                epoch_gate.lock().await
+            };
+            match self.connections.try_write() {
+                Ok(connections) => break (epoch_guard, connections),
+                Err(_) if non_queuing => {
+                    return CandidateSetTryApplyOutcome::ContendedConnections;
+                }
+                Err(_) => {
+                    // Preserve the canonical epoch -> connections order for
+                    // mutation, but never join Tokio's writer queue while the
+                    // epoch is held. Taking and immediately releasing a writer
+                    // turn without the epoch lets an older reader finish its
+                    // epoch-fenced work before this transaction retries.
+                    drop(epoch_guard);
+                    drop(self.connections.write().await);
+                }
+            }
+        };
         let generation = self.current_network_generation_sync();
         let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
-            return CandidateSetApplyResult::PeerMissing;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::PeerMissing);
         };
-        let mut connections = self.connections.write().await;
         let Some(conn) = connections.get_mut(node_id) else {
-            return CandidateSetApplyResult::PeerMissing;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::PeerMissing);
         };
         if sender_public_key.map(str::trim).is_some_and(|public_key| {
             public_key.is_empty() || conn.public_key.trim() != public_key
@@ -106,7 +176,7 @@ impl PeerManager {
                 None,
                 "ignored candidate signal bound to a retired sender public key",
             );
-            return CandidateSetApplyResult::IgnoredStale;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredStale);
         }
         let valid_candidates = candidates
             .iter()
@@ -122,7 +192,7 @@ impl PeerManager {
                 None,
                 "ignored empty or entirely invalid signaled UDP candidate set",
             );
-            return CandidateSetApplyResult::IgnoredEmpty;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredEmpty);
         }
 
         let now_ms = SystemTime::now()
@@ -141,7 +211,7 @@ impl PeerManager {
                 None,
                 "ignored expired signaled UDP candidate set",
             );
-            return CandidateSetApplyResult::IgnoredExpired;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredExpired);
         }
         let candidate_incarnation =
             crate::control::candidate_generation_incarnation(candidate_generation);
@@ -156,7 +226,7 @@ impl PeerManager {
                     "ignored malformed incarnation-encoded candidate generation {candidate_generation}"
                 ),
             );
-            return CandidateSetApplyResult::IgnoredStale;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredStale);
         }
         if candidate_incarnation.is_some_and(|incoming| {
             conn.remote_candidate_incarnation_high_water
@@ -172,7 +242,7 @@ impl PeerManager {
                     "ignored candidate generation {candidate_generation} from a retired remote incarnation"
                 ),
             );
-            return CandidateSetApplyResult::IgnoredStale;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredStale);
         }
         if candidate_generation != 0 && candidate_generation <= conn.last_candidate_generation {
             conn.record_direct_event(
@@ -183,7 +253,7 @@ impl PeerManager {
                 None,
                 format!("ignored stale candidate generation {candidate_generation}"),
             );
-            return CandidateSetApplyResult::IgnoredStale;
+            return CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::IgnoredStale);
         }
         if candidate_generation != 0 {
             conn.last_candidate_generation = candidate_generation;
@@ -386,7 +456,7 @@ impl PeerManager {
                 self.clear_hard_hard_sessions(Some(node_id)).await;
             }
         }
-        CandidateSetApplyResult::Applied
+        CandidateSetTryApplyOutcome::Completed(CandidateSetApplyResult::Applied)
     }
 
 }

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -76,6 +76,7 @@ impl PeerManager {
             relay_confirm_seq_mirror: Arc::new(std::sync::Mutex::new(HashMap::new())),
             relay_confirm_notify: Arc::new(Notify::new()),
             relay_probe_expectations: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            pending_relay_business_evidence: Arc::new(std::sync::Mutex::new(HashMap::new())),
             path_commit_expectations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             quarantined_peers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             quarantine_deadline_mirror: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -43,6 +43,7 @@ impl PeerManager {
             ip_to_node: Arc::new(RwLock::new(HashMap::new())),
             network_generation: Arc::new(RwLock::new(0)),
             network_generation_sync: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            network_generation_handshake_cancel_hook: Arc::new(std::sync::Mutex::new(None)),
             network_epoch_gate: Arc::new(tokio::sync::Mutex::new(())),
             direct_validation_registry: Arc::new(RwLock::new(None)),
             dplpmtud_runtime: Arc::new(RwLock::new(None)),
@@ -761,6 +762,8 @@ impl PeerManager {
                 .store(*generation, std::sync::atomic::Ordering::Release);
             *generation
         };
+        let stale_handshake_probe_bindings =
+            self.cancel_handshakes_before_network_generation(generation);
         if let Some(registry) = self.direct_validation_registry.read().await.clone() {
             registry.cancel_before_generation(generation).await;
         }
@@ -775,6 +778,11 @@ impl PeerManager {
         let mut direct_reclaim_count = 0usize;
         let mut relay_confirmation_cancellations = Vec::new();
         let mut conns = self.connections.write().await;
+        for (peer_id, token) in stale_handshake_probe_bindings {
+            if let Some(conn) = conns.get_mut(&peer_id) {
+                conn.pending_probe_bindings.remove(&token);
+            }
+        }
         for conn in conns.values_mut() {
             let Some(peer_session_generation) =
                 self.peer_session_generation_any_sync(&conn.node_id)
@@ -821,6 +829,33 @@ impl PeerManager {
         generation
     }
 
+    /// Install the daemon-owned short transaction that retires handshake
+    /// reservations when the local network generation advances.
+    pub(crate) fn set_network_generation_handshake_cancel_hook(
+        &self,
+        hook: NetworkGenerationHandshakeCancelHook,
+    ) {
+        *self
+            .network_generation_handshake_cancel_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(hook);
+    }
+
+    fn cancel_handshakes_before_network_generation(
+        &self,
+        generation: u64,
+    ) -> Vec<(String, String)> {
+        let hook = self
+            .network_generation_handshake_cancel_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        hook.map_or_else(Vec::new, |cancel_stale_handshakes| {
+            let (_, _, stale_probe_bindings) = cancel_stale_handshakes(generation);
+            stale_probe_bindings
+        })
+    }
+
     /// Advance local generation after a candidate refresh.
     ///
     /// Unlike a true interface transition, a periodic candidate refresh may
@@ -845,6 +880,8 @@ impl PeerManager {
                 .store(*generation, std::sync::atomic::Ordering::Release);
             *generation
         };
+        let stale_handshake_probe_bindings =
+            self.cancel_handshakes_before_network_generation(generation);
         if let Some(registry) = self.direct_validation_registry.read().await.clone() {
             registry.cancel_before_generation(generation).await;
         }
@@ -859,6 +896,11 @@ impl PeerManager {
         let mut retained_confirmed_direct_count = 0usize;
         let mut direct_reclaim_count = 0usize;
         let mut conns = self.connections.write().await;
+        for (peer_id, token) in stale_handshake_probe_bindings {
+            if let Some(conn) = conns.get_mut(&peer_id) {
+                conn.pending_probe_bindings.remove(&token);
+            }
+        }
         for conn in conns.values_mut() {
             let Some(peer_session_generation) =
                 self.peer_session_generation_any_sync(&conn.node_id)

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -670,6 +670,15 @@ impl PeerManager {
         self.connections.write().await
     }
 
+    /// Hold a connection reader while a second task queues a writer.  This
+    /// models Tokio's fair RwLock admission rule without timing sleeps.
+    #[cfg(test)]
+    pub(crate) async fn hold_connections_reader_for_test(
+        &self,
+    ) -> tokio::sync::OwnedRwLockReadGuard<HashMap<String, PeerConnection>> {
+        self.connections.clone().read_owned().await
+    }
+
     #[cfg(test)]
     pub(crate) fn install_authenticated_probe_verify_gate_for_test(
         &self,

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -67,6 +67,16 @@ impl PeerManager {
         self.connections.read().await.values().cloned().collect()
     }
 
+    /// Snapshot every connection without joining Tokio's writer-preferred
+    /// wait queue.  `/status` uses this so a queued lifecycle writer cannot
+    /// place every later diagnostics reader behind it indefinitely.
+    pub(crate) fn try_all_connections(&self) -> Option<Vec<PeerConnection>> {
+        self.connections
+            .try_read()
+            .ok()
+            .map(|connections| connections.values().cloned().collect())
+    }
+
     /// Return peers that need an active relay data-plane confirmation.
     pub async fn relay_validation_targets(
         &self,

--- a/client/daemon/src/peer/manager/fresh_mapping.rs
+++ b/client/daemon/src/peer/manager/fresh_mapping.rs
@@ -554,8 +554,21 @@ impl PeerManager {
     ) -> bool {
         let sender_public_key = sender_public_key.map(str::trim);
         let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
-        let connections = self.connections.read().await;
+        let (_epoch_guard, connections) = loop {
+            let epoch_guard = epoch_gate.lock().await;
+            match self.connections.try_read() {
+                Ok(connections) => break (epoch_guard, connections),
+                Err(_) => {
+                    // A queued writer makes Tokio reject new readers. Never
+                    // wait behind it while retaining the lifecycle epoch: an
+                    // older connection reader may itself be finishing an
+                    // epoch-fenced transaction. Wait for a reader turn with
+                    // no epoch ownership, then retry in canonical order.
+                    drop(epoch_guard);
+                    drop(self.connections.read().await);
+                }
+            }
+        };
         if sender_public_key.is_some_and(|public_key| {
             public_key.is_empty()
                 || connections

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -327,8 +327,20 @@ impl PeerManager {
         sender_public_key: Option<&str>,
     ) -> RemoteCandidateIncarnationClaim {
         let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
-        let mut connections = self.connections.write().await;
+        let (_epoch_guard, mut connections) = loop {
+            let epoch_guard = epoch_gate.lock().await;
+            match self.connections.try_write() {
+                Ok(connections) => break (epoch_guard, connections),
+                Err(_) => {
+                    // A connection reader may itself be finishing an
+                    // epoch-fenced transaction. Never retain the epoch while
+                    // joining Tokio's fair writer queue: wait for one writer
+                    // turn without the epoch, then retry in canonical order.
+                    drop(epoch_guard);
+                    drop(self.connections.write().await);
+                }
+            }
+        };
         self.claim_remote_candidate_incarnation_in_connection(
             node_id,
             candidate_generation,
@@ -472,8 +484,23 @@ impl PeerManager {
     ) -> bool {
         let had_relay_confirmation = {
             let epoch_gate = self.network_epoch_gate();
-            let _epoch_guard = epoch_gate.lock().await;
-            let mut connections = self.connections.write().await;
+            let (_epoch_guard, mut connections) = loop {
+                let epoch_guard = epoch_gate.lock().await;
+                match self.connections.try_write() {
+                    Ok(connections) => break (epoch_guard, connections),
+                    Err(_) => {
+                        // Remote-incarnation cleanup already owns the peer's
+                        // adoption fence. A connection reader can still need
+                        // the epoch to retire its pre-cleanup observation, so
+                        // queueing the writer while retaining the epoch would
+                        // close a reader -> epoch -> writer -> reader cycle.
+                        // Wait fairly without epoch ownership and retry the
+                        // actual mutation in canonical order.
+                        drop(epoch_guard);
+                        drop(self.connections.write().await);
+                    }
+                }
+            };
             let Some(conn) = connections.get_mut(node_id) else {
                 return false;
             };

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -1350,23 +1350,6 @@ impl PeerManager {
         ))
     }
 
-    /// Queue once for connection-writer availability without retaining the
-    /// writer. The independently scheduled initiator retry task calls this
-    /// only after the cooperative control-loop future has released every
-    /// upper guard and returned. Dropping this future on cancellation removes
-    /// its waiter from Tokio's writer-preferred queue; the explicit bound
-    /// prevents this availability barrier from starving later readers.
-    pub(crate) async fn wait_for_probe_session_binding_writer(
-        &self,
-        max_wait: Duration,
-    ) -> bool {
-        tokio::time::timeout(max_wait, async {
-            drop(self.connections.write().await);
-        })
-        .await
-        .is_ok()
-    }
-
     /// Extend a staged responder binding after the control-plane answer
     /// delivery attempt completes. This keeps signaling latency separate from
     /// the authenticated adoption window.

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -1370,20 +1370,29 @@ impl PeerManager {
     /// Extend a staged responder binding after the control-plane answer
     /// delivery attempt completes. This keeps signaling latency separate from
     /// the authenticated adoption window.
-    pub(crate) async fn refresh_pending_probe_session_binding_grace(
+    /// Refresh a responder binding without joining the connection writer
+    /// queue.  The original staging grace remains valid on contention; later
+    /// authenticated ingress is the authoritative promotion trigger.
+    pub(crate) fn try_refresh_pending_probe_session_binding_grace(
         &self,
         node_id: &str,
         token: &str,
-    ) -> bool {
-        let mut conns = self.connections.write().await;
+    ) -> PendingProbeBindingCommitOutcome {
+        let Ok(mut conns) = self.connections.try_write() else {
+            return PendingProbeBindingCommitOutcome::ContendedConnections;
+        };
         let Some(conn) = conns.get_mut(node_id) else {
-            return false;
+            return PendingProbeBindingCommitOutcome::Missing;
         };
         let Some(pending) = conn.pending_probe_bindings.get_mut(token) else {
-            return false;
+            return if conn.probe_binding_token.as_deref() == Some(token) {
+                PendingProbeBindingCommitOutcome::AlreadyCurrent
+            } else {
+                PendingProbeBindingCommitOutcome::Missing
+            };
         };
         pending.expires_at = Instant::now() + PENDING_PROBE_SESSION_BINDING_GRACE;
-        true
+        PendingProbeBindingCommitOutcome::Committed
     }
 
     /// Install an answer-confirmed Probe-v2 binding for outbound traffic while
@@ -1433,28 +1442,51 @@ impl PeerManager {
 
     /// Promote a responder's staged Probe-v2 binding after a packet validates
     /// under that exact key and token.
-    pub(crate) async fn confirm_pending_probe_session_binding(
+    /// Promote the responder binding at an authenticated WireGuard boundary
+    /// without parking the serial inbound actor behind a connection reader.
+    /// On contention the promoted transport token remains in its bounded
+    /// queue and the next authenticated packet retries the same transaction.
+    pub(crate) fn try_confirm_pending_probe_session_binding(
         &self,
         node_id: &str,
         token: &str,
-    ) -> bool {
-        let mut conns = self.connections.write().await;
+    ) -> PendingProbeBindingCommitOutcome {
+        let Ok(mut conns) = self.connections.try_write() else {
+            return PendingProbeBindingCommitOutcome::ContendedConnections;
+        };
         let Some(conn) = conns.get_mut(node_id) else {
-            return false;
+            return PendingProbeBindingCommitOutcome::Missing;
         };
         let should_promote = conn
             .pending_probe_bindings
             .get(token)
             .is_some_and(|pending| pending.promote_on_match);
         if !should_promote {
-            return conn.probe_binding_token.as_deref() == Some(token);
+            return if conn.probe_binding_token.as_deref() == Some(token) {
+                PendingProbeBindingCommitOutcome::AlreadyCurrent
+            } else {
+                PendingProbeBindingCommitOutcome::Missing
+            };
         }
         let pending = conn
             .pending_probe_bindings
             .remove(token)
             .expect("pending Probe binding checked above");
         install_active_probe_binding(conn, pending.binding, true);
-        true
+        PendingProbeBindingCommitOutcome::Committed
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn confirm_pending_probe_session_binding(
+        &self,
+        node_id: &str,
+        token: &str,
+    ) -> bool {
+        matches!(
+            self.try_confirm_pending_probe_session_binding(node_id, token),
+            PendingProbeBindingCommitOutcome::Committed
+                | PendingProbeBindingCommitOutcome::AlreadyCurrent
+        )
     }
 
     /// Bridge a Probe-v2 adoption check with its matching WireGuard responder

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -211,28 +211,45 @@ impl PeerManager {
             .record_candidate_generation_replay_floor(node_id, public_key, generation);
     }
 
-    /// Publish the strict replay floor for one valid encoded generation, then
-    /// claim a strictly newer remote daemon incarnation when necessary.
-    ///
-    /// The replay floor is published for first-incarnation and same-incarnation
-    /// signals too: candidate apply happens after this helper returns, so a
-    /// PeerLeft/rejoin in that gap must not admit a lower counter. A new
-    /// incarnation claim remains the high-water linearization point before
-    /// slow WireGuard/UDP cleanup.
-    pub(crate) async fn claim_remote_candidate_incarnation_for_identity(
+    /// Snapshot the currently published peer identity without waiting on the
+    /// async connection map.  The identity ledger is populated before the
+    /// membership lifecycle is published; re-checking that lifecycle after
+    /// the ledger read closes a concurrent remove/rejoin boundary.
+    pub(crate) fn peer_identity_public_key_sync(&self, node_id: &str) -> Option<String> {
+        let lifecycle = self.peer_session_generation_sync(node_id)?;
+        let public_key = self
+            .remote_identity_ledger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(node_id)
+            .map(|identity| identity.public_key.clone())?;
+        self.peer_session_is_current_sync(node_id, lifecycle)
+            .then_some(public_key)
+    }
+
+    pub(crate) fn signal_sender_identity_matches_peer_sync(
+        &self,
+        node_id: &str,
+        sender_public_key: Option<&str>,
+    ) -> bool {
+        let Some(sender_public_key) = sender_public_key.map(str::trim) else {
+            return true;
+        };
+        !sender_public_key.is_empty()
+            && self
+                .peer_identity_public_key_sync(node_id)
+                .is_some_and(|known| known.trim() == sender_public_key)
+    }
+
+    fn claim_remote_candidate_incarnation_in_connection(
         &self,
         node_id: &str,
         candidate_generation: u64,
         sender_public_key: Option<&str>,
+        conn: Option<&mut PeerConnection>,
     ) -> RemoteCandidateIncarnationClaim {
-        // Only an absent fingerprint is legacy-compatible. An explicitly
-        // present but empty fingerprint is malformed identity evidence and
-        // must fail closed like every other non-matching `Some` value.
         let sender_public_key = sender_public_key.map(str::trim);
-        let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
-        let mut connections = self.connections.write().await;
-        let Some(conn) = connections.get_mut(node_id) else {
+        let Some(conn) = conn else {
             return if sender_public_key.is_some() {
                 RemoteCandidateIncarnationClaim::IdentityMismatch
             } else {
@@ -244,6 +261,9 @@ impl PeerManager {
         {
             return RemoteCandidateIncarnationClaim::IdentityMismatch;
         }
+        if crate::control::candidate_generation_is_malformed_encoded(candidate_generation) {
+            return RemoteCandidateIncarnationClaim::RejectedLifecycle;
+        }
         let Some(new_incarnation) =
             crate::control::candidate_generation_incarnation(candidate_generation)
         else {
@@ -254,6 +274,14 @@ impl PeerManager {
         else {
             return RemoteCandidateIncarnationClaim::NoReset;
         };
+        if conn
+            .remote_candidate_incarnation_high_water
+            .is_some_and(|accepted| new_incarnation < accepted)
+            || (conn.remote_candidate_incarnation_high_water == Some(new_incarnation)
+                && candidate_generation < conn.last_candidate_generation)
+        {
+            return RemoteCandidateIncarnationClaim::RejectedLifecycle;
+        }
         conn.last_candidate_generation = conn.last_candidate_generation.max(claim_floor);
         self.record_remote_candidate_generation_replay_floor(
             node_id,
@@ -273,9 +301,6 @@ impl PeerManager {
             return RemoteCandidateIncarnationClaim::NoReset;
         }
         conn.remote_candidate_incarnation_high_water = Some(new_incarnation);
-        // The predecessor was published above before this claim. Mirror the
-        // new incarnation itself before slow transport cleanup as the second
-        // half of the replay fence.
         self.record_remote_candidate_incarnation_high_water(
             node_id,
             &conn.public_key,
@@ -285,6 +310,132 @@ impl PeerManager {
             old_incarnation,
             new_incarnation,
         }
+    }
+
+    /// Publish the strict replay floor for one valid encoded generation, then
+    /// claim a strictly newer remote daemon incarnation when necessary.
+    ///
+    /// The replay floor is published for first-incarnation and same-incarnation
+    /// signals too: candidate apply happens after this helper returns, so a
+    /// PeerLeft/rejoin in that gap must not admit a lower counter. A new
+    /// incarnation claim remains the high-water linearization point before
+    /// slow WireGuard/UDP cleanup.
+    pub(crate) async fn claim_remote_candidate_incarnation_for_identity(
+        &self,
+        node_id: &str,
+        candidate_generation: u64,
+        sender_public_key: Option<&str>,
+    ) -> RemoteCandidateIncarnationClaim {
+        let epoch_gate = self.network_epoch_gate();
+        let _epoch_guard = epoch_gate.lock().await;
+        let mut connections = self.connections.write().await;
+        self.claim_remote_candidate_incarnation_in_connection(
+            node_id,
+            candidate_generation,
+            sender_public_key,
+            connections.get_mut(node_id),
+        )
+    }
+
+    /// Non-queuing remote-incarnation transaction for the inbound control
+    /// coordinator.  It preserves the canonical `epoch -> connections`
+    /// ordering, but never joins either wait queue.
+    pub(crate) fn try_claim_remote_candidate_incarnation_for_identity(
+        &self,
+        node_id: &str,
+        candidate_generation: u64,
+        sender_public_key: Option<&str>,
+    ) -> RemoteCandidateIncarnationTryClaim {
+        // The synchronous ledger is published in the same transaction as the
+        // connection high-water.  Once this incarnation is already current,
+        // a later revision needs no lifecycle mutation and must not touch the
+        // fair connection lock at all.  This is the common candidate-first ->
+        // handshake sequence: candidate application may already be queued on
+        // the writer, while the responder can still proceed immediately.
+        let sender_public_key = sender_public_key.map(str::trim);
+        let lifecycle = self.peer_session_generation_sync(node_id);
+        let known_identity = lifecycle.and_then(|expected| {
+            let identity = {
+                self.remote_identity_ledger
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get(node_id)
+                    .cloned()
+            };
+            identity.filter(|_| self.peer_session_is_current_sync(node_id, expected))
+        });
+        if sender_public_key.is_some_and(|sender| {
+            sender.is_empty()
+                || known_identity
+                    .as_ref()
+                    .is_some_and(|identity| identity.public_key.trim() != sender)
+        }) {
+            return RemoteCandidateIncarnationTryClaim::Committed(
+                RemoteCandidateIncarnationClaim::IdentityMismatch,
+            );
+        }
+        if crate::control::candidate_generation_is_malformed_encoded(candidate_generation) {
+            return RemoteCandidateIncarnationTryClaim::Committed(
+                RemoteCandidateIncarnationClaim::RejectedLifecycle,
+            );
+        }
+        match crate::control::candidate_generation_incarnation(candidate_generation) {
+            None if sender_public_key.is_none() || known_identity.is_some() => {
+                return RemoteCandidateIncarnationTryClaim::Committed(
+                    RemoteCandidateIncarnationClaim::NoReset,
+                );
+            }
+            Some(incoming) => {
+                if let Some(identity) = known_identity.as_ref() {
+                    match identity.candidate_incarnation_high_water {
+                        Some(accepted) if incoming < accepted => {
+                            return RemoteCandidateIncarnationTryClaim::Committed(
+                                RemoteCandidateIncarnationClaim::RejectedLifecycle,
+                            );
+                        }
+                        Some(accepted) if incoming == accepted => {
+                            let outcome = if candidate_generation
+                                < identity.candidate_generation_replay_floor
+                            {
+                                RemoteCandidateIncarnationClaim::RejectedLifecycle
+                            } else {
+                                if let Some(claim_floor) =
+                                    crate::control::candidate_generation_predecessor_floor(
+                                        candidate_generation,
+                                    )
+                                {
+                                    self.record_remote_candidate_generation_replay_floor(
+                                        node_id,
+                                        &identity.public_key,
+                                        claim_floor,
+                                    );
+                                }
+                                RemoteCandidateIncarnationClaim::NoReset
+                            };
+                            return RemoteCandidateIncarnationTryClaim::Committed(outcome);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        let epoch_gate = self.network_epoch_gate();
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            return RemoteCandidateIncarnationTryClaim::ContendedEpoch;
+        };
+        let Ok(mut connections) = self.connections.try_write() else {
+            return RemoteCandidateIncarnationTryClaim::ContendedConnections;
+        };
+        RemoteCandidateIncarnationTryClaim::Committed(
+            self.claim_remote_candidate_incarnation_in_connection(
+                node_id,
+                candidate_generation,
+                sender_public_key,
+                connections.get_mut(node_id),
+            ),
+        )
     }
 
     /// Compatibility wrapper for internal tests that exercise only incarnation
@@ -304,6 +455,7 @@ impl PeerManager {
                 new_incarnation,
             } => Some((old_incarnation, new_incarnation)),
             RemoteCandidateIncarnationClaim::IdentityMismatch
+            | RemoteCandidateIncarnationClaim::RejectedLifecycle
             | RemoteCandidateIncarnationClaim::NoReset => None,
         }
     }
@@ -945,19 +1097,57 @@ impl PeerManager {
         let generation = self.current_network_generation_sync();
         let stage = stage.into();
         let detail = detail.into();
-        if Self::direct_event_requires_durable_ring(&stage) {
-            let mut connections = self.connections.write().await;
-            if let Some(conn) = connections.get_mut(node_id) {
-                conn.record_direct_event(
-                    generation,
-                    stage.clone(),
-                    endpoint,
-                    candidate_count,
-                    sent_probes,
-                    detail.clone(),
-                );
-            }
-        } else if let Ok(mut connections) = self.connections.try_write() {
+        if !Self::direct_event_requires_durable_ring(&stage) {
+            self.record_direct_event_non_queuing(
+                node_id,
+                stage,
+                endpoint,
+                candidate_count,
+                sent_probes,
+                detail,
+            );
+            return;
+        }
+        let mut connections = self.connections.write().await;
+        if let Some(conn) = connections.get_mut(node_id) {
+            conn.record_direct_event(
+                generation,
+                stage.clone(),
+                endpoint,
+                candidate_count,
+                sent_probes,
+                detail.clone(),
+            );
+        }
+        self.emit_direct_traversal_debug(
+            node_id,
+            generation,
+            &stage,
+            endpoint,
+            None,
+            candidate_count,
+            sent_probes,
+            &detail,
+        );
+    }
+
+    /// Best-effort diagnostic event for serial actor paths. This method never
+    /// joins the fair connection-writer queue; the structured debug timeline
+    /// is still emitted when the in-memory per-peer ring is contended.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_direct_event_non_queuing(
+        &self,
+        node_id: &str,
+        stage: impl Into<String>,
+        endpoint: Option<SocketAddr>,
+        candidate_count: Option<usize>,
+        sent_probes: Option<u32>,
+        detail: impl Into<String>,
+    ) {
+        let generation = self.current_network_generation_sync();
+        let stage = stage.into();
+        let detail = detail.into();
+        if let Ok(mut connections) = self.connections.try_write() {
             if let Some(conn) = connections.get_mut(node_id) {
                 conn.record_direct_event(
                     generation,

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -1295,6 +1295,7 @@ impl PeerManager {
     /// responder marks its staged key promotable by authenticated inbound
     /// traffic; an initiator waits for the matching answer and installs it
     /// explicitly.
+    #[cfg(test)]
     pub(crate) async fn stage_probe_session_binding(
         &self,
         node_id: &str,
@@ -1421,6 +1422,27 @@ impl PeerManager {
         }
         conn.pending_probe_bindings.remove(token);
         true
+    }
+
+    /// Roll back an unpublished Probe-v2 replacement without entering the
+    /// fair connection-writer queue. `None` means the caller must leave the
+    /// exact token to its bounded TTL or retry the cleanup from an owning
+    /// lifecycle worker; it must not turn cleanup into a global reader gate.
+    pub(crate) fn try_discard_pending_probe_session_binding(
+        &self,
+        node_id: &str,
+        token: &str,
+    ) -> Option<bool> {
+        let mut conns = self.connections.try_write().ok()?;
+        let Some(conn) = conns.get_mut(node_id) else {
+            return Some(true);
+        };
+        prune_probe_session_bindings(conn, Instant::now());
+        if conn.probe_binding_token.as_deref() == Some(token) {
+            return Some(false);
+        }
+        conn.pending_probe_bindings.remove(token);
+        Some(true)
     }
 
     /// Promote a responder's staged Probe-v2 binding after a packet validates

--- a/client/daemon/src/peer/manager/quarantine.rs
+++ b/client/daemon/src/peer/manager/quarantine.rs
@@ -208,7 +208,6 @@ impl PeerManager {
                         conn.relay_first.business_received_generation = None;
                         conn.relay_first.business_exchange_generation = None;
                         conn.relay_first.business_pathcommit_generation = None;
-                        conn.relay_first.preconfirmation = None;
                         conn.relay_ready_generation = None;
                         conn.relay_ready_at = None;
                         conn.relay_ready_endpoint = None;

--- a/client/daemon/src/peer/manager/relay.rs
+++ b/client/daemon/src/peer/manager/relay.rs
@@ -80,7 +80,25 @@ impl PeerManager {
     /// packet, writer completion, or unsolicited business frame cannot make
     /// an unconfirmed relay appear as the active path.
     pub(crate) async fn record_relay_observation(&self, node_id: &str, relay_server: &str) {
-        if let Some(conn) = self.connections.write().await.get_mut(node_id) {
+        // This method runs after an authenticated Relay frame on the single
+        // WireGuard inbound actor.  Observation is advisory and retried by
+        // every later frame, so it must never enqueue a writer behind an
+        // unrelated connection-map reader and stop the actor.
+        let Ok(mut connections) = self.connections.try_write() else {
+            let generation = self.current_network_generation_sync();
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_observation_connections_contended",
+                Some("relay"),
+                Some("fair_rwlock_writer_unavailable"),
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_server} wait_us=0 queued_writer=false retry=next_authenticated_frame"
+                )),
+            );
+            return;
+        };
+        if let Some(conn) = connections.get_mut(node_id) {
             conn.relay_server = Some(relay_server.to_string());
             // Untimed ingress is useful liveness evidence, but it must not
             // refresh the timestamp used to schedule a real RTT probe.
@@ -204,14 +222,85 @@ impl PeerManager {
         generation: u64,
         relay_connection_id: Option<u64>,
     ) {
+        let _ = self.try_mark_relay_transport_ready_with_transport(
+            node_id,
+            relay_endpoint,
+            generation,
+            relay_connection_id,
+        );
+    }
+
+    /// Attempt the exact relay-ready transaction without ever joining either
+    /// the epoch mutex or writer-preferred connection-map wait queue.
+    ///
+    /// The forced-relay probe loop and authenticated ingress both retry this
+    /// idempotent transaction.  Returning typed contention is therefore safer
+    /// than parking the process-wide serial inbound actor while it owns the
+    /// per-peer WireGuard evidence guard.
+    pub(crate) fn try_mark_relay_transport_ready_with_transport(
+        &self,
+        node_id: &str,
+        relay_endpoint: &str,
+        generation: u64,
+        relay_connection_id: Option<u64>,
+    ) -> RelayReadyCommitOutcome {
+        let started = Instant::now();
+        let finish = |outcome: RelayReadyCommitOutcome, connections_wait_us: Option<u128>| {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_ready_commit_finished",
+                Some("relay"),
+                match outcome {
+                    RelayReadyCommitOutcome::ContendedEpoch => Some("network_epoch_busy"),
+                    RelayReadyCommitOutcome::ContendedConnections => {
+                        Some("fair_rwlock_writer_unavailable")
+                    }
+                    RelayReadyCommitOutcome::Rejected => Some("lifecycle_rejected"),
+                    RelayReadyCommitOutcome::Committed
+                    | RelayReadyCommitOutcome::AlreadyCurrent => None,
+                },
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} outcome={outcome:?} total_us={} connections_wait_us={}",
+                    started.elapsed().as_micros(),
+                    connections_wait_us
+                        .map(|wait| wait.to_string())
+                        .unwrap_or_else(|| "not_attempted".to_string())
+                )),
+            );
+            outcome
+        };
+        self.emit_timeline_first(
+            node_id,
+            generation,
+            "relay_ready_commit_started",
+            Some("relay"),
+            None,
+            Some(format!(
+                "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?}"
+            )),
+        );
         // READY is part of the same per-generation path state as the
         // confirmation and first-business markers.  Hold the epoch gate from
         // the generation check through the connection write so a network
         // advance cannot clear the state between those two operations.
         let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_ready_epoch_contended",
+                Some("relay"),
+                Some("network_epoch_busy"),
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} wait_us={} retry=next_probe_or_authenticated_frame",
+                    started.elapsed().as_micros()
+                )),
+            );
+            return finish(RelayReadyCommitOutcome::ContendedEpoch, None);
+        };
         let current_generation = self.current_network_generation_sync();
-        if generation != current_generation || self.peer_quarantined(node_id).await {
+        if generation != current_generation || self.peer_quarantined_sync(node_id) {
             self.emit_timeline(
                 "relay_transport_ready_rejected",
                 Some("relay"),
@@ -220,14 +309,35 @@ impl PeerManager {
                     "peer={node_id} generation={generation} current_generation={current_generation} relay_endpoint={relay_endpoint}"
                 )),
             );
-            return;
+            return finish(RelayReadyCommitOutcome::Rejected, None);
         }
         let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
-            return;
+            return finish(RelayReadyCommitOutcome::Rejected, None);
         };
         let now = Instant::now();
         let mut invalidated_confirmation = None;
-        if let Some(conn) = self.connections.write().await.get_mut(node_id) {
+        let connection_wait_started = Instant::now();
+        let Ok(mut connections) = self.connections.try_write() else {
+            let connections_wait_us = connection_wait_started.elapsed().as_micros();
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_ready_connections_contended",
+                Some("relay"),
+                Some("fair_rwlock_writer_unavailable"),
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} wait_us={} queued_writer=false retry=next_probe_or_authenticated_frame",
+                    connection_wait_started.elapsed().as_micros()
+                )),
+            );
+            return finish(
+                RelayReadyCommitOutcome::ContendedConnections,
+                Some(connections_wait_us),
+            );
+        };
+        let connections_wait_us = connection_wait_started.elapsed().as_micros();
+        let mut commit_outcome = RelayReadyCommitOutcome::AlreadyCurrent;
+        if let Some(conn) = connections.get_mut(node_id) {
             // Re-check quarantine after acquiring the connection lock. The
             // first check above only avoids needless work; quarantine can be
             // committed while this task is waiting for the lock.
@@ -235,7 +345,10 @@ impl PeerManager {
                 || conn.state == ConnectionState::Closed
                 || self.peer_quarantined_sync(node_id)
             {
-                return;
+                return finish(
+                    RelayReadyCommitOutcome::Rejected,
+                    Some(connections_wait_us),
+                );
             }
             let endpoint_changed = conn.relay_ready_endpoint.as_deref() != Some(relay_endpoint);
             let transport_replaced = relay_connection_id.is_some_and(|new_id| {
@@ -333,10 +446,20 @@ impl PeerManager {
                     },
                 );
                 if !outcome.accepted() {
-                    return;
+                    return finish(
+                        RelayReadyCommitOutcome::Rejected,
+                        Some(connections_wait_us),
+                    );
                 }
+                commit_outcome = RelayReadyCommitOutcome::Committed;
             }
+        } else {
+            return finish(
+                RelayReadyCommitOutcome::Rejected,
+                Some(connections_wait_us),
+            );
         }
+        drop(connections);
         if let Some((previous_endpoint, previous_generation, previous_connection_id)) =
             invalidated_confirmation
         {
@@ -350,6 +473,7 @@ impl PeerManager {
                 )),
             );
         }
+        finish(commit_outcome, Some(connections_wait_us))
     }
 
     /// Confirm the relay path to a peer after a matching forced-relay probe ACK
@@ -476,7 +600,19 @@ impl PeerManager {
         // RelayPeerConfirmed in the new generation.
         let (confirmation_changed, preconfirmation_business_received) = {
             let epoch_gate = self.network_epoch_gate();
-            let _epoch_guard = epoch_gate.lock().await;
+            let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+                self.emit_timeline_first(
+                    node_id,
+                    generation,
+                    "relay_confirmation_epoch_contended",
+                    Some("relay"),
+                    Some("network_epoch_busy"),
+                    Some(format!(
+                        "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} queued_waiter=false retry=next_probe_or_business_frame"
+                    )),
+                );
+                return false;
+            };
             let current_generation = self.current_network_generation_sync();
             if generation != current_generation {
                 self.emit_timeline(
@@ -505,7 +641,7 @@ impl PeerManager {
             // Quarantine is authoritative isolation after a sustained relay
             // `peer_not_found`.  Check it immediately before taking the
             // connection lock so a late ACK cannot re-admit the stale peer.
-            if self.peer_quarantined(node_id).await {
+            if self.peer_quarantined_sync(node_id) {
                 self.emit_timeline(
                     "relay_peer_confirmation_rejected",
                     Some("relay"),
@@ -518,7 +654,19 @@ impl PeerManager {
             }
             let now = Instant::now();
             let result = {
-                let mut conns = self.connections.write().await;
+                let Ok(mut conns) = self.connections.try_write() else {
+                    self.emit_timeline_first(
+                        node_id,
+                        generation,
+                        "relay_confirmation_connections_contended",
+                        Some("relay"),
+                        Some("fair_rwlock_writer_unavailable"),
+                        Some(format!(
+                            "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} queued_writer=false retry=next_probe_or_business_frame"
+                        )),
+                    );
+                    return false;
+                };
                 let Some(conn) = conns.get_mut(node_id) else {
                     return false;
                 };
@@ -1251,10 +1399,10 @@ impl PeerManager {
         ack_ingress: &str,
         ack_connection_id: Option<u64>,
     ) -> bool {
-        // Remove any outstanding expectation before returning.  A late ACK
-        // must not revive a peer that was quarantined after the relay stopped
-        // registering it, even if its token is otherwise syntactically valid.
-        if self.peer_quarantined(node_id).await {
+        // Quarantine is mirrored synchronously.  The serial inbound actor
+        // must not await manager state before deciding whether this ACK can
+        // enter the lifecycle commit.
+        if self.peer_quarantined_sync(node_id) {
             let removed = self
                 .relay_probe_expectations
                 .lock()
@@ -1276,20 +1424,11 @@ impl PeerManager {
         }
         let now = Instant::now();
         let expectation = {
-            let mut expectations = self
+            let expectations = self
                 .relay_probe_expectations
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let expectation = expectations.get(node_id).cloned();
-            // A consumed (matched) expectation is removed so duplicate or late
-            // ACKs are no-ops.
-            if expectation.as_ref().is_some_and(|expectation| {
-                expectation.accepts(&token, now, ack_ingress)
-                    && expectation.accepts_connection(ack_connection_id)
-            }) {
-                expectations.remove(node_id);
-            }
-            expectation
+            expectations.get(node_id).cloned()
         };
         let Some(expectation) = expectation else {
             debug!(
@@ -1389,6 +1528,25 @@ impl PeerManager {
                 relay_rtt,
             )
             .await;
+        if confirmation_changed || accepted {
+            // Consume only after the lifecycle-bound commit succeeded.  A
+            // contended try-write keeps the exact expectation available for
+            // the next independently encrypted probe ACK instead of losing
+            // the sole proof to local lock scheduling.
+            let mut expectations = self
+                .relay_probe_expectations
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if expectations.get(node_id).is_some_and(|current| {
+                current.generation == expectation.generation
+                    && current.request_id == expectation.request_id
+                    && current.owner_token == expectation.owner_token
+                    && current.relay_connection_id == expectation.relay_connection_id
+                    && current.peer_session_generation == expectation.peer_session_generation
+            }) {
+                expectations.remove(node_id);
+            }
+        }
         info!(
             event = "relay_probe_ack_consumed",
             peer_id = %node_id,
@@ -1416,7 +1574,9 @@ impl PeerManager {
         relay_rtt: Option<Duration>,
     ) -> bool {
         let epoch_gate = self.network_epoch_gate();
-        let _epoch_guard = epoch_gate.lock().await;
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            return false;
+        };
         if generation != self.current_network_generation_sync() {
             return false;
         }
@@ -1426,7 +1586,9 @@ impl PeerManager {
         if !self.peer_session_is_current_sync(node_id, expected_lifecycle) {
             return false;
         }
-        let mut conns = self.connections.write().await;
+        let Ok(mut conns) = self.connections.try_write() else {
+            return false;
+        };
         let Some(conn) = conns.get_mut(node_id) else {
             return false;
         };
@@ -2158,7 +2320,27 @@ impl PeerManager {
 
     /// Record that a relay path was attempted without treating TCP write success as delivery.
     pub async fn record_relay_attempt(&self, node_id: &str, relay_server: &str) {
-        if let Some(conn) = self.connections.write().await.get_mut(node_id) {
+        // Writer completion is on the serial WireGuard inbound actor when it
+        // emits a Probe ACK.  This field is advisory and every later relay
+        // write retries it, so never queue a connection-map writer after the
+        // ciphertext has already crossed the relay writer boundary.  Doing so
+        // would make a retained diagnostics reader stop the entire inbound
+        // actor even though the peer has received the ACK.
+        let Ok(mut connections) = self.connections.try_write() else {
+            let generation = self.current_network_generation_sync();
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_attempt_connections_contended",
+                Some("relay"),
+                Some("fair_rwlock_writer_unavailable"),
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_server} wait_us=0 queued_writer=false write_already_completed=true retry=next_relay_write"
+                )),
+            );
+            return;
+        };
+        if let Some(conn) = connections.get_mut(node_id) {
             conn.relay_server = Some(relay_server.to_string());
         }
     }

--- a/client/daemon/src/peer/manager/relay.rs
+++ b/client/daemon/src/peer/manager/relay.rs
@@ -37,6 +37,148 @@ impl PeerManager {
         }
     }
 
+    fn pending_relay_business_evidence_matches(
+        current: &PendingRelayBusinessEvidence,
+        expected: &PendingRelayBusinessEvidence,
+    ) -> bool {
+        current.peer_id == expected.peer_id
+            && current.network_generation == expected.network_generation
+            && current.peer_session_generation == expected.peer_session_generation
+            && current.wireguard_session_instance == expected.wireguard_session_instance
+            && current.relay_endpoint == expected.relay_endpoint
+            && current.relay_connection_id == expected.relay_connection_id
+            && current.received_at == expected.received_at
+    }
+
+    fn prune_pending_relay_business_evidence_locked(
+        pending: &mut HashMap<String, PendingRelayBusinessEvidence>,
+        now: Instant,
+    ) {
+        pending.retain(|_, evidence| {
+            now.saturating_duration_since(evidence.received_at)
+                <= PENDING_RELAY_BUSINESS_EVIDENCE_TTL
+        });
+    }
+
+    /// Save authenticated evidence before attempting either async-owned lock.
+    /// The ordinary mutex protects only a bounded in-memory map and is never
+    /// held across an await. Newer evidence for one peer replaces older
+    /// evidence; at global capacity the oldest peer entry is evicted.
+    fn retain_pending_relay_business_evidence(
+        &self,
+        evidence: PendingRelayBusinessEvidence,
+    ) -> bool {
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let now = Instant::now();
+        Self::prune_pending_relay_business_evidence_locked(&mut pending, now);
+        if now.saturating_duration_since(evidence.received_at)
+            > PENDING_RELAY_BUSINESS_EVIDENCE_TTL
+        {
+            return false;
+        }
+
+        if pending
+            .get(&evidence.peer_id)
+            .is_some_and(|current| current.received_at > evidence.received_at)
+        {
+            return false;
+        }
+        if !pending.contains_key(&evidence.peer_id)
+            && pending.len() >= MAX_PENDING_RELAY_BUSINESS_EVIDENCE
+        {
+            let oldest_peer = pending
+                .iter()
+                .min_by_key(|(_, current)| current.received_at)
+                .map(|(peer_id, _)| peer_id.clone());
+            if let Some(oldest_peer) = oldest_peer {
+                pending.remove(&oldest_peer);
+            }
+        }
+        pending.insert(evidence.peer_id.clone(), evidence);
+        true
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn pending_relay_business_evidence_for_lifecycle(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+        now: Instant,
+    ) -> Option<PendingRelayBusinessEvidence> {
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::prune_pending_relay_business_evidence_locked(&mut pending, now);
+        pending.get(node_id).filter(|evidence| {
+            evidence.network_generation == generation
+                && evidence.peer_session_generation == peer_session_generation
+                && evidence.wireguard_session_instance == wireguard_session_instance
+                && evidence.relay_endpoint == relay_endpoint
+                && evidence.relay_connection_id == relay_connection_id
+        }).cloned()
+    }
+
+    fn remove_pending_relay_business_evidence_if_exact(
+        &self,
+        evidence: &PendingRelayBusinessEvidence,
+    ) {
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if pending
+            .get(&evidence.peer_id)
+            .is_some_and(|current| Self::pending_relay_business_evidence_matches(current, evidence))
+        {
+            pending.remove(&evidence.peer_id);
+        }
+    }
+
+    fn pending_relay_business_evidence_is_exact(
+        &self,
+        evidence: &PendingRelayBusinessEvidence,
+        now: Instant,
+    ) -> bool {
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::prune_pending_relay_business_evidence_locked(&mut pending, now);
+        pending.get(&evidence.peer_id).is_some_and(|current| {
+            Self::pending_relay_business_evidence_matches(current, evidence)
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_relay_business_evidence_present(&self, node_id: &str) -> bool {
+        let now = Instant::now();
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::prune_pending_relay_business_evidence_locked(&mut pending, now);
+        pending.contains_key(node_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_relay_business_evidence_len(&self) -> usize {
+        let now = Instant::now();
+        let mut pending = self
+            .pending_relay_business_evidence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::prune_pending_relay_business_evidence_locked(&mut pending, now);
+        pending.len()
+    }
+
     /// Whether the peer is direct in a specific generation.
     pub async fn is_direct_for_generation(&self, node_id: &str, generation: u64) -> bool {
         generation == self.current_network_generation().await && self.is_direct(node_id).await
@@ -79,7 +221,12 @@ impl PeerManager {
     /// method instead of [`Self::record_relay_success`], so a validation
     /// packet, writer completion, or unsolicited business frame cannot make
     /// an unconfirmed relay appear as the active path.
+    #[cfg(test)]
     pub(crate) async fn record_relay_observation(&self, node_id: &str, relay_server: &str) {
+        self.try_record_relay_observation(node_id, relay_server);
+    }
+
+    pub(crate) fn try_record_relay_observation(&self, node_id: &str, relay_server: &str) {
         // This method runs after an authenticated Relay frame on the single
         // WireGuard inbound actor.  Observation is advisory and retried by
         // every later frame, so it must never enqueue a writer behind an
@@ -400,7 +547,6 @@ impl PeerManager {
                     conn.relay_first.business_received_generation = None;
                     conn.relay_first.business_exchange_generation = None;
                     conn.relay_first.business_pathcommit_generation = None;
-                    conn.relay_first.preconfirmation = None;
                     conn.relay_confirm_seq = conn.relay_confirm_seq.wrapping_add(1);
                     // Keep the synchronous waiter mirror aligned with the
                     // state transition while the epoch gate is held.
@@ -426,7 +572,6 @@ impl PeerManager {
                 conn.relay_first.business_received_generation = None;
                 conn.relay_first.business_exchange_generation = None;
                 conn.relay_first.business_pathcommit_generation = None;
-                conn.relay_first.preconfirmation = None;
                 debug!(
                     event = "relay_transport_ready_peer",
                     peer_id = %node_id,
@@ -505,9 +650,9 @@ impl PeerManager {
             generation,
             None,
             peer_session_generation,
+            Some(0),
             "encrypted_probe_ack",
         )
-        .await
     }
 
     /// Confirm a relay path and bind the proof to one local relay transport
@@ -528,17 +673,18 @@ impl PeerManager {
             generation,
             relay_connection_id,
             peer_session_generation,
+            Some(0),
         )
-        .await
     }
 
-    async fn confirm_relay_peer_with_transport_for_lifecycle(
+    fn confirm_relay_peer_with_transport_for_lifecycle(
         &self,
         node_id: &str,
         relay_endpoint: &str,
         generation: u64,
         relay_connection_id: Option<u64>,
         peer_session_generation: Option<PeerSessionGeneration>,
+        wireguard_session_instance: Option<u64>,
     ) -> bool {
         self.confirm_relay_peer_inner(
             node_id,
@@ -546,9 +692,9 @@ impl PeerManager {
             generation,
             relay_connection_id,
             peer_session_generation,
+            wireguard_session_instance,
             "encrypted_probe_ack",
         )
-        .await
     }
 
     /// Confirm a relay from a real encrypted business packet that arrived
@@ -579,18 +725,41 @@ impl PeerManager {
             generation,
             relay_connection_id,
             peer_session_generation,
+            Some(0),
             "encrypted_business_ingress",
         )
-        .await
     }
 
-    async fn confirm_relay_peer_inner(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn confirm_relay_peer_from_business_ingress_for_session(
+        &self,
+        node_id: &str,
+        relay_endpoint: &str,
+        generation: u64,
+        relay_connection_id: Option<u64>,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+    ) -> bool {
+        self.confirm_relay_peer_inner(
+            node_id,
+            relay_endpoint,
+            generation,
+            relay_connection_id,
+            Some(peer_session_generation),
+            Some(wireguard_session_instance),
+            "encrypted_business_ingress",
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn confirm_relay_peer_inner(
         &self,
         node_id: &str,
         relay_endpoint: &str,
         generation: u64,
         relay_connection_id: Option<u64>,
         peer_session_generation: Option<PeerSessionGeneration>,
+        wireguard_session_instance: Option<u64>,
         confirmation_source: &'static str,
     ) -> bool {
         // The ACK expectation is checked before this method is called, but
@@ -598,7 +767,21 @@ impl PeerManager {
         // can advance after the expectation is consumed.  Re-check and
         // commit under the shared epoch gate so an old ACK can never install
         // RelayPeerConfirmed in the new generation.
-        let (confirmation_changed, preconfirmation_business_received) = {
+        let now = Instant::now();
+        let pending_evidence = peer_session_generation.and_then(|peer_lifecycle| {
+            wireguard_session_instance.and_then(|session_instance| {
+                self.pending_relay_business_evidence_for_lifecycle(
+                    node_id,
+                    generation,
+                    peer_lifecycle,
+                    session_instance,
+                    relay_endpoint,
+                    relay_connection_id,
+                    now,
+                )
+            })
+        });
+        let (confirmation_changed, pending_committed, exchange_confirmed, first_usable_recorded) = {
             let epoch_gate = self.network_epoch_gate();
             let Ok(_epoch_guard) = epoch_gate.try_lock() else {
                 self.emit_timeline_first(
@@ -652,7 +835,6 @@ impl PeerManager {
                 );
                 return false;
             }
-            let now = Instant::now();
             let result = {
                 let Ok(mut conns) = self.connections.try_write() else {
                     self.emit_timeline_first(
@@ -724,7 +906,10 @@ impl PeerManager {
                     relay_endpoint,
                     relay_connection_id,
                 );
-                let mut result = (false, false);
+                let pending_is_current = pending_evidence.as_ref().is_some_and(|evidence| {
+                    self.pending_relay_business_evidence_is_exact(evidence, Instant::now())
+                });
+                let mut result = (false, false, false, false);
                 let outcome = conn.commit_path_transition(
                     PathEvent::RelayPeerConfirmed {
                         relay: relay_identity,
@@ -737,32 +922,14 @@ impl PeerManager {
                         if confirmation_lifecycle_changed {
                             conn.relay_health.clear_timing_for_lifecycle_change();
                         }
-                        // A real overlay packet can arrive from the relay before this
-                        // daemon consumes the matching path-probe ACK.  Keep that
-                        // evidence only across the bounded confirmation grace period and
-                        // only for the exact relay transport incarnation.  The packet has
-                        // already crossed WireGuard's replay window, so it cannot be
-                        // replayed after confirmation to reconstruct the evidence.
-                        let preconfirmation_business_received = conn
-                            .relay_first
-                            .preconfirmation
-                            .take()
-                            .filter(|pending| {
-                                pending.generation == generation
-                                    && pending.relay_endpoint == relay_endpoint
-                                    && pending.relay_connection_id == relay_connection_id
-                                    && now.saturating_duration_since(pending.received_at)
-                                        <= RELAY_FIRST_CONFIRMATION_GRACE
-                            })
-                            .is_some();
-                        result = if conn.relay_confirmed_at.is_some()
+                        let changed = if conn.relay_confirmed_at.is_some()
                             && conn.relay_confirmed_generation == Some(generation)
                             && conn.relay_confirmed_endpoint.as_deref() == Some(relay_endpoint)
                             && conn.relay_confirmed_connection_id == relay_connection_id
                         {
                             // The exact endpoint and generation was already confirmed.
                             // Duplicate encrypted ACKs are deliberately idempotent.
-                            (false, preconfirmation_business_received)
+                            false
                         } else if conn.relay_confirmed_at.is_some()
                             && conn.relay_confirmed_generation == Some(generation)
                         {
@@ -784,8 +951,7 @@ impl PeerManager {
                             conn.relay_first.business_received_generation = None;
                             conn.relay_first.business_exchange_generation = None;
                             conn.relay_first.business_pathcommit_generation = None;
-                            conn.relay_first.preconfirmation = None;
-                            (true, preconfirmation_business_received)
+                            true
                         } else {
                             // A confirmation from an older generation is never reused.
                             if conn.relay_confirmed_endpoint.as_deref() != Some(relay_endpoint) {
@@ -810,18 +976,34 @@ impl PeerManager {
                             conn.relay_first.business_received_generation = None;
                             conn.relay_first.business_exchange_generation = None;
                             conn.relay_first.business_pathcommit_generation = None;
-                            conn.relay_first.preconfirmation = None;
-                            (true, preconfirmation_business_received)
+                            true
                         };
-                        if preconfirmation_business_received {
+                        let mut pending_committed = false;
+                        let mut exchange_confirmed = false;
+                        let mut first_usable_recorded = false;
+                        if pending_is_current {
+                            pending_committed = conn.relay_first.business_received_generation
+                                != Some(generation);
                             conn.relay_first.business_received_generation = Some(generation);
-                            if conn.relay_first.business_sent_generation == Some(generation) {
+                            if conn.relay_first.business_sent_generation == Some(generation)
+                                && conn.relay_first.business_exchange_generation
+                                    != Some(generation)
+                            {
                                 conn.relay_first.business_exchange_generation = Some(generation);
                                 conn.relay_first.business_gate_completed_generation =
                                     Some(generation);
+                                exchange_confirmed = true;
                             }
+                            first_usable_recorded =
+                                conn.record_first_usable(NetworkPath::Relay, generation);
                         }
-                        if result.0 {
+                        result = (
+                            changed,
+                            pending_committed,
+                            exchange_confirmed,
+                            first_usable_recorded,
+                        );
+                        if changed {
                             // Keep the synchronous waiter mirror in the same critical
                             // section as the connection state transition.  Otherwise a
                             // waiter could observe the state before its notification
@@ -835,8 +1017,11 @@ impl PeerManager {
                 }
                 result
             };
-            (result.0, result.1)
+            result
         };
+        if let Some(pending_evidence) = pending_evidence.as_ref() {
+            self.remove_pending_relay_business_evidence_if_exact(pending_evidence);
+        }
         if confirmation_changed {
             info!(
                 event = "relay_peer_confirmed",
@@ -857,7 +1042,7 @@ impl PeerManager {
                 )),
             );
         }
-        if preconfirmation_business_received {
+        if pending_committed {
             // This is a production TUN ingress fact retained from before the
             // ACK, not a writer/queue success or a probe result.  Publish it
             // only after the matching relay confirmation has established the
@@ -871,24 +1056,36 @@ impl PeerManager {
                     , relay_connection_id.map_or_else(|| "none".to_string(), |id| id.to_string())
                 )),
             );
-            if self
-                .record_verified_first_usable(
-                    node_id,
-                    generation,
-                    NetworkPath::Relay,
-                    &format!("relay:{relay_endpoint}"),
-                )
-                .await
-            {
-                self.emit_timeline(
-                    "relay_first_business_evidence_promoted",
-                    Some("relay"),
-                    None,
-                    Some(format!(
-                        "peer={node_id} generation={generation} relay_endpoint={relay_endpoint}"
-                    )),
-                );
-            }
+        }
+        if exchange_confirmed {
+            self.emit_timeline(
+                "relay_first_business_exchange_confirmed",
+                Some("relay"),
+                None,
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} retained_preconfirmation_business=true"
+                )),
+            );
+        }
+        if first_usable_recorded {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "first_usable_path",
+                Some("relay"),
+                None,
+                Some(format!(
+                    "peer={node_id} generation={generation} ingress=relay:{relay_endpoint} retained_preconfirmation_business=true"
+                )),
+            );
+            self.emit_timeline(
+                "relay_first_business_evidence_promoted",
+                Some("relay"),
+                None,
+                Some(format!(
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint}"
+                )),
+            );
         }
         confirmation_changed
     }
@@ -938,6 +1135,125 @@ impl PeerManager {
         let _epoch_guard = epoch_gate.lock().await;
         self.record_verified_first_usable_in_epoch(node_id, generation, path, ingress_label)
             .await
+    }
+
+    /// Serial-inbound Direct business fast path. It preserves the same
+    /// lifecycle/generation gates as `record_verified_first_usable`, but never
+    /// joins the epoch or connection writer queues while the WireGuard
+    /// current-session evidence guard is held.
+    pub(crate) fn try_record_verified_direct_first_usable_for_lifecycle(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+    ) -> bool {
+        let epoch_gate = self.network_epoch_gate();
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "direct_first_usable_epoch_contended",
+                Some("direct"),
+                Some("network_epoch_busy"),
+                Some(format!(
+                    "peer={node_id} generation={generation} queued_waiter=false retry=next_authenticated_frame"
+                )),
+            );
+            return false;
+        };
+        if generation != self.current_network_generation_sync()
+            || !self.peer_session_is_current_sync(node_id, peer_session_generation)
+        {
+            return false;
+        }
+        let Ok(mut conns) = self.connections.try_write() else {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "direct_first_usable_connections_contended",
+                Some("direct"),
+                Some("fair_rwlock_writer_unavailable"),
+                Some(format!(
+                    "peer={node_id} generation={generation} queued_writer=false retry=next_authenticated_frame"
+                )),
+            );
+            return false;
+        };
+        let Some(conn) = conns.get_mut(node_id) else {
+            return false;
+        };
+        if !conn.online
+            || conn.state == ConnectionState::Closed
+            || !self.peer_session_is_current_sync(node_id, peer_session_generation)
+        {
+            return false;
+        }
+        let (recorded, rejected_reason, fallback_reason) =
+            if conn.is_on_link_direct_for_generation(generation) {
+                (conn.record_first_usable(NetworkPath::Direct, generation), None, None)
+            } else if !conn.has_current_authoritative_direct(generation)
+                && conn.relay_confirmed_generation == Some(generation)
+                && conn.relay_confirmed_endpoint.is_some()
+                && conn.relay_first.business_gate_completed_generation != Some(generation)
+                && conn.relay_first.business_exchange_generation != Some(generation)
+            {
+                (false, Some(REASON_FIRST_DIRECT_BEFORE_RELAY_BUSINESS), None)
+            } else if !conn.has_current_authoritative_direct(generation)
+                && (conn.relay_ready_generation == Some(generation)
+                    || conn.relay_first.gate_generation == Some(generation))
+                && conn.relay_confirmed_generation != Some(generation)
+            {
+                let gate_expired = conn
+                    .relay_ready_at
+                    .or(conn.relay_first.gate_started_at)
+                    .is_some_and(|started_at| {
+                        started_at.elapsed() >= RELAY_FIRST_CONFIRMATION_GRACE
+                    });
+                if gate_expired {
+                    (
+                        conn.record_first_usable(NetworkPath::Direct, generation),
+                        None,
+                        Some(REASON_FIRST_DIRECT_AFTER_RELAY_BUSINESS_DEADLINE),
+                    )
+                } else {
+                    (false, Some(REASON_FIRST_DIRECT_BEFORE_RELAY_BUSINESS), None)
+                }
+            } else {
+                (conn.record_first_usable(NetworkPath::Direct, generation), None, None)
+            };
+        drop(conns);
+        if let Some(reason_code) = rejected_reason {
+            self.emit_timeline(
+                "first_usable_rejected",
+                Some("direct"),
+                Some(reason_code),
+                Some(format!("peer={node_id} generation={generation}")),
+            );
+            return false;
+        }
+        if recorded {
+            if let Some(reason_code) = fallback_reason {
+                self.emit_timeline(
+                    "first_usable_fallback",
+                    Some("direct"),
+                    Some(reason_code),
+                    Some(format!(
+                        "peer={node_id} generation={generation} ingress=direct"
+                    )),
+                );
+            }
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "first_usable_path",
+                Some("direct"),
+                fallback_reason,
+                Some(format!(
+                    "peer={node_id} generation={generation} ingress=direct"
+                )),
+            );
+        }
+        recorded
     }
 
     async fn record_verified_first_usable_in_epoch(
@@ -1375,12 +1691,12 @@ impl PeerManager {
         token: crate::relay_probe::RelayProbeToken,
         ack_ingress: &str,
     ) -> bool {
-        self.consume_relay_probe_ack_inner(node_id, token, ack_ingress, None)
-            .await
+        self.consume_relay_probe_ack_inner(node_id, token, ack_ingress, None, Some(0))
     }
 
     /// Consume an ACK from a live relay reader, including the local relay
     /// connection incarnation that delivered it.
+    #[cfg(test)]
     pub(crate) async fn consume_relay_probe_ack_with_transport(
         &self,
         node_id: &str,
@@ -1388,16 +1704,39 @@ impl PeerManager {
         ack_ingress: &str,
         relay_connection_id: Option<u64>,
     ) -> bool {
-        self.consume_relay_probe_ack_inner(node_id, token, ack_ingress, relay_connection_id)
-            .await
+        self.consume_relay_probe_ack_inner(
+            node_id,
+            token,
+            ack_ingress,
+            relay_connection_id,
+            Some(0),
+        )
     }
 
-    async fn consume_relay_probe_ack_inner(
+    pub(crate) fn consume_relay_probe_ack_with_transport_for_session(
+        &self,
+        node_id: &str,
+        token: crate::relay_probe::RelayProbeToken,
+        ack_ingress: &str,
+        relay_connection_id: Option<u64>,
+        wireguard_session_instance: u64,
+    ) -> bool {
+        self.consume_relay_probe_ack_inner(
+            node_id,
+            token,
+            ack_ingress,
+            relay_connection_id,
+            Some(wireguard_session_instance),
+        )
+    }
+
+    fn consume_relay_probe_ack_inner(
         &self,
         node_id: &str,
         token: crate::relay_probe::RelayProbeToken,
         ack_ingress: &str,
         ack_connection_id: Option<u64>,
+        wireguard_session_instance: Option<u64>,
     ) -> bool {
         // Quarantine is mirrored synchronously.  The serial inbound actor
         // must not await manager state before deciding whether this ACK can
@@ -1502,32 +1841,29 @@ impl PeerManager {
         let relay_rtt = expectation
             .rtt_sample_eligible
             .then(|| now.saturating_duration_since(expectation.sent_at));
-        let confirmation_changed = self
-            .confirm_relay_peer_with_transport_for_lifecycle(
-                node_id,
-                &relay_endpoint,
-                generation,
-                ack_connection_id,
-                Some(expectation.peer_session_generation),
-            )
-            .await;
+        let confirmation_changed = self.confirm_relay_peer_with_transport_for_lifecycle(
+            node_id,
+            &relay_endpoint,
+            generation,
+            ack_connection_id,
+            Some(expectation.peer_session_generation),
+            wireguard_session_instance,
+        );
         // A periodic timed probe normally hits an already-confirmed relay, so
         // confirmation_changed is false.  Commit the RTT only after re-checking
         // the exact online peer/network/relay lifecycle at the write boundary.
-        let accepted = self
-            .accept_relay_probe_ack_for_current_lifecycle(
-                node_id,
-                &relay_endpoint,
-                generation,
-                ack_connection_id,
-                Some(expectation.peer_session_generation),
-                RelayHealthObservationIdentity {
-                    owner_token: expectation.owner_token,
-                    request_id: expectation.request_id,
-                },
-                relay_rtt,
-            )
-            .await;
+        let accepted = self.accept_relay_probe_ack_for_current_lifecycle(
+            node_id,
+            &relay_endpoint,
+            generation,
+            ack_connection_id,
+            Some(expectation.peer_session_generation),
+            RelayHealthObservationIdentity {
+                owner_token: expectation.owner_token,
+                request_id: expectation.request_id,
+            },
+            relay_rtt,
+        );
         if confirmation_changed || accepted {
             // Consume only after the lifecycle-bound commit succeeded.  A
             // contended try-write keeps the exact expectation available for
@@ -1563,7 +1899,7 @@ impl PeerManager {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn accept_relay_probe_ack_for_current_lifecycle(
+    fn accept_relay_probe_ack_for_current_lifecycle(
         &self,
         node_id: &str,
         relay_endpoint: &str,
@@ -1902,13 +2238,8 @@ impl PeerManager {
         changed
     }
 
-    /// Commit the first normal business packet received through the
-    /// same-generation confirmed relay.  This is deliberately separate from
-    /// writer completion: Direct may not become the active path until both
-    /// the local send and the remote-to-local receive direction have crossed
-    /// the same relay transport.  The two markers may arrive in either order;
-    /// their generation/endpoint binding, not local event ordering, is the
-    /// invariant.
+    /// Compatibility helper for manager unit tests which do not model the
+    /// process-local WireGuard session instance.
     #[cfg(test)]
     pub(crate) async fn mark_relay_first_business_received_for_generation(
         &self,
@@ -1916,20 +2247,24 @@ impl PeerManager {
         relay_endpoint: &str,
         generation: u64,
     ) -> bool {
-        self.mark_relay_first_business_received_for_generation_with_transport(
-            node_id,
-            relay_endpoint,
-            generation,
-            None,
+        let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
+            return false;
+        };
+        matches!(
+            self.try_commit_relay_business_evidence(
+                node_id,
+                generation,
+                peer_session_generation,
+                0,
+                relay_endpoint,
+                None,
+                Instant::now(),
+            ),
+            RelayBusinessEvidenceCommitOutcome::Committed
         )
-        .await
     }
 
-    /// Record a decrypted relay business packet with the local relay
-    /// transport incarnation.  Before the path-probe ACK this stores a
-    /// bounded pending tuple; after confirmation it commits the normal
-    /// receive/exchange markers.  The ACK and packet may therefore arrive in
-    /// either order without trying to replay a WireGuard ciphertext.
+    #[cfg(test)]
     pub(crate) async fn mark_relay_first_business_received_for_generation_with_transport(
         &self,
         node_id: &str,
@@ -1937,133 +2272,279 @@ impl PeerManager {
         generation: u64,
         relay_connection_id: Option<u64>,
     ) -> bool {
-        let now = Instant::now();
-        let (first_receive, exchange_confirmed, endpoint, pending) = {
-            let epoch_gate = self.network_epoch_gate();
-            let _epoch_guard = epoch_gate.lock().await;
-            if generation != self.current_network_generation_sync() {
-                self.emit_timeline(
-                    "relay_first_business_received_rejected",
-                    Some("relay"),
-                    Some("stale_generation"),
-                    Some(format!(
-                        "peer={node_id} generation={generation} current_generation={} relay_endpoint={relay_endpoint}",
-                        self.current_network_generation_sync()
-                    )),
-                );
-                return false;
-            }
-            let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
-                return false;
-            };
-            let mut conns = self.connections.write().await;
-            let Some(conn) = conns.get_mut(node_id) else {
-                return false;
-            };
-            let relay_session_matches = conn.online
-                && conn.state != ConnectionState::Closed
-                && conn.relay_confirmed_generation == Some(generation)
-                && conn.relay_confirmed_endpoint.as_deref() == Some(relay_endpoint)
-                && conn.relay_confirmed_connection_id == relay_connection_id;
-            let result = if !relay_session_matches {
-                let ready_session_matches = conn.online
-                    && conn.state != ConnectionState::Closed
-                    && conn.relay_ready_generation == Some(generation)
-                    && conn.relay_ready_endpoint.as_deref() == Some(relay_endpoint);
-                let pending = if ready_session_matches {
-                    let should_replace =
-                        conn.relay_first
-                            .preconfirmation
-                            .as_ref()
-                            .is_none_or(|existing| {
-                                existing.generation != generation
-                                    || existing.relay_endpoint != relay_endpoint
-                                    || existing.relay_connection_id != relay_connection_id
-                                    || now.saturating_duration_since(existing.received_at)
-                                        > RELAY_FIRST_CONFIRMATION_GRACE
-                            });
-                    if should_replace {
-                        conn.relay_first.preconfirmation = Some(PendingRelayBusinessEvidence {
-                            generation,
-                            relay_endpoint: relay_endpoint.to_string(),
-                            relay_connection_id,
-                            received_at: now,
-                        });
-                    }
-                    should_replace
-                } else {
-                    false
-                };
-                (false, false, None, pending)
-            } else {
-                let relay_identity = RelayConnectionIdentity::new(
-                    PathEpoch::new(
-                        generation,
-                        peer_session_generation,
-                        conn.remote_candidate_epoch(),
-                    ),
-                    relay_endpoint,
-                    relay_connection_id,
-                );
-                let mut usable_result = (false, false, None, false);
-                let outcome = conn.commit_path_transition(
-                    PathEvent::RelayBusinessUsable {
-                        relay: relay_identity,
-                        observation: RelayBusinessObservation::Received,
-                    },
-                    |conn| {
-                        let first_receive =
-                            conn.relay_first.business_received_generation != Some(generation);
-                        if first_receive {
-                            conn.relay_first.business_received_generation = Some(generation);
-                        }
-                        let exchange_confirmed = conn.relay_first.business_sent_generation
-                            == Some(generation)
-                            && conn.relay_first.business_exchange_generation != Some(generation);
-                        if exchange_confirmed {
-                            conn.relay_first.business_exchange_generation = Some(generation);
-                            conn.relay_first.business_gate_completed_generation = Some(generation);
-                        }
-                        usable_result = if !first_receive && !exchange_confirmed {
-                            (false, false, None, false)
-                        } else {
-                            (
-                                first_receive,
-                                exchange_confirmed,
-                                conn.relay_confirmed_endpoint
-                                    .clone()
-                                    .or_else(|| conn.relay_ready_endpoint.clone())
-                                    .or_else(|| Some(relay_endpoint.to_string())),
-                                false,
-                            )
-                        };
-                    },
-                );
-                if !outcome.accepted() {
-                    return false;
-                }
-                usable_result
-            };
-            result
+        let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
+            return false;
         };
-        if pending {
-            self.emit_timeline(
-                "relay_first_business_received_pending",
+        matches!(
+            self.try_commit_relay_business_evidence(
+                node_id,
+                generation,
+                peer_session_generation,
+                0,
+                relay_endpoint,
+                relay_connection_id,
+                Instant::now(),
+            ),
+            RelayBusinessEvidenceCommitOutcome::Committed
+        )
+    }
+
+    /// Retain and attempt one exact authenticated Relay business transaction.
+    /// Both async-owned locks are try-only; a contended packet is handed to TUN
+    /// immediately while its evidence remains in the bounded ledger.
+    #[allow(clippy::too_many_arguments)]
+    fn relay_business_evidence_for_current_lifecycle(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+        received_at: Instant,
+    ) -> Option<PendingRelayBusinessEvidence> {
+        if generation != self.current_network_generation_sync()
+            || !self.peer_session_is_current_sync(node_id, peer_session_generation)
+            || self.peer_quarantined_sync(node_id)
+        {
+            return None;
+        }
+        Some(PendingRelayBusinessEvidence {
+            peer_id: node_id.to_string(),
+            network_generation: generation,
+            peer_session_generation,
+            wireguard_session_instance,
+            relay_endpoint: relay_endpoint.to_string(),
+            relay_connection_id,
+            received_at,
+        })
+    }
+
+    /// Preserve authenticated Relay business evidence when the final
+    /// current-session fence itself is contended. The evidence is deliberately
+    /// retained without committing: only a later frame authenticated by the
+    /// same exact WireGuard session/Relay incarnation can retry it.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn retain_relay_business_evidence_for_retry(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+        received_at: Instant,
+    ) -> bool {
+        let Some(evidence) = self.relay_business_evidence_for_current_lifecycle(
+            node_id,
+            generation,
+            peer_session_generation,
+            wireguard_session_instance,
+            relay_endpoint,
+            relay_connection_id,
+            received_at,
+        ) else {
+            return false;
+        };
+        self.retain_pending_relay_business_evidence(evidence)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_commit_relay_business_evidence(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+        received_at: Instant,
+    ) -> RelayBusinessEvidenceCommitOutcome {
+        let Some(evidence) = self.relay_business_evidence_for_current_lifecycle(
+            node_id,
+            generation,
+            peer_session_generation,
+            wireguard_session_instance,
+            relay_endpoint,
+            relay_connection_id,
+            received_at,
+        ) else {
+            return RelayBusinessEvidenceCommitOutcome::RejectedLifecycle;
+        };
+        // Save before either try-lock. WireGuard replay protection can make
+        // this the only copy of the authenticated business evidence.
+        let _ = self.retain_pending_relay_business_evidence(evidence.clone());
+        self.try_commit_retained_relay_business_evidence(evidence)
+    }
+
+    /// Retry the ledger entry matching a later authenticated frame.  The
+    /// caller owns the exact current-session evidence guard and has already
+    /// verified the Relay transport slot incarnation.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_commit_pending_relay_business_evidence_for_session(
+        &self,
+        node_id: &str,
+        generation: u64,
+        peer_session_generation: PeerSessionGeneration,
+        wireguard_session_instance: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+    ) -> Option<RelayBusinessEvidenceCommitOutcome> {
+        let evidence = self.pending_relay_business_evidence_for_lifecycle(
+            node_id,
+            generation,
+            peer_session_generation,
+            wireguard_session_instance,
+            relay_endpoint,
+            relay_connection_id,
+            Instant::now(),
+        )?;
+        Some(self.try_commit_retained_relay_business_evidence(evidence))
+    }
+
+    fn try_commit_retained_relay_business_evidence(
+        &self,
+        evidence: PendingRelayBusinessEvidence,
+    ) -> RelayBusinessEvidenceCommitOutcome {
+        let node_id = evidence.peer_id.as_str();
+        let generation = evidence.network_generation;
+        let relay_endpoint = evidence.relay_endpoint.as_str();
+        let relay_connection_id = evidence.relay_connection_id;
+        let finish = |outcome| {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "relay_business_evidence_commit",
                 Some("relay"),
-                Some("awaiting_relay_probe_confirmation"),
+                match outcome {
+                    RelayBusinessEvidenceCommitOutcome::PendingConfirmation => {
+                        Some("awaiting_relay_probe_confirmation")
+                    }
+                    RelayBusinessEvidenceCommitOutcome::ContendedEpoch => {
+                        Some("network_epoch_busy")
+                    }
+                    RelayBusinessEvidenceCommitOutcome::ContendedConnections => {
+                        Some("fair_rwlock_writer_unavailable")
+                    }
+                    RelayBusinessEvidenceCommitOutcome::RejectedLifecycle => {
+                        Some("lifecycle_rejected")
+                    }
+                    RelayBusinessEvidenceCommitOutcome::Committed
+                    | RelayBusinessEvidenceCommitOutcome::AlreadyCurrent => None,
+                },
                 Some(format!(
-                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint}"
+                    "peer={node_id} generation={generation} peer_session_generation={} wireguard_session_instance={} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} outcome={outcome:?} queued_writer=false",
+                    evidence.peer_session_generation.0,
+                    evidence.wireguard_session_instance,
                 )),
             );
+            outcome
+        };
+
+        let epoch_gate = self.network_epoch_gate();
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            return finish(RelayBusinessEvidenceCommitOutcome::ContendedEpoch);
+        };
+        if generation != self.current_network_generation_sync()
+            || !self.peer_session_is_current_sync(node_id, evidence.peer_session_generation)
+            || self.peer_quarantined_sync(node_id)
+        {
+            self.remove_pending_relay_business_evidence_if_exact(&evidence);
+            return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
         }
+        let Ok(mut conns) = self.connections.try_write() else {
+            return finish(RelayBusinessEvidenceCommitOutcome::ContendedConnections);
+        };
+        let Some(conn) = conns.get_mut(node_id) else {
+            drop(conns);
+            self.remove_pending_relay_business_evidence_if_exact(&evidence);
+            return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
+        };
+        if !conn.online
+            || conn.state == ConnectionState::Closed
+            || !self.peer_session_is_current_sync(node_id, evidence.peer_session_generation)
+            || self.peer_quarantined_sync(node_id)
+        {
+            drop(conns);
+            self.remove_pending_relay_business_evidence_if_exact(&evidence);
+            return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
+        }
+        if !self.pending_relay_business_evidence_is_exact(&evidence, Instant::now()) {
+            return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
+        }
+        let confirmed = conn.relay_confirmed_at.is_some()
+            && conn.relay_confirmed_generation == Some(generation)
+            && conn.relay_confirmed_endpoint.as_deref() == Some(relay_endpoint)
+            && conn.relay_confirmed_connection_id == relay_connection_id;
+        if !confirmed {
+            let current_relay_incarnation_mismatch =
+                (conn.relay_ready_generation == Some(generation)
+                    && (conn.relay_ready_endpoint.as_deref() != Some(relay_endpoint)
+                        || conn.relay_ready_connection_id != relay_connection_id))
+                    || (conn.relay_confirmed_at.is_some()
+                        && conn.relay_confirmed_generation == Some(generation)
+                        && (conn.relay_confirmed_endpoint.as_deref() != Some(relay_endpoint)
+                            || conn.relay_confirmed_connection_id != relay_connection_id));
+            if current_relay_incarnation_mismatch {
+                drop(conns);
+                self.remove_pending_relay_business_evidence_if_exact(&evidence);
+                return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
+            }
+            // A READY marker may itself have lost a try-write race. Keep the
+            // exact evidence bounded until a later authenticated frame first
+            // retries READY and then retries this transaction. A mismatched
+            // generation/session/Relay incarnation can never pass the exact
+            // confirmation predicate above and expires without side effects.
+            return finish(RelayBusinessEvidenceCommitOutcome::PendingConfirmation);
+        }
+
+        let relay_identity = RelayConnectionIdentity::new(
+            PathEpoch::new(
+                generation,
+                evidence.peer_session_generation,
+                conn.remote_candidate_epoch(),
+            ),
+            relay_endpoint,
+            relay_connection_id,
+        );
+        let mut first_receive = false;
+        let mut exchange_confirmed = false;
+        let mut first_usable_recorded = false;
+        let outcome = conn.commit_path_transition(
+            PathEvent::RelayBusinessUsable {
+                relay: relay_identity,
+                observation: RelayBusinessObservation::Received,
+            },
+            |conn| {
+                first_receive =
+                    conn.relay_first.business_received_generation != Some(generation);
+                if first_receive {
+                    conn.relay_first.business_received_generation = Some(generation);
+                }
+                exchange_confirmed = conn.relay_first.business_sent_generation == Some(generation)
+                    && conn.relay_first.business_exchange_generation != Some(generation);
+                if exchange_confirmed {
+                    conn.relay_first.business_exchange_generation = Some(generation);
+                    conn.relay_first.business_gate_completed_generation = Some(generation);
+                }
+                first_usable_recorded = conn.record_first_usable(NetworkPath::Relay, generation);
+            },
+        );
+        if !outcome.accepted() {
+            drop(conns);
+            self.remove_pending_relay_business_evidence_if_exact(&evidence);
+            return finish(RelayBusinessEvidenceCommitOutcome::RejectedLifecycle);
+        }
+        drop(conns);
+        self.remove_pending_relay_business_evidence_if_exact(&evidence);
+
         if first_receive {
             self.emit_timeline(
                 "relay_first_business_received",
                 Some("relay"),
                 None,
                 Some(format!(
-                    "peer={node_id} generation={generation} relay_endpoint={}",
-                    endpoint.as_deref().unwrap_or("unknown")
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?}"
                 )),
             );
         }
@@ -2073,12 +2554,27 @@ impl PeerManager {
                 Some("relay"),
                 None,
                 Some(format!(
-                    "peer={node_id} generation={generation} relay_endpoint={}",
-                    endpoint.as_deref().unwrap_or("unknown")
+                    "peer={node_id} generation={generation} relay_endpoint={relay_endpoint}"
                 )),
             );
         }
-        first_receive || exchange_confirmed
+        if first_usable_recorded {
+            self.emit_timeline_first(
+                node_id,
+                generation,
+                "first_usable_path",
+                Some("relay"),
+                None,
+                Some(format!(
+                    "peer={node_id} generation={generation} ingress=relay:{relay_endpoint}"
+                )),
+            );
+        }
+        finish(if first_receive || exchange_confirmed || first_usable_recorded {
+            RelayBusinessEvidenceCommitOutcome::Committed
+        } else {
+            RelayBusinessEvidenceCommitOutcome::AlreadyCurrent
+        })
     }
 
     /// The per-peer first-usable instant, if any (daemon-local monotonic).
@@ -2108,80 +2604,73 @@ impl PeerManager {
         generation: u64,
         relay_endpoint: &str,
     ) -> bool {
-        self.mark_relay_first_business_pathcommit_for_generation_inner(
-            node_id,
-            generation,
-            relay_endpoint,
-            None,
-            false,
-        )
-        .await
-    }
-
-    async fn mark_relay_first_business_pathcommit_for_generation_with_transport(
-        &self,
-        node_id: &str,
-        generation: u64,
-        relay_endpoint: &str,
-        relay_connection_id: Option<u64>,
-    ) -> bool {
-        self.mark_relay_first_business_pathcommit_for_generation_inner(
-            node_id,
-            generation,
-            relay_endpoint,
-            relay_connection_id,
-            true,
-        )
-        .await
-    }
-
-    async fn mark_relay_first_business_pathcommit_for_generation_inner(
-        &self,
-        node_id: &str,
-        generation: u64,
-        relay_endpoint: &str,
-        relay_connection_id: Option<u64>,
-        bind_transport: bool,
-    ) -> bool {
-        let (changed, endpoint) = {
-            let epoch_gate = self.network_epoch_gate();
-            let _epoch_guard = epoch_gate.lock().await;
-            if generation != self.current_network_generation_sync() {
-                return false;
-            }
-            let mut conns = self.connections.write().await;
-            let Some(conn) = conns.get_mut(node_id) else {
-                return false;
-            };
-            let confirmed = conn.online
-                && conn.state != ConnectionState::Closed
-                && conn.relay_confirmed_at.is_some()
-                && conn.relay_confirmed_generation == Some(generation)
-                && conn.relay_confirmed_endpoint.as_deref() == Some(relay_endpoint)
-                && (!bind_transport || conn.relay_confirmed_connection_id == relay_connection_id);
-            if !confirmed || conn.relay_first.business_pathcommit_generation == Some(generation) {
-                return false;
-            }
-            conn.relay_first.business_pathcommit_generation = Some(generation);
-            conn.relay_first.business_gate_completed_generation = Some(generation);
-            (
-                true,
-                conn.relay_confirmed_endpoint
-                    .clone()
-                    .unwrap_or_else(|| relay_endpoint.to_string()),
-            )
+        let Some(peer_session_generation) = self.peer_session_generation_sync(node_id) else {
+            return false;
         };
-        if changed {
-            self.emit_timeline(
-                "relay_first_business_pathcommit",
-                Some("relay"),
+        matches!(
+            self.try_mark_relay_first_business_pathcommit_for_lifecycle(
+                node_id,
+                generation,
+                relay_endpoint,
                 None,
-                Some(format!(
-                    "peer={node_id} generation={generation} relay_endpoint={endpoint}"
-                )),
-            );
+                peer_session_generation,
+                false,
+            ),
+            PathCommitCommitOutcome::Committed
+        )
+    }
+
+    fn try_mark_relay_first_business_pathcommit_for_lifecycle(
+        &self,
+        node_id: &str,
+        generation: u64,
+        relay_endpoint: &str,
+        relay_connection_id: Option<u64>,
+        peer_session_generation: PeerSessionGeneration,
+        bind_transport: bool,
+    ) -> PathCommitCommitOutcome {
+        let epoch_gate = self.network_epoch_gate();
+        let Ok(_epoch_guard) = epoch_gate.try_lock() else {
+            return PathCommitCommitOutcome::ContendedEpoch;
+        };
+        if generation != self.current_network_generation_sync()
+            || !self.peer_session_is_current_sync(node_id, peer_session_generation)
+            || self.peer_quarantined_sync(node_id)
+        {
+            return PathCommitCommitOutcome::RejectedLifecycle;
         }
-        changed
+        let Ok(mut conns) = self.connections.try_write() else {
+            return PathCommitCommitOutcome::ContendedConnections;
+        };
+        let Some(conn) = conns.get_mut(node_id) else {
+            return PathCommitCommitOutcome::RejectedLifecycle;
+        };
+        let confirmed = conn.online
+            && conn.state != ConnectionState::Closed
+            && self.peer_session_is_current_sync(node_id, peer_session_generation)
+            && !self.peer_quarantined_sync(node_id)
+            && conn.relay_confirmed_at.is_some()
+            && conn.relay_confirmed_generation == Some(generation)
+            && conn.relay_confirmed_endpoint.as_deref() == Some(relay_endpoint)
+            && (!bind_transport || conn.relay_confirmed_connection_id == relay_connection_id);
+        if !confirmed {
+            return PathCommitCommitOutcome::RejectedLifecycle;
+        }
+        if conn.relay_first.business_pathcommit_generation == Some(generation) {
+            return PathCommitCommitOutcome::AlreadyCurrent;
+        }
+        conn.relay_first.business_pathcommit_generation = Some(generation);
+        conn.relay_first.business_gate_completed_generation = Some(generation);
+        drop(conns);
+        self.emit_timeline(
+            "relay_first_business_pathcommit",
+            Some("relay"),
+            None,
+            Some(format!(
+                "peer={node_id} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?}"
+            )),
+        );
+        PathCommitCommitOutcome::Committed
     }
 
     /// Register the expectation for one outstanding path-commit request.  The
@@ -2257,6 +2746,7 @@ impl PeerManager {
     /// was sent on.  A late ACK from an old relay must never release the current
     /// generation's gate.  Returns whether the ACK matched and committed the
     /// path-commit marker.
+    #[cfg(test)]
     pub(crate) async fn consume_path_commit_ack_with_transport(
         &self,
         node_id: &str,
@@ -2264,47 +2754,69 @@ impl PeerManager {
         ack_ingress: &str,
         relay_connection_id: Option<u64>,
     ) -> bool {
-        self.consume_path_commit_ack_inner(node_id, token, ack_ingress, relay_connection_id)
-            .await
+        matches!(
+            self.try_consume_path_commit_ack_with_transport(
+                node_id,
+                token,
+                ack_ingress,
+                relay_connection_id,
+            ),
+            PathCommitCommitOutcome::Committed | PathCommitCommitOutcome::AlreadyCurrent
+        )
     }
 
-    async fn consume_path_commit_ack_inner(
+    pub(crate) fn try_consume_path_commit_ack_with_transport(
         &self,
         node_id: &str,
         token: crate::path_commit::PathCommitToken,
         ack_ingress: &str,
         relay_connection_id: Option<u64>,
-    ) -> bool {
+    ) -> PathCommitCommitOutcome {
         let now = Instant::now();
-        let expectation = {
-            let mut expectations = self
-                .path_commit_expectations
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let expectation = expectations.get(node_id).cloned();
-            if expectation.as_ref().is_some_and(|e| {
-                e.accepts(&token, now, ack_ingress) && e.accepts_connection(relay_connection_id)
-            }) {
-                expectations.remove(node_id);
-            }
-            expectation
-        };
+        // Retain the short bounded expectation-map guard from exact clone
+        // through the try-only state transaction. This prevents a concurrent
+        // newest-wins owner replacement from being crossed by the old ACK.
+        let mut expectations = self
+            .path_commit_expectations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let expectation = expectations.get(node_id).cloned();
         let Some(expectation) = expectation else {
-            return false;
+            return PathCommitCommitOutcome::RejectedLifecycle;
         };
         if !expectation.accepts(&token, now, ack_ingress)
             || !expectation.accepts_connection(relay_connection_id)
+            || expectation.generation != self.current_network_generation_sync()
             || !self.peer_session_is_current_sync(node_id, expectation.peer_session_generation)
         {
-            return false;
+            return PathCommitCommitOutcome::RejectedLifecycle;
         }
-        self.mark_relay_first_business_pathcommit_for_generation_with_transport(
+        let outcome = self.try_mark_relay_first_business_pathcommit_for_lifecycle(
             node_id,
             token.generation,
             ack_ingress,
             relay_connection_id,
-        )
-        .await
+            expectation.peer_session_generation,
+            true,
+        );
+        if matches!(
+            outcome,
+            PathCommitCommitOutcome::Committed | PathCommitCommitOutcome::AlreadyCurrent
+        ) {
+            // Delete only the exact expectation which was cloned above.
+            if expectations.get(node_id).is_some_and(|current| {
+                current.generation == expectation.generation
+                    && current.request_id == expectation.request_id
+                    && current.owner_token == expectation.owner_token
+                    && current.relay_endpoint == expectation.relay_endpoint
+                    && current.relay_connection_id == expectation.relay_connection_id
+                    && current.peer_session_generation == expectation.peer_session_generation
+                    && current.sent_at == expectation.sent_at
+            }) {
+                expectations.remove(node_id);
+            }
+        }
+        outcome
     }
 
     /// Whether a peer is inside the network-generation window that the first
@@ -2472,7 +2984,6 @@ impl PeerManager {
                             conn.relay_first.business_received_generation = None;
                             conn.relay_first.business_exchange_generation = None;
                             conn.relay_first.business_pathcommit_generation = None;
-                            conn.relay_first.preconfirmation = None;
                             conn.relay_ready_generation = None;
                             conn.relay_ready_at = None;
                             conn.relay_ready_endpoint = None;
@@ -2704,7 +3215,6 @@ impl PeerManager {
                         conn.relay_first.business_received_generation = None;
                         conn.relay_first.business_exchange_generation = None;
                         conn.relay_first.business_pathcommit_generation = None;
-                        conn.relay_first.preconfirmation = None;
                         if had_confirmed {
                             conn.relay_confirm_seq = conn.relay_confirm_seq.wrapping_add(1);
                             self.bump_relay_confirm_seq(&conn.node_id);

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -2,6 +2,12 @@
 // Peer Manager
 // ============================================================
 
+type NetworkGenerationHandshakeCancellation = (usize, usize, Vec<(String, String)>);
+type NetworkGenerationHandshakeCancelHook =
+    Arc<dyn Fn(u64) -> NetworkGenerationHandshakeCancellation + Send + Sync>;
+type NetworkGenerationHandshakeCancelHookSlot =
+    Arc<std::sync::Mutex<Option<NetworkGenerationHandshakeCancelHook>>>;
+
 /// The local, non-wire identity fence for one Hard↔Hard rendezvous.
 ///
 /// The session id alone is not sufficient: a late response from an older
@@ -334,6 +340,10 @@ pub struct PeerManager {
     /// advances between the read and the lock would let a stale entry pass the
     /// check).
     network_generation_sync: Arc<std::sync::atomic::AtomicU64>,
+    /// Nonblocking daemon hook that cancels exact handshake reservations from
+    /// older generations in the same generation-advance transaction.  The
+    /// hook performs only a short synchronous pending-state mutation.
+    network_generation_handshake_cancel_hook: NetworkGenerationHandshakeCancelHookSlot,
     /// Shared network-epoch gate serializing every generation advance against
     /// every UDP socket-state mutation that stamps, commits, finalizes or
     /// adopts socket ownership for a generation.

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -495,6 +495,11 @@ pub struct PeerManager {
     /// is verified before RelayPeerConfirmed is set.
     relay_probe_expectations:
         Arc<std::sync::Mutex<HashMap<String, crate::relay_probe::RelayProbeExpectation>>>,
+    /// Authenticated Relay business evidence which could not immediately take
+    /// the epoch/connection transaction. One newest-wins entry per peer, with
+    /// a strict TTL and global capacity bound.
+    pending_relay_business_evidence:
+        Arc<std::sync::Mutex<HashMap<String, PendingRelayBusinessEvidence>>>,
     /// Bounded per-peer path-commit expectations: the token the local daemon
     /// sent in a synthetic path-commit request, against which a relay-ingress
     /// ACK is verified before the relay-first business gate is closed for

--- a/client/daemon/src/peer/tests.rs
+++ b/client/daemon/src/peer/tests.rs
@@ -22,3 +22,4 @@ include!("tests/part15.rs");
 include!("tests/part16.rs");
 include!("tests/part17.rs");
 include!("tests/part18.rs");
+include!("tests/part19.rs");

--- a/client/daemon/src/peer/tests/part02a.rs
+++ b/client/daemon/src/peer/tests/part02a.rs
@@ -801,6 +801,98 @@ async fn peer_left_after_remote_restart_reset_preserves_claimed_generation_floor
 }
 
 #[tokio::test]
+async fn remote_incarnation_try_claim_is_non_queuing_and_fences_retired_work() {
+    let manager = PeerManager::new(test_config());
+    let endpoint: SocketAddr = "1.2.3.4:5000".parse().unwrap();
+    let peer = test_peer("peer-incarnation-try-claim", endpoint);
+    manager.add_peer(&peer).await;
+
+    let generation =
+        |incarnation: u64, counter: u64| 0x4000_0000_0000_0000u64 | (incarnation << 21) | counter;
+    let first = generation(4_000, 10);
+    assert_eq!(
+        manager.try_claim_remote_candidate_incarnation_for_identity(
+            &peer.node_id,
+            first,
+            Some(&peer.public_key),
+        ),
+        RemoteCandidateIncarnationTryClaim::Committed(
+            RemoteCandidateIncarnationClaim::NoReset,
+        )
+    );
+    assert_eq!(
+        manager
+            .add_candidates_with_metadata(
+                &peer.node_id,
+                &[endpoint.to_string()],
+                &HashMap::new(),
+                first,
+                None,
+            )
+            .await,
+        CandidateSetApplyResult::Applied
+    );
+
+    let reader = manager.connections.clone().read_owned().await;
+    let same_incarnation = generation(4_000, 20);
+    assert_eq!(
+        manager.try_claim_remote_candidate_incarnation_for_identity(
+            &peer.node_id,
+            same_incarnation,
+            Some(&peer.public_key),
+        ),
+        RemoteCandidateIncarnationTryClaim::Committed(
+            RemoteCandidateIncarnationClaim::NoReset,
+        ),
+        "the synchronous incarnation ledger must bypass a contended connection map",
+    );
+    assert!(
+        manager.connections.try_read().is_ok(),
+        "the same-incarnation fast path must not queue a fair writer",
+    );
+
+    let newer_incarnation = generation(4_001, 1);
+    assert_eq!(
+        manager.try_claim_remote_candidate_incarnation_for_identity(
+            &peer.node_id,
+            newer_incarnation,
+            Some(&peer.public_key),
+        ),
+        RemoteCandidateIncarnationTryClaim::ContendedConnections,
+    );
+    assert!(
+        manager.connections.try_read().is_ok(),
+        "explicit contention must return without joining the writer queue",
+    );
+    assert_eq!(
+        manager.try_claim_remote_candidate_incarnation_for_identity(
+            &peer.node_id,
+            first,
+            Some(&peer.public_key),
+        ),
+        RemoteCandidateIncarnationTryClaim::Committed(
+            RemoteCandidateIncarnationClaim::RejectedLifecycle,
+        ),
+        "an older counter below the synchronous replay floor is terminally stale",
+    );
+
+    drop(reader);
+    assert!(matches!(
+        manager.try_claim_remote_candidate_incarnation_for_identity(
+            &peer.node_id,
+            newer_incarnation,
+            Some(&peer.public_key),
+        ),
+        RemoteCandidateIncarnationTryClaim::Committed(
+            RemoteCandidateIncarnationClaim::Reset {
+                old_incarnation: 4_000,
+                new_incarnation: 4_001,
+            },
+        )
+    ));
+}
+
+#[tokio::test]
 async fn peer_left_before_candidate_apply_preserves_first_and_same_incarnation_floors() {
     let manager = PeerManager::new(test_config());
     let endpoint: SocketAddr = "1.2.3.4:5000".parse().unwrap();

--- a/client/daemon/src/peer/tests/part05a.rs
+++ b/client/daemon/src/peer/tests/part05a.rs
@@ -507,7 +507,9 @@ async fn direct_business_cannot_be_first_usable_before_relay_receive() {
             generation,
         )
         .await);
-    assert!(manager
+    // Relay business received + first-usable are one atomic connection
+    // transaction now; the compatibility call is therefore idempotent.
+    assert!(!manager
         .record_verified_first_usable(
             "peer1",
             generation,
@@ -515,6 +517,63 @@ async fn direct_business_cannot_be_first_usable_before_relay_receive() {
             "relay:tcp://relay.test:18081",
         )
         .await);
+}
+
+#[test]
+fn relay_business_pending_ledger_is_newest_wins_ttl_and_capacity_bounded() {
+    let manager = PeerManager::new(test_config());
+    let base = Instant::now();
+    let evidence = |peer_id: String, received_at: Instant| PendingRelayBusinessEvidence {
+        peer_id,
+        network_generation: 1,
+        peer_session_generation: PeerSessionGeneration(1),
+        wireguard_session_instance: 7,
+        relay_endpoint: "tcp://relay.test:18081".to_string(),
+        relay_connection_id: Some(11),
+        received_at,
+    };
+
+    let expired_at = base
+        .checked_sub(PENDING_RELAY_BUSINESS_EVIDENCE_TTL + Duration::from_millis(1))
+        .expect("test instant is representable");
+    assert!(!manager.retain_pending_relay_business_evidence(evidence(
+        "expired".to_string(),
+        expired_at,
+    )));
+    assert_eq!(manager.pending_relay_business_evidence_len(), 0);
+
+    for index in 0..=MAX_PENDING_RELAY_BUSINESS_EVIDENCE {
+        assert!(manager.retain_pending_relay_business_evidence(evidence(
+            format!("peer-{index}"),
+            base + Duration::from_nanos(index as u64),
+        )));
+    }
+    assert_eq!(
+        manager.pending_relay_business_evidence_len(),
+        MAX_PENDING_RELAY_BUSINESS_EVIDENCE
+    );
+    assert!(!manager.pending_relay_business_evidence_present("peer-0"));
+    let newest_peer = format!("peer-{MAX_PENDING_RELAY_BUSINESS_EVIDENCE}");
+    assert!(manager.pending_relay_business_evidence_present(&newest_peer));
+
+    let current_received_at = base
+        + Duration::from_nanos(MAX_PENDING_RELAY_BUSINESS_EVIDENCE as u64);
+    assert!(!manager.retain_pending_relay_business_evidence(evidence(
+        newest_peer.clone(),
+        base,
+    )));
+    let retained = manager
+        .pending_relay_business_evidence_for_lifecycle(
+            &newest_peer,
+            1,
+            PeerSessionGeneration(1),
+            7,
+            "tcp://relay.test:18081",
+            Some(11),
+            Instant::now(),
+        )
+        .expect("newest entry remains retained");
+    assert_eq!(retained.received_at, current_received_at);
 }
 
 #[tokio::test]
@@ -540,8 +599,9 @@ async fn relay_receive_before_local_send_completes_after_local_send() {
         .await);
 
     // The inbound relay packet arrived before this daemon had sent its own
-    // first relay business packet. It is valid same-generation receive
-    // evidence, but Direct remains gated until this daemon also sends one.
+    // first relay business packet. Its receive marker and Relay first-usable
+    // evidence commit atomically, while Direct remains gated until this daemon
+    // also sends one.
     assert!(!manager
         .record_verified_first_usable("peer1", generation, NetworkPath::Direct, "direct")
         .await);
@@ -556,9 +616,11 @@ async fn relay_receive_before_local_send_completes_after_local_send() {
     // two-direction gate without requiring an unrelated later TUN packet.
     let selection = manager.select_path_for_data("peer1", true, true).await;
     assert_eq!(selection.path, Some(NetworkPath::Direct));
-    assert!(manager
+    assert!(!manager
         .record_verified_first_usable("peer1", generation, NetworkPath::Direct, "direct")
         .await);
+    let connection = manager.get_connection("peer1").await.unwrap();
+    assert_eq!(connection.first_usable_path, Some(NetworkPath::Relay));
 }
 
 #[tokio::test]
@@ -673,7 +735,9 @@ async fn encrypted_business_ingress_can_confirm_relay_before_probe_ack() {
             Some(17),
         )
         .await);
-    assert!(manager
+    // The typed Relay business transaction records first-usable atomically
+    // with the receive marker.
+    assert!(!manager
         .record_verified_first_usable(
             "peer1",
             generation,

--- a/client/daemon/src/peer/tests/part06a.rs
+++ b/client/daemon/src/peer/tests/part06a.rs
@@ -295,7 +295,7 @@ async fn relay_confirmation_and_business_markers_reject_retired_generation() {
 }
 
 #[tokio::test]
-async fn generation_advance_wins_over_queued_relay_confirmation() {
+async fn generation_advance_wins_over_nonqueued_relay_confirmation() {
     let manager = std::sync::Arc::new(PeerManager::new(test_config()));
     manager
         .add_peer(&test_peer("peer1", "127.0.0.1:51837".parse().unwrap()))
@@ -306,34 +306,34 @@ async fn generation_advance_wins_over_queued_relay_confirmation() {
         .mark_relay_transport_ready("peer1", "relay.test:443", old_generation)
         .await;
 
-    // Queue the lifecycle transition ahead of the stale confirmation while
-    // the epoch gate is held. Tokio's mutex is FIFO, so releasing the gate
-    // deterministically lets the generation advance retire the state before
-    // the old ACK's commit attempt runs.
+    // Queue the lifecycle transition while the epoch gate is held. Relay
+    // confirmation is a serial-inbound transaction and must reject contention
+    // immediately instead of joining the mutex queue behind that transition.
     let epoch_gate = manager.network_epoch_gate();
     let epoch_guard = epoch_gate.lock().await;
     let advance_task = tokio::spawn({
         let manager = manager.clone();
         async move { manager.advance_network_generation("queued_before_old_ack").await }
     });
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    tokio::task::yield_now().await;
     assert!(!advance_task.is_finished());
 
-    let confirm_task = tokio::spawn({
-        let manager = manager.clone();
-        async move {
-            manager
-                .confirm_relay_peer("peer1", "relay.test:443", old_generation)
-                .await
-        }
-    });
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    assert!(!confirm_task.is_finished());
+    assert!(
+        !manager
+            .confirm_relay_peer("peer1", "relay.test:443", old_generation)
+            .await,
+        "relay confirmation must not queue behind the generation owner"
+    );
     drop(epoch_guard);
 
     let new_generation = advance_task.await.unwrap();
     assert!(new_generation > old_generation);
-    assert!(!confirm_task.await.unwrap());
+    assert!(
+        !manager
+            .confirm_relay_peer("peer1", "relay.test:443", old_generation)
+            .await,
+        "the old generation must remain rejected after the transition"
+    );
     let connection = manager.get_connection("peer1").await.unwrap();
     assert_eq!(connection.relay_confirmed_generation, None);
     assert_eq!(connection.relay_ready_generation, None);

--- a/client/daemon/src/peer/tests/part19.rs
+++ b/client/daemon/src/peer/tests/part19.rs
@@ -1,0 +1,125 @@
+// ============================================================
+// Relay first-packet liveness: non-queuing commit interleavings
+// ============================================================
+
+#[tokio::test]
+async fn relay_first_packet_transactions_survive_128_controlled_interleavings() {
+    let manager = PeerManager::new(test_config());
+    let peer_id = "peer-relay-first-packet-model";
+    manager
+        .add_peer(&test_peer(
+            peer_id,
+            "220.165.178.32:9090".parse().unwrap(),
+        ))
+        .await;
+    let generation = manager.current_network_generation_sync();
+    let endpoint = "relay.test:443";
+
+    // Exercise more than the requested 100 schedules. Each round models a
+    // responder grace refresh, pending-binding promotion, relay-ready commit,
+    // and observation arriving while a production connection snapshot owns a
+    // reader. None may register a fair-queue writer; a second reader remains
+    // admissible, and the exact lifecycle transaction succeeds after release.
+    for interleaving in 0..128u64 {
+        let token = format!("responder-owner-{interleaving}");
+        assert_eq!(
+            manager
+                .stage_probe_session_binding(
+                    peer_id,
+                    token.clone(),
+                    Some(format!("probe-session-{interleaving}")),
+                    Some([interleaving as u8; 32]),
+                    true,
+                )
+                .await,
+            ProbeBindingStage::Staged
+        );
+
+        let reader = manager.connection_map_for_test().read_owned().await;
+        // Factoradic selection walks all 4! orderings of the four contended
+        // transactions across every 24 rounds; 128 rounds therefore cover
+        // each ordering at least five times with distinct lifecycle owners.
+        let mut schedule = [0u8, 1, 2, 3];
+        let mut rank = (interleaving as usize) % 24;
+        for position in 0..schedule.len() {
+            let remaining = schedule.len() - position;
+            let choice = rank % remaining;
+            rank /= remaining;
+            schedule.swap(position, position + choice);
+        }
+        for step in schedule {
+            match step {
+                0 => assert_eq!(
+                    manager.try_mark_relay_transport_ready_with_transport(
+                        peer_id,
+                        endpoint,
+                        generation,
+                        Some(interleaving + 1),
+                    ),
+                    RelayReadyCommitOutcome::ContendedConnections
+                ),
+                1 => assert_eq!(
+                    manager.try_refresh_pending_probe_session_binding_grace(peer_id, &token),
+                    PendingProbeBindingCommitOutcome::ContendedConnections
+                ),
+                2 => assert_eq!(
+                    manager.try_confirm_pending_probe_session_binding(peer_id, &token),
+                    PendingProbeBindingCommitOutcome::ContendedConnections
+                ),
+                3 => manager.record_relay_observation(peer_id, endpoint).await,
+                _ => unreachable!("four-step schedule is closed"),
+            }
+            assert!(
+                manager.try_all_connections().is_some(),
+                "interleaving {interleaving} step {step} queued a writer and fairly blocked readers"
+            );
+        }
+        drop(reader);
+
+        assert_eq!(
+            manager.try_refresh_pending_probe_session_binding_grace(peer_id, &token),
+            PendingProbeBindingCommitOutcome::Committed
+        );
+        assert_eq!(
+            manager.try_mark_relay_transport_ready_with_transport(
+                peer_id,
+                endpoint,
+                generation,
+                Some(interleaving + 1),
+            ),
+            RelayReadyCommitOutcome::Committed
+        );
+        assert_eq!(
+            manager.try_confirm_pending_probe_session_binding(peer_id, &token),
+            PendingProbeBindingCommitOutcome::Committed
+        );
+        assert_eq!(
+            manager
+                .get_connection(peer_id)
+                .await
+                .unwrap()
+                .probe_binding_token
+                .as_deref(),
+            Some(token.as_str())
+        );
+    }
+
+    // The same non-queuing entry point must still preserve the epoch and peer
+    // lifecycle fences: an old task cannot publish into a new generation.
+    let next_generation = manager
+        .advance_network_generation("relay first-packet stale-event fence")
+        .await;
+    assert!(next_generation > generation);
+    assert_eq!(
+        manager.try_mark_relay_transport_ready_with_transport(
+            peer_id,
+            endpoint,
+            generation,
+            Some(999),
+        ),
+        RelayReadyCommitOutcome::Rejected
+    );
+    let connection = manager.get_connection(peer_id).await.unwrap();
+    assert_eq!(connection.relay_ready_generation, None);
+    assert_ne!(connection.state, ConnectionState::Direct);
+}

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -703,6 +703,7 @@ struct RelayProbeIngress<'a> {
     packet: &'a [u8],
     relay_endpoint: &'a str,
     relay_connection_id: Option<u64>,
+    wireguard_session_instance: Option<u64>,
     token: crate::relay_probe::RelayProbeToken,
 }
 
@@ -715,6 +716,12 @@ struct PathCommitIngress<'a> {
     relay_endpoint: &'a str,
     relay_connection_id: Option<u64>,
     token: crate::path_commit::PathCommitToken,
+}
+
+enum CurrentSessionEvidenceGuardOutcome {
+    Current(OwnedMutexGuard<()>),
+    Contended,
+    Stale,
 }
 
 /// Whether a decrypted IP packet looks like an overlay business payload (UDP
@@ -807,7 +814,8 @@ pub struct WireGuardTransport {
     /// through the actual transport handoff.
     outbound_ingress_locks: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
     outbound_emit_locks: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
-    promoted_responder_tokens: Arc<Mutex<HashMap<String, VecDeque<PromotedResponderToken>>>>,
+    promoted_responder_tokens:
+        Arc<std::sync::Mutex<HashMap<String, VecDeque<PromotedResponderToken>>>>,
     hedge_replay_counters: Arc<std::sync::Mutex<HashMap<String, HedgeReplayCounter>>>,
     /// Feed of RAW (not yet encrypted) outbound packets handed to the network
     /// outbound worker.  The worker — not the transport — decides whether the
@@ -871,7 +879,7 @@ impl WireGuardTransport {
                 pending_outbound: Arc::new(Mutex::new(HashMap::new())),
                 outbound_ingress_locks: Arc::new(Mutex::new(HashMap::new())),
                 outbound_emit_locks: Arc::new(Mutex::new(HashMap::new())),
-                promoted_responder_tokens: Arc::new(Mutex::new(HashMap::new())),
+                promoted_responder_tokens: Arc::new(std::sync::Mutex::new(HashMap::new())),
                 hedge_replay_counters: Arc::new(std::sync::Mutex::new(HashMap::new())),
                 outbound_tx,
                 outbound_loss_sink: Arc::new(std::sync::Mutex::new(None)),
@@ -902,6 +910,15 @@ impl WireGuardTransport {
     async fn session_instance_state(&self, peer_id: &str, session_instance: u64) -> (bool, bool) {
         let now = Instant::now();
         let mut sessions = self.sessions.lock().await;
+        Self::session_instance_state_locked(&mut sessions, peer_id, session_instance, now)
+    }
+
+    fn session_instance_state_locked(
+        sessions: &mut HashMap<String, PeerTransportSessions>,
+        peer_id: &str,
+        session_instance: u64,
+        now: Instant,
+    ) -> (bool, bool) {
         let Some(peer_sessions) = sessions.get_mut(peer_id) else {
             return (false, false);
         };
@@ -916,6 +933,24 @@ impl WireGuardTransport {
                 .values()
                 .any(|pending| pending.slot.session_instance == session_instance);
         (retained, current)
+    }
+
+    /// Try-only form used after the per-peer emit fence has been acquired.
+    /// Session lifecycle writers use the canonical `emit -> sessions` order,
+    /// so waiting here would stall the serial inbound actor while it owns the
+    /// emit guard. Contention is retryable on the next authenticated frame.
+    fn try_session_instance_state(
+        &self,
+        peer_id: &str,
+        session_instance: u64,
+    ) -> Option<(bool, bool)> {
+        let mut sessions = self.sessions.try_lock().ok()?;
+        Some(Self::session_instance_state_locked(
+            &mut sessions,
+            peer_id,
+            session_instance,
+            Instant::now(),
+        ))
     }
 
     /// Re-check a decrypted packet's session immediately before it is allowed
@@ -935,9 +970,11 @@ impl WireGuardTransport {
             return true;
         };
         let emit_lock = self.outbound_emit_lock(peer_id).await;
-        let _emit_guard = emit_lock.lock().await;
-        let (_, current) = self.session_instance_state(peer_id, session_instance).await;
-        current
+        let Ok(_emit_guard) = emit_lock.try_lock() else {
+            return false;
+        };
+        self.try_session_instance_state(peer_id, session_instance)
+            .is_some_and(|(_, current)| current)
     }
 
     /// Acquire the per-peer emit guard and verify that a decrypted packet was
@@ -949,11 +986,33 @@ impl WireGuardTransport {
         peer_id: &str,
         session_instance: Option<u64>,
     ) -> Option<OwnedMutexGuard<()>> {
-        let session_instance = session_instance?;
+        match self
+            .acquire_current_session_evidence_guard_outcome(peer_id, session_instance)
+            .await
+        {
+            CurrentSessionEvidenceGuardOutcome::Current(guard) => Some(guard),
+            CurrentSessionEvidenceGuardOutcome::Contended
+            | CurrentSessionEvidenceGuardOutcome::Stale => None,
+        }
+    }
+
+    async fn acquire_current_session_evidence_guard_outcome(
+        &self,
+        peer_id: &str,
+        session_instance: Option<u64>,
+    ) -> CurrentSessionEvidenceGuardOutcome {
+        let Some(session_instance) = session_instance else {
+            return CurrentSessionEvidenceGuardOutcome::Stale;
+        };
         let emit_lock = self.outbound_emit_lock(peer_id).await;
-        let emit_guard = emit_lock.lock_owned().await;
-        let (_, current) = self.session_instance_state(peer_id, session_instance).await;
-        current.then_some(emit_guard)
+        let Ok(emit_guard) = emit_lock.try_lock_owned() else {
+            return CurrentSessionEvidenceGuardOutcome::Contended;
+        };
+        match self.try_session_instance_state(peer_id, session_instance) {
+            Some((_, true)) => CurrentSessionEvidenceGuardOutcome::Current(emit_guard),
+            Some((_, false)) => CurrentSessionEvidenceGuardOutcome::Stale,
+            None => CurrentSessionEvidenceGuardOutcome::Contended,
+        }
     }
 
     /// Share the peer manager's outbound-loss counters with this transport so
@@ -1543,16 +1602,18 @@ impl WireGuardTransport {
             result,
             ResponderSessionConfirmation::Promoted | ResponderSessionConfirmation::AlreadyActive
         ) {
-            self.remember_promoted_responder_token(peer_id, token.to_string())
-                .await;
+            self.remember_promoted_responder_token(peer_id, token.to_string());
         }
         result
     }
 
-    async fn remember_promoted_responder_token(&self, peer_id: &str, token: String) {
+    fn remember_promoted_responder_token(&self, peer_id: &str, token: String) {
         const MAX_PENDING_CONFIRMATIONS: usize = 8;
         let now = Instant::now();
-        let mut promoted = self.promoted_responder_tokens.lock().await;
+        let mut promoted = self
+            .promoted_responder_tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let queue = promoted.entry(peer_id.to_string()).or_default();
         queue.retain(|item| item.expires_at > now);
         if queue.iter().any(|item| item.token == token) {
@@ -1567,9 +1628,12 @@ impl WireGuardTransport {
         });
     }
 
-    async fn pending_promoted_responder_tokens(&self, peer_id: &str) -> Vec<String> {
+    fn pending_promoted_responder_tokens(&self, peer_id: &str) -> Vec<String> {
         let now = Instant::now();
-        let mut promoted = self.promoted_responder_tokens.lock().await;
+        let mut promoted = self
+            .promoted_responder_tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let Some(queue) = promoted.get_mut(peer_id) else {
             return Vec::new();
         };
@@ -1584,8 +1648,11 @@ impl WireGuardTransport {
         tokens
     }
 
-    pub(crate) async fn acknowledge_promoted_responder_token(&self, peer_id: &str, token: &str) {
-        let mut promoted = self.promoted_responder_tokens.lock().await;
+    pub(crate) fn acknowledge_promoted_responder_token(&self, peer_id: &str, token: &str) {
+        let mut promoted = self
+            .promoted_responder_tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(queue) = promoted.get_mut(peer_id) {
             queue.retain(|item| item.token != token);
             if queue.is_empty() {
@@ -1826,7 +1893,10 @@ impl WireGuardTransport {
             )
             .await;
         }
-        self.promoted_responder_tokens.lock().await.remove(peer_id);
+        self.promoted_responder_tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(peer_id);
         self.remove_idle_outbound_emit_lock(peer_id).await;
     }
 
@@ -2506,8 +2576,7 @@ impl WireGuardTransport {
         if let Some((peer_id, packet, token, session_instance)) = confirmed_active {
             drop(sessions);
             if let Some(token) = token {
-                self.remember_promoted_responder_token(&peer_id, token)
-                    .await;
+                self.remember_promoted_responder_token(&peer_id, token);
             }
             return Ok(Some(InboundPacket {
                 peer_id,
@@ -2597,8 +2666,7 @@ impl WireGuardTransport {
                 );
                 return Ok(None);
             }
-            self.remember_promoted_responder_token(&peer_id, token)
-                .await;
+            self.remember_promoted_responder_token(&peer_id, token);
             if promoted_now {
                 info!(
                     event = "wireguard_responder_session_promoted",
@@ -3100,6 +3168,8 @@ impl WireGuardTransport {
                             .await;
                         let session_current =
                             inbound.session_instance.is_none() || session_guard.is_some();
+                        let peer_session_generation =
+                            peer_manager.peer_session_generation_sync(&inbound.peer_id);
                         if session_current {
                             let _ = peer_manager.try_mark_relay_transport_ready_with_transport(
                                 &inbound.peer_id,
@@ -3107,8 +3177,37 @@ impl WireGuardTransport {
                                 generation,
                                 relay_connection_id,
                             );
+                            if let (Some(peer_session_generation), Some(session_instance)) =
+                                (peer_session_generation, inbound.session_instance)
+                            {
+                                let _ = peer_manager
+                                    .try_commit_pending_relay_business_evidence_for_session(
+                                        &inbound.peer_id,
+                                        generation,
+                                        peer_session_generation,
+                                        session_instance,
+                                        relay_endpoint,
+                                        relay_connection_id,
+                                    );
+                                if session_evidence_eligible
+                                    && is_real_overlay_business_packet(&inbound.packet)
+                                {
+                                    peer_manager
+                                        .confirm_relay_peer_from_business_ingress_for_session(
+                                            &inbound.peer_id,
+                                            relay_endpoint,
+                                            generation,
+                                            relay_connection_id,
+                                            peer_session_generation,
+                                            session_instance,
+                                        );
+                                }
+                            }
                         }
-                        let business_ingress_session_current = session_current;
+                        let legacy_business_confirmation = session_current
+                            && inbound.session_instance.is_none()
+                            && session_evidence_eligible
+                            && is_real_overlay_business_packet(&inbound.packet);
                         drop(session_guard);
                         // A real encrypted overlay packet arriving through
                         // the current relay is itself an end-to-end relay
@@ -3123,10 +3222,7 @@ impl WireGuardTransport {
                         // markers below are committed.  Direct remains
                         // independently gated by encrypted Direct validation
                         // and the bidirectional relay-business exchange.
-                        if business_ingress_session_current
-                            && session_evidence_eligible
-                            && is_real_overlay_business_packet(&inbound.packet)
-                        {
+                        if legacy_business_confirmation {
                             peer_manager
                                 .confirm_relay_peer_from_business_ingress(
                                     &inbound.peer_id,
@@ -3230,20 +3326,26 @@ impl WireGuardTransport {
                                         .await
                                     };
                                     if session_current {
-                                        self.handle_relay_probe_packet(
-                                            peers,
-                                            evidence.as_ref().map(|feed| &feed.relay_transport),
-                                            RelayProbeIngress {
-                                                peer_id: &inbound.peer_id,
-                                                packet: &inbound.packet,
-                                                relay_endpoint: relay_endpoint
-                                                    .as_deref()
-                                                    .unwrap_or("unknown"),
-                                                relay_connection_id,
-                                                token,
-                                            },
-                                        )
-                                        .await;
+                                        let probe = RelayProbeIngress {
+                                            peer_id: &inbound.peer_id,
+                                            packet: &inbound.packet,
+                                            relay_endpoint: relay_endpoint
+                                                .as_deref()
+                                                .unwrap_or("unknown"),
+                                            relay_connection_id,
+                                            wireguard_session_instance: inbound.session_instance,
+                                            token,
+                                        };
+                                        if token_kind == crate::relay_probe::RelayProbeKind::Ack {
+                                            self.handle_relay_probe_ack(peers, probe);
+                                        } else {
+                                            self.handle_relay_probe_packet(
+                                                peers,
+                                                evidence.as_ref().map(|feed| &feed.relay_transport),
+                                                probe,
+                                            )
+                                            .await;
+                                        }
                                     } else {
                                         peers.emit_timeline(
                                             "stale_session_evidence",
@@ -3302,20 +3404,25 @@ impl WireGuardTransport {
                                         .await
                                     };
                                     if path_session_current {
-                                        self.handle_path_commit_packet(
-                                            peers,
-                                            evidence.as_ref().map(|feed| &feed.relay_transport),
-                                            PathCommitIngress {
-                                                peer_id: &inbound.peer_id,
-                                                packet: &inbound.packet,
-                                                relay_endpoint: relay_endpoint
-                                                    .as_deref()
-                                                    .unwrap_or("unknown"),
-                                                relay_connection_id,
-                                                token: path_token,
-                                            },
-                                        )
-                                        .await;
+                                        let probe = PathCommitIngress {
+                                            peer_id: &inbound.peer_id,
+                                            packet: &inbound.packet,
+                                            relay_endpoint: relay_endpoint
+                                                .as_deref()
+                                                .unwrap_or("unknown"),
+                                            relay_connection_id,
+                                            token: path_token,
+                                        };
+                                        if path_kind == crate::path_commit::PathCommitKind::Ack {
+                                            self.handle_path_commit_ack(peers, probe);
+                                        } else {
+                                            self.handle_path_commit_packet(
+                                                peers,
+                                                evidence.as_ref().map(|feed| &feed.relay_transport),
+                                                probe,
+                                            )
+                                            .await;
+                                        }
                                     }
                                     drop(path_session_guard);
                                 } else {
@@ -3334,9 +3441,8 @@ impl WireGuardTransport {
                             let binding_session_current =
                                 inbound.session_instance.is_none() || binding_guard.is_some();
                             if binding_session_current {
-                                let promoted_tokens = self
-                                    .pending_promoted_responder_tokens(&inbound.peer_id)
-                                    .await;
+                                let promoted_tokens =
+                                    self.pending_promoted_responder_tokens(&inbound.peer_id);
                                 for token in promoted_tokens {
                                     let generation = packet_network_generation
                                         .unwrap_or_else(|| peers.current_network_generation_sync());
@@ -3349,8 +3455,7 @@ impl WireGuardTransport {
                                             self.acknowledge_promoted_responder_token(
                                                 &inbound.peer_id,
                                                 &token,
-                                            )
-                                            .await;
+                                            );
                                             peers.emit_timeline_first(
                                                 &inbound.peer_id,
                                                 generation,
@@ -3420,6 +3525,12 @@ impl WireGuardTransport {
                                         )
                                         .await
                                     };
+                                    // The exact authenticated session has been
+                                    // snapshotted. DPLPMTUD owns its own
+                                    // lifecycle/expectation transaction, so do
+                                    // not carry the emit/session evidence fence
+                                    // across its async locks and socket work.
+                                    drop(session_guard);
                                     if let (true, Some(peer_session_generation), Some(udp)) =
                                         (session_current, peer_session_generation, udp.as_ref())
                                     {
@@ -3450,7 +3561,6 @@ impl WireGuardTransport {
                                             )),
                                         );
                                     }
-                                    drop(session_guard);
                                 } else {
                                     debug!(
                                         peer_id = %inbound.peer_id,
@@ -3495,6 +3605,11 @@ impl WireGuardTransport {
                                         )
                                         .await
                                     };
+                                    // Direct validation revalidates the exact
+                                    // peer lifecycle and owned request token.
+                                    // Release the inbound evidence fence before
+                                    // any of its async manager/UDP transactions.
+                                    drop(session_guard);
                                     if let (true, Some(peer_session_generation)) =
                                         (session_current, peer_session_generation)
                                     {
@@ -3537,7 +3652,6 @@ impl WireGuardTransport {
                                             )),
                                         );
                                     }
-                                    drop(session_guard);
                                 } else {
                                     debug!(
                                         peer_id = %inbound.peer_id,
@@ -3567,6 +3681,11 @@ impl WireGuardTransport {
                                         .await;
                                     let session_current = inbound.session_instance.is_none()
                                         || session_guard.is_some();
+                                    // Endpoint learning is not a Relay/current-
+                                    // session evidence commit and has its own
+                                    // peer/UDP publication fences. Never await
+                                    // those while retaining the emit guard.
+                                    drop(session_guard);
                                     if !session_current {
                                         peers.emit_timeline(
                                             "stale_session_evidence",
@@ -3637,7 +3756,6 @@ impl WireGuardTransport {
                                             inbound.peer_id
                                         );
                                     }
-                                    drop(session_guard);
                                 } else if !owns_direct_packet {
                                     debug!(
                                         peer_id = %inbound.peer_id,
@@ -3663,9 +3781,10 @@ impl WireGuardTransport {
                                     // wall-clock validation payload remains
                                     // recognizable for wire compatibility but
                                     // is never interpreted as a timing sample.
-                                    peers
-                                        .record_relay_observation(&inbound.peer_id, relay_endpoint)
-                                        .await;
+                                    peers.try_record_relay_observation(
+                                        &inbound.peer_id,
+                                        relay_endpoint,
+                                    );
                                     debug!(
                                     "Observed decrypted relay ingress through {relay_endpoint} for peer {}; relay confirmation still requires a matching encrypted ACK",
                                     inbound.peer_id
@@ -3722,12 +3841,23 @@ impl WireGuardTransport {
                                 // both relay-business and first-usable writes
                                 // so a rekey cannot turn an old-session packet
                                 // into evidence for the new session.
-                                let session_guard = self
-                                    .acquire_current_session_evidence_guard(
+                                let session_guard_outcome = self
+                                    .acquire_current_session_evidence_guard_outcome(
                                         &inbound.peer_id,
                                         inbound.session_instance,
                                     )
                                     .await;
+                                let session_guard_contended = matches!(
+                                    &session_guard_outcome,
+                                    CurrentSessionEvidenceGuardOutcome::Contended
+                                );
+                                let session_guard = match session_guard_outcome {
+                                    CurrentSessionEvidenceGuardOutcome::Current(guard) => {
+                                        Some(guard)
+                                    }
+                                    CurrentSessionEvidenceGuardOutcome::Contended
+                                    | CurrentSessionEvidenceGuardOutcome::Stale => None,
+                                };
                                 let session_current =
                                     inbound.session_instance.is_none() || session_guard.is_some();
                                 if session_current {
@@ -3735,24 +3865,42 @@ impl WireGuardTransport {
                                         packet_network_generation.unwrap_or_else(|| {
                                             peer_manager.current_network_generation_sync()
                                         });
-                                    if path == crate::peer::NetworkPath::Relay {
-                                        peer_manager
-                                            .mark_relay_first_business_received_for_generation_with_transport(
-                                                &inbound.peer_id,
-                                                relay_id.unwrap_or("unknown"),
-                                                generation,
-                                                relay_connection_id,
+                                    let first_usable_recorded = if path
+                                        == crate::peer::NetworkPath::Relay
+                                    {
+                                        let outcome = peer_manager
+                                                .peer_session_generation_sync(&inbound.peer_id)
+                                                .map_or(
+                                                    crate::peer::RelayBusinessEvidenceCommitOutcome::RejectedLifecycle,
+                                                    |peer_session_generation| {
+                                                        peer_manager.try_commit_relay_business_evidence(
+                                                            &inbound.peer_id,
+                                                            generation,
+                                                            peer_session_generation,
+                                                            inbound.session_instance.unwrap_or(0),
+                                                            relay_id.unwrap_or("unknown"),
+                                                            relay_connection_id,
+                                                            decrypt_completed,
+                                                        )
+                                                    },
+                                                );
+                                        matches!(
+                                                outcome,
+                                                crate::peer::RelayBusinessEvidenceCommitOutcome::Committed
+                                                    | crate::peer::RelayBusinessEvidenceCommitOutcome::AlreadyCurrent
                                             )
-                                            .await;
-                                    }
-                                    let first_usable_recorded = peer_manager
-                                        .record_verified_first_usable(
-                                            &inbound.peer_id,
-                                            generation,
-                                            path,
-                                            &ingress_label,
-                                        )
-                                        .await;
+                                    } else {
+                                        peer_manager
+                                            .peer_session_generation_sync(&inbound.peer_id)
+                                            .is_some_and(|peer_session_generation| {
+                                                peer_manager
+                                                    .try_record_verified_direct_first_usable_for_lifecycle(
+                                                        &inbound.peer_id,
+                                                        generation,
+                                                        peer_session_generation,
+                                                    )
+                                            })
+                                    };
                                     // This is an ingress observation, not the
                                     // same milestone as first_usable_path.
                                     // Keep the first ingress event for backwards
@@ -3825,19 +3973,58 @@ impl WireGuardTransport {
                                             Some(detail),
                                         );
                                     }
-                                } else if let Some(timeline) = feed.timeline.as_ref() {
-                                    timeline.emit(
-                                        "stale_session_evidence",
-                                        Some(match path {
-                                            crate::peer::NetworkPath::Relay => "relay",
-                                            crate::peer::NetworkPath::Direct => "direct",
-                                        }),
-                                        Some("session_replaced_or_removed"),
-                                        Some(format!(
-                                            "peer={} session_instance={:?} business_ingress=stale",
-                                            inbound.peer_id, inbound.session_instance,
-                                        )),
-                                    );
+                                } else {
+                                    let retained = session_guard_contended
+                                        && path == crate::peer::NetworkPath::Relay
+                                        && peer_manager
+                                            .peer_session_generation_sync(&inbound.peer_id)
+                                            .is_some_and(|peer_session_generation| {
+                                                let generation = packet_network_generation
+                                                    .unwrap_or_else(|| {
+                                                        peer_manager
+                                                            .current_network_generation_sync()
+                                                    });
+                                                peer_manager
+                                                    .retain_relay_business_evidence_for_retry(
+                                                        &inbound.peer_id,
+                                                        generation,
+                                                        peer_session_generation,
+                                                        inbound
+                                                            .session_instance
+                                                            .unwrap_or_default(),
+                                                        relay_id.unwrap_or("unknown"),
+                                                        relay_connection_id,
+                                                        decrypt_completed,
+                                                    )
+                                            });
+                                    if let Some(timeline) = feed.timeline.as_ref() {
+                                        timeline.emit(
+                                            if session_guard_contended {
+                                                "business_ingress_evidence_deferred"
+                                            } else {
+                                                "stale_session_evidence"
+                                            },
+                                            Some(match path {
+                                                crate::peer::NetworkPath::Relay => "relay",
+                                                crate::peer::NetworkPath::Direct => "direct",
+                                            }),
+                                            Some(if session_guard_contended {
+                                                "session_or_emit_contended"
+                                            } else {
+                                                "session_replaced_or_removed"
+                                            }),
+                                            Some(format!(
+                                                "peer={} session_instance={:?} business_ingress={} evidence_retained={retained} queued_writer=false",
+                                                inbound.peer_id,
+                                                inbound.session_instance,
+                                                if session_guard_contended {
+                                                    "deferred"
+                                                } else {
+                                                    "stale"
+                                                },
+                                            )),
+                                        );
+                                    }
                                 }
                                 drop(session_guard);
                             }
@@ -5059,6 +5246,67 @@ impl WireGuardTransport {
         }
     }
 
+    fn handle_relay_probe_ack(&self, peers: &Arc<PeerManager>, probe: RelayProbeIngress<'_>) {
+        let confirmed = peers.consume_relay_probe_ack_with_transport_for_session(
+            probe.peer_id,
+            probe.token,
+            probe.relay_endpoint,
+            probe.relay_connection_id,
+            probe.wireguard_session_instance.unwrap_or(0),
+        );
+        if !confirmed {
+            debug!(
+                peer_id = %probe.peer_id,
+                "relay probe ACK from {} did not match a fresh outstanding expectation, or arrived over a different relay (or was already consumed)",
+                probe.peer_id,
+            );
+        }
+    }
+
+    fn handle_path_commit_ack(&self, peers: &Arc<PeerManager>, probe: PathCommitIngress<'_>) {
+        let outcome = peers.try_consume_path_commit_ack_with_transport(
+            probe.peer_id,
+            probe.token,
+            probe.relay_endpoint,
+            probe.relay_connection_id,
+        );
+        if matches!(
+            outcome,
+            crate::peer::PathCommitCommitOutcome::ContendedEpoch
+                | crate::peer::PathCommitCommitOutcome::ContendedConnections
+        ) {
+            peers.emit_timeline_first(
+                probe.peer_id,
+                probe.token.generation,
+                "path_commit_ack_contended",
+                Some("relay"),
+                Some(match outcome {
+                    crate::peer::PathCommitCommitOutcome::ContendedEpoch => "network_epoch_busy",
+                    crate::peer::PathCommitCommitOutcome::ContendedConnections => {
+                        "fair_rwlock_writer_unavailable"
+                    }
+                    _ => unreachable!(),
+                }),
+                Some(format!(
+                    "peer={} generation={} relay_endpoint={} relay_connection_id={:?} queued_writer=false expectation_retained=true",
+                    probe.peer_id,
+                    probe.token.generation,
+                    probe.relay_endpoint,
+                    probe.relay_connection_id,
+                )),
+            );
+        } else if matches!(
+            outcome,
+            crate::peer::PathCommitCommitOutcome::RejectedLifecycle
+        ) {
+            debug!(
+                peer_id = %probe.peer_id,
+                "path-commit ACK from {} did not match a fresh outstanding expectation, or arrived over a different relay (or was already consumed)",
+                probe.peer_id,
+            );
+        }
+    }
+
     /// Handle one forced-relay path-probe / path-ack packet after successful
     /// WireGuard decryption and a confirmed relay ingress (`relay_endpoint` is
     /// `Some` at the call site).
@@ -5086,32 +5334,10 @@ impl WireGuardTransport {
             packet,
             relay_endpoint,
             relay_connection_id,
+            wireguard_session_instance,
             token,
         } = probe;
-        // A relay renewal can leave an old reader draining briefly after the
-        // shared slot publishes its replacement.  Reject that reader before
-        // either answering a request or consuming an ACK; endpoint and
-        // network generation are intentionally not enough to identify the
-        // current transport.
-        if let Some(relay_transport) = relay_transport {
-            let current_connection_id = relay_transport
-                .read()
-                .await
-                .as_ref()
-                .map(RelayTransport::connection_id);
-            if relay_connection_id != current_connection_id {
-                peers.emit_timeline(
-                    "relay_probe_packet_stale",
-                    Some("relay"),
-                    Some("relay_transport_replaced"),
-                    Some(format!(
-                        "peer={peer_id} relay_endpoint={relay_endpoint} packet_connection_id={relay_connection_id:?} current_connection_id={current_connection_id:?}"
-                    )),
-                );
-                return;
-            }
-        }
-        if !peers.peer_online(peer_id).await {
+        if peers.peer_session_generation_sync(peer_id).is_none() {
             debug!(
                 peer_id = %peer_id,
                 "ignored relay probe for offline or closed peer {peer_id}"
@@ -5120,6 +5346,27 @@ impl WireGuardTransport {
         }
         match token.kind {
             crate::relay_probe::RelayProbeKind::Request => {
+                // ACK packets were already bound to the current Relay slot at
+                // the decrypt boundary and retain the session evidence guard;
+                // only the request branch may await this shared slot read.
+                if let Some(relay_transport) = relay_transport {
+                    let current_connection_id = relay_transport
+                        .read()
+                        .await
+                        .as_ref()
+                        .map(RelayTransport::connection_id);
+                    if relay_connection_id != current_connection_id {
+                        peers.emit_timeline(
+                            "relay_probe_packet_stale",
+                            Some("relay"),
+                            Some("relay_transport_replaced"),
+                            Some(format!(
+                                "peer={peer_id} relay_endpoint={relay_endpoint} packet_connection_id={relay_connection_id:?} current_connection_id={current_connection_id:?}"
+                            )),
+                        );
+                        return;
+                    }
+                }
                 let ack_started = Instant::now();
                 peers.emit_timeline_first(
                     peer_id,
@@ -5242,26 +5489,17 @@ impl WireGuardTransport {
                 }
             }
             crate::relay_probe::RelayProbeKind::Ack => {
-                // The caller guaranteed the ACK's real ingress was relay.  The
-                // peer manager verifies the token against the outstanding
-                // expectation (request id + generation + owner, within TTL)
-                // AND that the ACK arrived over the SAME relay the probe was
-                // sent on (real ingress binding); only then does it set
-                // RelayPeerConfirmed.
-                let confirmed = peers
-                    .consume_relay_probe_ack_with_transport(
+                self.handle_relay_probe_ack(
+                    peers,
+                    RelayProbeIngress {
                         peer_id,
-                        token,
+                        packet,
                         relay_endpoint,
                         relay_connection_id,
-                    )
-                    .await;
-                if !confirmed {
-                    debug!(
-                        peer_id = %peer_id,
-                        "relay probe ACK from {peer_id} did not match a fresh outstanding expectation, or arrived over a different relay (or was already consumed)"
-                    );
-                }
+                        wireguard_session_instance,
+                        token,
+                    },
+                );
             }
         }
     }
@@ -5286,25 +5524,7 @@ impl WireGuardTransport {
             relay_connection_id,
             token,
         } = probe;
-        if let Some(relay_transport) = relay_transport {
-            let current_connection_id = relay_transport
-                .read()
-                .await
-                .as_ref()
-                .map(RelayTransport::connection_id);
-            if relay_connection_id != current_connection_id {
-                peers.emit_timeline(
-                    "path_commit_packet_stale",
-                    Some("relay"),
-                    Some("relay_transport_replaced"),
-                    Some(format!(
-                        "peer={peer_id} relay_endpoint={relay_endpoint} packet_connection_id={relay_connection_id:?} current_connection_id={current_connection_id:?}"
-                    )),
-                );
-                return;
-            }
-        }
-        if !peers.peer_online(peer_id).await {
+        if peers.peer_session_generation_sync(peer_id).is_none() {
             debug!(
                 peer_id = %peer_id,
                 "ignored path-commit packet for offline or closed peer {peer_id}"
@@ -5313,6 +5533,24 @@ impl WireGuardTransport {
         }
         match token.kind {
             crate::path_commit::PathCommitKind::Request => {
+                if let Some(relay_transport) = relay_transport {
+                    let current_connection_id = relay_transport
+                        .read()
+                        .await
+                        .as_ref()
+                        .map(RelayTransport::connection_id);
+                    if relay_connection_id != current_connection_id {
+                        peers.emit_timeline(
+                            "path_commit_packet_stale",
+                            Some("relay"),
+                            Some("relay_transport_replaced"),
+                            Some(format!(
+                                "peer={peer_id} relay_endpoint={relay_endpoint} packet_connection_id={relay_connection_id:?} current_connection_id={current_connection_id:?}"
+                            )),
+                        );
+                        return;
+                    }
+                }
                 let Some(relay_transport) = relay_transport else {
                     debug!(
                         peer_id = %peer_id,
@@ -5381,26 +5619,16 @@ impl WireGuardTransport {
                 }
             }
             crate::path_commit::PathCommitKind::Ack => {
-                // The caller guaranteed the ACK's real ingress was relay.  The
-                // peer manager verifies the token against the outstanding
-                // expectation (request id + generation + owner, within TTL)
-                // AND that the ACK arrived over the SAME relay the request was
-                // sent on; only then does it commit the relay-first business
-                // path-commit marker (P0-4 one-way liveness).
-                let confirmed = peers
-                    .consume_path_commit_ack_with_transport(
+                self.handle_path_commit_ack(
+                    peers,
+                    PathCommitIngress {
                         peer_id,
-                        token,
+                        packet,
                         relay_endpoint,
                         relay_connection_id,
-                    )
-                    .await;
-                if !confirmed {
-                    debug!(
-                        peer_id = %peer_id,
-                        "path-commit ACK from {peer_id} did not match a fresh outstanding expectation, or arrived over a different relay (or was already consumed)"
-                    );
-                }
+                        token,
+                    },
+                );
             }
         }
     }

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -21,7 +21,7 @@ use crate::dataplane::{
     global_dataplane_profiler, DataplaneRxTrace, InboundPacket, OutboundPacket,
 };
 use crate::error::{DaemonError, Result};
-use crate::peer::{PeerManager, PeerSessionGeneration};
+use crate::peer::{PeerManager, PeerSessionGeneration, PendingProbeBindingCommitOutcome};
 use crate::relay::RelayTransport;
 
 /// Stable, non-reversible diagnostic fingerprint for an opaque encrypted
@@ -1309,16 +1309,59 @@ impl WireGuardTransport {
     /// answer delivery attempt completes. Signaling latency must not consume
     /// the authenticated adoption window.
     pub async fn refresh_responder_session_grace(&self, peer_id: &str, token: &str) -> bool {
+        let started = Instant::now();
+        info!(
+            event = "responder_session_grace_refresh_started",
+            peer_id = %peer_id,
+            "responder post-answer WireGuard grace refresh started"
+        );
+        let ingress_wait_started = Instant::now();
         let ingress_lock = self.outbound_ingress_lock(peer_id).await;
         let _ingress_guard = ingress_lock.lock().await;
+        let ingress_wait_us = ingress_wait_started.elapsed().as_micros() as u64;
+        info!(
+            event = "responder_session_grace_outbound_ingress_acquired",
+            peer_id = %peer_id,
+            wait_us = ingress_wait_us,
+            "responder post-answer outbound ingress lock acquired"
+        );
+        let sessions_wait_started = Instant::now();
         let mut sessions = self.sessions.lock().await;
+        let sessions_wait_us = sessions_wait_started.elapsed().as_micros() as u64;
         let Some(existing) = sessions.get_mut(peer_id) else {
+            info!(
+                event = "responder_session_grace_refresh_finished",
+                peer_id = %peer_id,
+                outcome = "peer_missing",
+                ingress_wait_us,
+                sessions_wait_us,
+                total_us = started.elapsed().as_micros() as u64,
+                "responder post-answer WireGuard grace refresh finished"
+            );
             return false;
         };
         let Some(pending) = existing.pending.get_mut(token) else {
+            info!(
+                event = "responder_session_grace_refresh_finished",
+                peer_id = %peer_id,
+                outcome = "pending_session_missing",
+                ingress_wait_us,
+                sessions_wait_us,
+                total_us = started.elapsed().as_micros() as u64,
+                "responder post-answer WireGuard grace refresh finished"
+            );
             return false;
         };
         pending.expires_at = Instant::now() + PENDING_RESPONDER_SESSION_GRACE;
+        info!(
+            event = "responder_session_grace_refresh_finished",
+            peer_id = %peer_id,
+            outcome = "refreshed",
+            ingress_wait_us,
+            sessions_wait_us,
+            total_us = started.elapsed().as_micros() as u64,
+            "responder post-answer WireGuard grace refresh finished"
+        );
         true
     }
 
@@ -2557,6 +2600,12 @@ impl WireGuardTransport {
             self.remember_promoted_responder_token(&peer_id, token)
                 .await;
             if promoted_now {
+                info!(
+                    event = "wireguard_responder_session_promoted",
+                    peer_id = %peer_id,
+                    session_instance,
+                    "authenticated inbound packet promoted the staged responder session"
+                );
                 self.flush_pending_outbound_for_peer(&peer_id).await;
             }
             return Ok(Some(InboundPacket {
@@ -2881,6 +2930,27 @@ impl WireGuardTransport {
                         network_generation = ?packet_network_generation,
                         "WireGuard authenticated and decrypted the envelope before lifecycle/path evidence gates"
                     );
+                    if let (Some(relay_endpoint), Some(feed)) =
+                        (relay_endpoint.as_deref(), evidence.as_ref())
+                    {
+                        if let Some(timeline) = feed.timeline.as_ref() {
+                            let generation = packet_network_generation.unwrap_or_default();
+                            let scope = format!("peer:{}:{generation}", inbound.peer_id);
+                            timeline.emit_first_scoped(
+                                &scope,
+                                "relay_inbound_authenticated",
+                                Some("relay"),
+                                None,
+                                Some(format!(
+                                    "peer={} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} session_instance={:?} decrypt_us={} encrypted_queue_depth={}",
+                                    inbound.peer_id,
+                                    inbound.session_instance,
+                                    decrypt_completed.duration_since(decrypt_started).as_micros(),
+                                    encrypted_rx.len(),
+                                )),
+                            );
+                        }
+                    }
                     if let (Some(packet_generation), Some(peer_manager)) =
                         (packet_network_generation, peers.as_ref())
                     {
@@ -3031,14 +3101,12 @@ impl WireGuardTransport {
                         let session_current =
                             inbound.session_instance.is_none() || session_guard.is_some();
                         if session_current {
-                            peer_manager
-                                .mark_relay_transport_ready_with_transport(
-                                    &inbound.peer_id,
-                                    relay_endpoint,
-                                    generation,
-                                    relay_connection_id,
-                                )
-                                .await;
+                            let _ = peer_manager.try_mark_relay_transport_ready_with_transport(
+                                &inbound.peer_id,
+                                relay_endpoint,
+                                generation,
+                                relay_connection_id,
+                            );
                         }
                         let business_ingress_session_current = session_current;
                         drop(session_guard);
@@ -3081,7 +3149,46 @@ impl WireGuardTransport {
                     let direct_validation_dplpmtud_capability = direct_validation.is_some()
                         && crate::dplpmtud::direct_validation_supports_dplpmtud(&inbound.packet);
                     let dplpmtud = crate::dplpmtud::parse_control_packet(&inbound.packet);
+                    if relay_endpoint.is_some() {
+                        if let Some(feed) = evidence.as_ref() {
+                            if let Some(timeline) = feed.timeline.as_ref() {
+                                let generation = packet_network_generation.unwrap_or_default();
+                                let scope = format!("peer:{}:{generation}", inbound.peer_id);
+                                timeline.emit_first_scoped(
+                                    &scope,
+                                    "relay_probe_classification_started",
+                                    Some("relay"),
+                                    None,
+                                    Some(format!(
+                                        "peer={} generation={generation} relay_connection_id={relay_connection_id:?} postdecrypt_us={}",
+                                        inbound.peer_id,
+                                        decrypt_completed.elapsed().as_micros(),
+                                    )),
+                                );
+                            }
+                        }
+                    }
                     let relay_probe = crate::relay_probe::parse_relay_probe_token(&inbound.packet);
+                    if let (Some(token), Some(feed)) = (relay_probe, evidence.as_ref()) {
+                        if let Some(timeline) = feed.timeline.as_ref() {
+                            let scope = format!("peer:{}:{}", inbound.peer_id, token.generation);
+                            timeline.emit_first_scoped(
+                                &scope,
+                                "relay_probe_classified",
+                                Some("relay"),
+                                Some(match token.kind {
+                                    crate::relay_probe::RelayProbeKind::Request => "request",
+                                    crate::relay_probe::RelayProbeKind::Ack => "ack",
+                                }),
+                                Some(format!(
+                                    "peer={} generation={} relay_connection_id={relay_connection_id:?} postdecrypt_us={}",
+                                    inbound.peer_id,
+                                    token.generation,
+                                    decrypt_completed.elapsed().as_micros(),
+                                )),
+                            );
+                        }
+                    }
                     let path_commit = crate::path_commit::parse_path_commit_token(&inbound.packet);
                     if session_evidence_eligible {
                         if let Some(peers) = peers.as_ref() {
@@ -3231,22 +3338,45 @@ impl WireGuardTransport {
                                     .pending_promoted_responder_tokens(&inbound.peer_id)
                                     .await;
                                 for token in promoted_tokens {
-                                    if peers
-                                        .confirm_pending_probe_session_binding(
-                                            &inbound.peer_id,
-                                            &token,
-                                        )
-                                        .await
-                                    {
-                                        self.acknowledge_promoted_responder_token(
-                                            &inbound.peer_id,
-                                            &token,
-                                        )
-                                        .await;
-                                        debug!(
-                                        "Promoted Probe v2 binding for peer {} after WireGuard rekey confirmation",
-                                        inbound.peer_id
-                                    );
+                                    let generation = packet_network_generation
+                                        .unwrap_or_else(|| peers.current_network_generation_sync());
+                                    match peers.try_confirm_pending_probe_session_binding(
+                                        &inbound.peer_id,
+                                        &token,
+                                    ) {
+                                        PendingProbeBindingCommitOutcome::Committed
+                                        | PendingProbeBindingCommitOutcome::AlreadyCurrent => {
+                                            self.acknowledge_promoted_responder_token(
+                                                &inbound.peer_id,
+                                                &token,
+                                            )
+                                            .await;
+                                            peers.emit_timeline_first(
+                                                &inbound.peer_id,
+                                                generation,
+                                                "responder_probe_binding_promoted",
+                                                relay_endpoint.as_ref().map(|_| "relay"),
+                                                None,
+                                                Some(format!(
+                                                    "peer={} generation={generation} session_instance={:?}",
+                                                    inbound.peer_id, inbound.session_instance
+                                                )),
+                                            );
+                                        }
+                                        PendingProbeBindingCommitOutcome::ContendedConnections => {
+                                            peers.emit_timeline_first(
+                                                &inbound.peer_id,
+                                                generation,
+                                                "responder_probe_binding_connections_contended",
+                                                relay_endpoint.as_ref().map(|_| "relay"),
+                                                Some("fair_rwlock_writer_unavailable"),
+                                                Some(format!(
+                                                    "peer={} generation={generation} session_instance={:?} queued_writer=false retry=next_authenticated_frame",
+                                                    inbound.peer_id, inbound.session_instance
+                                                )),
+                                            );
+                                        }
+                                        PendingProbeBindingCommitOutcome::Missing => {}
                                     }
                                 }
                             } else {
@@ -3776,6 +3906,29 @@ impl WireGuardTransport {
                                 .saturating_sub(inbound_tx.capacity())
                                 as u64,
                         );
+                    }
+                    if let (Some(relay_endpoint), Some(feed)) =
+                        (relay_endpoint.as_deref(), evidence.as_ref())
+                    {
+                        if let Some(timeline) = feed.timeline.as_ref() {
+                            let generation = packet_network_generation.unwrap_or_default();
+                            let scope = format!("peer:{}:{generation}", inbound.peer_id);
+                            timeline.emit_first_scoped(
+                                &scope,
+                                "relay_inbound_queue_handoff",
+                                Some("relay"),
+                                None,
+                                Some(format!(
+                                    "peer={} generation={generation} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} session_instance={:?} postdecrypt_us={} inbound_queue_depth={}",
+                                    inbound.peer_id,
+                                    inbound.session_instance,
+                                    validation_completed.duration_since(decrypt_completed).as_micros(),
+                                    inbound_tx
+                                        .max_capacity()
+                                        .saturating_sub(inbound_tx.capacity()),
+                                )),
+                            );
+                        }
                     }
                     inbound_tx.send(inbound).await.map_err(|_| {
                         DaemonError::Network("inbound packet channel closed".to_string())
@@ -4967,6 +5120,18 @@ impl WireGuardTransport {
         }
         match token.kind {
             crate::relay_probe::RelayProbeKind::Request => {
+                let ack_started = Instant::now();
+                peers.emit_timeline_first(
+                    peer_id,
+                    token.generation,
+                    "relay_probe_ack_encrypt_started",
+                    Some("relay"),
+                    None,
+                    Some(format!(
+                        "peer={peer_id} generation={} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?}",
+                        token.generation
+                    )),
+                );
                 // Without a live relay transport there is nothing to answer
                 // over; drop silently (the initiator retries its probe).
                 let Some(relay_transport) = relay_transport else {
@@ -5019,7 +5184,7 @@ impl WireGuardTransport {
                     .await
                 {
                     Ok(true) => {
-                        info!(
+                        debug!(
                             event = "relay_probe_ack_sent",
                             peer_id = %peer_id,
                             relay_endpoint = %relay_endpoint,
@@ -5027,15 +5192,51 @@ impl WireGuardTransport {
                             "relay_probe_ack_sent peer_id={peer_id} relay_endpoint={relay_endpoint} request_id={}",
                             token.request_id,
                         );
+                        peers.emit_timeline_first(
+                            peer_id,
+                            token.generation,
+                            "relay_probe_ack_sent",
+                            Some("relay"),
+                            None,
+                            Some(format!(
+                                "peer={peer_id} generation={} relay_endpoint={relay_endpoint} relay_connection_id={relay_connection_id:?} encrypt_and_send_us={}",
+                                token.generation,
+                                ack_started.elapsed().as_micros()
+                            )),
+                        );
                     }
                     Ok(false) => {
                         debug!(
                             "Could not answer relay probe from {peer_id}: WireGuard session is no longer ready"
                         );
+                        peers.emit_timeline_first(
+                            peer_id,
+                            token.generation,
+                            "relay_probe_ack_send_deferred",
+                            Some("relay"),
+                            Some("session_or_emit_unavailable"),
+                            Some(format!(
+                                "peer={peer_id} generation={} relay_connection_id={relay_connection_id:?} elapsed_us={}",
+                                token.generation,
+                                ack_started.elapsed().as_micros()
+                            )),
+                        );
                     }
                     Err(err) => {
                         debug!(
                             "Failed to answer relay probe from {peer_id} over {relay_endpoint}: {err}"
+                        );
+                        peers.emit_timeline_first(
+                            peer_id,
+                            token.generation,
+                            "relay_probe_ack_send_failed",
+                            Some("relay"),
+                            Some("relay_send_error"),
+                            Some(format!(
+                                "peer={peer_id} generation={} relay_connection_id={relay_connection_id:?} elapsed_us={}",
+                                token.generation,
+                                ack_started.elapsed().as_micros()
+                            )),
                         );
                     }
                 }

--- a/client/daemon/src/transport.rs
+++ b/client/daemon/src/transport.rs
@@ -1452,8 +1452,33 @@ impl WireGuardTransport {
         peer_id: &str,
         token: &str,
     ) -> ResponderSessionCommit {
-        let now = Instant::now();
         let mut sessions = self.sessions.lock().await;
+        Self::commit_responder_session_in(&mut sessions, peer_id, token, Instant::now())
+    }
+
+    /// Try-only responder commit used while the handshake owns both the peer
+    /// emit fence and the network epoch. A busy session actor is a typed retry
+    /// outcome; it must never become an `emit -> epoch -> sessions` waiter.
+    pub(crate) fn try_commit_responder_session_locked(
+        &self,
+        peer_id: &str,
+        token: &str,
+    ) -> Option<ResponderSessionCommit> {
+        let mut sessions = self.sessions.try_lock().ok()?;
+        Some(Self::commit_responder_session_in(
+            &mut sessions,
+            peer_id,
+            token,
+            Instant::now(),
+        ))
+    }
+
+    fn commit_responder_session_in(
+        sessions: &mut HashMap<String, PeerTransportSessions>,
+        peer_id: &str,
+        token: &str,
+        now: Instant,
+    ) -> ResponderSessionCommit {
         let Some(existing) = sessions.get_mut(peer_id) else {
             return ResponderSessionCommit::Missing;
         };
@@ -1940,6 +1965,21 @@ impl WireGuardTransport {
         status
     }
 
+    /// Read the active/pending session state without joining the session
+    /// mutex wait queue. Handshake publication calls this while it owns the
+    /// per-peer emit fence; returning `None` lets the exact prepared
+    /// transaction retry after releasing that fence instead of creating an
+    /// `emit -> sessions` wait edge.
+    pub(crate) fn try_session_status(&self, peer_id: &str) -> Option<TransportSessionStatus> {
+        let now = Instant::now();
+        let mut sessions = self.sessions.try_lock().ok()?;
+        let Some(existing) = sessions.get_mut(peer_id) else {
+            return Some(TransportSessionStatus::default());
+        };
+        existing.prepare_active(now);
+        Some(existing.status())
+    }
+
     /// Return whether a peer's session needs rekey.
     pub async fn session_needs_rekey(&self, peer_id: &str) -> bool {
         self.session_status(peer_id).await.needs_rekey
@@ -2012,6 +2052,17 @@ impl WireGuardTransport {
     /// `emit -> epoch -> sessions`.
     pub(crate) async fn acquire_outbound_emit_guard(&self, peer_id: &str) -> OwnedMutexGuard<()> {
         self.outbound_emit_lock(peer_id).await.lock_owned().await
+    }
+
+    /// Try to enter the per-peer counter-ordering boundary without waiting
+    /// behind either the lock registry or business/control emission. Any
+    /// contention is reported to the caller so it can retain exact work in
+    /// its bounded ledger.
+    pub(crate) fn try_acquire_outbound_emit_guard(
+        &self,
+        peer_id: &str,
+    ) -> Option<OwnedMutexGuard<()>> {
+        self.try_outbound_emit_lock(peer_id)?.try_lock_owned().ok()
     }
 
     /// Encrypt while the caller already owns the peer's emit guard.  Keeping
@@ -2148,6 +2199,18 @@ impl WireGuardTransport {
         let lock = Arc::new(Mutex::new(()));
         locks.insert(peer_id.to_string(), Arc::downgrade(&lock));
         lock
+    }
+
+    fn try_outbound_emit_lock(&self, peer_id: &str) -> Option<Arc<Mutex<()>>> {
+        let mut locks = self.outbound_emit_locks.try_lock().ok()?;
+        if let Some(lock) = locks.get(peer_id).and_then(Weak::upgrade) {
+            return Some(lock);
+        }
+
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(peer_id.to_string(), Arc::downgrade(&lock));
+        Some(lock)
     }
 
     async fn outbound_ingress_lock(&self, peer_id: &str) -> Arc<Mutex<()>> {

--- a/client/daemon/src/transport/tests.rs
+++ b/client/daemon/src/transport/tests.rs
@@ -3,14 +3,14 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use p2pnet_crypto::NodeIdentity;
     use p2pnet_tun::Ipv4Packet;
     use p2pnet_wireguard::{
         HandshakeInitiator, HandshakeResponder, MessageTransport, TransportSession,
     };
-    use tokio::sync::{mpsc, oneshot, watch, Notify, RwLock};
+    use tokio::sync::{mpsc, oneshot, watch, Barrier, Notify, RwLock};
 
     use super::*;
     use crate::config::Config;
@@ -173,6 +173,209 @@ mod tests {
         (
             TransportSession::new(node_a_keys),
             TransportSession::new(node_b_keys),
+        )
+    }
+
+    struct RelayInboundContentionHarness {
+        remote_session: TransportSession,
+        peers: Arc<PeerManager>,
+        relay_endpoint: String,
+        relay_connection_id: u64,
+        timeline: Arc<crate::connection_timeline::ConnectionTimeline>,
+        encrypted_tx: mpsc::Sender<ReceivedEncryptedPacket>,
+        inbound_rx: mpsc::Receiver<InboundPacket>,
+        worker: tokio::task::JoinHandle<Result<()>>,
+    }
+
+    impl RelayInboundContentionHarness {
+        async fn new() -> Self {
+            let peer_id = "peer-a";
+            let (remote_session, local_session) = establish_sessions();
+            let (transport, _raw_outbound_rx) = WireGuardTransport::new();
+            transport.add_session(peer_id, local_session).await;
+
+            let peers = Arc::new(PeerManager::new(
+                Config::generate_default("https://ctrl.test", "net1").unwrap(),
+            ));
+            peers
+                .add_peer(&PeerInfo {
+                    node_id: peer_id.to_string(),
+                    public_key: hex::encode(NodeIdentity::generate().public_key()),
+                    virtual_ip: "10.20.0.2".to_string(),
+                    online: true,
+                    ..PeerInfo::default()
+                })
+                .await;
+
+            let relay_endpoint = "tls://relay.test:443".to_string();
+            let relay = crate::relay::RelayTransport::connect_for_test(
+                "node-local",
+                &relay_endpoint,
+                peers.clone(),
+            );
+            let relay_connection_id = relay.connection_id();
+            let timeline = crate::connection_timeline::ConnectionTimeline::new("node-local", 1);
+            peers.set_timeline(timeline.clone());
+            let evidence = InboundEvidenceFeed {
+                relay_transport: Arc::new(RwLock::new(Some(relay))),
+                timeline: Some(timeline.clone()),
+                overlay_ingress_tx: None,
+            };
+            let (encrypted_tx, encrypted_rx) = mpsc::channel(16);
+            let (inbound_tx, inbound_rx) = mpsc::channel(16);
+            let (_udp_tx, udp_updates) = watch::channel(None);
+            let worker = tokio::spawn({
+                let peers = peers.clone();
+                async move {
+                    transport
+                        .run_inbound_with_peers_live_udp_and_relay(
+                            encrypted_rx,
+                            inbound_tx,
+                            Some(peers),
+                            udp_updates,
+                            Some(evidence),
+                        )
+                        .await
+                }
+            });
+
+            Self {
+                remote_session,
+                peers,
+                relay_endpoint,
+                relay_connection_id,
+                timeline,
+                encrypted_tx,
+                inbound_rx,
+                worker,
+            }
+        }
+
+        async fn send(&mut self, packet: &[u8]) {
+            let wire_bytes = self.remote_session.encrypt_to_bytes(packet).unwrap();
+            self.encrypted_tx
+                .send(ReceivedEncryptedPacket {
+                    source: None,
+                    local_endpoint: None,
+                    relay_endpoint: Some(self.relay_endpoint.clone()),
+                    relay_connection_id: Some(self.relay_connection_id),
+                    relay_peer_id: Some("peer-a".to_string()),
+                    socket_index: None,
+                    direct_socket: None,
+                    udp_transport_owner: None,
+                    network_generation: Some(0),
+                    profile_sampled: false,
+                    udp_received: None,
+                    transport_queue_send_started: None,
+                    wire_bytes,
+                })
+                .await
+                .unwrap();
+        }
+
+        async fn recv_business(&mut self, expected: &[u8]) {
+            let inbound = timeout(Duration::from_secs(1), self.inbound_rx.recv())
+                .await
+                .expect("serial inbound actor did not hand the business packet to TUN")
+                .expect("inbound actor closed its TUN channel");
+            assert_eq!(inbound.peer_id, "peer-a");
+            assert_eq!(inbound.packet, expected);
+        }
+
+        async fn shutdown(self) {
+            drop(self.encrypted_tx);
+            timeout(Duration::from_secs(1), self.worker)
+                .await
+                .expect("serial inbound actor remained blocked during shutdown")
+                .expect("serial inbound actor panicked")
+                .expect("serial inbound actor failed");
+        }
+    }
+
+    struct HeldConnectionReader {
+        release: Arc<Notify>,
+        released: Arc<Notify>,
+        worker: tokio::task::JoinHandle<()>,
+    }
+
+    impl HeldConnectionReader {
+        async fn acquire(peers: &Arc<PeerManager>) -> Self {
+            let acquired = Arc::new(Barrier::new(2));
+            let release = Arc::new(Notify::new());
+            let released = Arc::new(Notify::new());
+            let worker = tokio::spawn({
+                let connections = peers.connection_map_for_test();
+                let acquired = acquired.clone();
+                let release = release.clone();
+                let released = released.clone();
+                async move {
+                    let reader = connections.read_owned().await;
+                    acquired.wait().await;
+                    release.notified().await;
+                    drop(reader);
+                    released.notify_one();
+                }
+            });
+            acquired.wait().await;
+            Self {
+                release,
+                released,
+                worker,
+            }
+        }
+
+        async fn release(self) {
+            self.release.notify_one();
+            self.released.notified().await;
+            self.worker.await.expect("connection-reader gate panicked");
+        }
+    }
+
+    fn relay_business_packet(identifier: u16, payload: &[u8]) -> Vec<u8> {
+        Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            identifier,
+            1,
+            payload,
+        )
+    }
+
+    fn relay_probe_ack_packet(
+        generation: u64,
+        request_id: u16,
+        owner_token: u64,
+    ) -> Vec<u8> {
+        Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            request_id,
+            1,
+            &crate::relay_probe::build_relay_probe_payload(
+                crate::relay_probe::RelayProbeKind::Ack,
+                generation,
+                request_id,
+                owner_token,
+            ),
+        )
+    }
+
+    fn path_commit_ack_packet(
+        generation: u64,
+        request_id: u16,
+        owner_token: u64,
+    ) -> Vec<u8> {
+        Ipv4Packet::build_icmp_echo_request(
+            Ipv4Addr::new(10, 20, 0, 1),
+            Ipv4Addr::new(10, 20, 0, 2),
+            request_id,
+            1,
+            &crate::path_commit::build_path_commit_payload(
+                crate::path_commit::PathCommitKind::Ack,
+                generation,
+                request_id,
+                owner_token,
+            ),
         )
     }
 
@@ -1357,7 +1560,7 @@ mod tests {
         assert!(transport
             .promoted_responder_tokens
             .lock()
-            .await
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .get("peer-a")
             .is_none());
 
@@ -2202,6 +2405,227 @@ mod tests {
 
         local_relay.abort_writer();
         remote_relay.close().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relay_business_contention_preserves_evidence_without_blocking_tun() {
+        let mut harness = RelayInboundContentionHarness::new().await;
+        harness
+            .peers
+            .mark_relay_transport_ready_with_transport(
+                "peer-a",
+                &harness.relay_endpoint,
+                0,
+                Some(harness.relay_connection_id),
+            )
+            .await;
+        assert!(harness
+            .peers
+            .confirm_relay_peer_with_transport(
+                "peer-a",
+                &harness.relay_endpoint,
+                0,
+                Some(harness.relay_connection_id),
+            )
+            .await);
+        assert!(harness
+            .peers
+            .mark_relay_first_business_sent_for_generation_with_transport(
+                "peer-a",
+                0,
+                &harness.relay_endpoint,
+                Some(harness.relay_connection_id),
+            )
+            .await);
+
+        let reader = HeldConnectionReader::acquire(&harness.peers).await;
+        let business = relay_business_packet(0x7101, b"relay-business-under-reader");
+        harness.send(&business).await;
+        harness.recv_business(&business).await;
+
+        assert!(harness
+            .peers
+            .pending_relay_business_evidence_present("peer-a"));
+        assert!(
+            harness.peers.try_all_connections().is_some(),
+            "the business transaction must not leave a writer queued behind the reader"
+        );
+
+        reader.release().await;
+        let retry = relay_business_packet(0x7102, b"authenticated-retry-frame");
+        harness.send(&retry).await;
+        harness.recv_business(&retry).await;
+
+        let connection = harness.peers.get_connection("peer-a").await.unwrap();
+        assert_eq!(
+            connection.relay_first.business_received_generation,
+            Some(0)
+        );
+        assert_eq!(
+            connection.relay_first.business_exchange_generation,
+            Some(0)
+        );
+        assert_eq!(connection.first_usable_generation, Some(0));
+        assert_eq!(connection.first_usable_path, Some(NetworkPath::Relay));
+        assert!(!harness
+            .peers
+            .pending_relay_business_evidence_present("peer-a"));
+        harness.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preconfirmation_business_and_probe_ack_remain_live_under_contention() {
+        let mut harness = RelayInboundContentionHarness::new().await;
+        harness
+            .peers
+            .mark_relay_transport_ready_with_transport(
+                "peer-a",
+                &harness.relay_endpoint,
+                0,
+                Some(harness.relay_connection_id),
+            )
+            .await;
+        let request_id = 0x7201;
+        let owner_token = 0x7200_0001;
+        assert!(harness
+            .peers
+            .register_relay_probe_expectation_for_transport(
+                "peer-a",
+                0,
+                request_id,
+                owner_token,
+                &harness.relay_endpoint,
+                harness.relay_connection_id,
+            ));
+
+        let reader = HeldConnectionReader::acquire(&harness.peers).await;
+        let business = relay_business_packet(0x7202, b"business-before-probe-ack");
+        harness.send(&business).await;
+        harness.recv_business(&business).await;
+
+        let ack = relay_probe_ack_packet(0, request_id, owner_token);
+        harness.send(&ack).await;
+        let marker = relay_business_packet(0x7203, b"marker-after-contended-probe-ack");
+        harness.send(&marker).await;
+        harness.recv_business(&marker).await;
+
+        assert!(harness
+            .peers
+            .pending_relay_business_evidence_present("peer-a"));
+        assert!(harness.peers.relay_probe_expectation_present("peer-a"));
+        assert!(
+            harness.peers.try_all_connections().is_some(),
+            "the Probe ACK must not queue a connection writer"
+        );
+
+        reader.release().await;
+        harness.send(&ack).await;
+        let committed_marker = relay_business_packet(0x7204, b"marker-after-probe-retry");
+        harness.send(&committed_marker).await;
+        harness.recv_business(&committed_marker).await;
+
+        let connection = harness.peers.get_connection("peer-a").await.unwrap();
+        assert_eq!(connection.relay_confirmed_generation, Some(0));
+        assert_eq!(
+            connection.relay_confirmed_connection_id,
+            Some(harness.relay_connection_id)
+        );
+        assert_eq!(
+            connection.relay_first.business_received_generation,
+            Some(0)
+        );
+        assert_eq!(connection.first_usable_generation, Some(0));
+        assert_eq!(connection.first_usable_path, Some(NetworkPath::Relay));
+        assert!(!harness.peers.relay_probe_expectation_present("peer-a"));
+        assert!(!harness
+            .peers
+            .pending_relay_business_evidence_present("peer-a"));
+        harness.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn path_commit_ack_contention_retains_expectation_and_actor_progress() {
+        let mut harness = RelayInboundContentionHarness::new().await;
+        harness
+            .peers
+            .mark_relay_transport_ready_with_transport(
+                "peer-a",
+                &harness.relay_endpoint,
+                0,
+                Some(harness.relay_connection_id),
+            )
+            .await;
+        assert!(harness
+            .peers
+            .confirm_relay_peer_with_transport(
+                "peer-a",
+                &harness.relay_endpoint,
+                0,
+                Some(harness.relay_connection_id),
+            )
+            .await);
+        let peer_session_generation = harness
+            .peers
+            .peer_session_generation_sync("peer-a")
+            .unwrap();
+        let request_id = 0x7301;
+        let owner_token = 0x7300_0001;
+        assert!(harness
+            .peers
+            .register_path_commit_expectation_at_write_boundary(
+                "peer-a",
+                0,
+                request_id,
+                owner_token,
+                &harness.relay_endpoint,
+                harness.relay_connection_id,
+                peer_session_generation,
+                Instant::now(),
+            ));
+
+        let reader = HeldConnectionReader::acquire(&harness.peers).await;
+        let ack = path_commit_ack_packet(0, request_id, owner_token);
+        harness.send(&ack).await;
+        let marker = relay_business_packet(0x7302, b"marker-after-contended-path-ack");
+        harness.send(&marker).await;
+        harness.recv_business(&marker).await;
+        assert!(harness.peers.path_commit_expectation_present("peer-a"));
+        assert!(
+            harness.peers.try_all_connections().is_some(),
+            "the Path-commit ACK must not queue a connection writer"
+        );
+
+        reader.release().await;
+        harness.send(&ack).await;
+        let retry_marker = relay_business_packet(0x7303, b"marker-after-path-ack-retry");
+        harness.send(&retry_marker).await;
+        harness.recv_business(&retry_marker).await;
+
+        // A later independently encrypted duplicate cannot repeat the marker
+        // after the exact expectation has been consumed.
+        harness.send(&ack).await;
+        let duplicate_marker = relay_business_packet(0x7304, b"marker-after-path-ack-duplicate");
+        harness.send(&duplicate_marker).await;
+        harness.recv_business(&duplicate_marker).await;
+
+        assert!(!harness.peers.path_commit_expectation_present("peer-a"));
+        let connection = harness.peers.get_connection("peer-a").await.unwrap();
+        assert_eq!(
+            connection.relay_first.business_pathcommit_generation,
+            Some(0)
+        );
+        assert_eq!(
+            harness
+                .timeline
+                .snapshot()
+                .events
+                .iter()
+                .filter(|event| event.event == "relay_first_business_pathcommit")
+                .count(),
+            1,
+            "retry/duplicate ACKs must not repeat the path-commit side effect"
+        );
+        harness.shutdown().await;
     }
 
     #[tokio::test]

--- a/client/daemon/src/transport/tests.rs
+++ b/client/daemon/src/transport/tests.rs
@@ -1851,6 +1851,359 @@ mod tests {
         worker.await.unwrap().unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn first_relay_probe_on_pending_responder_session_survives_connection_contention() {
+        let peer_id = "node-remote";
+        let local_node_id = "node-local";
+        let responder_token = "answer-delivered-owner";
+        let endpoint_server = p2pnet_relay::RelayServer::start_random().await.unwrap();
+        let relay_endpoint = endpoint_server.addr.to_string();
+
+        let local_peers = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        local_peers
+            .add_peer(&PeerInfo {
+                node_id: peer_id.to_string(),
+                public_key: hex::encode(NodeIdentity::generate().public_key()),
+                virtual_ip: "10.20.0.2".to_string(),
+                online: true,
+                ..PeerInfo::default()
+            })
+            .await;
+        let remote_peers = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        remote_peers
+            .add_peer(&PeerInfo {
+                node_id: local_node_id.to_string(),
+                public_key: hex::encode(NodeIdentity::generate().public_key()),
+                virtual_ip: "10.20.0.1".to_string(),
+                online: true,
+                ..PeerInfo::default()
+            })
+            .await;
+
+        let (local_relay, _local_relay_rx) = crate::relay::RelayTransport::connect(
+            &relay_endpoint,
+            local_node_id,
+            local_peers.clone(),
+        )
+        .await
+        .unwrap();
+        let local_relay_connection_id = local_relay.connection_id();
+        let (remote_relay, mut remote_relay_rx) =
+            p2pnet_relay::RelayClient::connect(&relay_endpoint, peer_id)
+                .await
+                .unwrap();
+
+        let (mut remote_session, local_session) = establish_sessions();
+        let (transport, _raw_outbound_rx) = WireGuardTransport::new();
+        assert_eq!(
+            transport
+                .stage_responder_session(
+                    peer_id,
+                    responder_token.to_string(),
+                    local_session,
+                )
+                .await,
+            ResponderSessionStage::Staged { had_active: false }
+        );
+        assert_eq!(
+            local_peers
+                .stage_probe_session_binding(
+                    peer_id,
+                    responder_token.to_string(),
+                    Some("probe-session".to_string()),
+                    Some([0x5a; 32]),
+                    true,
+                )
+                .await,
+            ProbeBindingStage::Staged
+        );
+        let promoted_probe_key = local_peers
+            .probe_key_candidates_for_peer(peer_id)
+            .await
+            .into_iter()
+            .find_map(|candidate| {
+                matches!(candidate.role, ProbeKeyRole::Pending { ref token } if token == responder_token)
+                    .then_some(candidate.key)
+            })
+            .expect("the responder Probe binding must be staged");
+
+        let timeline = crate::connection_timeline::ConnectionTimeline::new(local_node_id, 1);
+        local_peers.set_timeline(timeline.clone());
+        let evidence = InboundEvidenceFeed {
+            relay_transport: Arc::new(RwLock::new(Some(local_relay.clone()))),
+            timeline: Some(timeline.clone()),
+            overlay_ingress_tx: None,
+        };
+        let (encrypted_tx, encrypted_rx) = mpsc::channel(8);
+        let (inbound_tx, mut inbound_rx) = mpsc::channel(8);
+        let (_udp_tx, udp_updates) = watch::channel(None);
+        let inbound_worker = tokio::spawn({
+            let transport = transport.clone();
+            let local_peers = local_peers.clone();
+            async move {
+                transport
+                    .run_inbound_with_peers_live_udp_and_relay(
+                        encrypted_rx,
+                        inbound_tx,
+                        Some(local_peers),
+                        udp_updates,
+                        Some(evidence),
+                    )
+                    .await
+            }
+        });
+
+        let build_probe = |kind, request_id, owner_token| {
+            Ipv4Packet::build_icmp_echo_request(
+                Ipv4Addr::new(10, 20, 0, 2),
+                Ipv4Addr::new(10, 20, 0, 1),
+                request_id,
+                1,
+                &crate::relay_probe::build_relay_probe_payload(
+                    kind,
+                    0,
+                    request_id,
+                    owner_token,
+                ),
+            )
+        };
+        let envelope = |wire_bytes| ReceivedEncryptedPacket {
+            source: None,
+            local_endpoint: None,
+            relay_endpoint: Some(relay_endpoint.clone()),
+            relay_connection_id: Some(local_relay_connection_id),
+            relay_peer_id: Some(peer_id.to_string()),
+            socket_index: None,
+            direct_socket: None,
+            udp_transport_owner: None,
+            network_generation: Some(0),
+            profile_sampled: false,
+            udp_received: None,
+            transport_queue_send_started: None,
+            wire_bytes,
+        };
+
+        // Hold the same map reader used by production relay target snapshots.
+        // The first Probe authenticates under the pending responder key. Ready,
+        // Probe-binding and health writes contend, but none may queue a writer
+        // or stop ACK encryption/sending on the serial inbound actor.
+        let connection_reader = local_peers.connection_map_for_test().read_owned().await;
+        let first_request = build_probe(crate::relay_probe::RelayProbeKind::Request, 1, 0x11);
+        encrypted_tx
+            .send(envelope(
+                remote_session.encrypt_to_bytes(&first_request).unwrap(),
+            ))
+            .await
+            .unwrap();
+        let first_ack = timeout(Duration::from_secs(1), remote_relay_rx.recv())
+            .await
+            .expect("the first pending-session Probe ACK must not wait for connections")
+            .expect("remote relay registration closed");
+        let first_ack_wire = match first_ack {
+            p2pnet_relay::RelayMessage::Data { from_node, data } => {
+                assert_eq!(from_node, local_node_id);
+                data
+            }
+            other => panic!("expected Relay data ACK, got {other:?}"),
+        };
+        let first_ack_packet = remote_session
+            .decrypt_from_bytes(&first_ack_wire)
+            .expect("the responder ACK must use the promoted pending session");
+        let first_ack_token = crate::relay_probe::parse_relay_probe_token(&first_ack_packet)
+            .expect("the responder must send a typed Relay Probe ACK");
+        assert_eq!(
+            first_ack_token.kind,
+            crate::relay_probe::RelayProbeKind::Ack
+        );
+        assert!(timeline.snapshot().events.iter().any(|event| {
+            event.event == "relay_ready_connections_contended"
+                && event.reason_code.as_deref() == Some("fair_rwlock_writer_unavailable")
+        }));
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if timeline
+                    .snapshot()
+                    .events
+                    .iter()
+                    .any(|event| event.event == "relay_probe_ack_sent")
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "ACK reached the peer but send completion was not recorded; events={:?}",
+                timeline
+                    .snapshot()
+                    .events
+                    .iter()
+                    .map(|event| event.event.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+        assert!(
+            local_peers.try_all_connections().is_some(),
+            "the first-packet path must not leave a fair-queue writer behind"
+        );
+
+        // The real ACK received above confirms the opposite endpoint through
+        // the same generation/owner/incarnation fences.
+        let remote_connection_id = 0x7001;
+        remote_peers
+            .mark_relay_transport_ready_with_transport(
+                local_node_id,
+                &relay_endpoint,
+                0,
+                Some(remote_connection_id),
+            )
+            .await;
+        remote_peers.register_relay_probe_expectation_for_transport(
+            local_node_id,
+            0,
+            1,
+            0x11,
+            &relay_endpoint,
+            remote_connection_id,
+        );
+        assert!(
+            remote_peers
+                .consume_relay_probe_ack_with_transport(
+                    local_node_id,
+                    first_ack_token,
+                    &relay_endpoint,
+                    Some(remote_connection_id),
+                )
+                .await
+        );
+
+        drop(connection_reader);
+
+        // A later independently encrypted request retries and commits both
+        // ready and pending Probe binding after the controlled reader exits.
+        let second_request = build_probe(crate::relay_probe::RelayProbeKind::Request, 2, 0x22);
+        encrypted_tx
+            .send(envelope(
+                remote_session.encrypt_to_bytes(&second_request).unwrap(),
+            ))
+            .await
+            .unwrap();
+        let second_ack = timeout(Duration::from_secs(1), remote_relay_rx.recv())
+            .await
+            .expect("the retry Probe ACK must be sent")
+            .expect("remote relay registration closed");
+        if let p2pnet_relay::RelayMessage::Data { data, .. } = second_ack {
+            remote_session
+                .decrypt_from_bytes(&data)
+                .expect("retry ACK must decrypt");
+        } else {
+            panic!("retry did not produce Relay data");
+        }
+        for _ in 0..64 {
+            let connection = local_peers.get_connection(peer_id).await.unwrap();
+            if connection.relay_ready_connection_id == Some(local_relay_connection_id)
+                && local_peers.probe_key_for_peer(peer_id).await == Some(promoted_probe_key)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let local_connection = local_peers.get_connection(peer_id).await.unwrap();
+        assert_eq!(
+            local_connection.relay_ready_connection_id,
+            Some(local_relay_connection_id)
+        );
+        assert_eq!(
+            local_peers.probe_key_for_peer(peer_id).await,
+            Some(promoted_probe_key)
+        );
+
+        // Complete the local endpoint's owned confirmation with a matching ACK
+        // over this exact relay incarnation.
+        local_peers.register_relay_probe_expectation_for_transport(
+            peer_id,
+            0,
+            3,
+            0x33,
+            &relay_endpoint,
+            local_relay_connection_id,
+        );
+        let local_ack = build_probe(crate::relay_probe::RelayProbeKind::Ack, 3, 0x33);
+        for _ in 0..16 {
+            encrypted_tx
+                .send(envelope(
+                    remote_session.encrypt_to_bytes(&local_ack).unwrap(),
+                ))
+                .await
+                .unwrap();
+            for _ in 0..16 {
+                if local_peers.is_relay_peer_confirmed(peer_id).await {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            if local_peers.is_relay_peer_confirmed(peer_id).await {
+                break;
+            }
+        }
+        assert!(local_peers.is_relay_peer_confirmed(peer_id).await);
+        assert!(remote_peers.is_relay_peer_confirmed(local_node_id).await);
+        assert!(!local_peers.is_direct(peer_id).await);
+        assert!(!remote_peers.is_direct(local_node_id).await);
+        assert_eq!(
+            local_peers
+                .get_connection(peer_id)
+                .await
+                .unwrap()
+                .active_path(),
+            Some(NetworkPath::Relay)
+        );
+        assert_eq!(
+            remote_peers
+                .get_connection(local_node_id)
+                .await
+                .unwrap()
+                .active_path(),
+            Some(NetworkPath::Relay)
+        );
+
+        // A generation advance revokes the proof, and an old-generation frame
+        // cannot recreate it even though the WireGuard session still decrypts.
+        assert_eq!(
+            local_peers
+                .advance_network_generation("test stale Relay frame")
+                .await,
+            1
+        );
+        let stale_ack = build_probe(crate::relay_probe::RelayProbeKind::Ack, 4, 0x44);
+        encrypted_tx
+            .send(envelope(
+                remote_session.encrypt_to_bytes(&stale_ack).unwrap(),
+            ))
+            .await
+            .unwrap();
+        drop(encrypted_tx);
+        timeout(Duration::from_secs(1), inbound_worker)
+            .await
+            .expect("encrypted frames accumulated in the serial inbound actor")
+            .expect("inbound actor panicked")
+            .expect("inbound actor failed");
+        assert!(!local_peers.is_relay_peer_confirmed(peer_id).await);
+        assert!(inbound_rx.try_recv().is_err(), "control Probes leaked to TUN");
+        let session_status = transport.session_status(peer_id).await;
+        assert!(session_status.has_active);
+        assert!(!session_status.has_pending_responder);
+
+        local_relay.abort_writer();
+        remote_relay.close().await.unwrap();
+    }
+
     #[tokio::test]
     async fn rekey_uses_new_session_for_outbound_packets() {
         let (_old_remote, old_local) = establish_sessions();

--- a/client/daemon/src/udp/inbound.rs
+++ b/client/daemon/src/udp/inbound.rs
@@ -20,9 +20,7 @@ impl UdpTransport {
         {
             return false;
         }
-        wireguard
-            .acknowledge_promoted_responder_token(peer_id, token)
-            .await;
+        wireguard.acknowledge_promoted_responder_token(peer_id, token);
         true
     }
 
@@ -53,9 +51,7 @@ impl UdpTransport {
         {
             return false;
         }
-        wireguard
-            .acknowledge_promoted_responder_token(peer_id, token)
-            .await;
+        wireguard.acknowledge_promoted_responder_token(peer_id, token);
         true
     }
 

--- a/scripts/nat-sim/nat-sim-smoke.sh
+++ b/scripts/nat-sim/nat-sim-smoke.sh
@@ -302,6 +302,99 @@ PY
   fi
 }
 
+# Sample the authenticated status endpoint without writing credentials or a
+# response body. `000` means no HTTP response; callers tolerate it only before
+# the daemon's first 200 during startup. Once the endpoint is live, every
+# sample through the Relay burst must remain 200.
+status_http_code() {
+  local url="$1" token_file="$2" code
+  code=$(DIAGNOSTICS_AUTH_TOKEN_FILE="$token_file" \
+    p2wlan_diagnostics_curl \
+      -sS --connect-timeout 0.2 --max-time 2 \
+      -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || true)
+  if ! [[ "$code" =~ ^[0-9]{3}$ ]]; then
+    code=000
+  fi
+  printf '%s\n' "$code"
+}
+
+record_relay_status_code() {
+  local side="$1" code="$2"
+  printf 'side=%s code=%s at_ms=%s\n' \
+    "$side" "$code" "$(python3 -c 'import time; print(int(time.time()*1000))')" \
+    >>"$ROUND_DIR/status-http-samples.log"
+  case "$side" in
+    a)
+      A_STATUS_SAMPLE_COUNT=$((A_STATUS_SAMPLE_COUNT + 1))
+      if [[ "$code" == 200 ]]; then
+        A_STATUS_SEEN_200=1
+        A_STATUS_200_COUNT=$((A_STATUS_200_COUNT + 1))
+      elif [[ "$code" != 000 || "$A_STATUS_SEEN_200" -eq 1 ]]; then
+        A_STATUS_ALWAYS_200=0
+      fi
+      ;;
+    b)
+      B_STATUS_SAMPLE_COUNT=$((B_STATUS_SAMPLE_COUNT + 1))
+      if [[ "$code" == 200 ]]; then
+        B_STATUS_SEEN_200=1
+        B_STATUS_200_COUNT=$((B_STATUS_200_COUNT + 1))
+      elif [[ "$code" != 000 || "$B_STATUS_SEEN_200" -eq 1 ]]; then
+        B_STATUS_ALWAYS_200=0
+      fi
+      ;;
+  esac
+}
+
+# Sample both daemons concurrently so observability cannot lengthen the
+# topology deadline by one client timeout per endpoint. Hidden scratch files
+# carry the two subshell results back to this shell; only the final bounded
+# code/timestamp stream is retained as acceptance evidence.
+sample_relay_status_pair() {
+  local a_url="$1" a_token_file="$2" b_url="$3" b_token_file="$4"
+  local a_code_file="$ROUND_DIR/.status-a-code"
+  local b_code_file="$ROUND_DIR/.status-b-code"
+  local a_pid b_pid a_code b_code
+
+  status_http_code "$a_url" "$a_token_file" >"$a_code_file" &
+  a_pid=$!
+  status_http_code "$b_url" "$b_token_file" >"$b_code_file" &
+  b_pid=$!
+  wait "$a_pid"
+  wait "$b_pid"
+  IFS= read -r a_code <"$a_code_file" || a_code=000
+  IFS= read -r b_code <"$b_code_file" || b_code=000
+  rm -f "$a_code_file" "$b_code_file"
+
+  record_relay_status_code a "${a_code:-000}"
+  record_relay_status_code b "${b_code:-000}"
+}
+
+# A topology run introduces no one-shot Relay owner tasks. Every supervised
+# critical task present in the final status must still be running, unfinished,
+# and error-free; this turns a silent task exit into a Relay acceptance failure.
+node_task_health_ok() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        status = json.load(handle)
+    health = status["health"]
+    tasks = health["critical_tasks"]
+    critical = [task for task in tasks if task.get("critical") is True]
+    ok = bool(critical) and all(
+        task.get("running") is True
+        and task.get("finished") is False
+        and task.get("error") is None
+        for task in critical
+    )
+except Exception:
+    ok = False
+print(1 if ok else 0)
+PY
+}
+
 cleanup() {
   for pid in "${PIDS[@]:-}"; do
     kill "$pid" 2>/dev/null || true
@@ -314,6 +407,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[nat-sim] mode=$MODE isolated network id: $NETWORK_ID"
+echo "[nat-sim] exact_head_sha=${NAT_TOPOLOGY_HEAD_SHA:-unknown} replica=${NAT_TOPOLOGY_REPLICA:-1}"
 echo "[nat-sim] traversal flags: strict_filtering=$STRICT_FILTERING fresh_mapping=$FRESH_MAPPING_PUNCH predicted_candidates=$PREDICTED_CANDIDATES birthday=$BIRTHDAY_PROBING socket_pool=${SOCKET_POOL:-default}"
 echo "[nat-sim] building control server, relay and daemon..."
 (
@@ -509,7 +603,21 @@ for round in $(seq 1 "$ROUNDS"); do
     # When OVERLAY_BURST is set, the round additionally waits for the burst to
     # complete on both sides.
     overlay_ok=0
-    for _ in $(seq 1 $((OVERLAY_TIMEOUT_S * 4))); do
+    A_STATUS_SEEN_200=0
+    B_STATUS_SEEN_200=0
+    A_STATUS_ALWAYS_200=1
+    B_STATUS_ALWAYS_200=1
+    A_STATUS_SAMPLE_COUNT=0
+    B_STATUS_SAMPLE_COUNT=0
+    A_STATUS_200_COUNT=0
+    B_STATUS_200_COUNT=0
+    OVERLAY_DEADLINE=$((SECONDS + OVERLAY_TIMEOUT_S))
+    while [[ "$SECONDS" -lt "$OVERLAY_DEADLINE" ]]; do
+      sample_relay_status_pair \
+        "http://127.0.0.1:$DIAG_A_PORT/status" \
+        "$NODE_A_RUNTIME/p2wlan-daemon.diag-auth" \
+        "http://127.0.0.1:$DIAG_B_PORT/status" \
+        "$NODE_B_RUNTIME/p2wlan-daemon.diag-auth"
       A_OVERLAY=$(grep -c 'overlay_payload_verified' "$ROUND_DIR/node-a.log" 2>/dev/null || true)
       B_OVERLAY=$(grep -c 'overlay_payload_verified' "$ROUND_DIR/node-b.log" 2>/dev/null || true)
       A_BURST=$(grep -c 'overlay_burst_complete' "$ROUND_DIR/node-a.log" 2>/dev/null || true)
@@ -699,6 +807,8 @@ except Exception:
     B_BURST=$(grep -c 'overlay_burst_complete' "$ROUND_DIR/node-b.log" 2>/dev/null || true)
     A_BURST_BAD=$(grep -c 'overlay_burst_incomplete' "$ROUND_DIR/node-a.log" 2>/dev/null || true)
     B_BURST_BAD=$(grep -c 'overlay_burst_incomplete' "$ROUND_DIR/node-b.log" 2>/dev/null || true)
+    A_TASKS_OK=$(node_task_health_ok "$ROUND_DIR/node-a.status.json")
+    B_TASKS_OK=$(node_task_health_ok "$ROUND_DIR/node-b.status.json")
     BURST_OK=1
     if [[ "$OVERLAY_BURST" -gt 0 ]]; then
       [[ "$A_BURST" -ge 1 && "$B_BURST" -ge 1 && "$A_BURST_BAD" -eq 0 && "$B_BURST_BAD" -eq 0 ]] || BURST_OK=0
@@ -712,10 +822,13 @@ except Exception:
           && "$A_DROPS" -eq 0 && "$B_DROPS" -eq 0 \
           && "$A_REPLAY" -eq 0 && "$B_REPLAY" -eq 0 \
           && "$A_INVALID" -eq 0 && "$B_INVALID" -eq 0 \
+          && "$A_STATUS_SEEN_200" -eq 1 && "$B_STATUS_SEEN_200" -eq 1 \
+          && "$A_STATUS_ALWAYS_200" -eq 1 && "$B_STATUS_ALWAYS_200" -eq 1 \
+          && "$A_TASKS_OK" -eq 1 && "$B_TASKS_OK" -eq 1 \
           && "$BURST_OK" -eq 1 ]]; then
-      echo "[nat-sim] ROUND $round: PASS relay_first_evidence overlay_ok=1 a_direct=$A_DIRECT b_direct=$B_DIRECT a_overlay=$A_OVERLAY b_overlay=$B_OVERLAY a_relay_confirmed=$A_RELAY_CONFIRMED b_relay_confirmed=$B_RELAY_CONFIRMED a_ingress=${A_INGRESS:-none} b_ingress=${B_INGRESS:-none} a_delta_ms=$A_DELTA b_delta_ms=$B_DELTA sum_delta_ms=$SUM_DELTA drops_a=$A_DROPS drops_b=$B_DROPS replay_a=$A_REPLAY replay_b=$B_REPLAY invalid_a=$A_INVALID invalid_b=$B_INVALID burst_a=$A_BURST burst_b=$B_BURST elapsed_ms=$ELAPSED_MS failure_reason=${FAIL_CODE:-none} evidence=$ROUND_DIR/evidence.log"
+      echo "[nat-sim] ROUND $round: PASS relay_first_evidence overlay_ok=1 a_direct=$A_DIRECT b_direct=$B_DIRECT a_overlay=$A_OVERLAY b_overlay=$B_OVERLAY a_relay_confirmed=$A_RELAY_CONFIRMED b_relay_confirmed=$B_RELAY_CONFIRMED a_ingress=${A_INGRESS:-none} b_ingress=${B_INGRESS:-none} a_delta_ms=$A_DELTA b_delta_ms=$B_DELTA sum_delta_ms=$SUM_DELTA drops_a=$A_DROPS drops_b=$B_DROPS replay_a=$A_REPLAY replay_b=$B_REPLAY invalid_a=$A_INVALID invalid_b=$B_INVALID burst_a=$A_BURST burst_b=$B_BURST status_http_200_a=$A_STATUS_200_COUNT/$A_STATUS_SAMPLE_COUNT status_http_200_b=$B_STATUS_200_COUNT/$B_STATUS_SAMPLE_COUNT task_leak_a=$((1 - A_TASKS_OK)) task_leak_b=$((1 - B_TASKS_OK)) elapsed_ms=$ELAPSED_MS failure_reason=${FAIL_CODE:-none} evidence=$ROUND_DIR/evidence.log"
     else
-      echo "[nat-sim] ROUND $round: FAIL relay_first_evidence overlay_ok=$overlay_ok a_direct=$A_DIRECT b_direct=$B_DIRECT a_overlay=$A_OVERLAY b_overlay=$B_OVERLAY a_relay_confirmed=$A_RELAY_CONFIRMED b_relay_confirmed=$B_RELAY_CONFIRMED a_ingress=${A_INGRESS:-none} b_ingress=${B_INGRESS:-none} a_delta_ms=$A_DELTA b_delta_ms=$B_DELTA sum_delta_ms=$SUM_DELTA drops_a=$A_DROPS drops_b=$B_DROPS replay_a=$A_REPLAY replay_b=$B_REPLAY invalid_a=$A_INVALID invalid_b=$B_INVALID burst_a=$A_BURST burst_b=$B_BURST burst_bad_a=$A_BURST_BAD burst_bad_b=$B_BURST_BAD elapsed_ms=$ELAPSED_MS failure_reason=${FAIL_CODE:-none} (strict relay-first evidence required: both RelayPeerConfirmed, ingress=relay:*, per-daemon delta <= 3000ms, zero drops/replay/invalid, burst complete)"
+      echo "[nat-sim] ROUND $round: FAIL relay_first_evidence overlay_ok=$overlay_ok a_direct=$A_DIRECT b_direct=$B_DIRECT a_overlay=$A_OVERLAY b_overlay=$B_OVERLAY a_relay_confirmed=$A_RELAY_CONFIRMED b_relay_confirmed=$B_RELAY_CONFIRMED a_ingress=${A_INGRESS:-none} b_ingress=${B_INGRESS:-none} a_delta_ms=$A_DELTA b_delta_ms=$B_DELTA sum_delta_ms=$SUM_DELTA drops_a=$A_DROPS drops_b=$B_DROPS replay_a=$A_REPLAY replay_b=$B_REPLAY invalid_a=$A_INVALID invalid_b=$B_INVALID burst_a=$A_BURST burst_b=$B_BURST burst_bad_a=$A_BURST_BAD burst_bad_b=$B_BURST_BAD status_http_200_a=$A_STATUS_200_COUNT/$A_STATUS_SAMPLE_COUNT status_http_200_b=$B_STATUS_200_COUNT/$B_STATUS_SAMPLE_COUNT status_always_200_a=$A_STATUS_ALWAYS_200 status_always_200_b=$B_STATUS_ALWAYS_200 task_health_a=$A_TASKS_OK task_health_b=$B_TASKS_OK elapsed_ms=$ELAPSED_MS failure_reason=${FAIL_CODE:-none} (strict relay-first evidence required: both RelayPeerConfirmed, ingress=relay:*, per-daemon delta <= 3000ms, zero drops/replay/invalid, burst complete, status always HTTP 200, no supervised task exit)"
       overall=1
     fi
   else

--- a/scripts/nat-sim/run-ci-topology.sh
+++ b/scripts/nat-sim/run-ci-topology.sh
@@ -7,10 +7,26 @@ SMOKE="$ROOT_DIR/scripts/nat-sim/nat-sim-smoke.sh"
 PROFILE=${1:-unit}
 RUN_ID=${GITHUB_RUN_ID:-local-$$}
 RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
+REPLICA=${NAT_TOPOLOGY_REPLICA:-1}
+EXPECTED_HEAD_SHA=${NAT_TOPOLOGY_HEAD_SHA:-}
 ARTIFACT_PARENT=${NAT_TOPOLOGY_ARTIFACT_ROOT:-${RUNNER_TEMP:-/tmp}}
-ARTIFACT_DIR="$ARTIFACT_PARENT/p2wlan-nat-topology-${RUN_ID}-${RUN_ATTEMPT}-${PROFILE}"
+ARTIFACT_DIR="$ARTIFACT_PARENT/p2wlan-nat-topology-${RUN_ID}-${RUN_ATTEMPT}-${PROFILE}-${REPLICA}"
 LOG_FILE="${ARTIFACT_DIR}.log"
-RUN_NAME="nat-ci-${PROFILE}-${RUN_ID}-${RUN_ATTEMPT}"
+RUN_NAME="nat-ci-${PROFILE}-${RUN_ID}-${RUN_ATTEMPT}-${REPLICA}"
+
+if ! [[ "$REPLICA" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[nat-ci] NAT_TOPOLOGY_REPLICA must be a positive integer" >&2
+  exit 2
+fi
+if [[ -n "$EXPECTED_HEAD_SHA" ]]; then
+  ACTUAL_HEAD_SHA=$(git -C "$ROOT_DIR" rev-parse HEAD)
+  if [[ "$ACTUAL_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
+    echo "[nat-ci] exact Head mismatch expected=$EXPECTED_HEAD_SHA actual=$ACTUAL_HEAD_SHA replica=$REPLICA" >&2
+    exit 2
+  fi
+else
+  ACTUAL_HEAD_SHA=$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo unknown)
+fi
 
 mkdir -p "$ARTIFACT_PARENT"
 if [[ -e "$ARTIFACT_DIR" || -e "$LOG_FILE" ]]; then
@@ -30,6 +46,8 @@ run_smoke() {
       ROUNDS=1 \
       NAT_SEED_BASE=20260828 \
       NAT_SIM_RUN_ID="$RUN_NAME" \
+      NAT_TOPOLOGY_HEAD_SHA="$ACTUAL_HEAD_SHA" \
+      NAT_TOPOLOGY_REPLICA="$REPLICA" \
       NAT_SIM_ARTIFACT_DIR="$ARTIFACT_DIR" \
       "$@" \
       bash "$SMOKE" 2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
## 问题与失败证据

本 PR 独立修复 main `788750efc27b2dccba633e69b91db37d747cf3e5` 上的 Relay 首包活性故障，不包含、重放或修改 PR #41。

失败来源：[run 33353252490 / job 99370500373](https://github.com/yhan-sun/p2wlan/actions/runs/33353252490/job/99370500373)，artifact `nat-topology-relay-33353252490-1.zip`（ID `9744416247`）。Node B 的证据边界是：

1. `peer_answer_staged`（约 11085 ms）
2. `peer_answer_control_result delivered=true`（约 11090 ms）
3. Relay counter=1 到达并在约 11113 ms 完成 `wireguard_inbound_decrypt_succeeded`
4. 此后没有 Relay-ready、Probe 分类/ACK、pending responder promotion、inbound queue handoff、`peer_answer_control_accepted` 或 responder commit
5. Relay TCP reader 仍持续收到更高 counter 的 encrypted frame；双端 Direct=0、RelayPeerConfirmed=0、overlay=0，`/status` 最终 503

因此它不是旧的 initiator publish 竞争：Offer/Answer 已交付，停点严格位于第一个 authenticated Relay frame 解密之后、首个连接状态提交之前。

## 根因与修改前 wait-for graph

旧 artifact 没有锁 owner/task ID，不能从旧日志诚实地区分当时已经获准的 connection-map owner 究竟来自哪一次 target/recovery/diagnostics/lifecycle snapshot；本 PR 增加的低频、首事件作用域诊断正是为了以后直接给出该归属。能由 artifact 的负边界、旧源码和确定性生产路径复现共同证明的是以下完整等待关系：

```text
T_conn_snapshot
  holds: PeerManager.connections R（已在 writer 排队前获准）

T_answer
  Answer 已成功交付
  responder arbiter: 已释放
  outbound ingress -> transport sessions: grace refresh 后均释放
  waits unbounded: PeerManager.connections W
    at refresh_pending_probe_session_binding_grace

T_wg_inbound（全进程唯一串行 WireGuard inbound consumer）
  holds: peer emit/current-session evidence guard
  holds: network epoch guard
  waits unbounded: PeerManager.connections W
    at mark_relay_transport_ready_with_transport

Tokio fair RwLock
  一旦上述 W 排队，拒绝所有后来 R，防止 writer starvation

T_status
  waits: PeerManager.connections R（排在 queued W 之后）
  diagnostics 外层超时 -> HTTP 503

T_relay_reader
  不依赖该锁，继续把高 counter ciphertext 放入 encrypted_rx
  但 T_wg_inbound 是唯一 consumer，已停在 counter=1，故不能分类下一帧、
  发送 ACK、promotion、确认 Relay 或 handoff business packet
```

确定性回归在真实 responder post-answer、真实 Relay client/server/reader、真实 WireGuard pending responder session 和真实 `/status` 上，于同一生产边界保留 connection snapshot，复现了旧路径的两个 writer waiter 和 Tokio writer-preference reader gate。旧实现没有等待上界、取消边界或 contention reschedule；串行 consumer 一旦排队，后续帧本身也无法成为 retry 驱动，所以该等待对首包活性没有任何有限进展保证。另一个次级阻塞点是 ACK 已完成 TCP write 后，`record_relay_attempt -> connections W` 仍能把同一个串行 actor 留在 writer 队列中。

## 修复后的锁序与事务语义

### Responder post-answer

```text
responder arbiter（短检查） -> release
outbound ingress -> transport sessions（只刷新 transport grace） -> release both
connections.try_write（binding grace；失败为 typed contention，不排队）
emit -> network epoch -> transport sessions（最终 responder commit）
```

Answer 成功交付后，等待 connection writer 时不再持有 arbiter、outbound ingress、transport sessions、emit 或 epoch。原 binding/token grace 在 contention 时保留，下一次 authenticated ingress 重试 promotion。

### Relay inbound / confirmation

```text
decrypt -> current-session evidence guard
  -> epoch.try_lock -> connections.try_write（Relay-ready 短事务）
  -> contention 返回 RelayReadyCommitOutcome，立即继续
release evidence guard
classify Probe -> encrypt/send ACK
promotion: connections.try_write；contention 时保留有界 promoted token
ACK confirmation: epoch.try_lock -> connections.try_write；
  只有 lifecycle commit 成功后才消费 exact expectation
post-write observation/attempt: connections.try_write（纯 advisory）
```

没有新增 detached 无界任务、sleep、全局锁或放宽成功条件。每个可重试事务仍校验 network generation、peer session generation、Relay endpoint/connection incarnation、request/owner token 和 quarantine；旧 generation、旧 peer lifecycle、旧 Relay reader 或旧 responder owner 都不能提交到新生命周期。

### `/status`

所有 connection-map capture/validation 改为 non-queuing `try_read`。live capture 通过 revision、generation 和 shape 双重校验后写入 cache；若 active/queued writer 令读失败，则返回同一个已验证 capture 并明确设置 `peer_snapshot_stale=true`，保持 HTTP 200。首次启动没有 cache 时使用 PeerManager 的非排队 bounded last-good diagnostics，不把状态接口加入公平锁等待队列。

## 有界可观测性

新增首事件/作用域时间线覆盖：

- Relay-ready epoch / connections transaction 的开始、结束、typed outcome、wait μs、peer、generation、Relay endpoint/connection ID
- 首个 authenticated Relay decrypt、ready、Probe classification、ACK encrypt/send、promotion、inbound queue handoff 与 queue depth
- responder arbiter 释放、transport grace 的 ingress/sessions 等待、binding grace contention、control accepted 与 commit
- `/status` connection-map read contention、fair queued-writer 可能性与 validated-cache fallback

日志只记录生命周期标识和不可逆 fingerprint，不记录密钥或原始敏感 token；首包阶段事件按 peer+generation 去重，后续每帧不会产生无界日志。

## 本地验证

- `cargo test --workspace --all-targets --all-features`：通过；daemon lib 1196/1196
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：通过
- `cargo fmt --all --check`、`git diff --check`、NAT shell `bash -n`：通过
- 128 个受控关键交错（4! 全排列，每种至少 5 次）连续执行 10 轮：1280/1280 schedules 通过，无 writer 入队；无任意 sleep
- 完整 responder/status/真实 Relay/WireGuard 首包回归连续 10/10；底层 pending responder Relay Probe 回归 20/20；状态公平队列回归 20/20
- NAT simulator Python 单元：12/12
- 本地真实双节点 Relay-blackhole smoke：通过：
  - exact base-derived Head tree
  - `a_relay_confirmed=1`, `b_relay_confirmed=1`
  - `a_direct=0`, `b_direct=0`
  - 双端 ingress=Relay
  - overlay `132/132`，burst `2/2`
  - first-usable delta `12 ms / 200 ms`
  - drops/replay/invalid 均为 0
  - `/status` 在 endpoint 首次 live 后始终 200
  - task leak `0/0`

## CI / 验收

Relay blackhole topology 改为五个 `fail-fast: false` 的独立 matrix job；每个 job checkout 并验证同一个 PR exact Head SHA，artifact 名含 run `1-of-5` ... `5-of-5`，不通过 rerun 拼接结果。保留原 topology 断言，并增加 `/status` 持续 200 与 supervised critical-task health 断言。

本 PR 不修改 Flutter、FVM 或 Dart。exact-Head Flutter workflow 自然运行并成功；Android Release 的 **Set up Flutter** 已通过，因此旧 exit 35 记录为外部 runner/TLS 波动。

### 上一轮 exact-Head 远端结果

上一轮 Head：`be4ca7155bf1dd823ad76f5e8f826ec0126633c5`。五个 job 均在 NAT Topology run `33365609166` 的第一次 attempt 中独立完成，没有 rerun；每个 job 的 exact-Head step 都打印并核对该 SHA。

- [Relay blackhole topology 1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99405537499)：PASS；delta `215/9 ms`，status HTTP 200 `20/20`、`4/4` live samples
- [Relay blackhole topology 2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99405537487)：PASS；delta `6/18 ms`，status HTTP 200 `20/20`、`4/4` live samples
- [Relay blackhole topology 3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99405537459)：PASS；delta `131/174 ms`，status HTTP 200 `16/16`、`5/5` live samples
- [Relay blackhole topology 4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99405537480)：PASS；delta `216/7 ms`，status HTTP 200 `20/20`、`4/4` live samples
- [Relay blackhole topology 5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99405537458)：PASS；delta `3/102 ms`，status HTTP 200 `15/15`、`5/5` live samples

五次共同结果：overlay `132/132`、burst `2/2`、双端 RelayConfirmed=1、Direct=0、ingress=Relay、drops/replay/invalid=0、task leak=0。status sampler 的 raw denominator 还包含 diagnostics listener bind 前的 `000`（无 HTTP 响应）；所有实际 HTTP 响应均为 200，且首次 200 后没有退化。

远端 gate 全部成功：

- [NAT Topology Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609166/job/99407110628)
- [DPLPMTUD Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609118/job/99409189551)
- [Path State Machine Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609130/job/99409108516)
- [Windows Lifecycle Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609136/job/99405504515)
- [Mobile Lifecycle Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609143/job/99405504616)
- [CI Required](https://github.com/yhan-sun/p2wlan/actions/runs/33365609222/job/99408061501)
- [Flutter Client](https://github.com/yhan-sun/p2wlan/actions/runs/33365609112)：SUCCESS；Android Release 的 **Set up Flutter** 成功，旧 exit 35 归为外部 runner/TLS 波动
- [Package Test Builds](https://github.com/yhan-sun/p2wlan/actions/runs/33365609379)：SUCCESS

## 明确不在范围内

- 不处理或重放 PR #41
- 不 merge、tag、release、签名、修改版本或部署


## 后续修复：Relay inbound 剩余 non-queuing 路径

本节对应新 Head `23e642ac79d9b8860bcc940b2603a80a6f53dad2`，覆盖上一轮 `be4ca7155bf1dd823ad76f5e8f826ec0126633c5` 验收之后暴露的普通 business evidence、preconfirmation ACK 和 Path-commit ACK 残余阻塞。PR #41 未被处理或重放。

### 实现与事务边界

- 新增 typed `RelayBusinessEvidenceCommitOutcome`：`Committed`、`AlreadyCurrent`、`PendingConfirmation`、`ContendedEpoch`、`ContendedConnections`、`RejectedLifecycle`。事务只使用 `epoch.try_lock` 与 `connections.try_write`。
- Relay received、business exchange 和 first usable 在同一个 connection transaction 中提交；connection reader contention 时普通 IPv4 business packet 不排队 writer，继续 TUN handoff。
- authenticated evidence 先写入 manager 级有界 ledger，再尝试提交。每 Peer 一个 newest-wins entry；TTL 3 秒；总容量 1024；绑定 peer、network generation、peer session generation、WireGuard session instance、Relay endpoint、Relay connection id 和 `received_at`。
- 每个后续 authenticated Relay frame 都可重试 exact ledger entry；Relay confirmation 也在同一 transaction 中吸收匹配的 preconfirmation evidence。旧 generation、peer lifecycle、WireGuard session 或 Relay incarnation 只能得到 `RejectedLifecycle`，不能提交。
- Probe ACK 路径不再在 confirmation 后调用阻塞式 `record_verified_first_usable`；contention 时保留 Probe expectation 与 pending business evidence。
- Path-commit ACK 先 clone exact expectation，校验 token/lifecycle/Relay incarnation，执行 typed try-only commit；只在 `Committed` 或 `AlreadyCurrent` 后删除 exact expectation。
- 未新增 detached task、sleep、版本、签名、Tag、Release 或部署修改。提交不含 `Co-authored-by` 尾注。

### `WireGuardTransport::run_inbound_with_udp_source` 静态审计

从 decrypt 成功到 `inbound_tx.send` 的调用点及结果：

1. initial session retention check：只等待 transport sessions，进入该调用前未持有 current-session、emit 或 epoch guard。
2. Relay slot incarnation snapshot：在 evidence guard 之前读取并 clone current Relay connection id；旧 reader 立即拒绝。
3. final current-session fence：emit acquisition 与 sessions recheck 均为 try-only；持有 emit guard 时不再等待 sessions mutex。
4. Relay-ready、pending business retry、business confirmation：同步 `epoch.try_lock -> connections.try_write`，无 await、无 queued writer。
5. Relay Probe ACK：同步 exact expectation validation + try-only confirmation；contention 保留 expectation，handler 不 await。Request 分支在不持有 inbound evidence guard 时走既有 bounded control-emission path。
6. Path-commit ACK：同步 exact expectation transaction；contention 保留 expectation，handler 不 await。Request 分支同样不保留 inbound evidence guard。
7. pending responder promotion：promoted-token ledger 改为短 `std::sync::Mutex`，manager commit 使用 `connections.try_write`；无 async mutex wait。
8. DPLPMTUD / Direct validation：current-session snapshot 后立即释放 session/emit evidence guard，再进入各自 owner/lifecycle transaction；这些 await 不与 inbound evidence guard 共持。
9. Relay observation：`try_record_relay_observation` 使用 `connections.try_write`。
10. ordinary business：Relay 使用单一 typed ledger transaction；Direct first-usable 使用 try-only lifecycle transaction；timeline emission 为同步。
11. overlay harness send 与最终 `inbound_tx.send`：执行时所有 current-session evidence guard、emit guard 和 Relay epoch guard 均已释放。

审计结论：Relay inbound evidence/ACK commit 在持有 current-session、emit 或 Relay epoch guard 时不再对 connections、network epoch、responder/outbound ingress 或 transport sessions 做无界等待。

### 确定性回归

- `relay_business_contention_preserves_evidence_without_blocking_tun`：持有真实 connection reader 时，真实 Relay IPv4 business 先到 TUN；无 queued writer；pending retained；authenticated retry 后 received/exchange/first usable 原子提交。
- `preconfirmation_business_and_probe_ack_remain_live_under_contention`：READY 未 confirmed，business 与 Probe ACK 均不阻塞 actor；marker frame 继续消费；expectation/evidence 保留；释放 reader 后 ACK retry 完成 confirmation + first usable。
- `path_commit_ack_contention_retains_expectation_and_actor_progress`：首个 ACK contention 时 expectation 保留且 marker frame 继续；retry ACK 只提交一次 marker，随后删除 expectation。
- `relay_business_pending_ledger_is_newest_wins_ttl_and_capacity_bounded`：无 sleep 验证 strict TTL、每 Peer newest-wins 与 1024 总容量。

新增 contention tests 使用 Barrier/Notify 与受控 channel timeout，不使用任意 sleep。

### 新 Head 本地验收

- `cargo fmt --all -- --check`：PASS
- `cargo check --workspace --all-targets --all-features`：PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：PASS
- `cargo test --workspace --all-targets --all-features`：PASS；daemon lib `1200/1200`，其余 workspace targets 全部通过
- `git diff --check`：PASS

### 新 Head 远端验收

首次 attempt 已全部结束；所有 workflow 均验证 exact Head `23e642ac79d9b8860bcc940b2603a80a6f53dad2`（tree `d99a3f167e0b437a03c399b8984de503cb5cfd5c`）。没有 rerun，也没有跨 attempt 拼接 Relay 5/5。

- [NAT Topology run 33386242662](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662)：FAIL。simulator unit 与 Direct cold-start 通过；Relay [1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432325)、[3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432317)、[4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432321)、[5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432247) 通过；[2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432231) 首轮失败，reason `first_usable_delta_missing`。
- [DPLPMTUD run 33386242632](https://github.com/yhan-sun/p2wlan/actions/runs/33386242632)：DPLPMTUD Linux、Windows 与全部 acceptance job 通过；workflow/Required 仅因 same-SHA NAT required gate 失败而失败。
- [Path run 33386242648](https://github.com/yhan-sun/p2wlan/actions/runs/33386242648)：Rust 与 Windows path-state job 通过；aggregate/Required 仅因 same-SHA NAT gate 失败而失败。
- [Windows Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33386242664)、[Mobile Lifecycle](https://github.com/yhan-sun/p2wlan/actions/runs/33386242702)、[CI](https://github.com/yhan-sun/p2wlan/actions/runs/33386242688)、[Flutter Client](https://github.com/yhan-sun/p2wlan/actions/runs/33386242748) 与 [Package Test Builds](https://github.com/yhan-sun/p2wlan/actions/runs/33386242742)：SUCCESS。

Relay 2/5 的 [artifact `nat-topology-relay-33386242662-1-2-of-5`](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/artifacts/9755834832) 显示双端 `relay_confirmed=0`、ingress none、overlay 0，且没有 drop/replay/invalid。later-started Node B 是 designated initiator；日志依次出现 `initiator_handshake_reserved owner=1 generation=0` 与 `initiator_handshake_lock_wait phase=preparation`，之后约 95 秒始终没有 `lock_acquired`、没有 WireGuard session，forced Relay Probe 因 `No WireGuard session` 被丢弃。因此该失败发生在 Relay inbound actor/decrypt/evidence transaction 之前；本 Head 未修改 handshake/control-event 仲裁代码。对上一 Head 首轮成功 shard 的对照显示另一调度下 maintenance reservation 先完成、event initiator 随后立即取得 arbiter，证据符合独立的、调度敏感的 pre-session arbiter stall，但现有日志没有 owner label，不能进一步诚实断定占有者。

结论：本次 Relay inbound actor 修复的本地回归和相关远端 Rust/Path/Windows/Mobile/CI/Flutter/Package job 通过，但用户要求的 Relay topology 首轮 5/5 验收为 **FAIL（4/5）**。未重跑失败 shard，PR 保持 OPEN；若要修复上述 handshake/control lifecycle 仲裁，需要单独明确扩大范围。



## 后续修复：Handshake / Control Lifecycle Arbitration Liveness

本节对应 exact Head `f79f908d10d9775b5f0250ccdf3c8a0c32cf1b1b`，tree `6e89b89ae4bb058e3f7296d1d8dd725ac0c47032`，起点为 `23e642ac79d9b8860bcc940b2603a80a6f53dad2` / tree `d99a3f167e0b437a03c399b8984de503cb5cfd5c`。范围只扩大到 handshake/control lifecycle arbitration；不包含、重放、rebase 或修改 PR #41，也未 merge、Tag、Release、签名、修改版本或部署。提交不含 `Co-authored-by` 尾注。

### 失败边界与 holder 诊断

失败证据仍是 [run 33386242662 / Relay topology 2/5 job 99469432231](https://github.com/yhan-sun/p2wlan/actions/runs/33386242662/job/99469432231)，artifact `9755834832`。关键时间线为：

```text
initiator_handshake_role role=initiator
initiator_handshake_reserved owner=1 generation=0
initiator_handshake_lock_wait phase=preparation
```

之后没有 `lock_acquired`、WireGuard session staging、Offer control result、peer Offer 或 session install。Relay TCP、diagnostics 与 supervised tasks 仍存活，所以失败严格位于 WireGuard session 建立之前，不是 Relay inbound actor、Probe ACK 或 business evidence transaction。

旧 artifact 没有 holder kind/phase，不能诚实地把历史现场的占有者追溯成某一个 producer。新诊断的受控旧边界复现证明：当 maintenance mutation turn 是实际 holder 时，Event contender 会精确报告 `holder_kind=maintenance_initiator`、`holder_phase=maintenance_snapshot_commit`、reservation owner、network generation、peer-session generation与当时 held duration；同一测试也验证 acquire/release、timeout、cancellation 成对。新的生产时间线因此可以直接识别今后的实际 holder，而不再靠推测。诊断只含 peer/lifecycle/owner metadata，不含私钥、session secret、原始握手 token 或可逆敏感材料。

### 修复前 wait-for graph

```text
Maintenance producer
  owns per-peer HandshakeArbiter
  -> awaits transport.session_status
  -> awaits pending-handshake mutex / Probe-binding cleanup
  -> awaits control peer snapshot

PeerJoined / PeerUpdated Event producer
  already owns exact starting reservation
  -> waits unbounded for the same HandshakeArbiter at preparation
  -> cannot stage WireGuard session or send Offer

Answer / lifecycle cleanup
  could also acquire the same arbiter and carry it across emit / epoch /
  transport / UDP / connection awaits

Relay data plane
  requires an installed WireGuard session
  -> encrypted Relay Probe is dropped as "No WireGuard session"
  -> RelayConfirmed / overlay can never begin
```

`HandshakeArbiter` 同时被当成短 mutation turn 和跨 await 的长事务锁；producer 的等待关系没有统一上界，reservation 虽已建立也没有精确 contention retry edge。

### 修复后的 coordinator / reservation 语义

```text
HandshakeArbiter
  protects only a short, in-memory mutation turn
  -> never crosses an actor/control/session/connection await

PendingHandshakeState reservation
  owns the long transaction across candidate/session/control awaits
  identity = peer + network generation + peer-session generation
           + reservation owner + cancellation generation

Event / retry coordinator
  synchronous lifecycle mirror check
  -> zero-wait reserve/prepare/publish turn
  -> exact prepared initiation or typed contention retry
  -> bounded slow-work lane performs all actor/control work

Maintenance
  snapshots session/control/identity before a zero-wait reserve
  -> skips immediately if Event/Responder/state owns the peer
  -> re-enters a zero-wait publish transaction

Responder / Answer / cleanup
  bounded or zero-wait admission only
  -> release arbiter
  -> exact worker/pending-id/lifecycle fences own slow commit
```

Event reservation admission and deferred-retry drain are now fully no-await. Online state comes from the synchronous peer lifecycle mirror; stale Probe-binding cleanup is transferred with the reservation to the bounded worker. The retry coordinator also performs no await: it only purges/claims the authoritative ledger and puts the claimed owner in the existing bounded slow-work lane.

### Arbiter acquisition 上界

| Call site | Owner kind | Upper bound | Contention behavior |
|---|---|---:|---|
| PeerJoined/PeerUpdated reserve | `EventInitiatorReserve` | 0 ms (`try_acquire`) | typed `Contended`; newest peer snapshot stays deferred |
| Event preparation | `EventInitiatorPrepare` | 0 ms | retain exact reservation; schedule Preparation retry |
| Event publication | `EventInitiatorPublish` | 0 ms | retain exact prepared initiation; schedule Publish retry |
| Maintenance reserve | `MaintenanceInitiator` | 0 ms | low-priority skip; next kick/tick reevaluates |
| Maintenance publish | `MaintenanceInitiator` | 0 ms | cancel exact low-priority owner; next kick/tick retries from a fresh snapshot |
| PeerLeft/offline/key cleanup | `Cleanup` | 0 ms | authoritative synchronous cancellation proceeds after releasing/without queuing the turn |
| Responder admission and post-delivery recheck | `Responder` | 750 ms hard bound, cancellation-aware | signal owner remains retryable; no permanent control blackout |
| One-shot initiator Answer admission | `InitiatorAnswer` | 100 ms hard bound | timeout is diagnostic only; exact pending-id/lifecycle transaction continues so the Answer is not lost |

生产代码不再存在 `handshake_arbiter.acquire(peer).await`。`acquire_with_timeout` 只用于 Responder 和 one-shot Answer；其余全部使用 `try_acquire`。

### Held-await / `OwnedMutexGuard` 静态审计

- Event reserve/prepare/publish：lease 只覆盖 lifecycle + pending-state 的同步检查/修改，任何 Probe cleanup、transport status、candidate gather、emit/epoch/session、connection 或 control await 前均已释放。
- Maintenance reserve/publish：所有 actor/control snapshot 在 reserve 前；publish lease 内只允许 `epoch.try_lock`、pending `try_lock` 和同步 mutation，随后显式释放。
- Responder：750 ms admission lease 在 identity lookup、crypto/session stage、Probe binding、control POST 前释放；post-delivery lease也在 grace refresh 前释放。
- Answer：100 ms admission observation 在 sender identity、emit、epoch、pending/session transaction 前结束；即使 admission timeout，one-shot Answer 仍按 exact pending/lifecycle fence 处理。
- Cleanup：try-only arbiter observation 后执行短同步 pending cancellation；transport/UDP/session cleanup 不持 lease。
- `HandshakeLease` 内部封装唯一的 arbiter `OwnedMutexGuard`，并用 `PhantomData<Rc<()>>` 明确设为 `!Send`；生产 Send future 若试图携带 lease 跨 `.await` 会编译失败。
- 仓库其余 `OwnedMutexGuard` occurrence 属于既有 WireGuard current-session/emit guard 或 UDP adoption guard，不是 HandshakeArbiter owner；本次未把它们引入 handshake mutation turn。

审计结果：所有 HandshakeArbiter holder 的 actor/control/session/connection await 数为 0。

### Exact retry、无丢唤醒与 strict TTL

- 每 Peer 一个 newest-wins retry；总容量 1024；每个 Preparation/Publish phase 的严格 TTL 为 30 秒。
- identity 绑定 peer、network generation、peer-session generation、reservation owner、phase、attempt、cancellation generation。
- backoff 为 `0/10/25/50/100/250/500 ms` 并封顶；claim/reschedule 保留 attempt 与原 phase expiry，不会用 contention 无限续 TTL。
- Publication contention 保留同一个 `HandshakeInitiator`、initiation bytes、candidate/source snapshot、session ID 与 Probe ephemeral key，不重新生成也不重复发送 Offer。
- 状态先写 ledger，再 `watch::send_replace(revision)`；25 ms supervised coordinator scan 读取 authoritative ledger，maintenance 10 秒周期重发 revision 作为 receiver replacement/coalescing backstop。
- 即使 slow-work lane 已满，每次 scan 也先同步 purge expired owner，因此 TTL 同时约束执行与资源保留。
- PeerLeft、offline、public-key/same-node lifecycle replacement、两条 network-generation advance、Responder success 和 active session 都同步取消 exact owner；stale watch 只是 hint，不能复活已清空的 ledger。
- 未创建 detached retry task；既有 handshake timeout owner 仍受 pending-id、peer lifecycle 与固定 timeout 约束。

### Single-flight 与 duplicate Offer 证明

- `starting_ids`、network generation、peer-session generation、owner kind 与 cancellation generation 在一个 pending-state transaction 中建立。
- Event 可在短 transaction 中抢占尚未 commit 的低优先级 maintenance reservation；maintenance 看到 Event/Responder/其他 owner 时立即跳过。
- prepared initiation 只由 exact owner `take`；connection/pending contention 时同一个对象被 restore 后进入 Publish retry。
- pending commit 产生 monotonic pending-id；旧 maintenance/timeout owner 使用 exact pending-id 删除，不能清除 replacement（ABA regression 覆盖）。
- 合法 Responder 在 staging/commit 路径同步取消旧 initiator reservation/retry；旧 worker 的 cancellation/lifecycle check 阻止 stale Offer。
- control delivery ambiguous 时保留现有 pending-id 语义直到 Answer 或固定 timeout；同一 reservation 最多发布一个有效 Offer。

### 确定性 targeted tests

- `handshake_arbiter_telemetry_pairs_holder_release_timeout_and_cancellation`
- `peer_scoped_handshake_arbiter_contention_does_not_block_another_peer_session`
- `exact_handshake_retry_cancellation_is_merged_and_stale_wake_is_harmless`
- `exact_handshake_retry_has_strict_ttl_and_all_lifecycle_cancellations_are_terminal`
- `network_generation_advance_synchronously_cancels_exact_handshake_retry_and_pending_offer`（同时覆盖 full generation 与 candidate-refresh generation）
- `stale_handshake_pending_owner_cannot_remove_replacement_transaction`
- `initiator_arbiter_is_released_before_candidate_refresh_wait`
- `initiator_publish_releases_epoch_while_connection_writer_is_contended`
- `relay_probe_snapshot_contention_preserves_exact_publish_retry_without_queued_writer`
- `maintenance_snapshot_race_yields_to_event_single_offer_and_one_session`
- `responder_preempts_contended_initiator_retry_with_bounded_turn_and_no_stale_offer`
- `handshake_lifecycle_model_checks_first_1000_deterministic_interleavings`

1000 个确定性交错枚举 maintenance snapshot、Event reserve、maintenance reserve、Event prepare、Responder Offer、publish、generation advance；结果为无死锁/活锁、每 lifecycle 最多一个 active initiator、最多一个有效 Offer、stale owner 零提交、终态无 reservation/retry leak。新增并发测试使用 Barrier、Notify、paused Tokio time 或受控 channel timeout，没有新增任意 sleep。

### 本地验收

- `cargo fmt --all -- --check`：PASS
- `cargo check --workspace --all-targets --all-features`：PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：PASS
- `cargo test --workspace`：单次完整运行 PASS；daemon lib `1208/1208`，其余 workspace/integration/doc tests 全部通过
- `git diff --check`：PASS
- `cargo test -p p2wlan-daemon handshake_`：`21/21` PASS
- `cargo test -p p2wlan-daemon contention`：`12/12` PASS，包含 Relay business、preconfirmation ACK、Path-commit ACK 与 Relay `/status` contention regressions
- `cargo test -p p2wlan-daemon initiator_`：`14/14` PASS
- maintenance/Event 真实 Offer/session targeted test：PASS

### Exact-Head Actions（attempt 1，进行中）

- [NAT Topology Gate run 33408064256](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256)
- [DPLPMTUD Required run 33408064089](https://github.com/yhan-sun/p2wlan/actions/runs/33408064089)
- [Path State Machine run 33408064320](https://github.com/yhan-sun/p2wlan/actions/runs/33408064320)
- [Windows Lifecycle run 33408064270](https://github.com/yhan-sun/p2wlan/actions/runs/33408064270)
- [Mobile Lifecycle run 33408064358](https://github.com/yhan-sun/p2wlan/actions/runs/33408064358)
- [CI run 33408064416](https://github.com/yhan-sun/p2wlan/actions/runs/33408064416)
- [Flutter Client run 33408064199](https://github.com/yhan-sun/p2wlan/actions/runs/33408064199)
- [Package Test Builds run 33408064421](https://github.com/yhan-sun/p2wlan/actions/runs/33408064421)

所有 run 均由同一次 push 创建、`attempt=1`、head SHA 为 `f79f908d10d9775b5f0250ccdf3c8a0c32cf1b1b`。Relay 1/5–5/5 和 required gate 的最终 job 链接及首次执行结果将在本轮完成后补齐；不会用 rerun 拼接结果。


## 第二轮跟进：Handshake publication / responder admission 残余等待边

本节覆盖 previous section 中 `f79f908d10d9775b5f0250ccdf3c8a0c32cf1b1b` Actions “进行中”的最终结果，并记录当前 exact Head `2c1ae414b155206cf937b8e1c97200b41200c664`、tree `321e28fbddc5e5d8ebbacd6003f80a094843068e`。它只继续修复已批准的 handshake/control lifecycle arbitration 范围；PR #41 未被处理、重放、rebase 或修改。没有 merge、Tag、Release、签名、版本或部署修改，提交不含 `Co-authored-by` 尾注。

### `f79f908d` 首次执行结果与新失败边界

[NAT Topology run 33408064256](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256) 为 attempt 1，exact Head `f79f908d`；没有 rerun。Direct cold-start 和 simulator unit 通过，但 Relay 只有 [3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256/job/99540555486) 通过；[1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256/job/99540555483)、[2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256/job/99540555511)、[4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256/job/99540555489)、[5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33408064256/job/99540555537) 首轮失败。因此 `f79f908d` 的 Relay 验收结论是 **FAIL（1/5）**，不是可复用的成功 Head。

artifact 将剩余边界收窄为两类：

1. Relay 1/5、2/5、5/5 的 designated initiator 已完成 reservation/preparation，并记录 `initiator_publish_emit_lock_acquired`，随后停在 `initiator_publish_epoch_gate_wait`。它不再等待 HandshakeArbiter，而是持有 per-peer emit fence 后无界等待 network epoch；同一期间不能进入 session/connection publication。
2. Relay 4/5 的 responder 已完成 Noise authentication 与 timestamp commit，随后停在 Probe binding 的 connection writer。旧代码在 writer contention 前尚未缓存 exact Answer；WireGuard timestamp replay protection 又会拒绝重新生成同一响应，因此一次已认证 Offer 可能永久丢失。

Relay 2/5 还显示第一次 initiator 尝试曾 staged 并发送 Offer，但 responder 在 authenticated timestamp commit 后没有 staging/Answer；后续 maintenance initiator 再次进入上述 publish 边界。证据说明 `f79f908d` 修复了 arbiter-held await，却仍留下 mutation turn 之后的 `emit -> epoch` 与 `timestamp -> queued connection writer` 等待边。

### 修复前 / 修复后 wait-for graph

修复前：

```text
Initiator publication
  owns per-peer emit fence
  -> waits unbounded for network epoch
  -> waits for transport session status
  -> connection writer contention can retain/queue publication

Responder admission
  authenticates Noise + commits replay-protected timestamp
  -> waits for transport session mutex
  -> queues PeerManager.connections writer for Probe binding
  -> exact Answer cache is still absent

Duplicate authenticated Offer
  -> timestamp replay rejection
  -> no Answer, no WireGuard session, Relay cannot confirm
```

修复后：

```text
Initiator exact prepared transaction
  emit.try_lock
  -> epoch.try_lock
  -> sessions.try_lock
  -> connections.try_write
  on any contention:
     release all acquired guards
     restore the same HandshakeInitiator / initiation bytes / candidates /
       session id / Probe ephemeral key
     commit one bounded Publish retry, then wake coordinator

Responder exact authenticated transaction
  authenticate Noise + commit timestamp
  -> cache exact Answer/keys with network + peer-session lifecycle
  -> bounded transport stage (750 ms)
  -> connections.try_write for Probe binding
  -> send exact Answer
  -> emit.try_lock -> epoch.try_lock -> sessions.try_lock for commit
  on typed contention:
     retain cache/pending responder state
     existing per-peer owner retries with bounded backoff
```

所有 contention 返回都先释放 emit/epoch/session guard，再恢复/重试 exact work；不会把 `try_lock` 失败当成永久失败，也不会重新生成 Noise initiation、Probe key 或 Answer。Responder cache 命中同时校验 network generation 与 peer-session generation；旧 network、same-node leave/rejoin 或旧 peer lifecycle 会移除并拒绝 cache，不会把 retired receive key 带入新 lifecycle。

### Transaction、retry 与 cancellation 语义

- initiator publish 的 emit registry、emit fence、network epoch、transport sessions 与 connection map 均为 zero-wait `try_*`；无 queued writer。
- `PreparedInitiatorHandshake` 在任何 contention 上原样写回 authoritative reservation，随后才提交 retry ledger 与 wake revision，保持 state-before-wake、无丢唤醒和 single Offer。
- connection binding 的 exact partial retry 接受 `ReplayableDuplicate`；pending-state contention 不撤销已 staged 的同 token binding，而由同一个 bounded retry owner重入。
- responder 在任何 transport/connection mutation 前缓存 exact authenticated Answer、transport keys 与 Probe shared material；connection contention 后 duplicate Offer 走 cache hit，不再次消费 timestamp。
- responder transport stage/restage 有 750 ms hard bound；Probe binding 使用 `connections.try_write`；post-Answer commit 使用 try-only emit、epoch 与 session transaction。
- `responder_session_stage_timeout`、`responder_probe_binding_connections_contended` 和 `responder_answer_commit_contended` 是 typed retryable reason；既有每 Peer 合并 owner 使用 `50/100/250 ms` bounded retry，最终仍通过 signal receipt 的 Retry 语义保留外层重投。
- superseded initiator Probe binding cleanup 为 try-only；contention 时由 token TTL/lifecycle cleanup 收敛，不创建公平锁 writer waiter。
- 未新增 detached task；PeerLeft、offline、network generation advance、same-node leave/rejoin 与 responder-owner cancellation 仍同步使旧 retry/cache/session 无资格提交。

### Arbiter / emit / epoch held-await 静态审计

生产 HandshakeArbiter acquisition 仍为：Event reserve、prepare、publish、maintenance reserve/publish、cleanup 全部 0 ms `try_acquire`；Responder admission/post-delivery 为 cancellation-aware 750 ms；one-shot Answer admission 为 100 ms。仓库生产代码没有 `handshake_arbiter.acquire(...).await`。

本轮额外审计结果：

- Event initiator publish：获取 arbiter 后只同步 take prepared 并立即释放；emit/epoch/session/connection transaction 内 `.await` 数为 0。
- Responder admission：arbiter 在 identity/crypto/session/connection/control 操作前释放；transport stage 是不持 arbiter 的 750 ms bounded wait。
- Responder post-Answer：recheck arbiter 在 grace refresh 前释放；最终 emit/epoch/session commit 内 `.await` 数为 0。
- connection writer contention：initiator 与 responder production path 都只调用 `try_stage_probe_session_binding`；不会进入 Tokio fair writer queue。
- stale lifecycle cleanup：任何 async discard 都在 arbiter、emit 和 epoch guard 已释放后执行。

结论：HandshakeArbiter holder 的 actor/control/session/connection await 仍为 0；本轮修复的 initiator/responder emit/epoch transaction 的 await 也为 0。

### 新增/更新的确定性回归

- `initiator_publish_epoch_contention_releases_emit_and_retries_exact_offer`：持有真实 epoch guard，断言 initiator bounded 返回、emit 已释放、exact prepared/retry 保留；释放后只发送一个 Offer。
- `responder_probe_binding_contention_retains_exact_answer_without_queued_writer`：持有 connection reader，断言 timestamp 后返回 typed contention、后续 reader 不被 queued writer 阻塞、exact Answer 与 pending responder session 保留；释放后 cache retry 只发送一个 Answer 并提交 session。
- `responder_handshake_cache_replays_exact_answer_and_rejects_token_reuse`：新增 network-generation 与 peer-session-generation 两条 stale lifecycle 拒绝/删除断言。
- `relay_first_packet_liveness_crosses_responder_status_and_writer_contention`：真实 Relay/WireGuard/diagnostics 回归继续验证 first Probe、validated `/status` stale cache 与 responder commit 不被公平 writer 队列阻塞。

既有 `handshake_lifecycle_model_checks_first_1000_deterministic_interleavings` 仍为 1000/1000；`handshake_` 21/21、`responder_` 23/23、`initiator_publish_` 2/2 均在 exact tree 通过。新增交错使用持有 guard、Notify/受控 channel timeout，不使用任意 sleep。

### 当前 Head 本地门禁

- `cargo fmt --all -- --check`：PASS
- `cargo check --workspace --all-targets --all-features`：PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：PASS
- `git diff --check`：PASS
- 同一 production diff 在最终两条 test-only lifecycle/timeout assertion 加入前曾取得一次完整 workspace PASS（daemon 1210/1210）；当前 macOS host 的 exact-tree 全套随后受未修改的 UDP/STUN/Hard↔Hard loopback 用例间歇性 `InsufficientSamples`/timeout 影响，未把这些失败误报为 exact-tree workspace PASS。上述所有本轮相关 targeted suites 均通过；干净 Ubuntu exact-Head Actions 作为最终 workspace/拓扑权威结果。

### `2c1ae414` exact-Head Actions（attempt 1）

以下 run 由同一次普通 push 自动创建，均为 exact Head `2c1ae414b155206cf937b8e1c97200b41200c664`、attempt 1；不会 rerun 失败 job 或拼接不同 attempt：

- [NAT Topology Gate 33417859727](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727)
- [DPLPMTUD Required 33417859742](https://github.com/yhan-sun/p2wlan/actions/runs/33417859742)
- [Path State Machine 33417859674](https://github.com/yhan-sun/p2wlan/actions/runs/33417859674)
- [Windows Lifecycle 33417859684](https://github.com/yhan-sun/p2wlan/actions/runs/33417859684)
- [Mobile Lifecycle 33417859677](https://github.com/yhan-sun/p2wlan/actions/runs/33417859677)：SUCCESS
- [CI 33417859730](https://github.com/yhan-sun/p2wlan/actions/runs/33417859730)
- [Flutter Client 33417859705](https://github.com/yhan-sun/p2wlan/actions/runs/33417859705)
- [Package Test Builds 33417859689](https://github.com/yhan-sun/p2wlan/actions/runs/33417859689)

Relay 1/5–5/5 首次执行 job 链接、required gate 和其余 workflow 结论将在同一 exact Head 全部结束后补齐。PR #43 保持 OPEN，等待人工验收。
## `f5dc475d0767417a0685343faee67249c0f42d3b` candidate durable HOL follow-up

本节记录 exact tree `4be93ee21e7160acd42c2fb724c65269d9e21085`。它只继续关闭已批准的 Handshake / Control Lifecycle Arbitration Liveness 边界；没有处理或重放 PR #41，没有 merge、Tag、Release、签名、版本或部署修改，提交不含 `Co-authored-by` 尾注。

### `2c1ae414` 首次执行的最终边界

[NAT Topology Gate 33417859727](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727) 为 attempt 1、exact Head `2c1ae414b155206cf937b8e1c97200b41200c664`，未 rerun。Relay [1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727/job/99573277387)、[2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727/job/99573277243)、[4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727/job/99573277267)、[5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727/job/99573277254) 首次通过；[3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33417859727/job/99573277308) 首次失败，因此该 Head 的 Relay 结论是 **FAIL（4/5）**。同一 Head 的 CI、Mobile、Windows、Flutter、Package 为 SUCCESS；DPLPMTUD 与 Path 首次运行失败，未用 rerun 拼接结果。

Relay 3/5 artifact 的 durable signal DB 有三个未确认的 A→B row：candidate-only `peer_offer` seq=1、handshake `peer_offer` seq=2、handshake retry seq=3。B 在 event loop 启动后只消费 seq=1；旧实现把 candidate-only 和 responder 放入同一个 owner，并把 exact durable receipt 保留到 candidate mutation 完成。candidate mutation 等待 connection writer 时，ordered durable reconciler 等待 seq=1 receipt，导致 seq=2/3 从未进入 daemon。Relay TCP、diagnostics 和 supervised tasks 仍存活，但 WireGuard responder transaction 没有被交付。

修复前 wait-for graph：

```text
signal receiver: seq1 candidate-only
  -> combined responder/candidate owner
  -> candidate mutation waits connection writer
  -> seq1 durable receipt remains Pending
ordered durable reconciler
  -> waits seq1 receipt
  -> seq2/seq3 authenticated handshake cannot be delivered
  -> no WireGuard session / Relay confirmation
```

### 修复后的 coordinator / owner 语义

- candidate offer 使用独立有界 ledger：全局最多 1024 个 Peer；每 Peer 一个 active owner 加一个 newest-wins queued payload；ledger 不保存 durable receipt。
- candidate-only row 在 payload 成功进入本地 ledger 后立即 `Applied`，candidate worker 在 event loop 自有 `FuturesUnordered` 中继续；connection/epoch/UDP 慢工作不能占用 responder owner，也不能阻塞下一条 ordered signal。
- handshake half 使用独立 per-peer responder owner，并保留 exact durable receipt，直到 exact responder transaction 为 Applied、Retry 或 TerminalRejected；candidate contention 不会夺走该 owner。
- remote incarnation preflight 使用 typed non-queuing transaction：`epoch.try_lock → connections.try_write`；contention 返回 `ContendedEpoch` / `ContendedConnections`，不加入 Tokio fair writer queue。
- 同 incarnation 的 candidate-first → handshake 通过同步 identity/replay ledger 快路径校验，不因 candidate writer contention 阻塞 responder；旧 incarnation、旧 counter、malformed generation 和 stale sender identity 均 fail closed。
- incarnation claim 到 transport/UDP cleanup commit 之间由每 Peer 一个 `remote_incarnation_resets` fence 覆盖。candidate 与 responder 两个独立 future 中的后到者得到 `PendingCleanup`，不会把已 claim 但尚未 cleanup 的 high-water 误判为已提交 `NoReset`。
- PeerOffer/PeerAnswer ingress diagnostics 使用 non-queuing ring write 并始终保留结构化 timeline；身份读取来自同步 lifecycle mirror，不再等待 connection reader。
- 没有新增 detached task；先前 responder reset 的 `tokio::spawn(...).await` 已移除。所有 worker 由主 event loop 所有并在 shutdown 时统一 drop。

### 确定性回归与本地门禁

新增/更新：

- `candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_offer`
- `candidate_offer_work_is_newest_wins_owner_scoped_and_capacity_bounded`
- `remote_incarnation_try_claim_is_non_queuing_and_fences_retired_work`
- `remote_incarnation_cleanup_fence_prevents_no_reset_race`
- `handshake_lifecycle_model_checks_first_1000_deterministic_interleavings`：1000/1000

candidate HOL 回归使用真实 control receipt、真实 Noise initiation、Barrier 和受控 connection reader：reader 持有期间 candidate receipt 已 Applied、没有 queued writer；handshake 进入独立 responder owner，后续 marker 仍被 actor 消费；释放 reader 后只发送一个 Answer 并安装一个 session。新增测试没有任意 sleep。

本地 exact tree：fmt、`git diff --check`、workspace check、clippy `-D warnings` 全部 PASS；standalone daemon full suite 曾为 1213/1213，新增第 1214 条测试单独通过。两次 `cargo test --workspace` 各为 1213/1214，分别只命中两条不同、未修改的 Hard↔Hard loopback 时序波动；两条失败用例各自立即单独运行均 PASS。因此没有把本机 full workspace 误报为 PASS，Ubuntu exact-Head Actions 仍是最终门禁。

### `f5dc475d` exact-Head Actions（attempt 1）

以下 8 个 run 均由同一次普通 push 创建，exact Head 为 `f5dc475d0767417a0685343faee67249c0f42d3b`、attempt 1；不会 rerun 或拼接 attempt：

- [NAT Topology Gate 33429104511](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511)
- [DPLPMTUD Required 33429104523](https://github.com/yhan-sun/p2wlan/actions/runs/33429104523)
- [Path State Machine 33429104604](https://github.com/yhan-sun/p2wlan/actions/runs/33429104604)
- [Windows Lifecycle 33429104515](https://github.com/yhan-sun/p2wlan/actions/runs/33429104515)
- [Mobile Lifecycle 33429104507](https://github.com/yhan-sun/p2wlan/actions/runs/33429104507)
- [CI 33429104519](https://github.com/yhan-sun/p2wlan/actions/runs/33429104519)
- [Flutter Client 33429104546](https://github.com/yhan-sun/p2wlan/actions/runs/33429104546)
- [Package Test Builds 33429104510](https://github.com/yhan-sun/p2wlan/actions/runs/33429104510)

Relay 1/5–5/5 首次 job 链接及最终 conclusions 将在这些 attempt 1 全部结束后补齐。PR #43 保持 OPEN，等待人工验收。


## 最终跟进：remote-incarnation turnover 后的 exact handshake replacement

本节补齐 `f5dc475d0767417a0685343faee67249c0f42d3b` 的首次执行结论、记录中间 Head `aff98892bb83a20423ab80b97e84d620ef0edc3c` 的新失败边界，并给出当前 exact Head `811351794f77619e0c98146896eeca6db3750152`、tree `d9f5367ff2e12753a4762104eadbe25d343376a0` 的最终验收。当前提交的父提交是 `aff98892bb83a20423ab80b97e84d620ef0edc3c`；提交未签名且没有尾注。PR #41 没有被处理、重放、rebase 或修改；没有 merge、Tag、Release、版本、部署或签名操作。

### 两个前序 Head 的首次执行结论

`f5dc475d` 的八个 workflow 均为 attempt 1，未 rerun。Windows、Mobile、CI、Flutter、Package 通过；NAT、DPLPMTUD、Path 失败。NAT 的 Relay [1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511/job/99609928241)、[2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511/job/99609928186)、[5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511/job/99609928190) 通过，[3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511/job/99609928364)、[4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33429104511/job/99609928316) 失败，因此该 Head 的 Relay 结论为 **FAIL（3/5）**。

`aff98892` 的 candidate durable-HOL follow-up 把 Relay 提升到 4/5：[1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894/job/99637131029)、[2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894/job/99637131019)、[4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894/job/99637131073)、[5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894/job/99637131053) 首次通过，[3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894/job/99637131164) 首次失败；[NAT run 33437406894](https://github.com/yhan-sun/p2wlan/actions/runs/33437406894) 因而为 FAIL。Windows、Mobile、Flutter、Package 通过；CI 与 Path 只命中既有、未修改的 `hard_hard_random_random_birthday_no_collision_cleans_up_without_direct` loopback 波动，DPLPMTUD 的所有专项 job 通过但 required aggregate 因依赖失败。所有结论都保留第一次 attempt，没有 rerun 拼接。

### `aff98892` Relay 3/5 的精确边界与实际 holder identity

失败端 B 是确定性 initiator。日志显示 reservation `owner=1`、network generation `0`、peer-session generation `1`；`EventInitiatorReserve` 持有 133 us、`EventInitiatorPrepare` 持有 101 us、`EventInitiatorPublish` 持有 107 us 后都正常释放。实际 publish holder identity 为：

```text
owner_kind=event_initiator_publish
phase=publish
reservation_owner=1
network_generation=0
peer_session_generation=1
held_us=107
```

随后 exact Publish 在 `network_epoch_contended` 上依次提交 attempt 1 和 attempt 2；日志明确为 `queued=false`，证明 retry ledger 的 state-before-wake 与 exact reservation 都正常。紧接着同一 Peer 的 candidate-only Offer 被独立 candidate owner 接收，remote candidate incarnation turnover 开始，出现 `direct_validation_registry_peer_cancelled reason_code=remote_candidate_generation_changed`；之后 `/status` 只能命中 validated cache，并报告 connection writer active/queued。没有 WireGuard session、Relay confirmation 或 overlay。

故障不在 HandshakeArbiter，也不在 Relay inbound actor。剩余循环位于 remote-incarnation claim/finish 的 lock order：

```text
remote-incarnation candidate owner
  owns the per-peer reset/adoption fence
  -> owns network epoch
  -> queues PeerManager.connections writer

pre-existing connection reader
  -> needs network epoch to retire its observation

epoch owner waits writer -> reader waits epoch
  -> incarnation cleanup cannot commit
  -> PeerSessionGeneration/replacement lifecycle cannot settle
  -> valid exact initiator cannot establish a session
```

即使 cleanup 最终完成，PeerSessionGeneration rotation 也应当终止旧 generation 的 reservation/retry；旧路径没有立即创建新 generation replacement 的独立 wake，只能等待 10 秒 maintenance tick，超出 Relay cold-start 验收窗口。这里不能通过保留旧 retry 来修复，因为旧 generation/session 的 Offer 必须 fail closed。

### 修复后的 lock order 与 replacement coordinator

- `claim_remote_candidate_incarnation_for_identity` 与 `finish_claimed_remote_incarnation_reset` 统一使用 canonical acquisition loop：先获取 epoch，再 `connections.try_write`；若 reader/writer contention，先释放 epoch，只在不持 epoch 时等待一次 fair connection-writer turn，然后重新从 epoch → try-write 开始事务。
- 因此 candidate owner 可以等待 connection map，但永远不会以 `epoch owner + queued writer` 的形态参与循环。它仍在既有有界、主 event-loop 所有的 candidate worker 中运行，不占 durable responder receipt，也没有 detached task。
- remote-incarnation cleanup 完成并实际旋转 PeerSessionGeneration 后，先完成所有旧 lifecycle 的同步取消，再通过 `path_setup_kick_tx.send_modify` 发布 monotonic `remote_incarnation_handshake_restart_kicked` 边。这是 commit-before-wake：maintenance 看到的必然是新 peer-session generation。
- deterministic initiator 收到该 edge 后立即在新 generation 建立 replacement reservation；deterministic responder 观察同一 edge但不会抢 initiator owner。`PreserveResponder` 与完整 reset 两条 rotation 路径都发布该 edge。
- 旧 reservation/retry 的 terminal cancellation 是正确语义；replacement 不能复用旧 initiation、session id 或 Probe key。新 generation 仍由既有每 Peer single-flight reservation、TTL、backoff、cancellation generation 与 duplicate-Offer fences 约束。

### Arbiter acquisition 上界与 held-await 静态审计

- Event reserve、Event prepare、Event publish：`try_acquire`，0 ms wait。
- Maintenance reserve/publish：`try_acquire`，0 ms wait；有其他 owner 时立即跳过。
- Cleanup：`try_acquire`，0 ms observation；权威 cancellation 若需等待 pending state，只在 lease 已释放后进行。
- Responder admission 与 post-delivery recheck：各自 cancellation-aware、hard bound 750 ms。
- one-shot Initiator Answer admission：hard bound 100 ms；超时仍按 exact pending-id/lifecycle fence处理 Answer。
- production code 不存在无界 `handshake_arbiter.acquire(peer).await`。`HandshakeLease` 是 `!Send`，所有 holder 都在 identity/lifecycle/pending-state 的同步短事务后显式释放。
- 对 Event、maintenance、Responder、Answer、cleanup 的每个 acquisition 重新审计：arbiter holder 下 actor/control/candidate/session/connection/epoch await 数为 **0**。
- 本轮两条 remote-incarnation transaction 不持 arbiter 或 emit guard；它们可以 await epoch，但只会在已经释放 epoch 后等待 connection writer。没有 `epoch -> queued writer` 边。

### 无丢唤醒、single-flight 与 stale rejection 证明

- `aff98892` artifact 已证明 valid exact retry 在 epoch contention 下以 owner 1、phase Publish、attempt 1/2、同 generation/session 和 cancellation generation 保存；不是通过 contention `return false` 丢失工作。
- 真实 incarnation rotation 必须使该 retry terminal；新增测试证明 reservation、retry 与 cancellation receiver 一起失效，不能发送 retired Offer。
- replacement kick 只在 PeerSessionGeneration commit 后发送；watch revision 的 authoritative state 是已旋转 lifecycle，coalescing 不会把 stale retry重标成新 generation。
- 新 generation 仍通过一个 per-peer reservation owner进入现有 bounded retry ledger；maintenance/Event/Responder 的优先级、pending-id ABA 防护、每 lifecycle 最多一个 active initiator和最多一个有效 Offer不变。
- PeerLeft、offline、network generation advance、same-node leave/rejoin、active responder session 与 remote-incarnation rotation 均拒绝 stale owner；没有新增无界 task或 10 秒碰运气路径。

### 新增确定性回归与本地门禁

- `remote_incarnation_claim_and_finish_never_queue_writer_with_epoch`：用真实 connection reader、Barrier 和受控 timeout 分别暂停 claim/finish，观察它们进入 fair writer turn 时 epoch 仍可获取；reader 释放后 mutation 完成并旋转 peer lifecycle。
- `remote_incarnation_rotation_cancels_retry_and_kicks_replacement`：建立真实旧 generation reservation/retry，完成 incarnation rotation，断言旧 owner terminal cancellation、PeerSessionGeneration 已变化，并且 replacement wake 只在 commit 后可见。
- `candidate_receipt_and_slow_work_do_not_head_of_line_block_responder_offer`：继续断言 candidate receipt 先完成、无 queued connection writer、epoch-free retry boundary、handshake responder/marker 不被慢 candidate工作阻塞。
- 所有新增交错只使用 Barrier、yield/受控 timeout 与 lifecycle signal，没有任意 sleep。既有 `handshake_lifecycle_model_checks_first_1000_deterministic_interleavings` 继续为 1000/1000。

Exact tree 本地结果：

- `cargo fmt --all -- --check`：PASS
- `git diff --check`：PASS
- `cargo check --workspace --all-targets --all-features`：PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：PASS
- `cargo test --workspace`：PASS；daemon lib `1217/1217`，其余 workspace/integration/doc tests 全部通过
- `cargo test -p p2wlan-daemon --lib remote_incarnation_`：`10/10` PASS
- Relay business/preconfirmation/Path-commit 与相关 actor contention group：`14/14` PASS
- exact retry cancellation、candidate HOL 与 1000 interleaving targeted tests：PASS

### `81135179` exact-Head Actions（全部 attempt 1）

以下八个 workflow 由同一次普通 fast-forward push 创建，head SHA 均为 `811351794f77619e0c98146896eeca6db3750152`、`attempt=1`，全部首次通过；没有 rerun：

- [NAT Topology Gate 33447553879](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879)：SUCCESS
- [DPLPMTUD Required 33447553982](https://github.com/yhan-sun/p2wlan/actions/runs/33447553982)：SUCCESS
- [Path State Machine 33447553939](https://github.com/yhan-sun/p2wlan/actions/runs/33447553939)：SUCCESS
- [Windows Lifecycle 33447553952](https://github.com/yhan-sun/p2wlan/actions/runs/33447553952)：SUCCESS
- [Mobile Lifecycle 33447553883](https://github.com/yhan-sun/p2wlan/actions/runs/33447553883)：SUCCESS
- [CI 33447553875](https://github.com/yhan-sun/p2wlan/actions/runs/33447553875)：SUCCESS
- [Flutter Client 33447553901](https://github.com/yhan-sun/p2wlan/actions/runs/33447553901)：SUCCESS
- [Package Test Builds 33447553871](https://github.com/yhan-sun/p2wlan/actions/runs/33447553871)：SUCCESS

NAT 同一 run 的独立 Relay jobs：

- [Relay 1/5](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99670408727)：SUCCESS；first-usable A/B `207/6 ms`
- [Relay 2/5](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99670408651)：SUCCESS；first-usable A/B `190/3 ms`
- [Relay 3/5](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99670408637)：SUCCESS；first-usable A/B `7/17 ms`
- [Relay 4/5](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99670408649)：SUCCESS；first-usable A/B `88/3 ms`
- [Relay 5/5](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99670408604)：SUCCESS；first-usable A/B `73/4 ms`
- [NAT Topology Required](https://github.com/yhan-sun/p2wlan/actions/runs/33447553879/job/99671627166)：SUCCESS

五个 Relay replica 均为独立进程和第一次 attempt：双端 overlay 完整（132/132 或 133/133）、`RelayConfirmed=1/1`、`Direct=0/0`、真实 relay ingress、零 drop/replay/invalid、完整 burst、status live 后始终 HTTP 200、`task_leak=0/0`。Path 的 [Required job](https://github.com/yhan-sun/p2wlan/actions/runs/33447553939/job/99674354929) 与 DPLPMTUD 的 [Required job](https://github.com/yhan-sun/p2wlan/actions/runs/33447553982/job/99674403310) 同样首次通过。

PR #43 保持 OPEN，等待人工验收；PR #41 与 main 的冻结引用保持不变。
