### PR TITLE
feat: add path observability and support diagnostics

### DIFF
--- a/.github/workflows/path-observability-required.yml
+++ b/.github/workflows/path-observability-required.yml
@@ -1,0 +1,165 @@
+name: Path Observability
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/path-observability-required.yml"
+      - "client/daemon/**"
+      - "client/cli/**"
+      - "apps/flutter_client/**"
+      - "contracts/**"
+      - "docs/path-observability.md"
+      - "scripts/path-observability-evidence.py"
+      - "server/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/path-observability-required.yml"
+      - "client/daemon/**"
+      - "client/cli/**"
+      - "apps/flutter_client/**"
+      - "contracts/**"
+      - "docs/path-observability.md"
+      - "scripts/path-observability-evidence.py"
+      - "server/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: path-observability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  P2WLAN_EXACT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  linux:
+    name: Path observability Linux checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+      - name: Verify exact head
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Install Linux workspace dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            libxdo-dev \
+            librsvg2-dev \
+            xdotool \
+            patchelf
+      - name: Rust format and clippy
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Typed path observability regressions
+        run: cargo test -p p2wlan-daemon --lib path_observability -- --test-threads=1
+      - name: Rust status contract
+        run: cargo test -p p2wlan-daemon --test contract_fixture -- --test-threads=1
+      - name: Generate structured evidence
+        env:
+          P2WLAN_PATH_OBSERVABILITY_EVIDENCE: ${{ runner.temp }}/path-observability-evidence.json
+        run: python3 scripts/path-observability-evidence.py
+      - name: Upload structured evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: path-observability-evidence-${{ github.run_id }}
+          path: ${{ runner.temp }}/path-observability-evidence.json
+          if-no-files-found: error
+          retention-days: 14
+
+  windows:
+    name: Path observability Windows checks
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+      - name: Verify exact head
+        shell: pwsh
+        run: |
+          if ((git rev-parse HEAD) -ne $env:P2WLAN_EXACT_HEAD) {
+            throw "exact head mismatch"
+          }
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Windows format and compile
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy -p p2wlan-daemon -p p2wlan-cli --all-targets --all-features -- -D warnings
+      - name: Windows typed regressions
+        run: cargo test -p p2wlan-daemon --lib path_observability -- --test-threads=1
+      - name: Windows status contract
+        run: cargo test -p p2wlan-daemon --test contract_fixture -- --test-threads=1
+
+  clients:
+    name: Flutter CLI and Go contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+      - name: Verify exact head
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: .fvmrc
+          cache: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Flutter contract
+        working-directory: apps/flutter_client
+        run: |
+          flutter pub get
+          dart format --output=none --set-exit-if-changed \
+            lib/core/models/diagnostics_models.dart \
+            lib/core/models/diagnostics_models/peer.dart \
+            lib/core/models/diagnostics_models/snapshot.dart \
+            lib/core/models/diagnostics_models/path_observability.dart \
+            test/contract_test.dart
+          flutter analyze
+          flutter test test/contract_test.dart
+      - name: Go contracts
+        working-directory: server
+        run: |
+          go vet ./...
+          go test ./... -count=1
+
+  required:
+    name: Path Observability Required
+    if: always()
+    needs: [linux, windows, clients]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce path observability gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ needs.linux.result }}" = "success"
+          test "${{ needs.windows.result }}" = "success"
+          test "${{ needs.clients.result }}" = "success"
+          echo "Path Observability Required passed for ${{ env.P2WLAN_EXACT_HEAD }}"

--- a/apps/flutter_client/lib/core/models/diagnostics_models.dart
+++ b/apps/flutter_client/lib/core/models/diagnostics_models.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 part 'diagnostics_models/app_settings.dart';
 part 'diagnostics_models/snapshot.dart';
 part 'diagnostics_models/peer.dart';
+part 'diagnostics_models/path_observability.dart';
 part 'diagnostics_models/speed_test.dart';
 part 'diagnostics_models/json_helpers.dart';
 part 'diagnostics_models/responses.dart';

--- a/apps/flutter_client/lib/core/models/diagnostics_models/path_observability.dart
+++ b/apps/flutter_client/lib/core/models/diagnostics_models/path_observability.dart
@@ -1,0 +1,384 @@
+part of '../diagnostics_models.dart';
+
+PathObservabilitySnapshot _pathObservabilityOrEmpty(dynamic value) {
+  final json = _mapOrNull(value);
+  return json == null
+      ? PathObservabilitySnapshot.empty()
+      : PathObservabilitySnapshot.fromJson(json);
+}
+
+/// Versioned, additive path-transition diagnostics. Older daemons omit this
+/// object; callers then receive [PathObservabilitySnapshot.empty].
+class PathObservabilitySnapshot {
+  PathObservabilitySnapshot({
+    required this.schemaVersion,
+    required this.networkEpoch,
+    required this.lifecycle,
+    required this.currentPath,
+    required this.previousPath,
+    required this.transitionReason,
+    required this.pathAgeMs,
+    required this.pathStateRevision,
+    required this.directState,
+    required this.relayState,
+    required this.recoveryState,
+    required this.directHealth,
+    required this.relayHealth,
+    required this.latestHandshake,
+    required this.latestValidation,
+    required this.candidatePunch,
+    required this.selectedPathMtu,
+    required this.selectedUdpDatagramSize,
+    required this.metrics,
+    required this.transitions,
+  });
+
+  factory PathObservabilitySnapshot.empty() => PathObservabilitySnapshot(
+    schemaVersion: 0,
+    networkEpoch: null,
+    lifecycle: 'unknown',
+    currentPath: null,
+    previousPath: null,
+    transitionReason: 'unavailable',
+    pathAgeMs: 0,
+    pathStateRevision: 0,
+    directState: 'unknown',
+    relayState: 'unknown',
+    recoveryState: 'unknown',
+    directHealth: PathHealthSnapshot.fromJson(const {}),
+    relayHealth: PathHealthSnapshot.fromJson(const {}),
+    latestHandshake: PathHandshakeSnapshot.empty(),
+    latestValidation: PathValidationSnapshot.empty(),
+    candidatePunch: CandidatePunchSummarySnapshot.empty(),
+    selectedPathMtu: null,
+    selectedUdpDatagramSize: null,
+    metrics: PathObservabilityMetricsSnapshot.empty(),
+    transitions: const [],
+  );
+
+  factory PathObservabilitySnapshot.fromJson(JsonMap json) {
+    final epochJson = _mapOrNull(json['network_epoch']);
+    return PathObservabilitySnapshot(
+      schemaVersion: _int(json['schema_version']),
+      networkEpoch: epochJson == null
+          ? null
+          : PathEpochSnapshot.fromJson(epochJson),
+      lifecycle: _string(json['lifecycle'], 'unknown'),
+      currentPath: _nullableString(json['current_path']),
+      previousPath: _nullableString(json['previous_path']),
+      transitionReason: _string(json['transition_reason'], 'unknown'),
+      pathAgeMs: _int(json['path_age_ms']),
+      pathStateRevision: _int(json['path_state_revision']),
+      directState: _string(json['direct_state'], 'unknown'),
+      relayState: _string(json['relay_state'], 'unknown'),
+      recoveryState: _string(json['recovery_state'], 'unknown'),
+      directHealth: PathHealthSnapshot.fromJson(_map(json['direct_health'])),
+      relayHealth: PathHealthSnapshot.fromJson(_map(json['relay_health'])),
+      latestHandshake: PathHandshakeSnapshot.fromJson(
+        _map(json['latest_handshake']),
+      ),
+      latestValidation: PathValidationSnapshot.fromJson(
+        _map(json['latest_validation']),
+      ),
+      candidatePunch: CandidatePunchSummarySnapshot.fromJson(
+        _map(json['candidate_punch']),
+      ),
+      selectedPathMtu: _intOrNull(json['selected_path_mtu']),
+      selectedUdpDatagramSize: _intOrNull(json['selected_udp_datagram_size']),
+      metrics: PathObservabilityMetricsSnapshot.fromJson(_map(json['metrics'])),
+      transitions: [
+        for (final item in _list(json['transitions']))
+          PathTransitionSnapshot.fromJson(_map(item)),
+      ],
+    );
+  }
+
+  final int schemaVersion;
+  final PathEpochSnapshot? networkEpoch;
+  final String lifecycle;
+  final String? currentPath;
+  final String? previousPath;
+  final String transitionReason;
+  final int pathAgeMs;
+  final int pathStateRevision;
+  final String directState;
+  final String relayState;
+  final String recoveryState;
+  final PathHealthSnapshot directHealth;
+  final PathHealthSnapshot relayHealth;
+  final PathHandshakeSnapshot latestHandshake;
+  final PathValidationSnapshot latestValidation;
+  final CandidatePunchSummarySnapshot candidatePunch;
+  final int? selectedPathMtu;
+  final int? selectedUdpDatagramSize;
+  final PathObservabilityMetricsSnapshot metrics;
+  final List<PathTransitionSnapshot> transitions;
+}
+
+class PathEpochSnapshot {
+  PathEpochSnapshot({
+    required this.networkGeneration,
+    required this.peerSessionGeneration,
+    required this.remoteCandidateEpoch,
+  });
+
+  factory PathEpochSnapshot.fromJson(JsonMap json) => PathEpochSnapshot(
+    networkGeneration: _int(json['network_generation']),
+    peerSessionGeneration: _int(json['peer_session_generation']),
+    remoteCandidateEpoch: _int(json['remote_candidate_epoch']),
+  );
+
+  final int networkGeneration;
+  final int peerSessionGeneration;
+  final int remoteCandidateEpoch;
+}
+
+class PathTransitionSnapshot {
+  PathTransitionSnapshot({
+    required this.ageMs,
+    required this.revision,
+    required this.eventKind,
+    required this.decision,
+    required this.reasonCode,
+    required this.epoch,
+    required this.previousPath,
+    required this.currentPath,
+  });
+
+  factory PathTransitionSnapshot.fromJson(JsonMap json) {
+    final epochJson = _mapOrNull(json['epoch']);
+    return PathTransitionSnapshot(
+      ageMs: _int(json['age_ms']),
+      revision: _int(json['revision']),
+      eventKind: _string(json['event_kind']),
+      decision: _string(json['decision']),
+      reasonCode: _string(json['reason_code']),
+      epoch: epochJson == null ? null : PathEpochSnapshot.fromJson(epochJson),
+      previousPath: _nullableString(json['previous_path']),
+      currentPath: _nullableString(json['current_path']),
+    );
+  }
+
+  final int ageMs;
+  final int revision;
+  final String eventKind;
+  final String decision;
+  final String reasonCode;
+  final PathEpochSnapshot? epoch;
+  final String? previousPath;
+  final String? currentPath;
+}
+
+class PathHandshakeSnapshot {
+  PathHandshakeSnapshot({
+    required this.latestStage,
+    required this.latestAgeMs,
+    required this.networkGeneration,
+  });
+
+  factory PathHandshakeSnapshot.empty() => PathHandshakeSnapshot(
+    latestStage: null,
+    latestAgeMs: null,
+    networkGeneration: null,
+  );
+
+  factory PathHandshakeSnapshot.fromJson(JsonMap json) => PathHandshakeSnapshot(
+    latestStage: _nullableString(json['latest_stage']),
+    latestAgeMs: _intOrNull(json['latest_age_ms']),
+    networkGeneration: _intOrNull(json['network_generation']),
+  );
+
+  final String? latestStage;
+  final int? latestAgeMs;
+  final int? networkGeneration;
+}
+
+class PathValidationSnapshot {
+  PathValidationSnapshot({
+    required this.latestStage,
+    required this.latestAgeMs,
+    required this.validationRttMs,
+    required this.ackEndpointAuthenticated,
+  });
+
+  factory PathValidationSnapshot.empty() => PathValidationSnapshot(
+    latestStage: null,
+    latestAgeMs: null,
+    validationRttMs: null,
+    ackEndpointAuthenticated: null,
+  );
+
+  factory PathValidationSnapshot.fromJson(JsonMap json) =>
+      PathValidationSnapshot(
+        latestStage: _nullableString(json['latest_stage']),
+        latestAgeMs: _intOrNull(json['latest_age_ms']),
+        validationRttMs: _intOrNull(json['validation_rtt_ms']),
+        ackEndpointAuthenticated: json.containsKey('ack_endpoint_authenticated')
+            ? _bool(json['ack_endpoint_authenticated'])
+            : null,
+      );
+
+  final String? latestStage;
+  final int? latestAgeMs;
+  final int? validationRttMs;
+  final bool? ackEndpointAuthenticated;
+}
+
+class CandidatePunchSummarySnapshot {
+  CandidatePunchSummarySnapshot({
+    required this.candidatePairCount,
+    required this.signaledCandidateCount,
+    required this.latestCandidateCount,
+    required this.latestSentProbes,
+    required this.latestUniqueTargetPorts,
+    required this.latestRepeatedTargetPorts,
+  });
+
+  factory CandidatePunchSummarySnapshot.empty() =>
+      CandidatePunchSummarySnapshot(
+        candidatePairCount: 0,
+        signaledCandidateCount: 0,
+        latestCandidateCount: null,
+        latestSentProbes: null,
+        latestUniqueTargetPorts: null,
+        latestRepeatedTargetPorts: null,
+      );
+
+  factory CandidatePunchSummarySnapshot.fromJson(JsonMap json) =>
+      CandidatePunchSummarySnapshot(
+        candidatePairCount: _int(json['candidate_pair_count']),
+        signaledCandidateCount: _int(json['signaled_candidate_count']),
+        latestCandidateCount: _intOrNull(json['latest_candidate_count']),
+        latestSentProbes: _intOrNull(json['latest_sent_probes']),
+        latestUniqueTargetPorts: _intOrNull(json['latest_unique_target_ports']),
+        latestRepeatedTargetPorts: _intOrNull(
+          json['latest_repeated_target_ports'],
+        ),
+      );
+
+  final int candidatePairCount;
+  final int signaledCandidateCount;
+  final int? latestCandidateCount;
+  final int? latestSentProbes;
+  final int? latestUniqueTargetPorts;
+  final int? latestRepeatedTargetPorts;
+}
+
+class PathLatencyHistogramSnapshot {
+  PathLatencyHistogramSnapshot({
+    required this.boundsMs,
+    required this.buckets,
+    required this.count,
+    required this.sumMs,
+    required this.maxMs,
+  });
+
+  factory PathLatencyHistogramSnapshot.empty() => PathLatencyHistogramSnapshot(
+    boundsMs: const [50, 100, 250, 500, 1000, 3000, 10000, 30000],
+    buckets: const [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    count: 0,
+    sumMs: 0,
+    maxMs: null,
+  );
+
+  factory PathLatencyHistogramSnapshot.fromJson(JsonMap json) =>
+      PathLatencyHistogramSnapshot(
+        boundsMs: [for (final value in _list(json['bounds_ms'])) _int(value)],
+        buckets: [for (final value in _list(json['buckets'])) _int(value)],
+        count: _int(json['count']),
+        sumMs: _int(json['sum_ms']),
+        maxMs: _intOrNull(json['max_ms']),
+      );
+
+  final List<int> boundsMs;
+  final List<int> buckets;
+  final int count;
+  final int sumMs;
+  final int? maxMs;
+}
+
+class PathObservabilityMetricsSnapshot {
+  PathObservabilityMetricsSnapshot({
+    required this.acceptedTransitions,
+    required this.acceptedObservations,
+    required this.duplicateEvents,
+    required this.rejectedTransitions,
+    required this.pathChanges,
+    required this.directAttempts,
+    required this.directRetries,
+    required this.directValidations,
+    required this.directSuccesses,
+    required this.directFailures,
+    required this.validationFailures,
+    required this.relayConfirmations,
+    required this.relayFallbacks,
+    required this.relayFailures,
+    required this.candidateRefreshes,
+    required this.controlReconnects,
+    required this.networkGenerationChanges,
+    required this.lifecycleResets,
+    required this.dplpmtudChanges,
+    required this.activeTasks,
+    required this.activeSockets,
+    required this.droppedTransitionEvents,
+    required this.directTimeToConnectMs,
+  });
+
+  factory PathObservabilityMetricsSnapshot.empty() =>
+      PathObservabilityMetricsSnapshot.fromJson(const {});
+
+  factory PathObservabilityMetricsSnapshot.fromJson(JsonMap json) {
+    final histogram = _mapOrNull(json['direct_time_to_connect_ms']);
+    return PathObservabilityMetricsSnapshot(
+      acceptedTransitions: _int(json['accepted_transitions']),
+      acceptedObservations: _int(json['accepted_observations']),
+      duplicateEvents: _int(json['duplicate_events']),
+      rejectedTransitions: _int(json['rejected_transitions']),
+      pathChanges: _int(json['path_changes']),
+      directAttempts: _int(json['direct_attempts']),
+      directRetries: _int(json['direct_retries']),
+      directValidations: _int(json['direct_validations']),
+      directSuccesses: _int(json['direct_successes']),
+      directFailures: _int(json['direct_failures']),
+      validationFailures: _int(json['validation_failures']),
+      relayConfirmations: _int(json['relay_confirmations']),
+      relayFallbacks: _int(json['relay_fallbacks']),
+      relayFailures: _int(json['relay_failures']),
+      candidateRefreshes: _int(json['candidate_refreshes']),
+      controlReconnects: _int(json['control_reconnects']),
+      networkGenerationChanges: _int(json['network_generation_changes']),
+      lifecycleResets: _int(json['lifecycle_resets']),
+      dplpmtudChanges: _int(json['dplpmtud_changes']),
+      activeTasks: _int(json['active_tasks']),
+      activeSockets: _int(json['active_sockets']),
+      droppedTransitionEvents: _int(json['dropped_transition_events']),
+      directTimeToConnectMs: histogram == null
+          ? PathLatencyHistogramSnapshot.empty()
+          : PathLatencyHistogramSnapshot.fromJson(histogram),
+    );
+  }
+
+  final int acceptedTransitions;
+  final int acceptedObservations;
+  final int duplicateEvents;
+  final int rejectedTransitions;
+  final int pathChanges;
+  final int directAttempts;
+  final int directRetries;
+  final int directValidations;
+  final int directSuccesses;
+  final int directFailures;
+  final int validationFailures;
+  final int relayConfirmations;
+  final int relayFallbacks;
+  final int relayFailures;
+  final int candidateRefreshes;
+  final int controlReconnects;
+  final int networkGenerationChanges;
+  final int lifecycleResets;
+  final int dplpmtudChanges;
+  final int activeTasks;
+  final int activeSockets;
+  final int droppedTransitionEvents;
+  final PathLatencyHistogramSnapshot directTimeToConnectMs;
+}

--- a/apps/flutter_client/lib/core/models/diagnostics_models/peer.dart
+++ b/apps/flutter_client/lib/core/models/diagnostics_models/peer.dart
@@ -31,6 +31,7 @@ class PeerSnapshot {
     required this.currentPathSelection,
     required this.relayConfirmedEndpoint,
     required this.relayConfirmedGeneration,
+    required this.pathObservability,
   });
 
   final String nodeId;
@@ -71,6 +72,8 @@ class PeerSnapshot {
   /// Network generation of the relay probe ACK confirmation.
   final int? relayConfirmedGeneration;
 
+  final PathObservabilitySnapshot pathObservability;
+
   factory PeerSnapshot.fromJson(JsonMap json) {
     final selectionJson = _mapOrNull(json['current_path_selection']);
     return PeerSnapshot(
@@ -104,6 +107,7 @@ class PeerSnapshot {
           : PathSelectionSnapshot.fromJson(selectionJson),
       relayConfirmedEndpoint: _nullableString(json['relay_confirmed_endpoint']),
       relayConfirmedGeneration: _intOrNull(json['relay_confirmed_generation']),
+      pathObservability: _pathObservabilityOrEmpty(json['path_observability']),
     );
   }
 

--- a/apps/flutter_client/lib/core/models/diagnostics_models/snapshot.dart
+++ b/apps/flutter_client/lib/core/models/diagnostics_models/snapshot.dart
@@ -534,6 +534,7 @@ class PeerManagerStatsSnapshot {
     required this.relayConnections,
     required this.totalBytesSent,
     required this.totalBytesReceived,
+    required this.pathObservability,
   });
 
   final int totalPeers;
@@ -541,6 +542,7 @@ class PeerManagerStatsSnapshot {
   final int relayConnections;
   final int totalBytesSent;
   final int totalBytesReceived;
+  final PathObservabilityMetricsSnapshot pathObservability;
 
   factory PeerManagerStatsSnapshot.fromJson(JsonMap json) {
     return PeerManagerStatsSnapshot(
@@ -549,6 +551,9 @@ class PeerManagerStatsSnapshot {
       relayConnections: _int(json['relay_connections']),
       totalBytesSent: _int(json['total_bytes_sent']),
       totalBytesReceived: _int(json['total_bytes_received']),
+      pathObservability: PathObservabilityMetricsSnapshot.fromJson(
+        _map(json['path_observability']),
+      ),
     );
   }
 }

--- a/apps/flutter_client/lib/core/security/redactor.dart
+++ b/apps/flutter_client/lib/core/security/redactor.dart
@@ -11,6 +11,7 @@
 /// Coverage:
 ///  - PEM private-key blocks (whole body masked);
 ///  - `Bearer <token>` (the standard Authorization header value);
+///  - non-Bearer `Authorization: value` headers;
 ///  - `key : "value"` / `key = 'value'` (quoted, e.g. JSON) — value masked,
 ///    quotes and key preserved;
 ///  - `key: value` / `key=value` (bare single-token, e.g. `token=abc`).
@@ -36,6 +37,28 @@ String redactSensitive(String input) {
     (_) => 'Bearer <redacted>',
   );
 
+  // A non-Bearer Authorization value can contain more than one token (for
+  // example, `Basic user:password`). Consume the complete value up to a log
+  // or JSON delimiter so a second token cannot remain exposed. JSON strings
+  // are handled by the quoted-field rule below.
+  result = _mapMatches(
+    result,
+    RegExp(
+      r'''(["']?authorization["']?\s*[:=]\s*)([^\r\n,;{}\]\)"']+)''',
+      caseSensitive: false,
+    ),
+    (m) {
+      final full = m[0] ?? '';
+      final value = m[2]?.trimLeft() ?? '';
+      // Preserve the standard Bearer spelling produced by the rule above;
+      // only non-Bearer schemes need this complete-value fallback.
+      if (RegExp(r'^Bearer\b', caseSensitive: false).hasMatch(value)) {
+        return full;
+      }
+      return '${m[1]}<redacted>';
+    },
+  );
+
   // Quoted form: key : "value" / key = 'value'.
   const quotedKeys = <String>[
     'authorization',
@@ -46,13 +69,16 @@ String redactSensitive(String input) {
     'session',
     'cookie',
     'api_key',
+    'api-key',
     'apikey',
     'secret',
     'password',
     'private_key',
     'device_credential',
     'access_token',
+    'access-token',
     'refresh_token',
+    'refresh-token',
     'jwt',
   ];
   result = _mapMatches(
@@ -64,10 +90,9 @@ String redactSensitive(String input) {
     (m) => '${m[1]}${m[3]}<redacted>${m[3]}',
   );
 
-  // Bare single-token form: key: value / key=value. `authorization` is excluded
-  // here because its real value is the multi-word `Bearer <tok>` handled above
-  // (and its quoted JSON form is handled by the quoted rule); masking only its
-  // first token would leave the actual credential intact.
+  // Bare single-token form: key: value / key=value. `authorization` is
+  // handled by the dedicated multi-token rule above so masking only its first
+  // token cannot leave the actual credential intact.
   const bareKeys = <String>[
     'token',
     'authtoken',
@@ -76,13 +101,16 @@ String redactSensitive(String input) {
     'session',
     'cookie',
     'api_key',
+    'api-key',
     'apikey',
     'secret',
     'password',
     'private_key',
     'device_credential',
     'access_token',
+    'access-token',
     'refresh_token',
+    'refresh-token',
     'jwt',
   ];
   result = _mapMatches(

--- a/apps/flutter_client/test/contract_test.dart
+++ b/apps/flutter_client/test/contract_test.dart
@@ -34,6 +34,11 @@ void main() {
         expect(snapshot.virtualIp, '10.20.0.7');
         expect(snapshot.revision, greaterThan(0));
         expect(snapshot.readyPhase, isNotEmpty);
+        expect(snapshot.stats.pathObservability.activeSockets, 1);
+        expect(
+          snapshot.stats.pathObservability.directTimeToConnectMs.boundsMs,
+          [50, 100, 250, 500, 1000, 3000, 10000, 30000],
+        );
       },
     );
 
@@ -66,6 +71,97 @@ void main() {
           ) as Map<String, dynamic>;
           expect(DiagnosticsSnapshot.fromJson(raw).readyPhase, phase);
         }
+      },
+    );
+
+    test(
+      'path observability is additive and old peer snapshots still parse',
+      () {
+        final legacyPeer = PeerSnapshot.fromJson({
+          'node_id': 'legacy-peer',
+          'device_name': 'Legacy',
+          'app_version': '0.1.146',
+          'virtual_ip': '10.20.0.2',
+          'nat_type': 'unknown',
+          'online': true,
+          'last_seen': 1,
+          'state': 'connecting',
+          'direct_type': 'unknown',
+          'is_relay': false,
+          'bytes_sent': 0,
+          'bytes_received': 0,
+          'direct': <String, dynamic>{},
+          'relay': <String, dynamic>{},
+        });
+        expect(legacyPeer.pathObservability.schemaVersion, 0);
+        expect(legacyPeer.pathObservability.transitions, isEmpty);
+
+        final currentPeer = PeerSnapshot.fromJson({
+          'node_id': 'current-peer',
+          'device_name': 'Current',
+          'app_version': '0.1.147',
+          'virtual_ip': '10.20.0.3',
+          'nat_type': 'endpoint_independent',
+          'online': true,
+          'last_seen': 1,
+          'state': 'direct',
+          'active_path': 'direct',
+          'direct_type': 'public_udp',
+          'is_relay': false,
+          'bytes_sent': 10,
+          'bytes_received': 20,
+          'direct': <String, dynamic>{},
+          'relay': <String, dynamic>{},
+          'path_observability': {
+            'schema_version': 1,
+            'network_epoch': {
+              'network_generation': 7,
+              'peer_session_generation': 3,
+              'remote_candidate_epoch': 11,
+            },
+            'lifecycle': 'online',
+            'current_path': 'direct',
+            'previous_path': 'relay',
+            'transition_reason': 'direct_committed',
+            'path_age_ms': 12,
+            'path_state_revision': 9,
+            'direct_state': 'committed',
+            'relay_state': 'usable',
+            'recovery_state': 'stable',
+            'direct_health': <String, dynamic>{},
+            'relay_health': <String, dynamic>{},
+            'latest_handshake': <String, dynamic>{},
+            'latest_validation': {'validation_rtt_ms': 18},
+            'candidate_punch': {
+              'candidate_pair_count': 2,
+              'signaled_candidate_count': 3,
+            },
+            'selected_path_mtu': 1360,
+            'metrics': <String, dynamic>{},
+            'transitions': [
+              {
+                'age_ms': 12,
+                'revision': 9,
+                'event_kind': 'direct_committed',
+                'decision': 'applied',
+                'reason_code': 'direct_committed',
+                'current_path': 'direct',
+              },
+            ],
+          },
+        });
+        expect(currentPeer.pathObservability.schemaVersion, 1);
+        expect(currentPeer.pathObservability.currentPath, 'direct');
+        expect(currentPeer.pathObservability.previousPath, 'relay');
+        expect(currentPeer.pathObservability.selectedPathMtu, 1360);
+        expect(
+          currentPeer.pathObservability.latestValidation.validationRttMs,
+          18,
+        );
+        expect(
+          currentPeer.pathObservability.transitions.single.decision,
+          'applied',
+        );
       },
     );
   });

--- a/apps/flutter_client/test/security_test.dart
+++ b/apps/flutter_client/test/security_test.dart
@@ -272,6 +272,12 @@ void main() {
       );
     });
 
+    test('masks complete non-Bearer authorization values', () {
+      final out = redactSensitive('Authorization: Basic user:password');
+      expect(out, 'Authorization: <redacted>');
+      expect(out, isNot(contains('user:password')));
+    });
+
     test('masks json token fields (double-quoted)', () {
       expect(
         redactSensitive(r'{"token":"secret123"}'),

--- a/apps/flutter_client/test/session_log_bundle_test.dart
+++ b/apps/flutter_client/test/session_log_bundle_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -46,5 +47,46 @@ void main() {
     expect(bundle.files.single.content, contains('showing its tail only'));
     expect(bundle.files.single.content, contains('line\n'));
     expect(bundle.files.single.content, isNot(contains('first line')));
+  });
+
+  test('redacts nested credentials while preserving valid JSON', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'p2wlan_session_logs_nested_secrets_',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final daemon = File('${directory.path}/p2wlan-daemon.log');
+    final client = File('${directory.path}/p2wlan-client.log');
+    await daemon.writeAsString(
+      '${jsonEncode({
+        'Authorization': 'Bearer auth-secret',
+        'nested': [
+          {'access_token': 'access-secret', 'refresh_token': 'refresh-secret', 'password': 'password-secret', 'secret': 'secret-value', 'api-key': 'api-secret'},
+        ],
+      })}\n',
+    );
+    await client.writeAsString('startup ok\n');
+
+    final bundle = await CurrentSessionLogBundle.collect(
+      daemonLogPath: daemon.path,
+      clientLogPath: client.path,
+    );
+
+    final content = bundle.files.first.content.trim();
+    final decoded = jsonDecode(content) as Map<String, dynamic>;
+    final nested =
+        (decoded['nested'] as List<dynamic>).single as Map<String, dynamic>;
+    expect(decoded['Authorization'], '<redacted>');
+    expect(nested.values, everyElement('<redacted>'));
+    for (final rawSecret in const [
+      'auth-secret',
+      'access-secret',
+      'refresh-secret',
+      'password-secret',
+      'secret-value',
+      'api-secret',
+    ]) {
+      expect(content, isNot(contains(rawSecret)));
+    }
+    expect(content, contains('<redacted>'));
   });
 }

--- a/client/cli/src/main/diagnostics.rs
+++ b/client/cli/src/main/diagnostics.rs
@@ -171,6 +171,7 @@ async fn doctor(config_path: &Path) -> Result<(), String> {
                 value_u64(stats, "direct_connections"),
                 value_u64(stats, "relay_connections")
             );
+            print_path_observability(stats);
             suggestions.extend(protocol_boundary_suggestions(&snapshot));
             suggestions.extend(mtu_snapshot_suggestions(config.network.mtu, &snapshot));
             let mtu_diagnostics = mtu_diagnostic_suggestions(&snapshot);
@@ -214,4 +215,26 @@ async fn doctor(config_path: &Path) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+fn print_path_observability(stats: &Value) {
+    let Some(metrics) = stats.get("path_observability") else {
+        return;
+    };
+    let histogram = metrics
+        .get("direct_time_to_connect_ms")
+        .unwrap_or(&Value::Null);
+    println!(
+        "Path observability：transitions={} changes={} direct={}/{} relay_fallbacks={} rejected={} tasks={} sockets={} connect_samples={}",
+        value_u64(metrics, "accepted_transitions")
+            .saturating_add(value_u64(metrics, "accepted_observations")),
+        value_u64(metrics, "path_changes"),
+        value_u64(metrics, "direct_successes"),
+        value_u64(metrics, "direct_attempts"),
+        value_u64(metrics, "relay_fallbacks"),
+        value_u64(metrics, "rejected_transitions"),
+        value_u64(metrics, "active_tasks"),
+        value_u64(metrics, "active_sockets"),
+        value_u64(histogram, "count"),
+    );
 }

--- a/client/daemon/src/connection_timeline.rs
+++ b/client/daemon/src/connection_timeline.rs
@@ -21,6 +21,7 @@
 //! - `direct_promoted` still requires the existing encrypted validation chain.
 
 use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -88,6 +89,10 @@ pub struct ConnectionTimeline {
     /// single choke point that covers all timeline emits without touching each
     /// call site. Absent in tests that do not need the diagnostics surface.
     status_events: Mutex<Option<Arc<crate::diagnostics::StatusEventBus>>>,
+    /// Monotonic control-plane registration count. This deliberately lives
+    /// outside the bounded event ring so reconnects remain observable after
+    /// older timeline entries have been evicted.
+    control_registration_count: AtomicU64,
 }
 
 impl ConnectionTimeline {
@@ -112,6 +117,7 @@ impl ConnectionTimeline {
             events: Mutex::new(VecDeque::new()),
             first_events: Mutex::new(HashSet::new()),
             status_events: Mutex::new(None),
+            control_registration_count: AtomicU64::new(0),
         })
     }
 
@@ -147,6 +153,10 @@ impl ConnectionTimeline {
         detail: Option<String>,
     ) -> u64 {
         let at_ms = self.started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        if event == "control_registered" {
+            self.control_registration_count
+                .fetch_add(1, Ordering::Relaxed);
+        }
         let fields = detail
             .as_deref()
             .map(parse_detail_fields)
@@ -188,6 +198,15 @@ impl ConnectionTimeline {
             bus.record(event, at_ms, path, reason_code, mirror_peer_id.as_deref());
         }
         at_ms
+    }
+
+    /// Number of control-plane reconnects observed after the initial
+    /// registration. Unlike the event timeline, this counter is not bounded
+    /// by `TIMELINE_MAX_EVENTS` and therefore survives ring eviction.
+    pub fn control_reconnects(&self) -> u64 {
+        self.control_registration_count
+            .load(Ordering::Relaxed)
+            .saturating_sub(1)
     }
 
     /// Record and log one timeline event with the shared correlation id and the
@@ -525,5 +544,29 @@ mod tests {
         assert_eq!(observed[0].path.as_deref(), Some("direct"));
         assert_eq!(observed[1].path.as_deref(), Some("relay"));
         assert_eq!(observed[1].relay_id.as_deref(), Some("relay.test"));
+    }
+
+    #[test]
+    fn control_reconnect_counter_survives_timeline_eviction() {
+        let timeline = ConnectionTimeline::new("node-a", 0);
+
+        // The first registration is the initial connection, not a reconnect.
+        timeline.emit("control_registered", None, None, None);
+        for _ in 0..TIMELINE_MAX_EVENTS {
+            timeline.record_event("diagnostic_noise", None, None, None);
+        }
+        // The initial registration has been evicted from the bounded ring.
+        timeline.emit("control_registered", None, None, None);
+
+        assert_eq!(
+            timeline
+                .snapshot()
+                .events
+                .iter()
+                .filter(|event| event.event == "control_registered")
+                .count(),
+            1
+        );
+        assert_eq!(timeline.control_reconnects(), 1);
     }
 }

--- a/client/daemon/src/diagnostics/snapshot.rs
+++ b/client/daemon/src/diagnostics/snapshot.rs
@@ -31,6 +31,14 @@ async fn build_snapshot(context: DiagnosticsContext) -> DiagnosticsSnapshot {
     stats.outbound_drops = outbound_loss.drops;
     stats.outbound_send_failures = outbound_loss.send_failures;
     stats.outbound_loss_events = outbound_loss.events;
+    stats.path_observability.active_tasks = health_snap
+        .critical_tasks
+        .iter()
+        .filter(|task| task.running && !task.finished)
+        .count() as u64;
+    stats.path_observability.active_sockets = udp_socket_count as u64;
+    stats.path_observability.control_reconnects = context.timeline.control_reconnects();
+    let connection_timeline = context.timeline.snapshot();
     let candidate_snapshot = context.candidate_snapshot.read().await.clone();
     let (local_candidates, candidate_snapshot_version, candidate_snapshot_hash) =
         candidate_snapshot
@@ -104,7 +112,7 @@ async fn build_snapshot(context: DiagnosticsContext) -> DiagnosticsSnapshot {
         control_proxy_consults_env: crate::control::proxy_consults_environment(
             context.config.control.proxy_mode,
         ),
-        connection_timeline: context.timeline.snapshot(),
+        connection_timeline,
         traversal_history,
         peers,
         stats,

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -630,6 +630,14 @@ pub use types::{
     PathScore, PathScoreDiagnostics, PathSelection, PathSelectionDiagnostics, PathSelectionEvent,
 };
 
+mod path_observability;
+use path_observability::PathObservabilityState;
+pub use path_observability::{
+    CandidatePunchSummaryDiagnostics, PathEpochDiagnostics, PathHandshakeDiagnostics,
+    PathLatencyHistogram, PathObservabilityMetrics, PathObservabilitySnapshot,
+    PathTransitionDiagnostics, PathValidationDiagnostics,
+};
+
 mod path_state_machine;
 pub(crate) use path_state_machine::{
     ActiveBusinessPath, DirectAttemptNumber, DirectCandidateContinuity, DirectValidationIdentity,

--- a/client/daemon/src/peer/connection/core.rs
+++ b/client/daemon/src/peer/connection/core.rs
@@ -150,6 +150,8 @@ pub struct PeerConnection {
     /// Authoritative typed path state. `state` above is updated atomically as
     /// its compatibility projection by `commit_path_transition`.
     path_state_machine: PathStateMachine,
+    /// Bounded, synchronous telemetry recorded only at the typed commit point.
+    path_observability: PathObservabilityState,
     /// When the connection was established.
     pub connected_at: Option<Instant>,
     /// Bytes sent to this peer.
@@ -382,6 +384,7 @@ impl PeerConnection {
             remote_relay_rtt_ms: None,
             state: ConnectionState::Idle,
             path_state_machine: PathStateMachine::new(ConnectionState::Idle),
+            path_observability: PathObservabilityState::default(),
             connected_at: None,
             bytes_sent: 0,
             bytes_received: 0,
@@ -527,10 +530,13 @@ impl PeerConnection {
         apply_side_effects: impl FnOnce(&mut Self),
     ) -> PathTransitionOutcome {
         let event_epoch = event.epoch();
+        let observability_event = event.clone();
         let previous_active = self.path_state_machine.active_path();
         let previous_state = self.state;
         let transition = self.path_state_machine.reduce(event);
         let outcome = self.path_state_machine.commit(transition);
+        self.path_observability
+            .record(&observability_event, &outcome, Instant::now());
         if !outcome.accepted() {
             debug!(
                 target: "p2pnet_daemon::peer::path_state_machine",

--- a/client/daemon/src/peer/diagnostics/manager_stats.rs
+++ b/client/daemon/src/peer/diagnostics/manager_stats.rs
@@ -6,6 +6,9 @@ pub struct PeerManagerStats {
     pub relay_connections: usize,
     pub total_bytes_sent: u64,
     pub total_bytes_received: u64,
+    /// Process-bounded path transition counters and fixed-bucket latency histogram.
+    #[serde(default)]
+    pub path_observability: PathObservabilityMetrics,
     /// Dropped outbound business packets (packets/bytes) by stable reason
     /// code, accumulated since daemon start.  Terminal loss only.
     #[serde(default)]
@@ -37,6 +40,13 @@ impl PeerManagerStats {
                 .count(),
             total_bytes_sent: peers.iter().map(|peer| peer.bytes_sent).sum(),
             total_bytes_received: peers.iter().map(|peer| peer.bytes_received).sum(),
+            path_observability: peers.iter().fold(
+                PathObservabilityMetrics::default(),
+                |mut aggregate, peer| {
+                    aggregate.merge_from(&peer.path_observability.metrics);
+                    aggregate
+                },
+            ),
             outbound_drops: HashMap::new(),
             outbound_send_failures: HashMap::new(),
             outbound_loss_events: Vec::new(),

--- a/client/daemon/src/peer/diagnostics/peer.rs
+++ b/client/daemon/src/peer/diagnostics/peer.rs
@@ -113,6 +113,9 @@ pub struct PeerDiagnostics {
     pub last_path_selection: Option<PathSelectionDiagnostics>,
     pub path_events: Vec<PathSelectionEventDiagnostics>,
     pub direct_events: Vec<DirectTraversalEventDiagnostics>,
+    /// Versioned, bounded transition/metric snapshot recorded at the typed path commit point.
+    #[serde(default)]
+    pub path_observability: PathObservabilitySnapshot,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fresh_mapping: Vec<FreshMappingDiag>,
     /// Read-only DPLPMTUD snapshot for the exact committed Direct UDP path.
@@ -531,6 +534,7 @@ impl PeerDiagnostics {
                 .iter()
                 .map(DirectTraversalEventDiagnostics::from)
                 .collect(),
+            path_observability: conn.path_observability.snapshot(conn),
             fresh_mapping: fresh_mapping_history
                 .and_then(|history| history.get(&conn.node_id))
                 .map(|results| {

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -197,6 +197,8 @@ impl PeerManager {
         };
         for peer in &mut peers {
             peer.dplpmtud = dplpmtud_reports.get(&peer.node_id).cloned();
+            peer.path_observability
+                .apply_dplpmtud_runtime(peer.dplpmtud.as_ref());
         }
         peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         self.cache_diagnostics(&peers);
@@ -276,6 +278,8 @@ impl PeerManager {
         };
         for peer in &mut peers {
             peer.dplpmtud = dplpmtud_reports.get(&peer.node_id).cloned();
+            peer.path_observability
+                .apply_dplpmtud_runtime(peer.dplpmtud.as_ref());
         }
         peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         self.cache_diagnostics(&peers);
@@ -348,6 +352,9 @@ impl PeerManager {
             Some(&fresh_mapping_history),
         );
         diagnostics.dplpmtud = dplpmtud;
+        diagnostics
+            .path_observability
+            .apply_dplpmtud_runtime(diagnostics.dplpmtud.as_ref());
         diagnostics.recovery = recovery;
         Some((generation, diagnostics))
     }
@@ -414,6 +421,7 @@ impl PeerManager {
             relay_connections: relay,
             total_bytes_sent,
             total_bytes_received,
+            path_observability: PathObservabilityMetrics::default(),
             outbound_drops: HashMap::new(),
             outbound_send_failures: HashMap::new(),
             outbound_loss_events: Vec::new(),

--- a/client/daemon/src/peer/path_observability.rs
+++ b/client/daemon/src/peer/path_observability.rs
@@ -1,0 +1,827 @@
+//! Bounded, generation-aware path observability.
+//!
+//! All transition telemetry is recorded synchronously at
+//! [`PeerConnection::commit_path_transition`], the sole authoritative path
+//! commit point. The recorder owns no async locks, performs no I/O and keeps a
+//! fixed-size event ring, so diagnostics cannot mutate or block the dataplane.
+
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+use super::path_state_machine::{
+    DirectPathState, PathEvent, PathRecoveryState, PathTransitionDecision, PathTransitionOutcome,
+    RelayPathState,
+};
+use super::{
+    DirectTraversalEvent, NetworkPath, PathHealthDiagnostics, PeerConnection, PeerPathLifecycle,
+};
+
+pub const PATH_OBSERVABILITY_SCHEMA_VERSION: u32 = 1;
+pub const PATH_TRANSITION_EVENT_LIMIT: usize = 32;
+pub const DIRECT_CONNECT_HISTOGRAM_BOUNDS_MS: [u64; 8] =
+    [50, 100, 250, 500, 1_000, 3_000, 10_000, 30_000];
+pub const RELAY_SAFE_PATH_MTU: u32 = 1_380;
+
+/// Stable metric names. These are field names rather than dynamic label
+/// values, which keeps cardinality bounded by construction.
+#[cfg_attr(not(test), allow(dead_code))]
+pub const PATH_OBSERVABILITY_METRIC_NAMES: [&str; 23] = [
+    "accepted_transitions",
+    "accepted_observations",
+    "duplicate_events",
+    "rejected_transitions",
+    "path_changes",
+    "direct_attempts",
+    "direct_retries",
+    "direct_validations",
+    "direct_successes",
+    "direct_failures",
+    "validation_failures",
+    "relay_confirmations",
+    "relay_fallbacks",
+    "relay_failures",
+    "candidate_refreshes",
+    "control_reconnects",
+    "network_generation_changes",
+    "lifecycle_resets",
+    "dplpmtud_changes",
+    "active_tasks",
+    "active_sockets",
+    "dropped_transition_events",
+    "direct_time_to_connect_ms",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathLatencyHistogram {
+    pub bounds_ms: Vec<u64>,
+    /// One bucket for every bound plus one overflow bucket.
+    pub buckets: Vec<u64>,
+    pub count: u64,
+    pub sum_ms: u64,
+    pub max_ms: Option<u64>,
+}
+
+impl Default for PathLatencyHistogram {
+    fn default() -> Self {
+        Self {
+            bounds_ms: DIRECT_CONNECT_HISTOGRAM_BOUNDS_MS.to_vec(),
+            buckets: vec![0; DIRECT_CONNECT_HISTOGRAM_BOUNDS_MS.len() + 1],
+            count: 0,
+            sum_ms: 0,
+            max_ms: None,
+        }
+    }
+}
+
+impl PathLatencyHistogram {
+    fn observe(&mut self, value_ms: u64) {
+        let index = self
+            .bounds_ms
+            .iter()
+            .position(|bound| value_ms <= *bound)
+            .unwrap_or(self.bounds_ms.len());
+        if let Some(bucket) = self.buckets.get_mut(index) {
+            *bucket = bucket.saturating_add(1);
+        }
+        self.count = self.count.saturating_add(1);
+        self.sum_ms = self.sum_ms.saturating_add(value_ms);
+        self.max_ms = Some(
+            self.max_ms
+                .map_or(value_ms, |current| current.max(value_ms)),
+        );
+    }
+
+    pub(crate) fn merge_from(&mut self, other: &Self) {
+        if self.bounds_ms != other.bounds_ms || self.buckets.len() != other.buckets.len() {
+            return;
+        }
+        for (target, source) in self.buckets.iter_mut().zip(&other.buckets) {
+            *target = target.saturating_add(*source);
+        }
+        self.count = self.count.saturating_add(other.count);
+        self.sum_ms = self.sum_ms.saturating_add(other.sum_ms);
+        if let Some(value) = other.max_ms {
+            self.max_ms = Some(self.max_ms.map_or(value, |current| current.max(value)));
+        }
+    }
+}
+
+/// Process-bounded counters. No peer ID, endpoint, IP, session identifier or
+/// arbitrary error text can become a label because the schema has no label
+/// map at all.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PathObservabilityMetrics {
+    pub accepted_transitions: u64,
+    pub accepted_observations: u64,
+    pub duplicate_events: u64,
+    pub rejected_transitions: u64,
+    pub path_changes: u64,
+    pub direct_attempts: u64,
+    pub direct_retries: u64,
+    pub direct_validations: u64,
+    pub direct_successes: u64,
+    pub direct_failures: u64,
+    pub validation_failures: u64,
+    pub relay_confirmations: u64,
+    pub relay_fallbacks: u64,
+    pub relay_failures: u64,
+    pub candidate_refreshes: u64,
+    pub control_reconnects: u64,
+    pub network_generation_changes: u64,
+    pub lifecycle_resets: u64,
+    pub dplpmtud_changes: u64,
+    pub active_tasks: u64,
+    pub active_sockets: u64,
+    pub dropped_transition_events: u64,
+    pub direct_time_to_connect_ms: PathLatencyHistogram,
+}
+
+impl PathObservabilityMetrics {
+    pub(crate) fn merge_from(&mut self, other: &Self) {
+        macro_rules! add {
+            ($field:ident) => {
+                self.$field = self.$field.saturating_add(other.$field)
+            };
+        }
+        add!(accepted_transitions);
+        add!(accepted_observations);
+        add!(duplicate_events);
+        add!(rejected_transitions);
+        add!(path_changes);
+        add!(direct_attempts);
+        add!(direct_retries);
+        add!(direct_validations);
+        add!(direct_successes);
+        add!(direct_failures);
+        add!(validation_failures);
+        add!(relay_confirmations);
+        add!(relay_fallbacks);
+        add!(relay_failures);
+        add!(candidate_refreshes);
+        add!(control_reconnects);
+        add!(network_generation_changes);
+        add!(lifecycle_resets);
+        add!(dplpmtud_changes);
+        add!(active_tasks);
+        add!(active_sockets);
+        add!(dropped_transition_events);
+        self.direct_time_to_connect_ms
+            .merge_from(&other.direct_time_to_connect_ms);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathEpochDiagnostics {
+    pub network_generation: u64,
+    pub peer_session_generation: u64,
+    pub remote_candidate_epoch: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PathTransitionDiagnostics {
+    pub age_ms: u64,
+    pub revision: u64,
+    pub event_kind: String,
+    pub decision: String,
+    pub reason_code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<PathEpochDiagnostics>,
+    pub previous_path: Option<NetworkPath>,
+    pub current_path: Option<NetworkPath>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PathHandshakeDiagnostics {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_age_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_generation: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PathValidationDiagnostics {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_age_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_rtt_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ack_endpoint_authenticated: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CandidatePunchSummaryDiagnostics {
+    pub candidate_pair_count: usize,
+    pub signaled_candidate_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_candidate_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_sent_probes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_unique_target_ports: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_repeated_target_ports: Option<u32>,
+}
+
+/// Versioned, backward-compatible per-peer diagnostics snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathObservabilitySnapshot {
+    pub schema_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_epoch: Option<PathEpochDiagnostics>,
+    pub lifecycle: String,
+    pub current_path: Option<NetworkPath>,
+    pub previous_path: Option<NetworkPath>,
+    pub transition_reason: String,
+    pub path_age_ms: u64,
+    pub path_state_revision: u64,
+    pub direct_state: String,
+    pub relay_state: String,
+    pub recovery_state: String,
+    pub direct_health: PathHealthDiagnostics,
+    pub relay_health: PathHealthDiagnostics,
+    pub latest_handshake: PathHandshakeDiagnostics,
+    pub latest_validation: PathValidationDiagnostics,
+    pub candidate_punch: CandidatePunchSummaryDiagnostics,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_path_mtu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_udp_datagram_size: Option<u32>,
+    pub metrics: PathObservabilityMetrics,
+    pub transitions: Vec<PathTransitionDiagnostics>,
+}
+
+impl Default for PathObservabilitySnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: PATH_OBSERVABILITY_SCHEMA_VERSION,
+            network_epoch: None,
+            lifecycle: "unbound".to_string(),
+            current_path: None,
+            previous_path: None,
+            transition_reason: "initial".to_string(),
+            path_age_ms: 0,
+            path_state_revision: 0,
+            direct_state: "idle".to_string(),
+            relay_state: "unavailable".to_string(),
+            recovery_state: "stable".to_string(),
+            direct_health: PathHealthDiagnostics {
+                last_success_age_ms: None,
+                last_failure_age_ms: None,
+                consecutive_failures: 0,
+                last_error: None,
+                last_error_code: None,
+                last_liveness: None,
+                latency_ms: None,
+                rtt_ewma_ms: None,
+                jitter_ms: None,
+                success_count: 0,
+                failure_count: 0,
+            },
+            relay_health: PathHealthDiagnostics {
+                last_success_age_ms: None,
+                last_failure_age_ms: None,
+                consecutive_failures: 0,
+                last_error: None,
+                last_error_code: None,
+                last_liveness: None,
+                latency_ms: None,
+                rtt_ewma_ms: None,
+                jitter_ms: None,
+                success_count: 0,
+                failure_count: 0,
+            },
+            latest_handshake: PathHandshakeDiagnostics::default(),
+            latest_validation: PathValidationDiagnostics::default(),
+            candidate_punch: CandidatePunchSummaryDiagnostics::default(),
+            selected_path_mtu: None,
+            selected_udp_datagram_size: None,
+            metrics: PathObservabilityMetrics::default(),
+            transitions: Vec::new(),
+        }
+    }
+}
+
+impl PathObservabilitySnapshot {
+    pub(crate) fn apply_dplpmtud_runtime(
+        &mut self,
+        dplpmtud: Option<&crate::dplpmtud::DplpmtudSnapshot>,
+    ) {
+        match self.current_path {
+            Some(NetworkPath::Direct) => {
+                self.selected_path_mtu =
+                    dplpmtud.and_then(|snapshot| snapshot.overlay_payload_budget);
+                self.selected_udp_datagram_size =
+                    dplpmtud.and_then(|snapshot| snapshot.confirmed_udp_datagram_size);
+            }
+            Some(NetworkPath::Relay) => {
+                self.selected_path_mtu = Some(RELAY_SAFE_PATH_MTU);
+                self.selected_udp_datagram_size = None;
+            }
+            None => {
+                self.selected_path_mtu = None;
+                self.selected_udp_datagram_size = None;
+            }
+        }
+        self.metrics.dplpmtud_changes = dplpmtud.map_or(0, |snapshot| snapshot.revision);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RecordedPathTransition {
+    recorded_at: Instant,
+    revision: u64,
+    event_kind: &'static str,
+    decision: &'static str,
+    reason_code: &'static str,
+    epoch: Option<PathEpochDiagnostics>,
+    previous_path: Option<NetworkPath>,
+    current_path: Option<NetworkPath>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PathObservabilityState {
+    metrics: PathObservabilityMetrics,
+    transitions: VecDeque<RecordedPathTransition>,
+    previous_path: Option<NetworkPath>,
+    current_path_since: Instant,
+    last_reason_code: &'static str,
+    direct_attempt_started: Option<Instant>,
+}
+
+impl Default for PathObservabilityState {
+    fn default() -> Self {
+        Self {
+            metrics: PathObservabilityMetrics::default(),
+            transitions: VecDeque::with_capacity(PATH_TRANSITION_EVENT_LIMIT),
+            previous_path: None,
+            current_path_since: Instant::now(),
+            last_reason_code: "initial",
+            direct_attempt_started: None,
+        }
+    }
+}
+
+impl PathObservabilityState {
+    pub(crate) fn record(
+        &mut self,
+        event: &PathEvent,
+        outcome: &PathTransitionOutcome,
+        now: Instant,
+    ) {
+        let previous_path = outcome.previous.active.network_path();
+        let current_path = outcome.snapshot.state.active.network_path();
+        let event_kind = event_kind(event);
+        let decision = decision_label(outcome.decision);
+        let reason_code = event_reason_code(event);
+
+        match outcome.decision {
+            PathTransitionDecision::Applied => {
+                self.metrics.accepted_transitions =
+                    self.metrics.accepted_transitions.saturating_add(1);
+            }
+            PathTransitionDecision::AcceptedObservation => {
+                self.metrics.accepted_observations =
+                    self.metrics.accepted_observations.saturating_add(1);
+            }
+            PathTransitionDecision::Duplicate => {
+                self.metrics.duplicate_events = self.metrics.duplicate_events.saturating_add(1);
+            }
+            _ => {
+                self.metrics.rejected_transitions =
+                    self.metrics.rejected_transitions.saturating_add(1);
+            }
+        }
+
+        if outcome.applies_side_effects() {
+            self.record_applied_event(event, now);
+        }
+
+        if previous_path != current_path && outcome.applies_side_effects() {
+            self.metrics.path_changes = self.metrics.path_changes.saturating_add(1);
+            if current_path == Some(NetworkPath::Relay) {
+                self.metrics.relay_fallbacks = self.metrics.relay_fallbacks.saturating_add(1);
+            }
+            self.previous_path = previous_path;
+            self.current_path_since = now;
+        }
+        if outcome.applies_side_effects() {
+            self.last_reason_code = reason_code;
+        }
+
+        if self.transitions.len() == PATH_TRANSITION_EVENT_LIMIT {
+            self.transitions.pop_front();
+            self.metrics.dropped_transition_events =
+                self.metrics.dropped_transition_events.saturating_add(1);
+        }
+        self.transitions.push_back(RecordedPathTransition {
+            recorded_at: now,
+            revision: outcome.snapshot.revision,
+            event_kind,
+            decision,
+            reason_code,
+            epoch: event.epoch().map(|epoch| PathEpochDiagnostics {
+                network_generation: epoch.network_generation,
+                peer_session_generation: epoch.peer_session_generation.value(),
+                remote_candidate_epoch: epoch.remote_candidate_epoch,
+            }),
+            previous_path,
+            current_path,
+        });
+    }
+
+    fn record_applied_event(&mut self, event: &PathEvent, now: Instant) {
+        match event {
+            PathEvent::PeerOnline { .. } => {}
+            PathEvent::PeerLeft { .. } | PathEvent::IdentityReset => {
+                self.metrics.lifecycle_resets = self.metrics.lifecycle_resets.saturating_add(1);
+                self.direct_attempt_started = None;
+            }
+            PathEvent::NetworkGenerationAdvanced { .. } => {
+                self.metrics.network_generation_changes =
+                    self.metrics.network_generation_changes.saturating_add(1);
+                self.direct_attempt_started = None;
+            }
+            PathEvent::RemoteCandidateEpochAdvanced { .. } => {
+                self.metrics.candidate_refreshes =
+                    self.metrics.candidate_refreshes.saturating_add(1);
+            }
+            PathEvent::RelayPeerConfirmed { .. } => {
+                self.metrics.relay_confirmations =
+                    self.metrics.relay_confirmations.saturating_add(1);
+            }
+            PathEvent::RelayTransportLost { .. } | PathEvent::RelayPathFailed { .. } => {
+                self.metrics.relay_failures = self.metrics.relay_failures.saturating_add(1);
+            }
+            PathEvent::DirectProbeStarted { .. } => {
+                self.metrics.direct_attempts = self.metrics.direct_attempts.saturating_add(1);
+                self.direct_attempt_started = Some(now);
+            }
+            PathEvent::DirectRetryScheduled { .. } => {
+                self.metrics.direct_retries = self.metrics.direct_retries.saturating_add(1);
+                self.direct_attempt_started.get_or_insert(now);
+            }
+            PathEvent::DirectValidationStarted { .. } => {
+                self.metrics.direct_validations = self.metrics.direct_validations.saturating_add(1);
+                self.direct_attempt_started.get_or_insert(now);
+            }
+            PathEvent::DirectCommitted { .. } => {
+                self.metrics.direct_successes = self.metrics.direct_successes.saturating_add(1);
+                if let Some(started) = self.direct_attempt_started.take() {
+                    self.metrics
+                        .direct_time_to_connect_ms
+                        .observe(duration_millis(now.saturating_duration_since(started)));
+                }
+            }
+            PathEvent::DirectProbeFailed { .. }
+            | PathEvent::DirectPathFailed { .. }
+            | PathEvent::DirectAttemptCancelled { .. } => {
+                self.metrics.direct_failures = self.metrics.direct_failures.saturating_add(1);
+                self.metrics.validation_failures =
+                    self.metrics.validation_failures.saturating_add(1);
+                self.direct_attempt_started = None;
+            }
+            PathEvent::RelayTransportReady { .. }
+            | PathEvent::RelayBusinessUsable { .. }
+            | PathEvent::RelayHealthObserved { .. }
+            | PathEvent::CompatibilityStateRequested { .. } => {}
+        }
+    }
+
+    pub(crate) fn snapshot(&self, connection: &PeerConnection) -> PathObservabilitySnapshot {
+        let machine = connection.path_state_snapshot();
+        let current_path = machine.state.active.network_path();
+        let latest_handshake = latest_handshake(&connection.direct_events);
+        let latest_validation = latest_validation(&connection.direct_events);
+        let candidate_punch = latest_candidate_punch(connection, &connection.direct_events);
+        let mut snapshot = PathObservabilitySnapshot {
+            schema_version: PATH_OBSERVABILITY_SCHEMA_VERSION,
+            network_epoch: machine.state.epoch.map(|epoch| PathEpochDiagnostics {
+                network_generation: epoch.network_generation,
+                peer_session_generation: epoch.peer_session_generation.value(),
+                remote_candidate_epoch: epoch.remote_candidate_epoch,
+            }),
+            lifecycle: lifecycle_label(machine.state.lifecycle).to_string(),
+            current_path,
+            previous_path: self.previous_path,
+            transition_reason: self.last_reason_code.to_string(),
+            path_age_ms: duration_millis(self.current_path_since.elapsed()),
+            path_state_revision: machine.revision,
+            direct_state: direct_state_label(&machine.state.direct).to_string(),
+            relay_state: relay_state_label(&machine.state.relay).to_string(),
+            recovery_state: recovery_state_label(&machine.state.recovery).to_string(),
+            direct_health: PathHealthDiagnostics::from(&connection.direct_health),
+            relay_health: PathHealthDiagnostics::from(&connection.relay_health),
+            latest_handshake,
+            latest_validation,
+            candidate_punch,
+            selected_path_mtu: (current_path == Some(NetworkPath::Relay))
+                .then_some(RELAY_SAFE_PATH_MTU),
+            selected_udp_datagram_size: None,
+            metrics: self.metrics.clone(),
+            transitions: self
+                .transitions
+                .iter()
+                .map(|transition| PathTransitionDiagnostics {
+                    age_ms: duration_millis(transition.recorded_at.elapsed()),
+                    revision: transition.revision,
+                    event_kind: transition.event_kind.to_string(),
+                    decision: transition.decision.to_string(),
+                    reason_code: transition.reason_code.to_string(),
+                    epoch: transition.epoch.clone(),
+                    previous_path: transition.previous_path,
+                    current_path: transition.current_path,
+                })
+                .collect(),
+        };
+        snapshot.metrics.rejected_transitions = machine
+            .rejected_transitions
+            .max(snapshot.metrics.rejected_transitions);
+        snapshot
+    }
+}
+
+fn latest_handshake(events: &[DirectTraversalEvent]) -> PathHandshakeDiagnostics {
+    events
+        .iter()
+        .rev()
+        .find(|event| {
+            let stage = event.stage.to_ascii_lowercase();
+            stage.contains("handshake")
+                || stage.contains("offer")
+                || stage.contains("answer")
+                || stage.contains("session")
+        })
+        .map(|event| PathHandshakeDiagnostics {
+            latest_stage: Some(event.stage.clone()),
+            latest_age_ms: Some(duration_millis(event.recorded_at.elapsed())),
+            network_generation: Some(event.network_generation),
+        })
+        .unwrap_or_default()
+}
+
+fn latest_validation(events: &[DirectTraversalEvent]) -> PathValidationDiagnostics {
+    events
+        .iter()
+        .rev()
+        .find(|event| {
+            event.validation_session_id.is_some()
+                || event.request_id.is_some()
+                || event.validation_rtt_ms.is_some()
+                || event.stage.to_ascii_lowercase().contains("validation")
+        })
+        .map(|event| PathValidationDiagnostics {
+            latest_stage: Some(event.stage.clone()),
+            latest_age_ms: Some(duration_millis(event.recorded_at.elapsed())),
+            validation_rtt_ms: event.validation_rtt_ms,
+            ack_endpoint_authenticated: event.ack_endpoint_authenticated,
+        })
+        .unwrap_or_default()
+}
+
+fn latest_candidate_punch(
+    connection: &PeerConnection,
+    events: &[DirectTraversalEvent],
+) -> CandidatePunchSummaryDiagnostics {
+    let latest = events.iter().rev().find(|event| {
+        event.candidate_count.is_some()
+            || event.sent_probes.is_some()
+            || event.probe_tx_unique_target_ports.is_some()
+    });
+    CandidatePunchSummaryDiagnostics {
+        candidate_pair_count: connection.candidate_pairs.len(),
+        signaled_candidate_count: connection.candidates.len(),
+        latest_candidate_count: latest.and_then(|event| event.candidate_count),
+        latest_sent_probes: latest.and_then(|event| event.sent_probes),
+        latest_unique_target_ports: latest.and_then(|event| event.probe_tx_unique_target_ports),
+        latest_repeated_target_ports: latest.and_then(|event| event.probe_tx_repeated_target_ports),
+    }
+}
+
+fn event_kind(event: &PathEvent) -> &'static str {
+    match event {
+        PathEvent::PeerOnline { .. } => "peer_online",
+        PathEvent::PeerLeft { .. } => "peer_left",
+        PathEvent::IdentityReset => "identity_reset",
+        PathEvent::NetworkGenerationAdvanced { .. } => "network_generation_advanced",
+        PathEvent::RemoteCandidateEpochAdvanced { .. } => "remote_candidate_epoch_advanced",
+        PathEvent::RelayTransportReady { .. } => "relay_transport_ready",
+        PathEvent::RelayPeerConfirmed { .. } => "relay_peer_confirmed",
+        PathEvent::RelayBusinessUsable { .. } => "relay_business_usable",
+        PathEvent::RelayHealthObserved { .. } => "relay_health_observed",
+        PathEvent::RelayTransportLost { .. } => "relay_transport_lost",
+        PathEvent::RelayPathFailed { .. } => "relay_path_failed",
+        PathEvent::DirectProbeStarted { .. } => "direct_probe_started",
+        PathEvent::DirectValidationStarted { .. } => "direct_validation_started",
+        PathEvent::DirectCommitted { .. } => "direct_committed",
+        PathEvent::DirectProbeFailed { .. } => "direct_probe_failed",
+        PathEvent::DirectPathFailed { .. } => "direct_path_failed",
+        PathEvent::DirectAttemptCancelled { .. } => "direct_attempt_cancelled",
+        PathEvent::DirectRetryScheduled { .. } => "direct_retry_scheduled",
+        PathEvent::CompatibilityStateRequested { .. } => "compatibility_state_requested",
+    }
+}
+
+fn event_reason_code(event: &PathEvent) -> &'static str {
+    event_kind(event)
+}
+
+fn decision_label(decision: PathTransitionDecision) -> &'static str {
+    match decision {
+        PathTransitionDecision::Applied => "applied",
+        PathTransitionDecision::AcceptedObservation => "accepted_observation",
+        PathTransitionDecision::Duplicate => "duplicate",
+        PathTransitionDecision::RejectedNetworkGeneration => "rejected_network_generation",
+        PathTransitionDecision::RejectedPeerSessionGeneration => "rejected_peer_session_generation",
+        PathTransitionDecision::RejectedRemoteCandidateEpoch => "rejected_remote_candidate_epoch",
+        PathTransitionDecision::RejectedPeerOffline => "rejected_peer_offline",
+        PathTransitionDecision::RejectedDirectValidationIdentity => {
+            "rejected_direct_validation_identity"
+        }
+        PathTransitionDecision::RejectedRelayConnectionIdentity => {
+            "rejected_relay_connection_identity"
+        }
+        PathTransitionDecision::RejectedRevision => "rejected_revision",
+        PathTransitionDecision::RejectedIllegalTransition => "rejected_illegal_transition",
+    }
+}
+
+fn lifecycle_label(lifecycle: PeerPathLifecycle) -> &'static str {
+    match lifecycle {
+        PeerPathLifecycle::Unbound => "unbound",
+        PeerPathLifecycle::Online => "online",
+        PeerPathLifecycle::Offline => "offline",
+    }
+}
+
+fn direct_state_label(state: &DirectPathState) -> &'static str {
+    match state {
+        DirectPathState::Idle => "idle",
+        DirectPathState::Probing { .. } => "probing",
+        DirectPathState::Validating(_) => "validating",
+        DirectPathState::Committed(_) => "committed",
+    }
+}
+
+fn relay_state_label(state: &RelayPathState) -> &'static str {
+    match state {
+        RelayPathState::Unavailable => "unavailable",
+        RelayPathState::Ready(_) => "ready",
+        RelayPathState::Confirmed(_) => "confirmed",
+        RelayPathState::Usable(_) => "usable",
+    }
+}
+
+fn recovery_state_label(state: &PathRecoveryState) -> &'static str {
+    match state {
+        PathRecoveryState::Stable => "stable",
+        PathRecoveryState::Degraded { .. } => "degraded",
+        PathRecoveryState::Recovering { .. } => "recovering",
+    }
+}
+
+fn duration_millis(duration: std::time::Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer::{
+        DirectAttemptNumber, DirectValidationIdentity, PathEpoch, PathEvent, PeerSessionGeneration,
+    };
+
+    fn epoch() -> PathEpoch {
+        PathEpoch::new(7, PeerSessionGeneration::for_test(3), 11)
+    }
+
+    #[test]
+    fn path_observability_metrics_are_bounded() {
+        let mut connection = PeerConnection::new("peer-sensitive-id", "10.20.0.2");
+        connection.commit_path_transition(PathEvent::PeerOnline { epoch: epoch() }, |_| {});
+        for attempt in 0..(PATH_TRANSITION_EVENT_LIMIT as u32 + 9) {
+            connection.commit_path_transition(
+                PathEvent::DirectProbeStarted {
+                    epoch: epoch(),
+                    attempt: DirectAttemptNumber(u64::from(attempt.saturating_add(1))),
+                },
+                |_| {},
+            );
+            connection
+                .commit_path_transition(PathEvent::DirectProbeFailed { epoch: epoch() }, |_| {});
+        }
+        let snapshot = connection.path_observability.snapshot(&connection);
+        assert_eq!(snapshot.schema_version, PATH_OBSERVABILITY_SCHEMA_VERSION);
+        assert_eq!(snapshot.transitions.len(), PATH_TRANSITION_EVENT_LIMIT);
+        assert!(snapshot.metrics.dropped_transition_events > 0);
+        assert_eq!(
+            snapshot.metrics.direct_time_to_connect_ms.buckets.len(),
+            DIRECT_CONNECT_HISTOGRAM_BOUNDS_MS.len() + 1
+        );
+        let json = serde_json::to_string(&snapshot).expect("snapshot serializes");
+        assert!(!json.contains("peer-sensitive-id"));
+        assert!(!json.contains("10.20.0.2"));
+    }
+
+    #[test]
+    fn path_observability_tests_direct_to_relay_to_direct_timeline() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        use super::super::path_state_machine::RelayConnectionIncarnation;
+        use crate::peer::RelayConnectionIdentity;
+
+        let mut connection = PeerConnection::new("peer-a", "10.20.0.2");
+        let epoch = epoch();
+        connection.commit_path_transition(PathEvent::PeerOnline { epoch }, |_| {});
+        let relay = RelayConnectionIdentity {
+            epoch,
+            endpoint: "relay.test:443".to_string(),
+            incarnation: RelayConnectionIncarnation::Known(9),
+        };
+        connection.commit_path_transition(
+            PathEvent::RelayPeerConfirmed {
+                relay: relay.clone(),
+            },
+            |_| {},
+        );
+
+        let endpoint = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40001);
+        connection.commit_path_transition(
+            PathEvent::DirectValidationStarted {
+                validation: DirectValidationIdentity::owned(epoch, 1, Some(7), Some(endpoint)),
+            },
+            |_| {},
+        );
+        connection.commit_path_transition(
+            PathEvent::DirectCommitted {
+                validation: DirectValidationIdentity::authenticated_ack(
+                    epoch,
+                    1,
+                    7,
+                    Some(endpoint),
+                    endpoint,
+                ),
+            },
+            |_| {},
+        );
+        connection.commit_path_transition(PathEvent::DirectPathFailed { epoch }, |_| {});
+        connection.commit_path_transition(
+            PathEvent::DirectValidationStarted {
+                validation: DirectValidationIdentity::owned(epoch, 2, Some(8), Some(endpoint)),
+            },
+            |_| {},
+        );
+        connection.commit_path_transition(
+            PathEvent::DirectCommitted {
+                validation: DirectValidationIdentity::authenticated_ack(
+                    epoch,
+                    2,
+                    8,
+                    Some(endpoint),
+                    endpoint,
+                ),
+            },
+            |_| {},
+        );
+
+        let snapshot = connection.path_observability.snapshot(&connection);
+        assert!(snapshot.metrics.path_changes >= 3);
+        assert_eq!(snapshot.metrics.direct_successes, 2);
+        assert!(snapshot
+            .transitions
+            .iter()
+            .any(|event| event.previous_path == Some(NetworkPath::Direct)
+                && event.current_path == Some(NetworkPath::Relay)));
+        assert!(snapshot
+            .transitions
+            .iter()
+            .any(|event| event.previous_path == Some(NetworkPath::Relay)
+                && event.current_path == Some(NetworkPath::Direct)));
+    }
+
+    #[test]
+    fn rejected_and_duplicate_events_are_observable_without_side_effect_labels() {
+        let mut connection = PeerConnection::new("peer-a", "10.20.0.2");
+        let epoch = epoch();
+        connection.commit_path_transition(PathEvent::PeerOnline { epoch }, |_| {});
+        connection.commit_path_transition(PathEvent::PeerOnline { epoch }, |_| {});
+        connection.commit_path_transition(
+            PathEvent::DirectProbeStarted {
+                epoch: PathEpoch::new(6, PeerSessionGeneration::for_test(3), 11),
+                attempt: DirectAttemptNumber(1),
+            },
+            |_| {},
+        );
+        let snapshot = connection.path_observability.snapshot(&connection);
+        assert!(snapshot.metrics.duplicate_events >= 1);
+        assert!(snapshot.metrics.rejected_transitions >= 1);
+        assert!(PATH_OBSERVABILITY_METRIC_NAMES
+            .iter()
+            .all(|name| !name.contains("peer") && !name.contains("endpoint")));
+    }
+}

--- a/client/daemon/tests/contract_fixture.rs
+++ b/client/daemon/tests/contract_fixture.rs
@@ -39,6 +39,15 @@ fn status_fixture_deserializes_into_daemon_snapshot() {
     assert_eq!(snapshot.node_id, "node-a");
     assert_eq!(snapshot.network_id, "net1");
     assert_eq!(snapshot.virtual_ip, "10.20.0.7");
+    assert_eq!(snapshot.stats.path_observability.active_sockets, 1);
+    assert_eq!(
+        snapshot
+            .stats
+            .path_observability
+            .direct_time_to_connect_ms
+            .bounds_ms,
+        vec![50, 100, 250, 500, 1_000, 3_000, 10_000, 30_000]
+    );
     // Contract fields introduced for the Flutter unification.
     assert!(snapshot.revision > 0);
     assert!(

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -111,7 +111,57 @@
     "total_bytes_received": 0,
     "outbound_drops": {},
     "outbound_send_failures": {},
-    "outbound_loss_events": []
+    "outbound_loss_events": [],
+    "path_observability": {
+      "accepted_transitions": 0,
+      "accepted_observations": 0,
+      "duplicate_events": 0,
+      "rejected_transitions": 0,
+      "path_changes": 0,
+      "direct_attempts": 0,
+      "direct_retries": 0,
+      "direct_validations": 0,
+      "direct_successes": 0,
+      "direct_failures": 0,
+      "validation_failures": 0,
+      "relay_confirmations": 0,
+      "relay_fallbacks": 0,
+      "relay_failures": 0,
+      "candidate_refreshes": 0,
+      "control_reconnects": 0,
+      "network_generation_changes": 0,
+      "lifecycle_resets": 0,
+      "dplpmtud_changes": 0,
+      "active_tasks": 0,
+      "active_sockets": 1,
+      "dropped_transition_events": 0,
+      "direct_time_to_connect_ms": {
+        "bounds_ms": [
+          50,
+          100,
+          250,
+          500,
+          1000,
+          3000,
+          10000,
+          30000
+        ],
+        "buckets": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "count": 0,
+        "sum_ms": 0,
+        "max_ms": null
+      }
+    }
   },
   "health": {
     "status": "healthy",

--- a/docs/path-observability.md
+++ b/docs/path-observability.md
@@ -1,0 +1,137 @@
+# Path observability contract
+
+`Path Observability` is the bounded diagnostic contract for Direct/Relay path
+selection. It observes the generation-aware Path State Machine; it does not
+make path decisions, alter health, enqueue network work, or block the data
+plane.
+
+## Ownership and non-blocking rule
+
+The authoritative recorder is called only from
+`PeerConnection::commit_path_transition`, after the pure reducer commits and
+before compatibility side effects are published. The recorder:
+
+- uses only fields already protected by the current `PeerConnection` writer;
+- performs no `await`, socket operation, file operation or metric export;
+- allocates no dynamic metric labels;
+- retains at most 32 transition records per peer;
+- reports evictions in `dropped_transition_events`;
+- preserves rejected and duplicate transitions as typed evidence.
+
+The `/status` serializer reads this already-committed state. Telemetry cannot
+write path state and cannot become a lock owner in the Direct/Relay dataplane.
+
+## Wire schema
+
+The additive object `peers[].path_observability` has
+`schema_version = 1`. Older clients can ignore it. The Flutter parser treats a
+missing object as schema version `0`, so an older daemon remains readable.
+
+A snapshot includes:
+
+- the exact network generation, peer-session generation and remote-candidate
+  epoch;
+- lifecycle, current and previous active path, transition reason and path age;
+- typed Direct, Relay and recovery states;
+- Direct and Relay health snapshots;
+- the latest handshake and Direct-validation timing summary;
+- bounded candidate/punch counts without endpoint labels;
+- the selected Direct overlay budget and UDP datagram size, or the conservative
+  Relay MTU of 1380;
+- a bounded typed transition ring;
+- fixed-field counters and one fixed-bucket Direct time-to-connect histogram.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "network_epoch": {
+    "network_generation": 7,
+    "peer_session_generation": 3,
+    "remote_candidate_epoch": 11
+  },
+  "lifecycle": "online",
+  "current_path": "direct",
+  "previous_path": "relay",
+  "transition_reason": "direct_committed",
+  "path_age_ms": 42,
+  "path_state_revision": 19,
+  "direct_state": "committed",
+  "relay_state": "usable",
+  "recovery_state": "stable",
+  "selected_path_mtu": 1360,
+  "selected_udp_datagram_size": 1392
+}
+```
+
+## Metric table
+
+Metrics are serialized under `stats.path_observability` and mirrored inside
+each peer snapshot. They are JSON fields, not Prometheus-style dynamic label
+sets. Consequently peer IDs, endpoints, IP addresses, session IDs and arbitrary
+error text cannot increase cardinality.
+
+| Field | Type | Meaning |
+|---|---:|---|
+| `accepted_transitions` | counter | State-changing reducer commits. |
+| `accepted_observations` | counter | Typed observations that execute once without changing the state enum. |
+| `duplicate_events` | counter | Exact idempotent event replays. |
+| `rejected_transitions` | counter | Stale/illegal/revision-fenced events. |
+| `path_changes` | counter | Authoritative active-path changes. |
+| `direct_attempts` | counter | New Direct probe attempts. |
+| `direct_retries` | counter | Typed Direct retry schedules. |
+| `direct_validations` | counter | Encrypted Direct validations started. |
+| `direct_successes` | counter | Direct commit events. |
+| `direct_failures` | counter | Direct probe/path/cancellation failures. |
+| `validation_failures` | counter | Direct validation lifecycle failures. |
+| `relay_confirmations` | counter | Encrypted Relay peer confirmations. |
+| `relay_fallbacks` | counter | Active-path transitions to Relay. |
+| `relay_failures` | counter | Relay transport/path failure events. |
+| `candidate_refreshes` | counter | Remote candidate epoch advances. |
+| `control_reconnects` | counter | Control registrations after the initial registration; held outside the bounded event ring so timeline eviction cannot erase reconnect evidence. |
+| `network_generation_changes` | counter | Local network generation advances. |
+| `lifecycle_resets` | counter | Peer-left or identity reset events. |
+| `dplpmtud_changes` | gauge/counter snapshot | Current bounded DPLPMTUD revision for the exact path. |
+| `active_tasks` | gauge | Running supervised daemon tasks. |
+| `active_sockets` | gauge | Live Direct UDP socket publications. |
+| `dropped_transition_events` | counter | Oldest transition-ring entries evicted at the 32-entry bound. |
+| `direct_time_to_connect_ms` | histogram | Attempt-to-Direct-commit latency. |
+
+The histogram bounds are fixed at
+`50, 100, 250, 500, 1000, 3000, 10000, 30000` milliseconds and have one final
+overflow bucket. Bucket boundaries cannot be supplied by peers or runtime
+errors.
+
+## Transition reason codes
+
+Reason codes are a closed set derived from typed `PathEvent` variants, such as
+`direct_probe_started`, `direct_committed`, `relay_peer_confirmed`,
+`network_generation_advanced` and `remote_candidate_epoch_advanced`. Reducer
+decisions are also closed labels (`applied`, `duplicate`,
+`rejected_network_generation`, and so on). Arbitrary error strings remain in
+ordinary human diagnostics and never become metric dimensions.
+
+## Operator output
+
+`p2wlan doctor` prints a compact aggregate including transition count, path
+changes, Direct successes/attempts, Relay fallbacks, rejections, active tasks,
+active sockets and Direct-connect sample count. Full per-peer timelines remain
+available through authenticated `/status` and support logs.
+
+## Test mapping
+
+- `path_observability_metrics_are_bounded`: transition-ring and histogram
+  bounds, plus absence of peer/endpoint data in the serialized object.
+- `path_observability_tests_direct_to_relay_to_direct_timeline`: typed recovery
+  history.
+- `rejected_and_duplicate_events_are_observable_without_side_effect_labels`:
+  stale/duplicate visibility and fixed metric names.
+- `connection_timeline::tests::control_reconnect_counter_survives_timeline_eviction`:
+  reconnect count remains correct after the bounded process timeline evicts the
+  initial registration.
+- Rust and Flutter shared contract fixtures: additive schema compatibility.
+- `scripts/path-observability-evidence.py`: repository policy, metric table,
+  forbidden-label and workflow-name verification.
+
+The stable aggregate check is named exactly `Path Observability Required`.

--- a/scripts/path-observability-evidence.py
+++ b/scripts/path-observability-evidence.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate the bounded path-observability contract and emit CI evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "client/daemon/src/peer/path_observability.rs"
+DOC = ROOT / "docs/path-observability.md"
+WORKFLOW = ROOT / ".github/workflows/path-observability-required.yml"
+FIXTURE = ROOT / "contracts/fixtures/status.json"
+EXPECTED_METRICS = [
+    "accepted_transitions",
+    "accepted_observations",
+    "duplicate_events",
+    "rejected_transitions",
+    "path_changes",
+    "direct_attempts",
+    "direct_retries",
+    "direct_validations",
+    "direct_successes",
+    "direct_failures",
+    "validation_failures",
+    "relay_confirmations",
+    "relay_fallbacks",
+    "relay_failures",
+    "candidate_refreshes",
+    "control_reconnects",
+    "network_generation_changes",
+    "lifecycle_resets",
+    "dplpmtud_changes",
+    "active_tasks",
+    "active_sockets",
+    "dropped_transition_events",
+    "direct_time_to_connect_ms",
+]
+FORBIDDEN_LABELS = ["peer_id", "endpoint", "ip", "session_id", "error_text"]
+EXPECTED_BOUNDS = [50, 100, 250, 500, 1000, 3000, 10000, 30000]
+
+
+def main() -> int:
+    source = SOURCE.read_text(encoding="utf-8")
+    documentation = DOC.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    metrics = fixture["stats"]["path_observability"]
+
+    errors: list[str] = []
+    if "PATH_TRANSITION_EVENT_LIMIT: usize = 32" not in source:
+        errors.append("transition ring is not fixed at 32")
+    if "Path Observability Required" not in workflow:
+        errors.append("stable aggregate check name is missing")
+    if "schema_version" not in source or "PATH_OBSERVABILITY_SCHEMA_VERSION" not in source:
+        errors.append("versioned path observability schema is missing")
+    if "commit_path_transition" not in documentation:
+        errors.append("single transition owner is not documented")
+    if "control_reconnect_counter_survives_timeline_eviction" not in documentation:
+        errors.append("timeline-eviction reconnect regression is not documented")
+
+    for metric in EXPECTED_METRICS:
+        if metric not in source:
+            errors.append(f"metric missing from source: {metric}")
+        if metric not in documentation:
+            errors.append(f"metric missing from documentation: {metric}")
+        if metric not in metrics:
+            errors.append(f"metric missing from status fixture: {metric}")
+
+    histogram = metrics.get("direct_time_to_connect_ms", {})
+    if histogram.get("bounds_ms") != EXPECTED_BOUNDS:
+        errors.append("fixture histogram bounds changed")
+    if len(histogram.get("buckets", [])) != len(EXPECTED_BOUNDS) + 1:
+        errors.append("histogram bucket count is not bounds+1")
+
+    # The metric struct must stay a fixed field set. Maps may exist elsewhere
+    # in the module, but not inside PathObservabilityMetrics.
+    match = re.search(
+        r"pub struct PathObservabilityMetrics \{(?P<body>.*?)\n\}",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        errors.append("PathObservabilityMetrics struct not found")
+    else:
+        body = match.group("body")
+        if "HashMap" in body or "BTreeMap" in body:
+            errors.append("dynamic metric-label map found")
+        for label in FORBIDDEN_LABELS:
+            if re.search(rf"pub\s+{re.escape(label)}\s*:", body):
+                errors.append(f"forbidden metric label field found: {label}")
+
+    evidence = {
+        "schema_version": 1,
+        "result": "pass" if not errors else "fail",
+        "transition_event_limit": 32,
+        "histogram_bounds_ms": EXPECTED_BOUNDS,
+        "metric_count": len(EXPECTED_METRICS),
+        "forbidden_labels": FORBIDDEN_LABELS,
+        "errors": errors,
+    }
+    destination = Path(
+        os.environ.get(
+            "P2WLAN_PATH_OBSERVABILITY_EVIDENCE",
+            ROOT / "path-observability-evidence.json",
+        )
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(evidence, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #27

## Summary

- Add bounded path observability counters and transition history at the typed path state-machine commit point.
- Expose additive, versioned status fields for Rust diagnostics and the Flutter client.
- Include redacted status snapshots in current-session support bundles.
- Add bounded-cardinality, transition, timeline-eviction, contract, and redaction regression coverage.
- Add a stable Linux/Windows/Flutter+Go `Path Observability Required` CI gate.

## Clean reconstruction

- Base `main`: `2c9ebe8bc85bf8b4556fd2365c075fa2341a91db`
- Exact source head: `4a44a75406cfebdd6b75af1902454531b01e8eea`
- This ready-for-review branch points to the exact same commit already validated in clean Draft PR #46.
- A replacement PR was necessary only because the connected GitHub GraphQL action could not transition #46 out of Draft; no source file or commit changed.
- Replaces PR #45's chunk/materialization approach.
- Contains no chunk payloads, compressed patches, or temporary materialization workflows.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Rust path observability and control-reconnect timeline tests
- Rust contract fixture tests
- Flutter 3.47.2 `flutter analyze`
- Flutter contract and support-bundle tests
- Full Flutter test suite: 517 passed, 8 existing skipped
- Exact-head PR #46 validation: 10 workflows successful; 54 checks total, 52 successful and 2 conditional skips

## Safety

- Support bundle secrets use the canonical `<redacted>` marker.
- Raw authorization, access/refresh token, password, secret, and API-key values are asserted absent, including nested JSON values.
- Redacted JSON is parsed again in regression coverage.
- Merge must use expected head `4a44a75406cfebdd6b75af1902454531b01e8eea`.