### PR TITLE
chore: remove accidental repository probe

### DIFF
--- a/.tmp/SHOULD_NOT_WRITE.txt
+++ b/.tmp/SHOULD_NOT_WRITE.txt
@@ -1,1 +1,0 @@
-do not write


### PR DESCRIPTION
## Summary

- Delete the accidental connector-validation probe `.tmp/SHOULD_NOT_WRITE.txt`.
- Preserve Git history; this is a normal cleanup commit.
- No project code, workflow, dependency, documentation, tag, release, publication, or repository-setting change.

## Identity and validation

- Base SHA: `bcfa18ae6e6f5fb11246ab43b9615e5ab7971eaa`
- Source head SHA: `6ce8ec740c2b55065dca572f4c1848eef420ed92`
- Changed files: exactly one deletion, `.tmp/SHOULD_NOT_WRITE.txt`
- Exact-head CI: run `33629431627`, completed successfully

## Relationship to PR #50

This PR points to the same branch and exact same source commit as validated Draft PR #50. PR #50 was closed without merge only because the GitHub Connector's Draft → Ready mutation failed on a GraphQL schema compatibility error.