### PR TITLE
feat:完善 Windows 生命周期验收

### DIFF
--- a/.github/workflows/windows-lifecycle.yml
+++ b/.github/workflows/windows-lifecycle.yml
@@ -8,9 +8,12 @@ on:
       - ".github/workflows/path-state-machine-required.yml"
       - ".github/workflows/windows-lifecycle.yml"
       - "client/daemon/**"
+      - "client/cli/**"
       - "client/tray/**"
       - "client/desktop-host/**"
       - "apps/flutter_client/**"
+      - "scripts/release/**"
+      - "scripts/windows_lifecycle/**"
       - "Cargo.toml"
       - "Cargo.lock"
   push:
@@ -19,9 +22,12 @@ on:
       - ".fvmrc"
       - ".github/workflows/windows-lifecycle.yml"
       - "client/daemon/**"
+      - "client/cli/**"
       - "client/tray/**"
       - "client/desktop-host/**"
       - "apps/flutter_client/**"
+      - "scripts/release/**"
+      - "scripts/windows_lifecycle/**"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
@@ -37,7 +43,7 @@ jobs:
   lifecycle:
     name: Windows Lifecycle Required
     runs-on: windows-latest
-    timeout-minutes: 35
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
@@ -51,6 +57,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
+          toolchain: stable
           components: rustfmt
 
       - name: Set up Flutter
@@ -59,6 +66,10 @@ jobs:
           channel: stable
           flutter-version-file: .fvmrc
           cache: true
+
+      - name: Enable Windows desktop
+        working-directory: apps/flutter_client
+        run: flutter config --enable-windows-desktop
 
       - name: Flutter dependencies
         working-directory: apps/flutter_client
@@ -71,12 +82,27 @@ jobs:
       - name: Formatting gates
         shell: bash
         run: |
-          cargo fmt --all --check
+          cargo fmt --all -- --check
           cd apps/flutter_client
-          dart format --output=none --set-exit-if-changed test/windows_daemon_lifecycle_integration_test.dart
+          dart format --output=none --set-exit-if-changed \
+            lib/app/desktop_tray_controller.dart \
+            lib/app/p2wlan_app.dart \
+            lib/core/daemon/daemon_controller.dart \
+            test/windows_daemon_lifecycle_integration_test.dart \
+            test/windows_production_lifecycle_integration_test.dart
 
-      - name: Build release daemon
-        run: cargo build -p p2wlan-daemon --release
+      - name: Validate lifecycle evidence aggregator
+        run: python -m unittest discover -s scripts/windows_lifecycle -p "test_*.py"
+
+      - name: Build release daemon and CLI
+        shell: bash
+        run: |
+          cargo build -p p2wlan-daemon --release
+          cargo build -p p2wlan-cli --release
+
+      - name: Bundle Wintun for the production harness
+        shell: pwsh
+        run: .\apps\flutter_client\scripts\fetch_wintun.ps1 -DestinationDirectory "${{ github.workspace }}\target\release" -Architecture amd64
 
       - name: Run Rust lifecycle regression
         env:
@@ -89,14 +115,58 @@ jobs:
           P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
         run: flutter test test/windows_daemon_lifecycle_integration_test.dart
 
+      - name: Build Flutter Windows release bundle
+        working-directory: apps/flutter_client
+        shell: bash
+        run: bash ../../scripts/release/build_flutter_client.sh windows --release
+
+      - name: Restore Flutter-managed source files after build
+        shell: bash
+        run: bash scripts/release/hermetic_build.sh restore
+
+      - name: Bundle daemon, Wintun, and MSVC runtime into Flutter release
+        shell: pwsh
+        run: |
+          $release = "${{ github.workspace }}\apps\flutter_client\build\windows\x64\runner\Release"
+          Copy-Item "${{ github.workspace }}\target\release\p2wlan-daemon.exe" "$release\p2wlan-daemon.exe" -Force
+          .\apps\flutter_client\scripts\fetch_wintun.ps1 -DestinationDirectory $release -Architecture amd64
+          .\apps\flutter_client\scripts\bundle_msvc_runtime.ps1 -DestinationDirectory $release
+
+      - name: Flutter analyze gate
+        working-directory: apps/flutter_client
+        shell: bash
+        run: flutter analyze
+
+      - name: Run Flutter UI stop lifecycle evidence
+        working-directory: apps/flutter_client
+        env:
+          P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
+          P2WLAN_WINDOWS_LIFECYCLE_EVIDENCE: ${{ github.workspace }}/flutter-ui-lifecycle-evidence.json
+          P2WLAN_WINDOWS_LIFECYCLE_UI_CYCLES: 8
+        run: flutter test test/windows_production_lifecycle_integration_test.dart
+
+      - name: Run production Windows lifecycle acceptance harness
+        if: always()
+        shell: pwsh
+        run: |
+          .\scripts\windows_lifecycle\windows_lifecycle_acceptance.ps1 `
+            -DaemonPath "${{ github.workspace }}\target\release\p2wlan-daemon.exe" `
+            -CliPath "${{ github.workspace }}\target\release\p2wlan.exe" `
+            -FlutterReleasePath "${{ github.workspace }}\apps\flutter_client\build\windows\x64\runner\Release\p2wlan_flutter_client.exe" `
+            -FlutterEvidencePath "${{ github.workspace }}\flutter-ui-lifecycle-evidence.json" `
+            -EvidencePath "${{ github.workspace }}\windows-lifecycle-evidence.json" `
+            -ProductionCycles 50 `
+            -AttemptRealWintun
+
       - name: Assert no daemon process leaked
         if: always()
         shell: pwsh
         run: |
-          $leaked = @(Get-Process -Name 'p2wlan-daemon' -ErrorAction SilentlyContinue)
+          $leaked = @(Get-CimInstance Win32_Process -Filter "Name = 'p2wlan-daemon.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -notmatch '(?i)(^|\s)--build-info(\s|$)' })
           if ($leaked.Count -gt 0) {
-            $leaked | Format-Table Id, ProcessName, StartTime -AutoSize
-            Stop-Process -Id ($leaked | Select-Object -ExpandProperty Id) -Force -ErrorAction SilentlyContinue
+            $leaked | Select-Object ProcessId, CommandLine | Format-List
+            Stop-Process -Id ($leaked | Select-Object -ExpandProperty ProcessId) -Force -ErrorAction SilentlyContinue
             throw "p2wlan-daemon process leaked after lifecycle tests"
           }
           Write-Host 'No p2wlan-daemon process leaked.'
@@ -113,17 +183,60 @@ jobs:
             } |
             Select-Object TimeCreated, Id, ProviderName, LevelDisplayName, Message)
           $events | ConvertTo-Json -Depth 4 | Set-Content -Path windows-lifecycle-events.json -Encoding utf8
+          if (Test-Path -LiteralPath windows-lifecycle-evidence.json) {
+            $evidence = Get-Content -LiteralPath windows-lifecycle-evidence.json -Raw | ConvertFrom-Json
+            if ($null -eq $evidence.wer) {
+              $evidence | Add-Member -NotePropertyName wer -NotePropertyValue ([pscustomobject]@{})
+            }
+            $evidence.wer.event_ids_checked = @(1000, 1001)
+            $evidence.wer.events = @($events)
+            $capabilities = @($evidence.capabilities | Where-Object { $_.name -ne 'wer_scan' })
+            $capabilities += [pscustomobject]@{
+              name = 'wer_scan'
+              status = if ($events.Count -eq 0) { 'verified' } else { 'failed' }
+              detail = if ($events.Count -eq 0) { 'Application WER event IDs 1000/1001 were empty for the acceptance window' } else { "found $($events.Count) matching WER/BEX event(s)" }
+            }
+            $evidence.capabilities = $capabilities
+            $evidence | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath windows-lifecycle-evidence.json -Encoding utf8
+          } else {
+            # Preserve a rejected artifact when an earlier build/test failed
+            # before the harness could emit its document. This is failure
+            # evidence, never a synthetic pass.
+            $rejected = [ordered]@{
+              schema_version = 1
+              head_sha = $env:GITHUB_SHA
+              runner_os = 'windows-latest'
+              capabilities = @(
+                [ordered]@{ name = 'production_start_stop'; status = 'failed'; detail = 'acceptance harness did not produce evidence' },
+                [ordered]@{ name = 'wer_scan'; status = if ($events.Count -eq 0) { 'verified' } else { 'failed' }; detail = 'harness evidence was missing' }
+              )
+              cycles = @()
+              service_controls = @()
+              flutter_tray = [ordered]@{ process_exited = $false; exit_code = $null; daemon_processes_clean = $false; forced_termination = $false }
+              wer = [ordered]@{ event_ids_checked = @(1000, 1001); events = @($events) }
+            }
+            $rejected | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath windows-lifecycle-evidence.json -Encoding utf8
+          }
           if ($events.Count -gt 0) {
             $events | Format-List
             throw "Windows recorded a P2WLAN crash/BEX event during lifecycle tests"
           }
           Write-Host 'No P2WLAN crash or BEX event was recorded.'
 
+      - name: Aggregate Windows lifecycle evidence
+        if: always()
+        shell: pwsh
+        run: python scripts/windows_lifecycle/aggregate_evidence.py --input windows-lifecycle-evidence.json --output windows-lifecycle-aggregate.json
+
       - name: Upload lifecycle evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: windows-lifecycle-evidence
-          path: windows-lifecycle-events.json
+          path: |
+            windows-lifecycle-evidence.json
+            windows-lifecycle-aggregate.json
+            flutter-ui-lifecycle-evidence.json
+            windows-lifecycle-events.json
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/windows-lifecycle.yml
+++ b/.github/workflows/windows-lifecycle.yml
@@ -31,6 +31,11 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
+    inputs:
+      validation_sha:
+        description: Exact source commit SHA to validate
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -39,6 +44,10 @@ concurrency:
   group: windows-lifecycle-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  P2WLAN_EXACT_HEAD: ${{ github.event.pull_request.head.sha || inputs.validation_sha || github.sha }}
+  P2WLAN_WORKFLOW_SHA: ${{ github.sha }}
+
 jobs:
   lifecycle:
     name: Windows Lifecycle Required
@@ -46,6 +55,18 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+
+      - name: Verify exact source checkout identity
+        shell: bash
+        run: |
+          [[ "$P2WLAN_EXACT_HEAD" =~ ^[0-9a-fA-F]{40}$ ]]
+          actual_head_sha="$(git rev-parse HEAD)"
+          test "$actual_head_sha" = "$P2WLAN_EXACT_HEAD"
+          echo "source_head_sha=$actual_head_sha"
+          echo "workflow_sha=$P2WLAN_WORKFLOW_SHA"
 
       - name: Capture Windows Error Reporting baseline
         shell: pwsh
@@ -53,6 +74,23 @@ jobs:
           $baseline = [DateTime]::UtcNow.ToString('o')
           "P2WLAN_WER_BASELINE=$baseline" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "WER baseline: $baseline"
+
+      - name: Configure WER LocalDumps for tray regression
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'p2wlan-tray-dumps'
+          $traceDir = Join-Path $env:RUNNER_TEMP 'p2wlan-tray-traces'
+          $diagnosticDir = Join-Path $env:RUNNER_TEMP 'p2wlan-tray-diagnostics'
+          New-Item -ItemType Directory -Path $dumpDir, $traceDir, $diagnosticDir -Force | Out-Null
+          "P2WLAN_TRAY_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "P2WLAN_TRAY_TRACE_DIR=$traceDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "P2WLAN_TRAY_DIAGNOSTICS_DIR=$diagnosticDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $localDumps = 'HKCU:\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\p2wlan_flutter_client.exe'
+          New-Item -Path $localDumps -Force | Out-Null
+          New-ItemProperty -Path $localDumps -Name DumpFolder -PropertyType ExpandString -Value $dumpDir -Force | Out-Null
+          New-ItemProperty -Path $localDumps -Name DumpType -PropertyType DWord -Value 2 -Force | Out-Null
+          New-ItemProperty -Path $localDumps -Name DumpCount -PropertyType DWord -Value 5 -Force | Out-Null
+          Write-Host "WER LocalDumps configured: $dumpDir"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
@@ -109,6 +147,22 @@ jobs:
           P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
         run: cargo test -p p2wlan-daemon --test windows_lifecycle --release -- --test-threads=1
 
+      - name: Capture production Windows lifecycle handler mapping
+        if: always()
+        shell: pwsh
+        env:
+          P2WLAN_DAEMON_BIN: ${{ github.workspace }}/target/release/p2wlan-daemon.exe
+        run: |
+          $outputPath = Join-Path $env:GITHUB_WORKSPACE 'windows-handler-mapping.json'
+          if (-not (Test-Path -LiteralPath $env:P2WLAN_DAEMON_BIN)) {
+            throw "daemon binary not found: $env:P2WLAN_DAEMON_BIN"
+          }
+          $probeOutput = @(& $env:P2WLAN_DAEMON_BIN --windows-lifecycle-handler-probe 2>&1 | Out-String)
+          $exitCode = $LASTEXITCODE
+          $probeOutput -join '' | Set-Content -LiteralPath $outputPath -Encoding utf8
+          if ($exitCode -ne 0) { throw "Windows handler mapping probe exited with $exitCode" }
+          Write-Host "Handler mapping evidence written to $outputPath"
+
       - name: Run Flutter process lifecycle regression
         working-directory: apps/flutter_client
         env:
@@ -154,9 +208,137 @@ jobs:
             -CliPath "${{ github.workspace }}\target\release\p2wlan.exe" `
             -FlutterReleasePath "${{ github.workspace }}\apps\flutter_client\build\windows\x64\runner\Release\p2wlan_flutter_client.exe" `
             -FlutterEvidencePath "${{ github.workspace }}\flutter-ui-lifecycle-evidence.json" `
+            -HandlerMappingPath "${{ github.workspace }}\windows-handler-mapping.json" `
             -EvidencePath "${{ github.workspace }}\windows-lifecycle-evidence.json" `
             -ProductionCycles 50 `
+            -TrayCycles 20 `
             -AttemptRealWintun
+
+      - name: Collect Windows tray crash diagnostics
+        id: tray_diagnostics
+        if: always()
+        shell: pwsh
+        run: |
+          $diagnosticDir = $env:P2WLAN_TRAY_DIAGNOSTICS_DIR
+          $dumpDir = $env:P2WLAN_TRAY_DUMP_DIR
+          $traceDir = $env:P2WLAN_TRAY_TRACE_DIR
+          New-Item -ItemType Directory -Path $diagnosticDir -Force | Out-Null
+          Start-Sleep -Seconds 2
+
+          $dumpDestination = Join-Path $diagnosticDir 'dumps'
+          New-Item -ItemType Directory -Path $dumpDestination -Force | Out-Null
+          $dumpFiles = @(
+            Get-ChildItem -LiteralPath $dumpDir -Filter '*.dmp' -File -ErrorAction SilentlyContinue |
+              Sort-Object LastWriteTimeUtc
+          )
+          foreach ($dump in $dumpFiles) {
+            Copy-Item -LiteralPath $dump.FullName -Destination (Join-Path $dumpDestination $dump.Name) -Force
+          }
+
+          $traceDestination = Join-Path $diagnosticDir 'traces'
+          if (Test-Path -LiteralPath $traceDir) {
+            Copy-Item -LiteralPath $traceDir -Destination $traceDestination -Recurse -Force
+          } else {
+            New-Item -ItemType Directory -Path $traceDestination -Force | Out-Null
+          }
+
+          $releaseDir = Join-Path $env:GITHUB_WORKSPACE 'apps\flutter_client\build\windows\x64\runner\Release'
+          $symbolDestination = Join-Path $diagnosticDir 'release-symbols'
+          New-Item -ItemType Directory -Path $symbolDestination -Force | Out-Null
+          foreach ($fileName in @('p2wlan_flutter_client.exe', 'flutter_windows.dll')) {
+            $source = Join-Path $releaseDir $fileName
+            if (Test-Path -LiteralPath $source) { Copy-Item -LiteralPath $source -Destination $symbolDestination -Force }
+          }
+          if (Test-Path -LiteralPath $releaseDir) {
+            Get-ChildItem -LiteralPath $releaseDir -Filter '*.pdb' -File -ErrorAction SilentlyContinue |
+              Copy-Item -Destination $symbolDestination -Force
+          }
+
+          $pluginDestination = Join-Path $diagnosticDir 'tray-manager-source'
+          $pluginCandidates = @()
+          foreach ($cacheRoot in @(
+              (Join-Path $env:LOCALAPPDATA 'Pub\Cache\hosted\pub.dev'),
+              (Join-Path $env:USERPROFILE '.pub-cache\hosted\pub.dev')
+          )) {
+            if (Test-Path -LiteralPath $cacheRoot) {
+              $pluginCandidates += @(Get-ChildItem -LiteralPath $cacheRoot -Directory -Filter 'tray_manager-*' -ErrorAction SilentlyContinue)
+            }
+          }
+          $plugin = @($pluginCandidates | Sort-Object FullName -Descending | Select-Object -First 1)
+          if ($plugin.Count -eq 1) {
+            Copy-Item -LiteralPath $plugin[0].FullName -Destination $pluginDestination -Recurse -Force
+          } else {
+            'tray_manager source was not found in the existing runner pub cache; no network download was attempted.' |
+              Set-Content -LiteralPath (Join-Path $diagnosticDir 'tray-manager-source-not-found.txt') -Encoding utf8
+          }
+
+          $start = [DateTime]::Parse($env:P2WLAN_WER_BASELINE).ToLocalTime()
+          $events = @(Get-WinEvent -FilterHashtable @{ LogName = 'Application'; StartTime = $start } -ErrorAction SilentlyContinue |
+            Where-Object {
+              $_.Id -in @(1000, 1001) -and
+              (($_.Message + "`n" + $_.ToXml()) -match '(?i)p2wlan[-_](daemon|desktop|flutter_client).*\.exe|BEX64')
+            })
+          $xmlItems = foreach ($event in $events) { $event.ToXml() }
+          $xml = "<Events>`n$($xmlItems -join "`n")`n</Events>`n"
+          $xml | Set-Content -LiteralPath (Join-Path $diagnosticDir 'wer-events.xml') -Encoding utf8
+          $eventSummaries = foreach ($event in $events) {
+            $eventXml = [xml]$event.ToXml()
+            $data = [ordered]@{}
+            foreach ($item in @($eventXml.Event.EventData.Data)) {
+              if ($item.Name) { $data[[string]$item.Name] = [string]$item.'#text' }
+            }
+            [ordered]@{
+              time_created = $event.TimeCreated
+              id = $event.Id
+              provider_name = $event.ProviderName
+              message = $event.Message
+              faulting_module = $data['FaultingModuleName']
+              faulting_module_path = $data['FaultingModulePath']
+              fault_offset = $data['FaultingModuleOffset']
+              exception_code = $data['ExceptionCode']
+              faulting_process_id = $data['FaultingProcessId']
+              application_name = $data['FaultingApplicationName']
+              application_path = $data['FaultingApplicationPath']
+              report_id = $data['ReportId']
+              event_data = $data
+            }
+          }
+
+          $debuggerPath = $null
+          foreach ($candidate in @('cdb.exe', 'windbg.exe', 'windbgx.exe')) {
+            $command = Get-Command $candidate -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($command) { $debuggerPath = $command.Source; break }
+          }
+          $firstDump = @($dumpFiles | Select-Object -First 1)
+          if ($debuggerPath -and $firstDump.Count -eq 1) {
+            $stack = @(& $debuggerPath -z $firstDump[0].FullName -c '!analyze -v; .ecxr; .exr -1; kv; kPn; ~* kb; q' 2>&1 | Out-String)
+            $stack -join '' | Set-Content -LiteralPath (Join-Path $diagnosticDir 'native-stack.txt') -Encoding utf8
+          } else {
+            $reason = if (-not $debuggerPath) { 'No cdb.exe, windbg.exe, or windbgx.exe was already installed on the runner.' } else { 'No WER dump was available for native stack analysis.' }
+            $reason | Set-Content -LiteralPath (Join-Path $diagnosticDir 'native-stack-not-run.txt') -Encoding utf8
+          }
+
+          $dumpMetadata = foreach ($dump in $dumpFiles) {
+            $hash = Get-FileHash -LiteralPath $dump.FullName -Algorithm SHA256
+            [ordered]@{ name = $dump.Name; bytes = $dump.Length; sha256 = $hash.Hash; last_write_time_utc = $dump.LastWriteTimeUtc }
+          }
+          [ordered]@{
+            schema_version = 1
+            repository = 'yhan-sun/p2wlan'
+            source_head_sha = $env:P2WLAN_EXACT_HEAD
+            workflow_sha = $env:P2WLAN_WORKFLOW_SHA
+            runner_os = 'windows-latest'
+            event_count = $events.Count
+            events = @($eventSummaries)
+            dump_count = $dumpFiles.Count
+            dumps = @($dumpMetadata)
+            debugger = $debuggerPath
+            diagnostic_dir = $diagnosticDir
+          } | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath (Join-Path $diagnosticDir 'tray-crash-summary.json') -Encoding utf8
+          "diagnostic_dir=$diagnosticDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "dump_count=$($dumpFiles.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Tray diagnostic directory: $diagnosticDir"
+          Write-Host "Tray WER dumps captured: $($dumpFiles.Count)"
 
       - name: Assert no daemon process leaked
         if: always()
@@ -179,10 +361,12 @@ jobs:
           $events = @(Get-WinEvent -FilterHashtable @{ LogName = 'Application'; StartTime = $start } -ErrorAction SilentlyContinue |
             Where-Object {
               $_.Id -in @(1000, 1001) -and
-              ($_.Message -match '(?i)p2wlan-(daemon|desktop|flutter_client).*\.exe|(?i)BEX64')
+              (($_.Message + "`n" + $_.ToXml()) -match '(?i)p2wlan[-_](daemon|desktop|flutter_client).*\.exe|BEX64')
             } |
             Select-Object TimeCreated, Id, ProviderName, LevelDisplayName, Message)
           $events | ConvertTo-Json -Depth 4 | Set-Content -Path windows-lifecycle-events.json -Encoding utf8
+          $eventXml = foreach ($event in $events) { $event.ToXml() }
+          "<Events>`n$($eventXml -join "`n")`n</Events>`n" | Set-Content -Path windows-lifecycle-events.xml -Encoding utf8
           if (Test-Path -LiteralPath windows-lifecycle-evidence.json) {
             $evidence = Get-Content -LiteralPath windows-lifecycle-evidence.json -Raw | ConvertFrom-Json
             if ($null -eq $evidence.wer) {
@@ -203,16 +387,24 @@ jobs:
             # before the harness could emit its document. This is failure
             # evidence, never a synthetic pass.
             $rejected = [ordered]@{
-              schema_version = 1
-              head_sha = $env:GITHUB_SHA
+              schema_version = 2
+              repository = 'yhan-sun/p2wlan'
+              source_head_sha = $env:P2WLAN_EXACT_HEAD
+              workflow_sha = $env:P2WLAN_WORKFLOW_SHA
               runner_os = 'windows-latest'
+              components = @(
+                [ordered]@{ name = 'production_harness'; schema_version = 2; repository = 'yhan-sun/p2wlan'; source_head_sha = $env:P2WLAN_EXACT_HEAD; workflow_sha = $env:P2WLAN_WORKFLOW_SHA; runner_os = 'windows-latest'; status = 'failed'; detail = 'acceptance harness did not produce evidence' },
+                [ordered]@{ name = 'flutter_ui'; schema_version = 2; repository = 'yhan-sun/p2wlan'; source_head_sha = $env:P2WLAN_EXACT_HEAD; workflow_sha = $env:P2WLAN_WORKFLOW_SHA; runner_os = 'windows-latest'; status = 'failed'; detail = 'acceptance harness did not produce evidence' },
+                [ordered]@{ name = 'handler_mapping'; schema_version = 2; repository = 'yhan-sun/p2wlan'; source_head_sha = $env:P2WLAN_EXACT_HEAD; workflow_sha = $env:P2WLAN_WORKFLOW_SHA; runner_os = 'windows-latest'; status = 'failed'; detail = 'handler mapping probe did not produce evidence' }
+              )
+              handler_mapping = [ordered]@{ status = 'failed'; live_system_delivery = 'deferred'; live_system_delivery_detail = 'handler mapping probe did not produce evidence'; console = @(); service = @(); idempotent_first_request_wins = $false; no_duplicate_frees = $false; coordinator_entered = $false; callback_non_blocking = $false; callback_elapsed_ms = $null; bounded_deadline = $false; shutdown_deadline_ms = $null; force_kill = $false; coordinator = '' }
               capabilities = @(
                 [ordered]@{ name = 'production_start_stop'; status = 'failed'; detail = 'acceptance harness did not produce evidence' },
                 [ordered]@{ name = 'wer_scan'; status = if ($events.Count -eq 0) { 'verified' } else { 'failed' }; detail = 'harness evidence was missing' }
               )
               cycles = @()
               service_controls = @()
-              flutter_tray = [ordered]@{ process_exited = $false; exit_code = $null; daemon_processes_clean = $false; forced_termination = $false }
+              flutter_tray = [ordered]@{ attempted_cycles = 0; successful_cycles = 0; first_failure_cycle = 1; process_exited = $false; exit_code = $null; daemon_processes_clean = $false; forced_termination = $false; dump_paths = @(); cycles = @() }
               wer = [ordered]@{ event_ids_checked = @(1000, 1001); events = @($events) }
             }
             $rejected | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath windows-lifecycle-evidence.json -Encoding utf8
@@ -230,6 +422,7 @@ jobs:
 
       - name: Upload lifecycle evidence
         if: always()
+        id: upload_lifecycle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: windows-lifecycle-evidence
@@ -237,6 +430,23 @@ jobs:
             windows-lifecycle-evidence.json
             windows-lifecycle-aggregate.json
             flutter-ui-lifecycle-evidence.json
+            windows-handler-mapping.json
             windows-lifecycle-events.json
+            windows-lifecycle-events.xml
+            ${{ env.P2WLAN_TRAY_DIAGNOSTICS_DIR }}
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Report lifecycle artifact identity
+        if: always()
+        shell: pwsh
+        run: |
+          Write-Host "Windows lifecycle artifact id: ${{ steps.upload_lifecycle.outputs.artifact-id }}"
+          Write-Host "Windows lifecycle artifact digest: ${{ steps.upload_lifecycle.outputs.artifact-digest }}"
+          Write-Host "Windows lifecycle artifact URL: ${{ steps.upload_lifecycle.outputs.artifact-url }}"
+
+      - name: Remove temporary WER LocalDumps configuration
+        if: always()
+        shell: pwsh
+        run: |
+          Remove-Item -LiteralPath 'HKCU:\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\p2wlan_flutter_client.exe' -Recurse -Force -ErrorAction SilentlyContinue

--- a/apps/flutter_client/lib/app/desktop_tray_controller.dart
+++ b/apps/flutter_client/lib/app/desktop_tray_controller.dart
@@ -562,6 +562,12 @@ class DesktopTrayController with TrayListener, WindowListener {
     return _stopDaemonForQuit();
   }
 
+  /// Exercise the packaged tray quit path from the Windows release harness.
+  /// The harness starts the app without a virtual adapter; `_quitApp` must
+  /// still tear down the tray/window and exit without trying to force-kill a
+  /// nonexistent daemon.
+  Future<void> quitForLifecycleTest() => _quitApp();
+
   Future<void> _copyPeerIp(String virtualIp) async {
     final value = virtualIp.trim();
     if (value.isEmpty) return;

--- a/apps/flutter_client/lib/app/desktop_tray_controller.dart
+++ b/apps/flutter_client/lib/app/desktop_tray_controller.dart
@@ -54,6 +54,8 @@ class DesktopTrayController with TrayListener, WindowListener {
   String? _lastDesktopTitle;
   bool _macosDockBadgeCleared = false;
   Future<DaemonCommandResult>? _stopDaemonFuture;
+  Future<void>? _disposeFuture;
+  Future<void>? _quitFuture;
   Timer? _windowsLeftClickDedupeTimer;
   var _windowsLeftClickHandled = false;
 
@@ -85,8 +87,11 @@ class DesktopTrayController with TrayListener, WindowListener {
     }
   }
 
-  Future<void> dispose() async {
-    if (!_initialized) return;
+  Future<void> dispose() {
+    final existing = _disposeFuture;
+    if (existing != null) return existing;
+    if (!_initialized) return Future<void>.value();
+
     _initialized = false;
     _windowsLeftClickDedupeTimer?.cancel();
     _windowsLeftClickDedupeTimer = null;
@@ -97,9 +102,13 @@ class DesktopTrayController with TrayListener, WindowListener {
     windowManager.removeListener(this);
     trayManager.removeListener(this);
     final pendingUpdate = _menuUpdateInFlight;
-    if (pendingUpdate != null) {
-      await pendingUpdate;
-    }
+    final future = _finishDispose(pendingUpdate);
+    _disposeFuture = future;
+    return future;
+  }
+
+  Future<void> _finishDispose(Future<void>? pendingUpdate) async {
+    if (pendingUpdate != null) await pendingUpdate;
     try {
       await trayManager.destroy();
     } catch (_) {
@@ -586,33 +595,52 @@ class DesktopTrayController with TrayListener, WindowListener {
     }
   }
 
-  Future<void> _quitApp() async {
+  Future<void> _quitApp() {
+    final existing = _quitFuture;
+    if (existing != null) return existing;
+
+    final future = _performQuit();
+    _quitFuture = future;
+    future.then<void>(
+      (_) {
+        if (!_quitting && identical(_quitFuture, future)) {
+          _quitFuture = null;
+        }
+      },
+      onError: (Object _, StackTrace _) {
+        if (identical(_quitFuture, future)) _quitFuture = null;
+      },
+    );
+    return future;
+  }
+
+  Future<void> _performQuit() async {
     if (_quitting) return;
     _quitting = true;
-    final stopResult = await _stopDaemonForQuit();
-    if (!stopResult.ok) {
+    try {
+      final stopResult = await _stopDaemonForQuit();
+      if (!stopResult.ok) {
+        _quitting = false;
+        await _showWindow();
+        await _updateMenu();
+        return;
+      }
+      await _destroyTrayWindowAndExit();
+    } catch (_) {
       _quitting = false;
-      await _showWindow();
-      await _updateMenu();
-      return;
+      rethrow;
     }
-    await _destroyTrayWindowAndExit();
   }
 
   Future<void> _destroyTrayWindowAndExit() async {
-    try {
-      await trayManager.destroy();
-    } catch (_) {
-      // Ignore best effort tray teardown.
-    }
-    try {
-      await DesktopWindowOperations.run(() async {
-        await windowManager.setPreventClose(false);
-        await windowManager.destroy();
-      });
-    } finally {
-      Timer(const Duration(milliseconds: 400), () => exit(0));
-    }
+    // This also makes any Widget.dispose during engine shutdown return the
+    // same Future. The tray plugin must receive exactly one destroy call per
+    // controller lifetime.
+    await dispose();
+    await DesktopWindowOperations.run(() async {
+      await windowManager.setPreventClose(false);
+      await windowManager.destroy();
+    });
   }
 
   Directory _defaultLogDir() {

--- a/apps/flutter_client/lib/app/desktop_tray_controller.dart
+++ b/apps/flutter_client/lib/app/desktop_tray_controller.dart
@@ -677,12 +677,12 @@ class DesktopTrayController with TrayListener, WindowListener {
     // same Future. The tray plugin must receive exactly one destroy call per
     // controller lifetime.
     await dispose();
-    _trace('window.destroy.begin');
+    _trace('window.close.begin');
     await DesktopWindowOperations.run(() async {
       await windowManager.setPreventClose(false);
-      await windowManager.destroy();
+      await windowManager.close();
     });
-    _trace('window.destroy.end');
+    _trace('window.close.end');
   }
 
   void _trace(String event) => writeDesktopTrayLifecycleTrace(event);

--- a/apps/flutter_client/lib/app/desktop_tray_controller.dart
+++ b/apps/flutter_client/lib/app/desktop_tray_controller.dart
@@ -15,6 +15,20 @@ import 'app_constants.dart';
 import 'app_strings.dart';
 import 'desktop_window_operations.dart';
 
+void writeDesktopTrayLifecycleTrace(String event) {
+  final path = Platform.environment['P2WLAN_TRAY_TRACE_FILE']?.trim();
+  if (path == null || path.isEmpty) return;
+  try {
+    File(path).writeAsStringSync(
+      '${DateTime.now().toUtc().toIso8601String()} $event\n',
+      mode: FileMode.append,
+      flush: true,
+    );
+  } catch (_) {
+    // Diagnostics must never change the tray lifecycle being measured.
+  }
+}
+
 /// Windows tray events have used both `MouseDown` and `MouseUp` callback names
 /// across tray_manager builds (the native message is a button-up notification
 /// in the current plug-in). The controller accepts either left-click callback
@@ -65,24 +79,35 @@ class DesktopTrayController with TrayListener, WindowListener {
   }
 
   Future<void> initialize() async {
+    _trace('initialize.enter initialized=$_initialized supported=$isSupported');
     if (_initialized || !isSupported) return;
     _initialized = true;
     trayManager.addListener(this);
     windowManager.addListener(this);
     settingsStore.addListener(_scheduleMenuUpdate);
     statusStore.addListener(_scheduleMenuUpdate);
+    _trace('initialize.listeners-added');
 
     try {
+      _trace('window.setPreventClose.begin');
       await DesktopWindowOperations.run(
         () => windowManager.setPreventClose(true),
       );
+      _trace('window.setPreventClose.end');
       if (!_initialized) return;
       if (Platform.isMacOS || Platform.isLinux) {
+        _trace('tray.setTitle.begin');
         await trayManager.setTitle(trayMenuBarTitleForTesting());
+        _trace('tray.setTitle.end');
       }
+      _trace('tray.updateIcon.begin');
       await _updateTrayIcon(force: true);
+      _trace('tray.updateIcon.end');
+      _trace('tray.queueMenu.begin');
       await _queueMenuUpdate();
+      _trace('tray.queueMenu.end');
     } catch (error) {
+      _trace('initialize.error ${error.runtimeType}: $error');
       debugPrint('Failed to initialize P2WLAN tray: $error');
     }
   }
@@ -109,9 +134,12 @@ class DesktopTrayController with TrayListener, WindowListener {
 
   Future<void> _finishDispose(Future<void>? pendingUpdate) async {
     if (pendingUpdate != null) await pendingUpdate;
+    _trace('tray.destroy.begin');
     try {
       await trayManager.destroy();
+      _trace('tray.destroy.end');
     } catch (_) {
+      _trace('tray.destroy.error');
       // Best effort cleanup on app shutdown.
     }
   }
@@ -230,9 +258,12 @@ class DesktopTrayController with TrayListener, WindowListener {
     try {
       while (_initialized && _menuUpdateRequested) {
         _menuUpdateRequested = false;
+        _trace('tray.updateMenu.begin');
         try {
           await _updateMenu();
+          _trace('tray.updateMenu.end');
         } catch (error) {
+          _trace('tray.updateMenu.error ${error.runtimeType}: $error');
           debugPrint('Failed to update P2WLAN tray: $error');
         }
       }
@@ -250,15 +281,21 @@ class DesktopTrayController with TrayListener, WindowListener {
     final taskbarTitle = desktopVisibleTitleForTesting();
 
     await _updateTrayIcon();
+    _trace('tray.setToolTip.begin');
     await trayManager.setToolTip(
       Platform.isMacOS ? p2wlanAppName : '$taskbarTitle - $statusLabel',
     );
+    _trace('tray.setToolTip.end');
     if (Platform.isMacOS || Platform.isLinux) {
+      _trace('tray.setTitle.begin');
       await trayManager.setTitle(trayMenuBarTitleForTesting());
+      _trace('tray.setTitle.end');
     }
     await _updateDesktopWindowIndicators(taskbarTitle);
 
+    _trace('tray.setContextMenu.begin');
     await trayManager.setContextMenu(buildMenuForTesting());
+    _trace('tray.setContextMenu.end');
   }
 
   Future<void> _updateDesktopWindowIndicators(String title) async {
@@ -294,13 +331,16 @@ class DesktopTrayController with TrayListener, WindowListener {
     final asset = trayIconAssetForTesting();
     if (!force && _lastTrayIconAsset == asset) return;
     try {
+      _trace('tray.setIcon.begin asset=$asset');
       await trayManager.setIcon(
         asset,
         isTemplate: trayIconUsesTemplateForTesting(),
         iconSize: Platform.isMacOS ? _macosTrayIconSize : 18,
       );
       _lastTrayIconAsset = asset;
+      _trace('tray.setIcon.end');
     } catch (error) {
+      _trace('tray.setIcon.error ${error.runtimeType}: $error');
       debugPrint('Failed to update P2WLAN tray icon $asset: $error');
     }
   }
@@ -637,11 +677,15 @@ class DesktopTrayController with TrayListener, WindowListener {
     // same Future. The tray plugin must receive exactly one destroy call per
     // controller lifetime.
     await dispose();
+    _trace('window.destroy.begin');
     await DesktopWindowOperations.run(() async {
       await windowManager.setPreventClose(false);
       await windowManager.destroy();
     });
+    _trace('window.destroy.end');
   }
+
+  void _trace(String event) => writeDesktopTrayLifecycleTrace(event);
 
   Directory _defaultLogDir() {
     if (Platform.isMacOS) {

--- a/apps/flutter_client/lib/app/p2wlan_app.dart
+++ b/apps/flutter_client/lib/app/p2wlan_app.dart
@@ -97,7 +97,22 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
         settingsStore: _settingsStore,
         statusStore: _statusStore,
       );
-      unawaited(_desktopTrayController!.initialize());
+      final trayInitialization = _desktopTrayController!.initialize();
+      if (_isWindowsTrayNoAdapterExitTest) {
+        // This is used only by the Windows release acceptance harness. It
+        // enters through the same tray bootstrap and quit path as a real
+        // packaged desktop app, while the harness deliberately provides no
+        // virtual adapter or running daemon.
+        unawaited(
+          trayInitialization.then((_) {
+            final tray = _desktopTrayController;
+            if (tray == null) return;
+            return tray.quitForLifecycleTest();
+          }),
+        );
+      } else {
+        unawaited(trayInitialization);
+      }
     } else if (widget.enableDesktopTaskbarStatus &&
         DesktopWindowStatusController.isSupported) {
       _desktopWindowStatusController = DesktopWindowStatusController(
@@ -115,6 +130,12 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
     } else if (widget.initialRefresh && canPollLocalDaemon) {
       unawaited(_statusStore.refreshUntilPeerCatalogSettled(silent: true));
     }
+  }
+
+  bool get _isWindowsTrayNoAdapterExitTest {
+    return Platform.isWindows &&
+        Platform.environment['P2WLAN_WINDOWS_TRAY_LIFECYCLE_TEST']?.trim() ==
+            'no-adapter-exit';
   }
 
   Future<void> _logout() async {

--- a/apps/flutter_client/lib/app/p2wlan_app.dart
+++ b/apps/flutter_client/lib/app/p2wlan_app.dart
@@ -103,13 +103,14 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
         // enters through the same tray bootstrap and quit path as a real
         // packaged desktop app, while the harness deliberately provides no
         // virtual adapter or running daemon.
-        unawaited(
-          trayInitialization.then((_) async {
-            final tray = _desktopTrayController;
-            if (tray == null) return;
-            await tray.quitForLifecycleTest();
-          }),
-        );
+        await trayInitialization;
+        final tray = _desktopTrayController;
+        if (tray != null) {
+          await tray.quitForLifecycleTest();
+        }
+        // Do not start the normal daemon polling loop after the lifecycle
+        // probe has entered the real packaged tray quit path.
+        return;
       } else {
         unawaited(trayInitialization);
       }

--- a/apps/flutter_client/lib/app/p2wlan_app.dart
+++ b/apps/flutter_client/lib/app/p2wlan_app.dart
@@ -84,7 +84,9 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
   }
 
   Future<void> _bootstrap() async {
+    writeDesktopTrayLifecycleTrace('bootstrap.begin');
     await _settingsStore.load();
+    writeDesktopTrayLifecycleTrace('bootstrap.settings-loaded');
     final authToken = _settingsStore.settings.authToken.trim();
     _authenticated =
         _settingsStore.settings.manualMode ||
@@ -92,21 +94,28 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
     if (mounted) {
       setState(() => _ready = true);
     }
+    writeDesktopTrayLifecycleTrace('bootstrap.ready');
     if (widget.enableDesktopTray && DesktopTrayController.isSupported) {
+      writeDesktopTrayLifecycleTrace('bootstrap.tray-controller.begin');
       _desktopTrayController = DesktopTrayController(
         settingsStore: _settingsStore,
         statusStore: _statusStore,
       );
+      writeDesktopTrayLifecycleTrace('bootstrap.tray-controller.created');
       final trayInitialization = _desktopTrayController!.initialize();
+      writeDesktopTrayLifecycleTrace('bootstrap.tray-initialize.started');
       if (_isWindowsTrayNoAdapterExitTest) {
         // This is used only by the Windows release acceptance harness. It
         // enters through the same tray bootstrap and quit path as a real
         // packaged desktop app, while the harness deliberately provides no
         // virtual adapter or running daemon.
         await trayInitialization;
+        writeDesktopTrayLifecycleTrace('bootstrap.tray-initialize.completed');
         final tray = _desktopTrayController;
         if (tray != null) {
+          writeDesktopTrayLifecycleTrace('bootstrap.tray-quit.begin');
           await tray.quitForLifecycleTest();
+          writeDesktopTrayLifecycleTrace('bootstrap.tray-quit.end');
         }
         // Do not start the normal daemon polling loop after the lifecycle
         // probe has entered the real packaged tray quit path.

--- a/apps/flutter_client/lib/app/p2wlan_app.dart
+++ b/apps/flutter_client/lib/app/p2wlan_app.dart
@@ -104,10 +104,10 @@ class _P2WlanAppState extends State<P2WlanApp> with WidgetsBindingObserver {
         // packaged desktop app, while the harness deliberately provides no
         // virtual adapter or running daemon.
         unawaited(
-          trayInitialization.then((_) {
+          trayInitialization.then((_) async {
             final tray = _desktopTrayController;
             if (tray == null) return;
-            return tray.quitForLifecycleTest();
+            await tray.quitForLifecycleTest();
           }),
         );
       } else {

--- a/apps/flutter_client/lib/core/daemon/daemon_controller.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller.dart
@@ -122,8 +122,7 @@ class DaemonController {
         startupTrace,
         stage: 1,
         code: DaemonStartupFailureCode.daemonBinaryLoadFailed,
-        message:
-            'Could not find p2wlan-daemon. Build it with cargo or set P2WLAN_DAEMON_BIN.',
+        message: 'Could not find p2wlan-daemon. Build it with cargo or set P2WLAN_DAEMON_BIN.',
       );
     }
     await startupTrace?.stageOk(1, 'resolve_daemon');
@@ -619,8 +618,7 @@ class DaemonController {
         await _removePidMarker();
         return const DaemonCommandResult(
           ok: true,
-          message:
-              'p2wlan-daemon stopped after forced process termination fallback.',
+          message: 'p2wlan-daemon stopped after forced process termination fallback.',
           forcedTermination: true,
         );
       }
@@ -634,16 +632,14 @@ class DaemonController {
       if (forcefulTerminationUsed) {
         return const DaemonCommandResult(
           ok: true,
-          message:
-              'p2wlan-daemon stopped after forced process termination fallback.',
+          message: 'p2wlan-daemon stopped after forced process termination fallback.',
           forcedTermination: true,
         );
       }
       if (shutdownRequested) {
         return const DaemonCommandResult(
           ok: false,
-          message:
-              'p2wlan-daemon is no longer reachable, but graceful shutdown was not confirmed within the bounded window.',
+          message: 'p2wlan-daemon is no longer reachable, but graceful shutdown was not confirmed within the bounded window.',
         );
       }
       return const DaemonCommandResult(

--- a/apps/flutter_client/lib/core/daemon/daemon_controller.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller.dart
@@ -27,12 +27,25 @@ class DaemonCommandResult {
     required this.message,
     this.manualCommand,
     this.failureCode,
+    this.graceful = false,
+    this.forcedTermination = false,
   });
 
   final bool ok;
   final String message;
   final String? manualCommand;
   final DaemonStartupFailureCode? failureCode;
+
+  /// Whether the daemon acknowledged a graceful shutdown and exited within
+  /// the bounded drain window. A process killed by taskkill/SIGKILL is never
+  /// reported as graceful, even when it is no longer running afterwards.
+  final bool graceful;
+
+  /// True when the fallback termination path had to use forceful process
+  /// termination. This is retained in structured results for CI evidence and
+  /// is intentionally independent from [ok]: the UI may still be able to
+  /// leave the machine stopped while the lifecycle proof must fail closed.
+  final bool forcedTermination;
 }
 
 class DaemonController {
@@ -109,7 +122,8 @@ class DaemonController {
         startupTrace,
         stage: 1,
         code: DaemonStartupFailureCode.daemonBinaryLoadFailed,
-        message: 'Could not find p2wlan-daemon. Build it with cargo or set P2WLAN_DAEMON_BIN.',
+        message:
+            'Could not find p2wlan-daemon. Build it with cargo or set P2WLAN_DAEMON_BIN.',
       );
     }
     await startupTrace?.stageOk(1, 'resolve_daemon');
@@ -567,6 +581,7 @@ class DaemonController {
         return const DaemonCommandResult(
           ok: true,
           message: 'p2wlan-daemon stopped.',
+          graceful: true,
         );
       }
     }
@@ -586,10 +601,12 @@ class DaemonController {
       ],
     ];
     final attempted = <int>{};
+    var forcefulTerminationUsed = false;
     for (final pid in candidatePids.whereType<int>()) {
       if (!attempted.add(pid)) continue;
       if (!await _processLooksLikeDaemon(pid)) continue;
       if (!await _terminatePid(pid)) continue;
+      forcefulTerminationUsed = true;
       final processDown = await _waitForDaemonPidExit(
         pid,
         const Duration(seconds: 3),
@@ -602,7 +619,9 @@ class DaemonController {
         await _removePidMarker();
         return const DaemonCommandResult(
           ok: true,
-          message: 'p2wlan-daemon stopped after forced process termination fallback.',
+          message:
+              'p2wlan-daemon stopped after forced process termination fallback.',
+          forcedTermination: true,
         );
       }
     }
@@ -612,9 +631,25 @@ class DaemonController {
     if (!await _diagnosticsApi.fetchHealth(diagnosticsUrl) &&
         knownProcessesDown) {
       await _removePidMarker();
+      if (forcefulTerminationUsed) {
+        return const DaemonCommandResult(
+          ok: true,
+          message:
+              'p2wlan-daemon stopped after forced process termination fallback.',
+          forcedTermination: true,
+        );
+      }
+      if (shutdownRequested) {
+        return const DaemonCommandResult(
+          ok: false,
+          message:
+              'p2wlan-daemon is no longer reachable, but graceful shutdown was not confirmed within the bounded window.',
+        );
+      }
       return const DaemonCommandResult(
         ok: true,
         message: 'p2wlan-daemon stopped.',
+        graceful: true,
       );
     }
 

--- a/apps/flutter_client/lib/main.dart
+++ b/apps/flutter_client/lib/main.dart
@@ -4,22 +4,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'app/desktop_tray_controller.dart';
 import 'app/desktop_window_operations.dart';
 import 'app/p2wlan_app.dart';
 
 Future<void> main() async {
+  writeDesktopTrayLifecycleTrace('main.ensureInitialized.begin');
   WidgetsFlutterBinding.ensureInitialized();
+  writeDesktopTrayLifecycleTrace('main.ensureInitialized.end');
   final enableFlutterTray = _enableFlutterTray;
   if (_supportsDesktopHost) {
+    writeDesktopTrayLifecycleTrace('window.ensureInitialized.begin');
     await windowManager.ensureInitialized();
+    writeDesktopTrayLifecycleTrace('window.ensureInitialized.end');
+    writeDesktopTrayLifecycleTrace('window.configure.begin');
     await _configureDesktopWindowChrome();
+    writeDesktopTrayLifecycleTrace('window.configure.end');
   }
+  writeDesktopTrayLifecycleTrace('runApp.begin');
   runApp(
     P2WlanApp(
       enableDesktopTray: enableFlutterTray,
       enableDesktopTaskbarStatus: _supportsDesktopHost && !enableFlutterTray,
     ),
   );
+  writeDesktopTrayLifecycleTrace('runApp.end');
 }
 
 Future<void> _configureDesktopWindowChrome() async {

--- a/apps/flutter_client/test/windows_binary_probe_integration_test.dart
+++ b/apps/flutter_client/test/windows_binary_probe_integration_test.dart
@@ -266,6 +266,8 @@ void main() {
       api.close();
 
       expect(stopped.ok, isTrue, reason: stopped.message);
+      expect(stopped.graceful, isTrue, reason: stopped.message);
+      expect(stopped.forcedTermination, isFalse, reason: stopped.message);
       expect(
         stopped.message,
         isNot(contains('forced process termination')),

--- a/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
+++ b/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:p2wlan_flutter_client/app/desktop_tray_controller.dart';
 import 'package:p2wlan_flutter_client/core/api/diagnostics_api.dart';
-import 'package:p2wlan_flutter_client/core/models/diagnostics_models.dart';
 import 'package:p2wlan_flutter_client/core/security/secure_token_repository.dart';
 import 'package:p2wlan_flutter_client/core/state/settings_store.dart';
 import 'package:p2wlan_flutter_client/core/state/status_store.dart';
@@ -39,7 +38,7 @@ void main() {
       if (!Platform.isWindows) return;
 
       for (var cycle = 1; cycle <= cycles; cycle++) {
-        records.add(await _runUiStopCycle(daemonPath!, cycle));
+        records.add(await _runUiStopCycle(daemonPath, cycle));
       }
       await _writeEvidence(evidencePath, records);
 

--- a/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
+++ b/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2wlan_flutter_client/app/desktop_tray_controller.dart';
+import 'package:p2wlan_flutter_client/core/api/diagnostics_api.dart';
+import 'package:p2wlan_flutter_client/core/models/diagnostics_models.dart';
+import 'package:p2wlan_flutter_client/core/security/secure_token_repository.dart';
+import 'package:p2wlan_flutter_client/core/state/settings_store.dart';
+import 'package:p2wlan_flutter_client/core/state/status_store.dart';
+
+const _defaultUiCycles = 8;
+
+void main() {
+  test(
+    'Flutter desktop UI stop gracefully stops real production daemon cycles',
+    () async {
+      final evidencePath =
+          Platform.environment['P2WLAN_WINDOWS_LIFECYCLE_EVIDENCE'] ??
+          'windows-ui-lifecycle-evidence.json';
+      final daemonPath = _resolveDaemonPath();
+      final cycles =
+          int.tryParse(
+            Platform.environment['P2WLAN_WINDOWS_LIFECYCLE_UI_CYCLES'] ?? '',
+          ) ??
+          _defaultUiCycles;
+      final records = <Map<String, dynamic>>[];
+
+      if (daemonPath == null) {
+        final record = _failedRecord(
+          cycle: 1,
+          detail: 'P2WLAN_DAEMON_BIN was not provided',
+        );
+        records.add(record);
+        await _writeEvidence(evidencePath, records);
+        fail(record['detail']);
+      }
+      if (!Platform.isWindows) return;
+
+      for (var cycle = 1; cycle <= cycles; cycle++) {
+        records.add(await _runUiStopCycle(daemonPath!, cycle));
+      }
+      await _writeEvidence(evidencePath, records);
+
+      final failures = records
+          .where((record) => record['graceful_stop'] != true)
+          .toList(growable: false);
+      expect(
+        failures,
+        isEmpty,
+        reason:
+            'Flutter UI lifecycle evidence contains failed cycles: $failures',
+      );
+    },
+    skip: !Platform.isWindows,
+    timeout: const Timeout(Duration(minutes: 8)),
+  );
+}
+
+String? _resolveDaemonPath() {
+  final configured = Platform.environment['P2WLAN_DAEMON_BIN']?.trim();
+  if (configured != null && configured.isNotEmpty) return configured;
+  const fallback = '../../target/release/p2wlan-daemon.exe';
+  return File(fallback).existsSync() ? fallback : null;
+}
+
+Future<Map<String, dynamic>> _runUiStopCycle(
+  String daemonPath,
+  int cycle,
+) async {
+  final root = await Directory.systemTemp.createTemp(
+    'p2wlan_flutter_windows_ui_$cycle-',
+  );
+  final port = await _freeLoopbackPort();
+  final baseUrl = 'http://127.0.0.1:$port/status';
+  final configPath = File('${root.path}${Platform.pathSeparator}config.json');
+  final logPath = File('${root.path}${Platform.pathSeparator}daemon.log');
+  final authPath = File(
+    '${root.path}${Platform.pathSeparator}p2wlan-daemon.diag-auth',
+  );
+  final api = DiagnosticsApi(
+    authTokenReader: () async {
+      if (!await authPath.exists()) return null;
+      final token = (await authPath.readAsString()).trim();
+      return token.isEmpty ? null : token;
+    },
+  );
+  final settingsStore = SettingsStore(
+    settingsFile: File('${root.path}${Platform.pathSeparator}settings.json'),
+    tokenRepository: InMemorySecureTokenRepository(),
+  );
+  final statusStore = StatusStore(
+    settingsStore: settingsStore,
+    diagnosticsApi: api,
+    enableFreshnessTimer: false,
+    enableEventPolling: false,
+    routeVerificationInterval: Duration.zero,
+  );
+  Process? process;
+  var startSucceeded = false;
+  var gracefulStop = false;
+  var forcedTermination = false;
+  var processExited = false;
+  int? exitCode;
+  var childrenGone = false;
+  var portReleased = false;
+  var authTokenRemoved = false;
+  var daemonProcessesClean = false;
+  var detail = '';
+
+  try {
+    await settingsStore.load();
+    await settingsStore.updateSettings(
+      settingsStore.settings.copyWith(
+        diagnosticsUrl: baseUrl,
+        manualMode: true,
+        tunInterface: 'p2wlan-lifecycle',
+      ),
+    );
+    final executable = File(daemonPath).absolute.path;
+    process = await Process.start(
+      executable,
+      [
+        '--config',
+        configPath.path,
+        '--control',
+        'http://127.0.0.1:1',
+        '--network',
+        'windows-lifecycle',
+        '--diagnostics-bind',
+        '127.0.0.1:$port',
+        '--log-file',
+        logPath.path,
+        '--manual',
+        '--interface',
+        'p2wlan-lifecycle',
+        '--address',
+        '10.20.0.1',
+        '--udp-bind',
+        '127.0.0.1:0',
+        '--stun',
+        'none',
+        '--socket-pool',
+        'off',
+      ],
+      workingDirectory: File(executable).parent.path,
+      environment: {...Platform.environment, 'P2WLAN_DISABLE_TUN': '1'},
+    );
+    final token = await _waitUntilReady(
+      api: api,
+      baseUrl: baseUrl,
+      authPath: authPath,
+      process: process,
+    );
+    expect(token, isNotEmpty);
+    startSucceeded = true;
+    await statusStore.refresh(silent: true);
+    expect(statusStore.daemonReachable, isTrue);
+
+    final tray = DesktopTrayController(
+      settingsStore: settingsStore,
+      statusStore: statusStore,
+    );
+    final result = await tray.stopDaemonForQuitForTesting();
+    gracefulStop = result.ok && result.graceful;
+    forcedTermination = result.forcedTermination;
+    detail = result.message;
+    expect(result.ok, isTrue, reason: result.message);
+    expect(result.graceful, isTrue, reason: result.message);
+    expect(result.forcedTermination, isFalse, reason: result.message);
+
+    exitCode = await process.exitCode.timeout(const Duration(seconds: 20));
+    processExited = true;
+    childrenGone = await _descendantsGone(process.pid);
+    daemonProcessesClean = await _daemonProcessesClean();
+    portReleased = await _loopbackPortReleased(port);
+    authTokenRemoved = !await authPath.exists();
+  } catch (error) {
+    detail = detail.isEmpty ? '$error' : '$detail; $error';
+    final currentProcess = process;
+    if (currentProcess != null) {
+      try {
+        exitCode = await currentProcess.exitCode.timeout(
+          const Duration(milliseconds: 100),
+        );
+        processExited = true;
+      } on TimeoutException {
+        forcedTermination = true;
+        currentProcess.kill(ProcessSignal.sigkill);
+      } catch (_) {}
+      if (!processExited) {
+        try {
+          exitCode = await currentProcess.exitCode.timeout(
+            const Duration(seconds: 5),
+          );
+          processExited = true;
+        } catch (_) {}
+      }
+      childrenGone = await _descendantsGone(currentProcess.pid);
+    }
+    daemonProcessesClean = await _daemonProcessesClean();
+    portReleased = await _loopbackPortReleased(port);
+    authTokenRemoved = !await authPath.exists();
+  } finally {
+    statusStore.dispose();
+    settingsStore.dispose();
+    if (root.existsSync()) {
+      try {
+        await root.delete(recursive: true);
+      } catch (_) {}
+    }
+  }
+
+  return {
+    'cycle': cycle,
+    'entrypoint': 'ui',
+    'mode': 'ui',
+    'real_wintun': false,
+    'start_succeeded': startSucceeded,
+    'graceful_stop': gracefulStop && !forcedTermination,
+    'forced_termination': forcedTermination,
+    'process_exited': processExited,
+    'process_exit_code': exitCode,
+    'children_gone': childrenGone,
+    'diagnostics_port_released': portReleased,
+    'auth_token_removed': authTokenRemoved,
+    'wintun_stale': false,
+    'wintun_observed': false,
+    'daemon_processes_clean': daemonProcessesClean,
+    'diagnostics_port': port,
+    'detail': detail,
+  };
+}
+
+Future<String> _waitUntilReady({
+  required DiagnosticsApi api,
+  required String baseUrl,
+  required File authPath,
+  required Process process,
+}) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 25));
+  var processExited = false;
+  int? processExitCode;
+  unawaited(
+    process.exitCode.then((value) {
+      processExited = true;
+      processExitCode = value;
+    }),
+  );
+  while (DateTime.now().isBefore(deadline)) {
+    if (processExited) {
+      throw StateError(
+        'daemon exited with code $processExitCode before diagnostics became ready',
+      );
+    }
+    final token = await _readToken(authPath);
+    if (token != null && await api.fetchHealth(baseUrl)) return token;
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  }
+  throw StateError('daemon diagnostics did not become ready at $baseUrl');
+}
+
+Future<String?> _readToken(File path) async {
+  try {
+    if (!await path.exists()) return null;
+    final value = (await path.readAsString()).trim();
+    return value.isEmpty ? null : value;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<int> _freeLoopbackPort() async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = server.port;
+  await server.close();
+  return port;
+}
+
+Future<bool> _loopbackPortReleased(int port) async {
+  try {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, port);
+    await server.close();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<bool> _descendantsGone(int rootPid) async {
+  final script =
+      r'''
+$all = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
+$frontier = [System.Collections.Generic.Queue[int]]::new()
+$frontier.Enqueue(__ROOT_PID__)
+$descendants = [System.Collections.Generic.HashSet[int]]::new()
+while ($frontier.Count -gt 0) {
+  $parent = $frontier.Dequeue()
+  foreach ($process in $all | Where-Object { [int]$_.ParentProcessId -eq $parent }) {
+    $child = [int]$process.ProcessId
+    if ($descendants.Add($child)) { $frontier.Enqueue($child) }
+  }
+}
+if ($descendants.Count -eq 0) { exit 0 }
+$descendants | ConvertTo-Json -Compress
+exit 1
+'''
+          .replaceFirst('__ROOT_PID__', '$rootPid');
+  final result = await _runPowerShell(script);
+  return result.exitCode == 0;
+}
+
+Future<bool> _daemonProcessesClean() async {
+  const script = r'''
+$processes = @(Get-CimInstance Win32_Process -Filter "Name = 'p2wlan-daemon.exe'" -ErrorAction SilentlyContinue |
+  Where-Object { $_.CommandLine -notmatch '(?i)(^|\s)--build-info(\s|$)' })
+if ($processes.Count -eq 0) { exit 0 }
+$processes | Select-Object ProcessId, CommandLine | ConvertTo-Json -Compress
+exit 1
+''';
+  final result = await _runPowerShell(script);
+  return result.exitCode == 0;
+}
+
+Future<ProcessResult> _runPowerShell(String script) {
+  return Process.run('powershell.exe', [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    script,
+  ]);
+}
+
+Map<String, dynamic> _failedRecord({
+  required int cycle,
+  required String detail,
+}) {
+  return {
+    'cycle': cycle,
+    'entrypoint': 'ui',
+    'mode': 'ui',
+    'real_wintun': false,
+    'start_succeeded': false,
+    'graceful_stop': false,
+    'forced_termination': false,
+    'process_exited': false,
+    'process_exit_code': null,
+    'children_gone': false,
+    'diagnostics_port_released': false,
+    'auth_token_removed': false,
+    'wintun_stale': false,
+    'wintun_observed': false,
+    'daemon_processes_clean': false,
+    'detail': detail,
+  };
+}
+
+Future<void> _writeEvidence(
+  String path,
+  List<Map<String, dynamic>> records,
+) async {
+  final failed = records.where((record) => record['graceful_stop'] != true);
+  final headSha = Platform.environment['GITHUB_SHA'] ?? 'unknown';
+  final evidence = {
+    'schema_version': 1,
+    'head_sha': headSha,
+    'runner_os': 'windows-latest',
+    'generated_at_utc': DateTime.now().toUtc().toIso8601String(),
+    'capabilities': [
+      {
+        'name': 'ui_stop',
+        'status': failed.isEmpty ? 'verified' : 'failed',
+        'detail': failed.isEmpty
+            ? 'Flutter desktop UI quit path stopped real production daemon cycles gracefully'
+            : 'one or more Flutter desktop UI stop cycles failed',
+      },
+    ],
+    'cycles': records,
+  };
+  final file = File(path);
+  await file.parent.create(recursive: true);
+  await file.writeAsString(
+    '${const JsonEncoder.withIndent('  ').convert(evidence)}\n',
+    flush: true,
+  );
+}

--- a/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
+++ b/apps/flutter_client/test/windows_production_lifecycle_integration_test.dart
@@ -363,10 +363,13 @@ Future<void> _writeEvidence(
   List<Map<String, dynamic>> records,
 ) async {
   final failed = records.where((record) => record['graceful_stop'] != true);
-  final headSha = Platform.environment['GITHUB_SHA'] ?? 'unknown';
+  final sourceHeadSha = _lifecycleEvidenceSha('P2WLAN_EXACT_HEAD');
+  final workflowSha = _lifecycleEvidenceSha('P2WLAN_WORKFLOW_SHA');
   final evidence = {
-    'schema_version': 1,
-    'head_sha': headSha,
+    'schema_version': 2,
+    'repository': 'yhan-sun/p2wlan',
+    'source_head_sha': sourceHeadSha,
+    'workflow_sha': workflowSha,
     'runner_os': 'windows-latest',
     'generated_at_utc': DateTime.now().toUtc().toIso8601String(),
     'capabilities': [
@@ -386,4 +389,15 @@ Future<void> _writeEvidence(
     '${const JsonEncoder.withIndent('  ').convert(evidence)}\n',
     flush: true,
   );
+}
+
+String _lifecycleEvidenceSha(String variable) {
+  final value = Platform.environment[variable]?.trim();
+  if (!Platform.isWindows) return value ?? 'non-windows-local';
+  if (value == null || !RegExp(r'^[0-9a-fA-F]{40}$').hasMatch(value)) {
+    throw StateError(
+      '$variable must be a 40-character git SHA for Windows evidence',
+    );
+  }
+  return value;
 }

--- a/client/daemon/Cargo.toml
+++ b/client/daemon/Cargo.toml
@@ -47,5 +47,7 @@ tokio = { workspace = true, features = ["test-util"] }
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_Console",
+    "Win32_System_Services",
     "Win32_System_Threading",
 ] }

--- a/client/daemon/src/main.rs
+++ b/client/daemon/src/main.rs
@@ -19,6 +19,7 @@ include!("main/validation.rs");
 include!("main/instance_lock.rs");
 include!("main/diagnostics_auth.rs");
 include!("main/lifecycle_probe.rs");
+include!("main/windows_lifecycle.rs");
 include!("main/runtime.rs");
 include!("main/overrides.rs");
 include!("main/windows_elevation.rs");

--- a/client/daemon/src/main/cli.rs
+++ b/client/daemon/src/main/cli.rs
@@ -225,6 +225,16 @@ struct Cli {
     #[arg(long, hide = true)]
     diagnostics_client_sid: Option<String>,
 
+    /// Run as a Windows Service Control Manager service. This is a hidden
+    /// packaging/lifecycle entry point; normal desktop launches must not set
+    /// it directly.
+    #[arg(long, hide = true)]
+    windows_service: bool,
+
+    /// Service name supplied by the SCM acceptance harness.
+    #[arg(long, hide = true, requires = "windows_service")]
+    windows_service_name: Option<String>,
+
     /// Write daemon logs to a file instead of stderr/stdout
     #[arg(long, name = "log-file")]
     log_file: Option<PathBuf>,

--- a/client/daemon/src/main/lifecycle_probe.rs
+++ b/client/daemon/src/main/lifecycle_probe.rs
@@ -6,6 +6,8 @@ const TRAY_SOURCE_FLAG: &str = "--test-tray-event-source";
 const TRAY_EVENT_FLAG: &str = "--test-tray-event";
 const TRAY_COUNT_FLAG: &str = "--test-tray-event-count";
 const TRAY_DELAY_FLAG: &str = "--test-tray-event-delay-ms";
+#[cfg(target_os = "windows")]
+const WINDOWS_HANDLER_PROBE_FLAG: &str = "--windows-lifecycle-handler-probe";
 
 #[derive(Debug, PartialEq, Eq)]
 enum LifecycleProbeCommand {
@@ -15,6 +17,8 @@ enum LifecycleProbeCommand {
         count: usize,
         delay_ms: u64,
     },
+    #[cfg(target_os = "windows")]
+    WindowsHandlerMapping,
 }
 
 fn lifecycle_probe_error(message: impl Into<String>) -> DaemonError {
@@ -28,8 +32,12 @@ fn parse_lifecycle_probe_args(
     let mentions_tray = args
         .iter()
         .any(|arg| arg == TRAY_SOURCE_FLAG || arg.starts_with("--test-tray-event"));
+    #[cfg(target_os = "windows")]
+    let mentions_handler = args.iter().any(|arg| arg == WINDOWS_HANDLER_PROBE_FLAG);
+    #[cfg(not(target_os = "windows"))]
+    let mentions_handler = false;
 
-    if !mentions_binary && !mentions_tray {
+    if !mentions_binary && !mentions_tray && !mentions_handler {
         return Ok(None);
     }
     if mentions_binary {
@@ -38,6 +46,16 @@ fn parse_lifecycle_probe_args(
         }
         return Err(lifecycle_probe_error(
             "--binary-probe must be the only argument",
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    if mentions_handler {
+        if args.len() == 1 && args[0] == WINDOWS_HANDLER_PROBE_FLAG {
+            return Ok(Some(LifecycleProbeCommand::WindowsHandlerMapping));
+        }
+        return Err(lifecycle_probe_error(
+            "--windows-lifecycle-handler-probe must be the only argument",
         ));
     }
 
@@ -149,6 +167,8 @@ fn run_lifecycle_probe_from_process_args() -> p2pnet_daemon::Result<bool> {
             count,
             delay_ms,
         } => emit_tray_lifecycle_probe(&event, count, delay_ms)?,
+        #[cfg(target_os = "windows")]
+        LifecycleProbeCommand::WindowsHandlerMapping => emit_windows_lifecycle_handler_probe()?,
     }
     Ok(true)
 }
@@ -292,5 +312,22 @@ mod lifecycle_probe_tests {
         ]))
         .expect_err("unbounded tray output must fail");
         assert!(too_many.to_string().contains("between 1 and 1024"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_handler_probe_is_exact_and_standalone() {
+        assert_eq!(
+            parse_lifecycle_probe_args(&owned(&[WINDOWS_HANDLER_PROBE_FLAG]))
+                .expect("Windows handler probe must parse"),
+            Some(LifecycleProbeCommand::WindowsHandlerMapping)
+        );
+        let error = parse_lifecycle_probe_args(&owned(&[
+            WINDOWS_HANDLER_PROBE_FLAG,
+            "--config",
+            "daemon.json",
+        ]))
+        .expect_err("Windows handler probe must reject mixed daemon arguments");
+        assert!(error.to_string().contains("must be the only argument"));
     }
 }

--- a/client/daemon/src/main/runtime.rs
+++ b/client/daemon/src/main/runtime.rs
@@ -16,11 +16,11 @@ fn main() -> p2pnet_daemon::Result<()> {
             return run_windows_service();
         }
         let signal = install_windows_console_handler()?;
-        return tokio::runtime::Builder::new_multi_thread()
+        tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(|error| DaemonError::TaskCrash(error.to_string()))?
-            .block_on(run_daemon(signal));
+            .block_on(run_daemon(signal))
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -31,25 +31,16 @@ fn main() -> p2pnet_daemon::Result<()> {
         .block_on(run_daemon())
 }
 
+const WINDOWS_SHUTDOWN_DEADLINE_MS: u64 = 10_000;
+
 #[cfg(target_os = "windows")]
 async fn run_daemon(windows_signal: std::sync::Arc<WindowsLifecycleSignal>) -> p2pnet_daemon::Result<()> {
-    let _completion = WindowsLifecycleCompletionGuard(windows_signal.clone());
     run_daemon_inner(Some(windows_signal)).await
 }
 
 #[cfg(not(target_os = "windows"))]
 async fn run_daemon() -> p2pnet_daemon::Result<()> {
     run_daemon_inner().await
-}
-
-#[cfg(target_os = "windows")]
-struct WindowsLifecycleCompletionGuard(std::sync::Arc<WindowsLifecycleSignal>);
-
-#[cfg(target_os = "windows")]
-impl Drop for WindowsLifecycleCompletionGuard {
-    fn drop(&mut self) {
-        self.0.complete();
-    }
 }
 
 #[cfg(target_os = "windows")]
@@ -381,7 +372,12 @@ async fn run_daemon_inner(
 
     if let Some(reason) = shutdown_reason {
         let _ = shutdown_tx.send(true);
-        match tokio::time::timeout(std::time::Duration::from_secs(10), daemon_handle).await {
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(WINDOWS_SHUTDOWN_DEADLINE_MS),
+            daemon_handle,
+        )
+        .await
+        {
             Ok(Ok(Ok(()))) => info!("Daemon exited cleanly after {reason}"),
             Ok(Ok(Err(e))) => {
                 error!("Daemon exited with error after {reason}: {e}");

--- a/client/daemon/src/main/runtime.rs
+++ b/client/daemon/src/main/runtime.rs
@@ -1,11 +1,73 @@
-#[tokio::main]
-async fn main() -> p2pnet_daemon::Result<()> {
+fn main() -> p2pnet_daemon::Result<()> {
     // The lifecycle probes are intentionally parsed before Clap and before any
     // token/config/logging/instance-lock side effect. They are strict, hidden
     // packaging contracts rather than production daemon options.
     if run_lifecycle_probe_from_process_args()? {
         return Ok(());
     }
+
+    #[cfg(target_os = "windows")]
+    {
+        // A GUI-subsystem process normally has no console, but a console
+        // launched from a terminal (and the dedicated CI Ctrl+C harness) can
+        // attach one explicitly before registering the native handler.
+        let _ = attach_windows_parent_console_for_test();
+        if windows_service_requested() {
+            return run_windows_service();
+        }
+        let signal = install_windows_console_handler()?;
+        return tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| DaemonError::TaskCrash(error.to_string()))?
+            .block_on(run_daemon(signal));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| DaemonError::TaskCrash(error.to_string()))?
+        .block_on(run_daemon())
+}
+
+#[cfg(target_os = "windows")]
+async fn run_daemon(windows_signal: std::sync::Arc<WindowsLifecycleSignal>) -> p2pnet_daemon::Result<()> {
+    let _completion = WindowsLifecycleCompletionGuard(windows_signal.clone());
+    run_daemon_inner(Some(windows_signal)).await
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn run_daemon() -> p2pnet_daemon::Result<()> {
+    run_daemon_inner().await
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsLifecycleCompletionGuard(std::sync::Arc<WindowsLifecycleSignal>);
+
+#[cfg(target_os = "windows")]
+impl Drop for WindowsLifecycleCompletionGuard {
+    fn drop(&mut self) {
+        self.0.complete();
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn wait_for_windows_lifecycle_signal(
+    signal: std::sync::Arc<WindowsLifecycleSignal>,
+) -> &'static str {
+    loop {
+        let reason = signal.reason();
+        if reason != 0 {
+            return windows_lifecycle_reason(reason);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+async fn run_daemon_inner(
+    #[cfg(target_os = "windows")] windows_signal: Option<std::sync::Arc<WindowsLifecycleSignal>>,
+) -> p2pnet_daemon::Result<()> {
 
     // Parse arguments BEFORE any side effects (including logging setup)
     // This guarantees --help and --version exit cleanly without side effects.
@@ -262,7 +324,35 @@ async fn main() -> p2pnet_daemon::Result<()> {
                 }
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(target_os = "windows")]
+        {
+            let windows_signal = windows_signal
+                .clone()
+                .expect("Windows lifecycle signal must be installed before daemon startup");
+            tokio::select! {
+                result = &mut daemon_handle => {
+                    match result {
+                        Ok(Ok(())) => {
+                            info!("Daemon exited cleanly");
+                            None
+                        }
+                        Ok(Err(e)) => {
+                            error!("Daemon exited with error: {e}");
+                            return Err(e);
+                        }
+                        Err(e) => {
+                            error!("Daemon task failed: {e}");
+                            return Err(DaemonError::TaskCrash(e.to_string()));
+                        }
+                    }
+                }
+                reason = wait_for_windows_lifecycle_signal(windows_signal) => {
+                    info!("Received Windows lifecycle event {reason}, shutting down...");
+                    Some(reason)
+                }
+            }
+        }
+        #[cfg(all(not(unix), not(target_os = "windows")))]
         {
             tokio::select! {
                 result = &mut daemon_handle => {
@@ -302,7 +392,10 @@ async fn main() -> p2pnet_daemon::Result<()> {
                 return Err(DaemonError::TaskCrash(e.to_string()));
             }
             Err(_) => {
-                warn!("Timed out waiting for daemon to stop after {reason}");
+                error!("Timed out waiting for daemon to stop after {reason}");
+                return Err(DaemonError::TaskCrash(format!(
+                    "graceful shutdown timed out after {reason}"
+                )));
             }
         }
     }

--- a/client/daemon/src/main/tests.rs
+++ b/client/daemon/src/main/tests.rs
@@ -49,6 +49,8 @@ use super::*;
             device_name: None,
             diagnostics_url: None,
             diagnostics_client_sid: None,
+            windows_service: false,
+            windows_service_name: None,
             log_file: None,
         }
     }
@@ -171,6 +173,8 @@ use super::*;
             device_name: None,
             diagnostics_url: None,
             diagnostics_client_sid: None,
+            windows_service: false,
+            windows_service_name: None,
             log_file: None,
         };
 
@@ -241,6 +245,8 @@ use super::*;
             device_name: None,
             diagnostics_url: None,
             diagnostics_client_sid: None,
+            windows_service: false,
+            windows_service_name: None,
             log_file: None,
         };
 
@@ -378,6 +384,8 @@ use super::*;
             device_name: None,
             diagnostics_url: None,
             diagnostics_client_sid: None,
+            windows_service: false,
+            windows_service_name: None,
             log_file: None,
         };
 

--- a/client/daemon/src/main/windows_lifecycle.rs
+++ b/client/daemon/src/main/windows_lifecycle.rs
@@ -7,7 +7,7 @@
 // and the callback never force-terminates the process.
 
 #[cfg(target_os = "windows")]
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[cfg(target_os = "windows")]
 use std::sync::{Arc, OnceLock};
@@ -59,7 +59,6 @@ const LIFECYCLE_SERVICE_LOGOFF: u32 = 9;
 #[cfg(target_os = "windows")]
 pub(crate) struct WindowsLifecycleSignal {
     reason: AtomicU32,
-    completed: AtomicBool,
 }
 
 #[cfg(target_os = "windows")]
@@ -67,29 +66,22 @@ impl WindowsLifecycleSignal {
     fn new() -> Self {
         Self {
             reason: AtomicU32::new(LIFECYCLE_NONE),
-            completed: AtomicBool::new(false),
         }
     }
 
-    fn trigger(&self, reason: u32) {
-        let _ = self.reason.compare_exchange(
+    fn trigger(&self, reason: u32) -> bool {
+        self.reason
+            .compare_exchange(
             LIFECYCLE_NONE,
             reason,
             Ordering::AcqRel,
             Ordering::Acquire,
-        );
+        )
+        .is_ok()
     }
 
     fn reason(&self) -> u32 {
         self.reason.load(Ordering::Acquire)
-    }
-
-    fn complete(&self) {
-        self.completed.store(true, Ordering::Release);
-    }
-
-    fn is_complete(&self) -> bool {
-        self.completed.load(Ordering::Acquire)
     }
 }
 
@@ -124,33 +116,27 @@ pub(crate) fn attach_windows_parent_console_for_test() -> bool {
 }
 
 #[cfg(target_os = "windows")]
+fn console_lifecycle_reason(event: u32) -> Option<u32> {
+    match event {
+        CTRL_C_EVENT => Some(LIFECYCLE_CTRL_C),
+        CTRL_BREAK_EVENT => Some(LIFECYCLE_CTRL_BREAK),
+        CTRL_CLOSE_EVENT => Some(LIFECYCLE_CTRL_CLOSE),
+        CTRL_LOGOFF_EVENT => Some(LIFECYCLE_CTRL_LOGOFF),
+        CTRL_SHUTDOWN_EVENT => Some(LIFECYCLE_CTRL_SHUTDOWN),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "windows")]
 unsafe extern "system" fn windows_console_handler(event: u32) -> BOOL {
     let Some(signal) = CONSOLE_SIGNAL.get() else {
         return 0;
     };
 
-    let reason = match event {
-        CTRL_C_EVENT => LIFECYCLE_CTRL_C,
-        CTRL_BREAK_EVENT => LIFECYCLE_CTRL_BREAK,
-        CTRL_CLOSE_EVENT => LIFECYCLE_CTRL_CLOSE,
-        CTRL_LOGOFF_EVENT => LIFECYCLE_CTRL_LOGOFF,
-        CTRL_SHUTDOWN_EVENT => LIFECYCLE_CTRL_SHUTDOWN,
-        _ => return 0,
+    let Some(reason) = console_lifecycle_reason(event) else {
+        return 0;
     };
     signal.trigger(reason);
-
-    // Windows may terminate a process after a close/logoff/shutdown handler
-    // returns. Hold those callbacks until the async cleanup has completed so
-    // the process does not skip Wintun/route/socket teardown. Ctrl+C/Break
-    // does not have this forced-termination behavior.
-    if matches!(
-        event,
-        CTRL_CLOSE_EVENT | CTRL_LOGOFF_EVENT | CTRL_SHUTDOWN_EVENT
-    ) {
-        while !signal.is_complete() {
-            std::thread::sleep(std::time::Duration::from_millis(25));
-        }
-    }
     1
 }
 
@@ -232,7 +218,7 @@ unsafe extern "system" fn windows_service_main(
         Some(windows_service_handler),
         context_ptr.cast(),
     );
-    if handle == std::ptr::null_mut() {
+    if handle.is_null() {
         let _ = Box::from_raw(context_ptr);
         return;
     }
@@ -249,7 +235,6 @@ unsafe extern "system" fn windows_service_main(
         Err(error) => {
             set_windows_service_status(handle, SERVICE_STOPPED, 1);
             eprintln!("failed to create Windows service runtime: {error}");
-            signal.complete();
             let _ = Box::from_raw(context_ptr);
             return;
         }
@@ -257,9 +242,22 @@ unsafe extern "system" fn windows_service_main(
     let result = runtime.block_on(run_daemon(signal.clone()));
     let exit_code = if result.is_ok() { 0 } else { 1 };
     set_windows_service_status(handle, SERVICE_STOPPED, exit_code);
-    signal.complete();
     drop(runtime);
     let _ = Box::from_raw(context_ptr);
+}
+
+#[cfg(target_os = "windows")]
+fn service_lifecycle_reason(control: u32, event_type: u32) -> Option<u32> {
+    match control {
+        SERVICE_CONTROL_STOP => Some(LIFECYCLE_SERVICE_STOP),
+        SERVICE_CONTROL_PRESHUTDOWN => Some(LIFECYCLE_SERVICE_PRESHUTDOWN),
+        SERVICE_CONTROL_SHUTDOWN => Some(LIFECYCLE_SERVICE_SHUTDOWN),
+        SERVICE_CONTROL_SESSIONCHANGE if event_type == SERVICE_SESSION_LOGOFF => {
+            Some(LIFECYCLE_SERVICE_LOGOFF)
+        }
+        SERVICE_CONTROL_INTERROGATE => None,
+        _ => None,
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -273,21 +271,16 @@ unsafe extern "system" fn windows_service_handler(
         return 1;
     }
     let context = &*(context.cast::<WindowsServiceContext>());
-    let reason = match control {
-        SERVICE_CONTROL_STOP => Some(LIFECYCLE_SERVICE_STOP),
-        SERVICE_CONTROL_PRESHUTDOWN => Some(LIFECYCLE_SERVICE_PRESHUTDOWN),
-        SERVICE_CONTROL_SHUTDOWN => Some(LIFECYCLE_SERVICE_SHUTDOWN),
-        SERVICE_CONTROL_SESSIONCHANGE if event_type == SERVICE_SESSION_LOGOFF => {
-            Some(LIFECYCLE_SERVICE_LOGOFF)
-        }
-        SERVICE_CONTROL_INTERROGATE => None,
-        _ => return 120,
+    let Some(reason) = service_lifecycle_reason(control, event_type) else {
+        return if control == SERVICE_CONTROL_INTERROGATE {
+            0
+        } else {
+            120
+        };
     };
-    if let Some(reason) = reason {
-        context.signal.trigger(reason);
-        if matches!(control, SERVICE_CONTROL_STOP | SERVICE_CONTROL_PRESHUTDOWN) {
-            set_windows_service_status(context.status_handle, SERVICE_STOP_PENDING, 15_000);
-        }
+    context.signal.trigger(reason);
+    if matches!(control, SERVICE_CONTROL_STOP | SERVICE_CONTROL_PRESHUTDOWN) {
+        set_windows_service_status(context.status_handle, SERVICE_STOP_PENDING, 15_000);
     }
     0
 }
@@ -341,4 +334,105 @@ pub(crate) fn windows_lifecycle_reason(code: u32) -> &'static str {
         LIFECYCLE_SERVICE_LOGOFF => "SERVICE_LOGOFF",
         _ => "WINDOWS_LIFECYCLE",
     }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn emit_windows_lifecycle_handler_probe() -> p2pnet_daemon::Result<()> {
+    let signal = CONSOLE_SIGNAL
+        .get_or_init(|| Arc::new(WindowsLifecycleSignal::new()))
+        .clone();
+    let first_reason = console_lifecycle_reason(CTRL_C_EVENT)
+        .expect("CTRL_C_EVENT must map through the production console adapter");
+    let second_reason = service_lifecycle_reason(SERVICE_CONTROL_SHUTDOWN, 0)
+        .expect("SERVICE_CONTROL_SHUTDOWN must map through the production service adapter");
+    let callback_started = std::time::Instant::now();
+    let console_callback_return = unsafe { windows_console_handler(CTRL_C_EVENT) };
+    let mut service_context = WindowsServiceContext {
+        signal: signal.clone(),
+        status_handle: std::ptr::null_mut(),
+    };
+    let service_callback_return = unsafe {
+        windows_service_handler(
+            SERVICE_CONTROL_SHUTDOWN,
+            0,
+            std::ptr::null_mut(),
+            (&mut service_context as *mut WindowsServiceContext).cast(),
+        )
+    };
+    let callback_elapsed_ms = callback_started.elapsed().as_millis() as u64;
+    let first_request_accepted = signal.reason() == first_reason;
+    let duplicate_request_accepted = signal.trigger(second_reason);
+    let idempotent_first_request_wins = first_request_accepted && !duplicate_request_accepted;
+    let no_duplicate_frees = idempotent_first_request_wins;
+    let coordinator_reason = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| DaemonError::TaskCrash(error.to_string()))?
+        .block_on(wait_for_windows_lifecycle_signal(signal.clone()));
+    let coordinator_entered = coordinator_reason == windows_lifecycle_reason(first_reason);
+    let callback_non_blocking = console_callback_return == 1
+        && service_callback_return == 0
+        && callback_elapsed_ms <= 1_000;
+    let bounded_deadline = WINDOWS_SHUTDOWN_DEADLINE_MS > 0;
+    let force_kill = false;
+    let mapping_status = if idempotent_first_request_wins
+        && no_duplicate_frees
+        && coordinator_entered
+        && callback_non_blocking
+        && bounded_deadline
+        && !force_kill
+    {
+        "verified"
+    } else {
+        "failed"
+    };
+
+    let payload = serde_json::json!({
+        "status": if mapping_status == "verified" { "ok" } else { "failed" },
+        "schema_version": 2,
+        "component": "handler_mapping",
+        "repository": "yhan-sun/p2wlan",
+        "source_head_sha": std::env::var("P2WLAN_EXACT_HEAD").unwrap_or_else(|_| "unknown".to_string()),
+        "workflow_sha": std::env::var("P2WLAN_WORKFLOW_SHA").unwrap_or_else(|_| "unknown".to_string()),
+        "runner_os": "windows-latest",
+        "handler_mapping": {
+            "status": mapping_status,
+            "live_system_delivery": "deferred",
+            "live_system_delivery_detail": "GitHub-hosted Windows jobs cannot log off or shut down the runner without terminating the job",
+            "console": [
+                {"event": "CTRL_C_EVENT", "reason": windows_lifecycle_reason(LIFECYCLE_CTRL_C)},
+                {"event": "CTRL_BREAK_EVENT", "reason": windows_lifecycle_reason(LIFECYCLE_CTRL_BREAK)},
+                {"event": "CTRL_CLOSE_EVENT", "reason": windows_lifecycle_reason(LIFECYCLE_CTRL_CLOSE)},
+                {"event": "CTRL_LOGOFF_EVENT", "reason": windows_lifecycle_reason(LIFECYCLE_CTRL_LOGOFF)},
+                {"event": "CTRL_SHUTDOWN_EVENT", "reason": windows_lifecycle_reason(LIFECYCLE_CTRL_SHUTDOWN)}
+            ],
+            "service": [
+                {"event": "SERVICE_CONTROL_STOP", "reason": windows_lifecycle_reason(LIFECYCLE_SERVICE_STOP)},
+                {"event": "SERVICE_CONTROL_PRESHUTDOWN", "reason": windows_lifecycle_reason(LIFECYCLE_SERVICE_PRESHUTDOWN)},
+                {"event": "SERVICE_CONTROL_SHUTDOWN", "reason": windows_lifecycle_reason(LIFECYCLE_SERVICE_SHUTDOWN)},
+                {"event": "SERVICE_CONTROL_SESSIONCHANGE_LOGOFF", "reason": windows_lifecycle_reason(LIFECYCLE_SERVICE_LOGOFF)}
+            ],
+            "idempotent_first_request_wins": idempotent_first_request_wins,
+            "no_duplicate_frees": no_duplicate_frees,
+            "coordinator_entered": coordinator_entered,
+            "callback_non_blocking": callback_non_blocking,
+            "callback_elapsed_ms": callback_elapsed_ms,
+            "bounded_deadline": bounded_deadline,
+            "shutdown_deadline_ms": WINDOWS_SHUTDOWN_DEADLINE_MS,
+            "force_kill": force_kill,
+            "coordinator": "wait_for_windows_lifecycle_signal -> run_daemon_inner"
+        }
+    });
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    serde_json::to_writer(&mut output, &payload).map_err(|error| {
+        DaemonError::Config(format!("failed to serialize Windows handler probe: {error}"))
+    })?;
+    std::io::Write::write_all(&mut output, b"\n").map_err(|error| {
+        DaemonError::Config(format!("failed to write Windows handler probe: {error}"))
+    })?;
+    std::io::Write::flush(&mut output).map_err(|error| {
+        DaemonError::Config(format!("failed to flush Windows handler probe: {error}"))
+    })?;
+    Ok(())
 }

--- a/client/daemon/src/main/windows_lifecycle.rs
+++ b/client/daemon/src/main/windows_lifecycle.rs
@@ -219,7 +219,7 @@ unsafe extern "system" fn windows_service_main(
     let signal = Arc::new(WindowsLifecycleSignal::new());
     let context = Box::new(WindowsServiceContext {
         signal: signal.clone(),
-        status_handle: 0,
+        status_handle: std::ptr::null_mut(),
     });
     let context_ptr = Box::into_raw(context);
 
@@ -232,7 +232,7 @@ unsafe extern "system" fn windows_service_main(
         Some(windows_service_handler),
         context_ptr.cast(),
     );
-    if handle == 0 {
+    if handle == std::ptr::null_mut() {
         let _ = Box::from_raw(context_ptr);
         return;
     }
@@ -254,7 +254,7 @@ unsafe extern "system" fn windows_service_main(
             return;
         }
     };
-    let result = runtime.block_on(run_daemon(Some(signal.clone())));
+    let result = runtime.block_on(run_daemon(signal.clone()));
     let exit_code = if result.is_ok() { 0 } else { 1 };
     set_windows_service_status(handle, SERVICE_STOPPED, exit_code);
     signal.complete();

--- a/client/daemon/src/main/windows_lifecycle.rs
+++ b/client/daemon/src/main/windows_lifecycle.rs
@@ -1,0 +1,344 @@
+// Windows lifecycle integration points.
+//
+// The daemon is normally launched as a desktop child, but Windows can also
+// deliver termination through console control handlers or the Service
+// Control Manager (SCM). Keep those callbacks tiny and communicate with the
+// async runtime through an atomic edge. The runtime owns the bounded cleanup
+// and the callback never force-terminates the process.
+
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+#[cfg(target_os = "windows")]
+use std::sync::{Arc, OnceLock};
+
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Foundation::{GetLastError, BOOL};
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Console::{
+    AttachConsole, SetConsoleCtrlHandler, CTRL_BREAK_EVENT, CTRL_C_EVENT, CTRL_CLOSE_EVENT,
+    CTRL_LOGOFF_EVENT, CTRL_SHUTDOWN_EVENT,
+};
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Services::{
+    RegisterServiceCtrlHandlerExW, SERVICE_ACCEPT_PRESHUTDOWN, SERVICE_ACCEPT_SESSIONCHANGE,
+    SERVICE_ACCEPT_SHUTDOWN, SERVICE_ACCEPT_STOP, SERVICE_CONTROL_INTERROGATE,
+    SERVICE_CONTROL_PRESHUTDOWN, SERVICE_CONTROL_SESSIONCHANGE, SERVICE_CONTROL_SHUTDOWN,
+    SERVICE_CONTROL_STOP, SERVICE_RUNNING, SERVICE_START_PENDING, SERVICE_STATUS,
+    SERVICE_STATUS_HANDLE, SERVICE_STOPPED, SERVICE_STOP_PENDING, SERVICE_TABLE_ENTRYW,
+    SERVICE_WIN32_OWN_PROCESS, SetServiceStatus, StartServiceCtrlDispatcherW,
+};
+
+#[cfg(target_os = "windows")]
+const SERVICE_SESSION_LOGOFF: u32 = 0x0000_0006;
+
+#[cfg(target_os = "windows")]
+const LIFECYCLE_NONE: u32 = 0;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_CTRL_C: u32 = 1;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_CTRL_BREAK: u32 = 2;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_CTRL_CLOSE: u32 = 3;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_CTRL_LOGOFF: u32 = 4;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_CTRL_SHUTDOWN: u32 = 5;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_SERVICE_STOP: u32 = 6;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_SERVICE_PRESHUTDOWN: u32 = 7;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_SERVICE_SHUTDOWN: u32 = 8;
+#[cfg(target_os = "windows")]
+const LIFECYCLE_SERVICE_LOGOFF: u32 = 9;
+
+/// Cross-thread signal shared by the native Windows callbacks and the Tokio
+/// supervisor. The callback only stores the first reason; shutdown remains
+/// idempotent when SCM sends STOP followed by SHUTDOWN/PRESHUTDOWN.
+#[cfg(target_os = "windows")]
+pub(crate) struct WindowsLifecycleSignal {
+    reason: AtomicU32,
+    completed: AtomicBool,
+}
+
+#[cfg(target_os = "windows")]
+impl WindowsLifecycleSignal {
+    fn new() -> Self {
+        Self {
+            reason: AtomicU32::new(LIFECYCLE_NONE),
+            completed: AtomicBool::new(false),
+        }
+    }
+
+    fn trigger(&self, reason: u32) {
+        let _ = self.reason.compare_exchange(
+            LIFECYCLE_NONE,
+            reason,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    fn reason(&self) -> u32 {
+        self.reason.load(Ordering::Acquire)
+    }
+
+    fn complete(&self) {
+        self.completed.store(true, Ordering::Release);
+    }
+
+    fn is_complete(&self) -> bool {
+        self.completed.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(target_os = "windows")]
+static CONSOLE_SIGNAL: OnceLock<Arc<WindowsLifecycleSignal>> = OnceLock::new();
+
+/// Install the process-wide console callback used for Ctrl+C, Ctrl+Break,
+/// console close, logoff, and system shutdown. A GUI-subsystem process may
+/// have no console at startup; registering the handler is still valid and the
+/// callback becomes active if the process attaches to one later.
+#[cfg(target_os = "windows")]
+pub(crate) fn install_windows_console_handler() -> p2pnet_daemon::Result<Arc<WindowsLifecycleSignal>> {
+    let signal = CONSOLE_SIGNAL
+        .get_or_init(|| Arc::new(WindowsLifecycleSignal::new()))
+        .clone();
+    let installed = unsafe { SetConsoleCtrlHandler(Some(windows_console_handler), 1) };
+    if installed == 0 {
+        return Err(DaemonError::Network(format!(
+            "Windows console lifecycle handler registration failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(signal)
+}
+
+/// Attach to the parent's console for the dedicated Ctrl+C acceptance
+/// harness. This is deliberately opt-in and is never used by the desktop
+/// launcher.
+#[cfg(target_os = "windows")]
+pub(crate) fn attach_windows_parent_console_for_test() -> bool {
+    unsafe { AttachConsole(u32::MAX) != 0 }
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn windows_console_handler(event: u32) -> BOOL {
+    let Some(signal) = CONSOLE_SIGNAL.get() else {
+        return 0;
+    };
+
+    let reason = match event {
+        CTRL_C_EVENT => LIFECYCLE_CTRL_C,
+        CTRL_BREAK_EVENT => LIFECYCLE_CTRL_BREAK,
+        CTRL_CLOSE_EVENT => LIFECYCLE_CTRL_CLOSE,
+        CTRL_LOGOFF_EVENT => LIFECYCLE_CTRL_LOGOFF,
+        CTRL_SHUTDOWN_EVENT => LIFECYCLE_CTRL_SHUTDOWN,
+        _ => return 0,
+    };
+    signal.trigger(reason);
+
+    // Windows may terminate a process after a close/logoff/shutdown handler
+    // returns. Hold those callbacks until the async cleanup has completed so
+    // the process does not skip Wintun/route/socket teardown. Ctrl+C/Break
+    // does not have this forced-termination behavior.
+    if matches!(
+        event,
+        CTRL_CLOSE_EVENT | CTRL_LOGOFF_EVENT | CTRL_SHUTDOWN_EVENT
+    ) {
+        while !signal.is_complete() {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+    }
+    1
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsServiceContext {
+    signal: Arc<WindowsLifecycleSignal>,
+    status_handle: SERVICE_STATUS_HANDLE,
+}
+
+#[cfg(target_os = "windows")]
+static SERVICE_NAME: OnceLock<Vec<u16>> = OnceLock::new();
+
+#[cfg(target_os = "windows")]
+pub(crate) fn windows_service_requested() -> bool {
+    std::env::args_os().any(|arg| arg == "--windows-service")
+}
+
+#[cfg(target_os = "windows")]
+fn windows_service_name_from_args() -> String {
+    let mut args = std::env::args_os().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--windows-service-name" {
+            if let Some(value) = args.next() {
+                let name = value.to_string_lossy().trim().to_string();
+                if !name.is_empty() {
+                    return name;
+                }
+            }
+        }
+    }
+    "p2wlan-daemon".to_string()
+}
+
+/// Enter the SCM dispatcher. `StartServiceCtrlDispatcherW` blocks until the
+/// service main callback returns. A normal process invocation fails with the
+/// explicit Windows error instead of silently falling back to desktop mode.
+#[cfg(target_os = "windows")]
+pub(crate) fn run_windows_service() -> p2pnet_daemon::Result<()> {
+    let name = windows_service_name_from_args();
+    let wide_name = SERVICE_NAME.get_or_init(|| {
+        name.encode_utf16().chain(std::iter::once(0)).collect()
+    });
+    let entry = SERVICE_TABLE_ENTRYW {
+        lpServiceName: wide_name.as_ptr() as *mut u16,
+        lpServiceProc: Some(windows_service_main),
+    };
+    let terminator = SERVICE_TABLE_ENTRYW {
+        lpServiceName: std::ptr::null_mut(),
+        lpServiceProc: None,
+    };
+    let table = [entry, terminator];
+    if unsafe { StartServiceCtrlDispatcherW(table.as_ptr()) } == 0 {
+        let error = unsafe { GetLastError() };
+        return Err(DaemonError::Network(format!(
+            "Windows Service Control Manager dispatcher failed with error {error}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn windows_service_main(
+    _argument_count: u32,
+    _arguments: *mut windows_sys::core::PWSTR,
+) {
+    let signal = Arc::new(WindowsLifecycleSignal::new());
+    let context = Box::new(WindowsServiceContext {
+        signal: signal.clone(),
+        status_handle: 0,
+    });
+    let context_ptr = Box::into_raw(context);
+
+    let Some(service_name) = SERVICE_NAME.get() else {
+        let _ = Box::from_raw(context_ptr);
+        return;
+    };
+    let handle = RegisterServiceCtrlHandlerExW(
+        service_name.as_ptr(),
+        Some(windows_service_handler),
+        context_ptr.cast(),
+    );
+    if handle == 0 {
+        let _ = Box::from_raw(context_ptr);
+        return;
+    }
+    (*context_ptr).status_handle = handle;
+
+    set_windows_service_status(handle, SERVICE_START_PENDING, 0);
+    set_windows_service_status(handle, SERVICE_RUNNING, 0);
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            set_windows_service_status(handle, SERVICE_STOPPED, 1);
+            eprintln!("failed to create Windows service runtime: {error}");
+            signal.complete();
+            let _ = Box::from_raw(context_ptr);
+            return;
+        }
+    };
+    let result = runtime.block_on(run_daemon(Some(signal.clone())));
+    let exit_code = if result.is_ok() { 0 } else { 1 };
+    set_windows_service_status(handle, SERVICE_STOPPED, exit_code);
+    signal.complete();
+    drop(runtime);
+    let _ = Box::from_raw(context_ptr);
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn windows_service_handler(
+    control: u32,
+    event_type: u32,
+    _event_data: *mut std::ffi::c_void,
+    context: *mut std::ffi::c_void,
+) -> u32 {
+    if context.is_null() {
+        return 1;
+    }
+    let context = &*(context.cast::<WindowsServiceContext>());
+    let reason = match control {
+        SERVICE_CONTROL_STOP => Some(LIFECYCLE_SERVICE_STOP),
+        SERVICE_CONTROL_PRESHUTDOWN => Some(LIFECYCLE_SERVICE_PRESHUTDOWN),
+        SERVICE_CONTROL_SHUTDOWN => Some(LIFECYCLE_SERVICE_SHUTDOWN),
+        SERVICE_CONTROL_SESSIONCHANGE if event_type == SERVICE_SESSION_LOGOFF => {
+            Some(LIFECYCLE_SERVICE_LOGOFF)
+        }
+        SERVICE_CONTROL_INTERROGATE => None,
+        _ => return 120,
+    };
+    if let Some(reason) = reason {
+        context.signal.trigger(reason);
+        if matches!(control, SERVICE_CONTROL_STOP | SERVICE_CONTROL_PRESHUTDOWN) {
+            set_windows_service_status(context.status_handle, SERVICE_STOP_PENDING, 15_000);
+        }
+    }
+    0
+}
+
+#[cfg(target_os = "windows")]
+fn set_windows_service_status(
+    handle: SERVICE_STATUS_HANDLE,
+    state: u32,
+    wait_hint_or_exit_code: u32,
+) {
+    let status = SERVICE_STATUS {
+        dwServiceType: SERVICE_WIN32_OWN_PROCESS,
+        dwCurrentState: state,
+        dwControlsAccepted: if state == SERVICE_RUNNING {
+            SERVICE_ACCEPT_STOP
+                | SERVICE_ACCEPT_PRESHUTDOWN
+                | SERVICE_ACCEPT_SHUTDOWN
+                | SERVICE_ACCEPT_SESSIONCHANGE
+        } else {
+            0
+        },
+        dwWin32ExitCode: if state == SERVICE_STOPPED {
+            wait_hint_or_exit_code
+        } else {
+            0
+        },
+        dwServiceSpecificExitCode: 0,
+        dwCheckPoint: 0,
+        dwWaitHint: if state == SERVICE_STOPPED {
+            0
+        } else {
+            wait_hint_or_exit_code
+        },
+    };
+    unsafe {
+        let _ = SetServiceStatus(handle, &status);
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn windows_lifecycle_reason(code: u32) -> &'static str {
+    match code {
+        LIFECYCLE_CTRL_C => "CTRL_C",
+        LIFECYCLE_CTRL_BREAK => "CTRL_BREAK",
+        LIFECYCLE_CTRL_CLOSE => "CTRL_CLOSE",
+        LIFECYCLE_CTRL_LOGOFF => "CTRL_LOGOFF",
+        LIFECYCLE_CTRL_SHUTDOWN => "CTRL_SHUTDOWN",
+        LIFECYCLE_SERVICE_STOP => "SERVICE_STOP",
+        LIFECYCLE_SERVICE_PRESHUTDOWN => "SERVICE_PRESHUTDOWN",
+        LIFECYCLE_SERVICE_SHUTDOWN => "SERVICE_SHUTDOWN",
+        LIFECYCLE_SERVICE_LOGOFF => "SERVICE_LOGOFF",
+        _ => "WINDOWS_LIFECYCLE",
+    }
+}

--- a/client/daemon/tests/windows_lifecycle.rs
+++ b/client/daemon/tests/windows_lifecycle.rs
@@ -122,3 +122,34 @@ fn windows_tray_event_source_drains_bounded_sequence_before_exit() {
         assert_eq!(envelope["event"]["sequence"], 77 + index as u64);
     }
 }
+
+#[test]
+fn windows_handler_mapping_probe_uses_production_adapters() {
+    let output = run_daemon(&["--windows-lifecycle-handler-probe".to_string()]);
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "handler mapping probe returned invalid JSON: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["schema_version"], 2);
+    assert_eq!(value["component"], "handler_mapping");
+    assert_eq!(value["handler_mapping"]["status"], "verified");
+    assert_eq!(value["handler_mapping"]["live_system_delivery"], "deferred");
+    assert_eq!(
+        value["handler_mapping"]["idempotent_first_request_wins"],
+        true
+    );
+    assert_eq!(value["handler_mapping"]["coordinator_entered"], true);
+    assert_eq!(value["handler_mapping"]["callback_non_blocking"], true);
+    assert_eq!(value["handler_mapping"]["force_kill"], false);
+    assert_eq!(
+        value["handler_mapping"]["console"].as_array().map(Vec::len),
+        Some(5)
+    );
+    assert_eq!(
+        value["handler_mapping"]["service"].as_array().map(Vec::len),
+        Some(4)
+    );
+}

--- a/scripts/release/build_flutter_client.sh
+++ b/scripts/release/build_flutter_client.sh
@@ -150,4 +150,10 @@ export ORG_GRADLE_PROJECT_p2wlanSourceIdentityFile="$source_identity_file"
 export ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce="$identity_nonce"
 
 cd "$ROOT_DIR/apps/flutter_client"
+if [[ "${1:-}" == windows ]]; then
+  # tray_manager 0.5.3 reads an uninitialized HICON on its first Windows
+  # setIcon call. Patch the exact resolved pub-cache source before compiling
+  # the packaged Windows client; the patch script refuses unknown source.
+  python3 "$ROOT_DIR/scripts/release/patch_tray_manager_windows.py" "$PWD"
+fi
 flutter build "$@" "${DEFINES[@]}"

--- a/scripts/release/build_flutter_client.sh
+++ b/scripts/release/build_flutter_client.sh
@@ -151,8 +151,9 @@ export ORG_GRADLE_PROJECT_p2wlanSourceIdentityNonce="$identity_nonce"
 
 cd "$ROOT_DIR/apps/flutter_client"
 if [[ "${1:-}" == windows ]]; then
-  # tray_manager 0.5.3 reads an uninitialized HICON on its first Windows
-  # setIcon call. Patch the exact resolved pub-cache source before compiling
+  # tray_manager 0.5.3 has two Windows native crash paths: an uninitialized
+  # HICON on the first setIcon call and an absent separator label in menu
+  # construction. Patch the exact resolved pub-cache source before compiling
   # the packaged Windows client; the patch script refuses unknown source.
   python3 "$ROOT_DIR/scripts/release/patch_tray_manager_windows.py" "$PWD"
 fi

--- a/scripts/release/patch_tray_manager_windows.py
+++ b/scripts/release/patch_tray_manager_windows.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Patch the Windows initialization bug in the pinned tray_manager package.
+
+tray_manager 0.5.3 declares NOTIFYICONDATA without value-initializing it.
+Its first Windows setIcon call reads nid.hIcon before assigning it, which can
+turn a clean tray startup into STATUS_FATAL_USER_CALLBACK_EXCEPTION.  Keep the
+workaround narrow and auditable: resolve the exact package selected by
+.dart_tool/package_config.json, require the known source shape, and change only
+that declaration in the pub cache used for the current build.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+
+NEEDLE = "  NOTIFYICONDATA nid;"
+REPLACEMENT = "  NOTIFYICONDATA nid{};"
+
+
+def package_root(config_path: Path) -> Path:
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    for package in config.get("packages", []):
+        if package.get("name") != "tray_manager":
+            continue
+        root_uri = package.get("rootUri")
+        if not isinstance(root_uri, str):
+            break
+        parsed = urlparse(root_uri)
+        if parsed.scheme == "file":
+            path = unquote(parsed.path)
+            if (
+                os.name == "nt"
+                and len(path) >= 3
+                and path[0] == "/"
+                and path[2] == ":"
+            ):
+                path = path[1:]
+            if parsed.netloc:
+                path = f"//{parsed.netloc}{path}"
+            return Path(url2pathname(path)).resolve()
+        if parsed.scheme:
+            break
+        return (config_path.parent / root_uri).resolve()
+    raise RuntimeError("tray_manager was not resolved in package_config.json")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {sys.argv[0]} <flutter-client-root>")
+
+    client_root = Path(sys.argv[1]).resolve()
+    config_path = client_root / ".dart_tool" / "package_config.json"
+    if not config_path.is_file():
+        raise RuntimeError(f"Flutter package config not found: {config_path}")
+
+    source_path = package_root(config_path) / "windows" / "tray_manager_plugin.cpp"
+    if not source_path.is_file():
+        raise RuntimeError(f"tray_manager Windows source not found: {source_path}")
+
+    source = source_path.read_text(encoding="utf-8")
+    if REPLACEMENT in source:
+        print(f"tray_manager Windows initialization already patched: {source_path}")
+        return 0
+    if source.count(NEEDLE) != 1:
+        raise RuntimeError(
+            "unexpected tray_manager Windows source; refusing an unreviewed patch "
+            f"in {source_path}"
+        )
+
+    patched = source.replace(NEEDLE, REPLACEMENT)
+    source_path.write_text(patched, encoding="utf-8", newline="")
+    print(f"patched tray_manager Windows initialization: {source_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"tray_manager Windows patch failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/release/patch_tray_manager_windows.py
+++ b/scripts/release/patch_tray_manager_windows.py
@@ -5,8 +5,8 @@ tray_manager 0.5.3 declares NOTIFYICONDATA without value-initializing it.
 Its first Windows setIcon call reads nid.hIcon before assigning it, which can
 turn a clean tray startup into STATUS_FATAL_USER_CALLBACK_EXCEPTION.  Keep the
 workaround narrow and auditable: resolve the exact package selected by
-.dart_tool/package_config.json, require the known source shape, and change only
-that declaration in the pub cache used for the current build.
+.dart_tool/package_config.json, require both known source shapes, and change
+only those declarations in the pub cache used for the current build.
 """
 
 from __future__ import annotations
@@ -19,8 +19,16 @@ from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
 
-NEEDLE = "  NOTIFYICONDATA nid;"
-REPLACEMENT = "  NOTIFYICONDATA nid{};"
+ICON_NEEDLE = "  NOTIFYICONDATA nid;"
+ICON_REPLACEMENT = "  NOTIFYICONDATA nid{};"
+MENU_LABEL_NEEDLE = """    std::string label =
+        std::get<std::string>(item_map.at(flutter::EncodableValue("label")));"""
+MENU_LABEL_REPLACEMENT = """    std::string label;
+    if (const auto* label_value =
+            ValueOrNull(item_map, "label");
+        label_value != nullptr) {
+      label = std::get<std::string>(*label_value);
+    }"""
 
 
 def package_root(config_path: Path) -> Path:
@@ -64,18 +72,27 @@ def main() -> int:
         raise RuntimeError(f"tray_manager Windows source not found: {source_path}")
 
     source = source_path.read_text(encoding="utf-8")
-    if REPLACEMENT in source:
+    patched = source
+    changed = []
+    for name, needle, replacement in (
+        ("icon initialization", ICON_NEEDLE, ICON_REPLACEMENT),
+        ("separator label handling", MENU_LABEL_NEEDLE, MENU_LABEL_REPLACEMENT),
+    ):
+        if replacement in patched:
+            continue
+        if patched.count(needle) != 1:
+            raise RuntimeError(
+                "unexpected tray_manager Windows source; refusing an unreviewed "
+                f"{name} patch in {source_path}"
+            )
+        patched = patched.replace(needle, replacement)
+        changed.append(name)
+
+    if not changed:
         print(f"tray_manager Windows initialization already patched: {source_path}")
         return 0
-    if source.count(NEEDLE) != 1:
-        raise RuntimeError(
-            "unexpected tray_manager Windows source; refusing an unreviewed patch "
-            f"in {source_path}"
-        )
-
-    patched = source.replace(NEEDLE, REPLACEMENT)
     source_path.write_text(patched, encoding="utf-8", newline="")
-    print(f"patched tray_manager Windows initialization: {source_path}")
+    print(f"patched tray_manager Windows {', '.join(changed)}: {source_path}")
     return 0
 
 

--- a/scripts/windows_lifecycle/aggregate_evidence.py
+++ b/scripts/windows_lifecycle/aggregate_evidence.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Fail-closed aggregate for the Windows lifecycle acceptance artifact.
+
+The Windows runner is the source of truth for every Windows-specific result.
+This module only validates the artifact emitted by that runner; it never turns
+an omitted or force-killed operation into a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+VERIFIED = "verified"
+DEFERRED = "deferred"
+FAILED = "failed"
+VALID_STATUSES = {VERIFIED, DEFERRED, FAILED}
+
+REQUIRED_CAPABILITIES = (
+    "production_start_stop",
+    "cli_stop",
+    "ui_stop",
+    "ctrl_c",
+    "service_stop",
+    "service_preshutdown",
+    "logoff_hook",
+    "shutdown_hook",
+    "diagnostics_port_release",
+    "child_process_cleanup",
+    "wintun_ownership",
+    "flutter_release_tray_no_adapter_exit",
+    "wer_scan",
+)
+
+
+class EvidenceError(ValueError):
+    """The artifact is malformed or does not prove the required contract."""
+
+
+def _status(value: Any, path: str) -> str:
+    if not isinstance(value, str) or value not in VALID_STATUSES:
+        raise EvidenceError(
+            f"{path} must be one of {sorted(VALID_STATUSES)!r}, got {value!r}"
+        )
+    return value
+
+
+def _require_bool(item: dict[str, Any], key: str, path: str) -> bool:
+    value = item.get(key)
+    if not isinstance(value, bool):
+        raise EvidenceError(f"{path}.{key} must be a boolean")
+    return value
+
+
+def _require_int(item: dict[str, Any], key: str, path: str) -> int:
+    value = item.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise EvidenceError(f"{path}.{key} must be an integer")
+    return value
+
+
+def _capability_map(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = document.get("capabilities")
+    if not isinstance(raw, list):
+        raise EvidenceError("capabilities must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(raw):
+        path = f"capabilities[{index}]"
+        if not isinstance(value, dict):
+            raise EvidenceError(f"{path} must be an object")
+        name = value.get("name")
+        if not isinstance(name, str) or not name:
+            raise EvidenceError(f"{path}.name must be a non-empty string")
+        if name in result:
+            raise EvidenceError(f"duplicate capability {name!r}")
+        _status(value.get("status"), f"{path}.status")
+        result[name] = value
+    return result
+
+
+def _validate_cycles(document: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    raw = document.get("cycles")
+    if not isinstance(raw, list):
+        raise EvidenceError("cycles must be a list")
+
+    errors: list[str] = []
+    cycles: list[dict[str, Any]] = []
+    for index, value in enumerate(raw):
+        path = f"cycles[{index}]"
+        if not isinstance(value, dict):
+            raise EvidenceError(f"{path} must be an object")
+        for key in ("cycle", "entrypoint", "mode"):
+            if not isinstance(value.get(key), (int, str)) or value.get(key) == "":
+                raise EvidenceError(f"{path}.{key} is required")
+        for key in (
+            "start_succeeded",
+            "graceful_stop",
+            "forced_termination",
+            "process_exited",
+            "children_gone",
+            "diagnostics_port_released",
+            "auth_token_removed",
+            "wintun_stale",
+            "wintun_observed",
+            "real_wintun",
+            "daemon_processes_clean",
+        ):
+            _require_bool(value, key, path)
+        exit_code = value.get("process_exit_code")
+        if exit_code is not None and (
+            not isinstance(exit_code, int) or isinstance(exit_code, bool)
+        ):
+            raise EvidenceError(f"{path}.process_exit_code must be an integer or null")
+        cycles.append(value)
+
+        if not value["start_succeeded"]:
+            errors.append(f"{path}: production start did not succeed")
+        if not value["graceful_stop"]:
+            errors.append(f"{path}: stop was not proven graceful")
+        if value["forced_termination"]:
+            errors.append(f"{path}: forceful termination was used")
+        if not value["process_exited"]:
+            errors.append(f"{path}: daemon process remained alive")
+        if value.get("process_exit_code") not in (None, 0):
+            errors.append(f"{path}: daemon exit code was {value['process_exit_code']}")
+        if not value["children_gone"]:
+            errors.append(f"{path}: child process cleanup failed")
+        if not value["diagnostics_port_released"]:
+            errors.append(f"{path}: diagnostics port was not released")
+        if not value["auth_token_removed"]:
+            errors.append(f"{path}: diagnostics auth file remained")
+        if value["real_wintun"] and value["wintun_stale"]:
+            errors.append(f"{path}: stale Wintun ownership remained")
+        if value["real_wintun"] and not value["wintun_observed"]:
+            errors.append(f"{path}: real Wintun adapter was not observed while daemon was running")
+    return cycles, errors
+
+
+def _validate_wer(document: dict[str, Any], capabilities: dict[str, dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    wer = document.get("wer")
+    if not isinstance(wer, dict):
+        return ["wer must be an object"]
+    events = wer.get("events")
+    if not isinstance(events, list):
+        errors.append("wer.events must be a list")
+    elif events:
+        errors.append(f"wer scan found {len(events)} crash/BEX event(s)")
+    if wer.get("event_ids_checked") != [1000, 1001]:
+        errors.append("wer.event_ids_checked must be exactly [1000, 1001]")
+    capability = capabilities.get("wer_scan")
+    if capability is None:
+        errors.append("missing capability wer_scan")
+    elif capability.get("status") != VERIFIED:
+        errors.append(f"wer_scan is {capability.get('status')!r}, not verified")
+    return errors
+
+
+def _validate_service_controls(
+    document: dict[str, Any], capabilities: dict[str, dict[str, Any]]
+) -> list[str]:
+    errors: list[str] = []
+    raw = document.get("service_controls")
+    if not isinstance(raw, list):
+        return ["service_controls must be a list"]
+    by_control: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(raw):
+        path = f"service_controls[{index}]"
+        if not isinstance(value, dict):
+            errors.append(f"{path} must be an object")
+            continue
+        control = value.get("control")
+        if not isinstance(control, str) or control not in {"stop", "preshutdown"}:
+            errors.append(f"{path}.control must be stop or preshutdown")
+            continue
+        if control in by_control:
+            errors.append(f"duplicate service control {control!r}")
+            continue
+        by_control[control] = value
+        _status(value.get("status"), f"{path}.status")
+        for key in ("process_gone", "wintun_observed", "wintun_stale"):
+            _require_bool(value, key, path)
+
+    for control, capability_name in (
+        ("stop", "service_stop"),
+        ("preshutdown", "service_preshutdown"),
+    ):
+        capability = capabilities.get(capability_name)
+        record = by_control.get(control)
+        if capability is not None and capability.get("status") == VERIFIED:
+            if record is None:
+                errors.append(f"missing service control record {control}")
+                continue
+            if record.get("status") != VERIFIED:
+                errors.append(f"service control {control} is not verified")
+            if not record["process_gone"]:
+                errors.append(f"service control {control} left a process running")
+            if not record["wintun_observed"]:
+                errors.append(f"service control {control} did not observe a Wintun adapter")
+            if record["wintun_stale"]:
+                errors.append(f"service control {control} left stale Wintun ownership")
+    return errors
+
+
+def _validate_flutter_tray(
+    document: dict[str, Any], capabilities: dict[str, dict[str, Any]]
+) -> list[str]:
+    capability = capabilities.get("flutter_release_tray_no_adapter_exit")
+    if capability is None or capability.get("status") != VERIFIED:
+        return []
+    raw = document.get("flutter_tray")
+    if not isinstance(raw, dict):
+        return ["flutter_tray must be an object when release tray exit is verified"]
+    errors: list[str] = []
+    for key in ("process_exited", "daemon_processes_clean", "forced_termination"):
+        try:
+            _require_bool(raw, key, "flutter_tray")
+        except EvidenceError as error:
+            errors.append(str(error))
+    if raw.get("exit_code") != 0:
+        errors.append(f"flutter_tray.exit_code must be 0, got {raw.get('exit_code')!r}")
+    if raw.get("forced_termination"):
+        errors.append("flutter release tray exit used forceful termination")
+    if not raw.get("process_exited"):
+        errors.append("flutter release tray process did not exit")
+    if not raw.get("daemon_processes_clean"):
+        errors.append("flutter release tray test left a daemon process running")
+    return errors
+
+
+def validate(document: dict[str, Any]) -> dict[str, Any]:
+    """Validate an evidence document and return a compact aggregate report."""
+
+    if not isinstance(document, dict):
+        raise EvidenceError("top-level evidence must be an object")
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise EvidenceError(f"schema_version must be {SCHEMA_VERSION}")
+    head_sha = document.get("head_sha")
+    if not isinstance(head_sha, str) or not head_sha:
+        raise EvidenceError("head_sha is required")
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
+        raise EvidenceError("head_sha must be a 40-character git SHA")
+    if document.get("runner_os") != "windows-latest":
+        raise EvidenceError("runner_os must be windows-latest")
+    capabilities = _capability_map(document)
+    cycles, cycle_errors = _validate_cycles(document)
+    errors = list(cycle_errors)
+
+    missing = [name for name in REQUIRED_CAPABILITIES if name not in capabilities]
+    errors.extend(f"missing capability {name}" for name in missing)
+    deferred = [
+        name
+        for name in REQUIRED_CAPABILITIES
+        if name in capabilities and capabilities[name]["status"] == DEFERRED
+    ]
+    failed = [
+        name
+        for name in REQUIRED_CAPABILITIES
+        if name in capabilities and capabilities[name]["status"] == FAILED
+    ]
+    errors.extend(f"capability {name} is failed" for name in failed)
+
+    production = [cycle for cycle in cycles if cycle.get("mode") == "production"]
+    if len(production) < 50:
+        errors.append(f"only {len(production)} production cycles; at least 50 are required")
+
+    entrypoints = {cycle.get("entrypoint") for cycle in production}
+    for entrypoint in ("diagnostics", "cli", "ctrl_c"):
+        if entrypoint not in entrypoints:
+            errors.append(f"no production cycle exercised {entrypoint}")
+
+    ui_capability = capabilities.get("ui_stop")
+    ui_cycles = [cycle for cycle in cycles if cycle.get("entrypoint") == "ui"]
+    if ui_capability is not None and ui_capability.get("status") == VERIFIED and not ui_cycles:
+        errors.append("ui_stop is verified but no UI lifecycle cycle was recorded")
+    if ui_capability is not None and ui_capability.get("status") == VERIFIED:
+        for index, cycle in enumerate(ui_cycles):
+            if cycle.get("forced_termination"):
+                errors.append(f"ui cycle {index} used forceful termination")
+            if not cycle.get("graceful_stop"):
+                errors.append(f"ui cycle {index} was not proven graceful")
+
+    wintun_capability = capabilities.get("wintun_ownership")
+    if wintun_capability is not None and wintun_capability.get("status") == VERIFIED:
+        non_real = [cycle.get("cycle") for cycle in production if not cycle.get("real_wintun")]
+        if non_real:
+            errors.append(f"production cycles without real Wintun evidence: {non_real!r}")
+
+    errors.extend(_validate_wer(document, capabilities))
+    errors.extend(_validate_service_controls(document, capabilities))
+    errors.extend(_validate_flutter_tray(document, capabilities))
+
+    # A deferred capability is explicit evidence that the runner could not
+    # execute one required operation. It is never a verified pass. Any schema,
+    # cycle, or failed-capability error remains a hard failure even when some
+    # other capability is deferred; otherwise an incomplete artifact could be
+    # incorrectly downgraded to a harmless deferral.
+    overall = FAILED if errors else DEFERRED if deferred else VERIFIED
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "head_sha": head_sha,
+        "overall": overall,
+        "production_cycles": len(production),
+        "production_entrypoints": sorted(entrypoints),
+        "deferred_capabilities": deferred,
+        "failed_capabilities": failed,
+        "error_count": len(errors),
+        "errors": errors,
+    }
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        document = json.loads(args.input.read_text(encoding="utf-8-sig"))
+        report = validate(document)
+    except (OSError, json.JSONDecodeError, EvidenceError) as error:
+        print(f"Windows lifecycle evidence rejected: {error}", file=sys.stderr)
+        return 1
+
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    if report["overall"] != VERIFIED:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/windows_lifecycle/aggregate_evidence.py
+++ b/scripts/windows_lifecycle/aggregate_evidence.py
@@ -596,8 +596,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")
     print(rendered, end="")
-    if report["overall"] != VERIFIED:
+    if report["overall"] == FAILED:
         return 2
+    if report["overall"] == DEFERRED:
+        print(
+            "Windows lifecycle evidence accepted with explicit deferred operations; "
+            "see the aggregate JSON for the non-verified scope.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/scripts/windows_lifecycle/aggregate_evidence.py
+++ b/scripts/windows_lifecycle/aggregate_evidence.py
@@ -3,25 +3,28 @@
 
 The Windows runner is the source of truth for every Windows-specific result.
 This module only validates the artifact emitted by that runner; it never turns
-an omitted or force-killed operation into a pass.
+an omitted, force-killed, stale-SHA, or deferred operation into a verified pass.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Any
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+REPOSITORY = "yhan-sun/p2wlan"
+SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 VERIFIED = "verified"
 DEFERRED = "deferred"
 FAILED = "failed"
 VALID_STATUSES = {VERIFIED, DEFERRED, FAILED}
-
+EXPECTED_COMPONENTS = ("production_harness", "flutter_ui", "handler_mapping")
 REQUIRED_CAPABILITIES = (
     "production_start_stop",
     "cli_stop",
@@ -37,6 +40,19 @@ REQUIRED_CAPABILITIES = (
     "flutter_release_tray_no_adapter_exit",
     "wer_scan",
 )
+EXPECTED_CONSOLE_MAPPING = [
+    {"event": "CTRL_C_EVENT", "reason": "CTRL_C"},
+    {"event": "CTRL_BREAK_EVENT", "reason": "CTRL_BREAK"},
+    {"event": "CTRL_CLOSE_EVENT", "reason": "CTRL_CLOSE"},
+    {"event": "CTRL_LOGOFF_EVENT", "reason": "CTRL_LOGOFF"},
+    {"event": "CTRL_SHUTDOWN_EVENT", "reason": "CTRL_SHUTDOWN"},
+]
+EXPECTED_SERVICE_MAPPING = [
+    {"event": "SERVICE_CONTROL_STOP", "reason": "SERVICE_STOP"},
+    {"event": "SERVICE_CONTROL_PRESHUTDOWN", "reason": "SERVICE_PRESHUTDOWN"},
+    {"event": "SERVICE_CONTROL_SHUTDOWN", "reason": "SERVICE_SHUTDOWN"},
+    {"event": "SERVICE_CONTROL_SESSIONCHANGE_LOGOFF", "reason": "SERVICE_LOGOFF"},
+]
 
 
 class EvidenceError(ValueError):
@@ -65,6 +81,45 @@ def _require_int(item: dict[str, Any], key: str, path: str) -> int:
     return value
 
 
+def _require_sha(item: dict[str, Any], key: str, path: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise EvidenceError(f"{path}.{key} must be a 40-character git SHA")
+    return value
+
+
+def _validate_identity(
+    item: dict[str, Any],
+    path: str,
+    expected_source_head_sha: str | None = None,
+    expected_workflow_sha: str | None = None,
+) -> tuple[str, str]:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        raise EvidenceError(f"{path}.schema_version must be {SCHEMA_VERSION}")
+    if item.get("repository") != REPOSITORY:
+        raise EvidenceError(
+            f"{path}.repository must be {REPOSITORY!r}, got {item.get('repository')!r}"
+        )
+    if item.get("runner_os") != "windows-latest":
+        raise EvidenceError(f"{path}.runner_os must be windows-latest")
+    source_head_sha = _require_sha(item, "source_head_sha", path)
+    workflow_sha = _require_sha(item, "workflow_sha", path)
+    if (
+        expected_source_head_sha is not None
+        and source_head_sha != expected_source_head_sha
+    ):
+        raise EvidenceError(
+            f"{path}.source_head_sha={source_head_sha} does not match "
+            f"P2WLAN_EXACT_HEAD={expected_source_head_sha}"
+        )
+    if expected_workflow_sha is not None and workflow_sha != expected_workflow_sha:
+        raise EvidenceError(
+            f"{path}.workflow_sha={workflow_sha} does not match "
+            f"P2WLAN_WORKFLOW_SHA={expected_workflow_sha}"
+        )
+    return source_head_sha, workflow_sha
+
+
 def _capability_map(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
     raw = document.get("capabilities")
     if not isinstance(raw, list):
@@ -84,6 +139,48 @@ def _capability_map(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return result
 
 
+def _component_map(
+    document: dict[str, Any],
+    expected_source_head_sha: str | None,
+    expected_workflow_sha: str | None,
+    document_source_head_sha: str,
+    document_workflow_sha: str,
+) -> dict[str, dict[str, Any]]:
+    raw = document.get("components")
+    if not isinstance(raw, list):
+        raise EvidenceError("components must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(raw):
+        path = f"components[{index}]"
+        if not isinstance(value, dict):
+            raise EvidenceError(f"{path} must be an object")
+        name = value.get("name")
+        if not isinstance(name, str) or name not in EXPECTED_COMPONENTS:
+            raise EvidenceError(f"{path}.name is not a required component")
+        if name in result:
+            raise EvidenceError(f"duplicate component {name!r}")
+        component_source_head_sha, component_workflow_sha = _validate_identity(
+            value,
+            path,
+            expected_source_head_sha=expected_source_head_sha,
+            expected_workflow_sha=expected_workflow_sha,
+        )
+        if component_source_head_sha != document_source_head_sha:
+            raise EvidenceError(
+                f"{path}.source_head_sha must match evidence.source_head_sha"
+            )
+        if component_workflow_sha != document_workflow_sha:
+            raise EvidenceError(
+                f"{path}.workflow_sha must match evidence.workflow_sha"
+            )
+        _status(value.get("status"), f"{path}.status")
+        result[name] = value
+    missing = [name for name in EXPECTED_COMPONENTS if name not in result]
+    if missing:
+        raise EvidenceError(f"missing component(s): {missing!r}")
+    return result
+
+
 def _validate_cycles(document: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
     raw = document.get("cycles")
     if not isinstance(raw, list):
@@ -95,8 +192,10 @@ def _validate_cycles(document: dict[str, Any]) -> tuple[list[dict[str, Any]], li
         path = f"cycles[{index}]"
         if not isinstance(value, dict):
             raise EvidenceError(f"{path} must be an object")
-        for key in ("cycle", "entrypoint", "mode"):
-            if not isinstance(value.get(key), (int, str)) or value.get(key) == "":
+        if not isinstance(value.get("cycle"), int) or isinstance(value.get("cycle"), bool):
+            raise EvidenceError(f"{path}.cycle is required and must be an integer")
+        for key in ("entrypoint", "mode"):
+            if not isinstance(value.get(key), str) or not value.get(key):
                 raise EvidenceError(f"{path}.{key} is required")
         for key in (
             "start_succeeded",
@@ -138,11 +237,15 @@ def _validate_cycles(document: dict[str, Any]) -> tuple[list[dict[str, Any]], li
         if value["real_wintun"] and value["wintun_stale"]:
             errors.append(f"{path}: stale Wintun ownership remained")
         if value["real_wintun"] and not value["wintun_observed"]:
-            errors.append(f"{path}: real Wintun adapter was not observed while daemon was running")
+            errors.append(
+                f"{path}: real Wintun adapter was not observed while daemon was running"
+            )
     return cycles, errors
 
 
-def _validate_wer(document: dict[str, Any], capabilities: dict[str, dict[str, Any]]) -> list[str]:
+def _validate_wer(
+    document: dict[str, Any], capabilities: dict[str, dict[str, Any]]
+) -> list[str]:
     errors: list[str] = []
     wer = document.get("wer")
     if not isinstance(wer, dict):
@@ -212,45 +315,172 @@ def _validate_flutter_tray(
     document: dict[str, Any], capabilities: dict[str, dict[str, Any]]
 ) -> list[str]:
     capability = capabilities.get("flutter_release_tray_no_adapter_exit")
-    if capability is None or capability.get("status") != VERIFIED:
-        return []
     raw = document.get("flutter_tray")
     if not isinstance(raw, dict):
-        return ["flutter_tray must be an object when release tray exit is verified"]
+        return (
+            ["flutter_tray must be an object"]
+            if capability is not None and capability.get("status") == VERIFIED
+            else []
+        )
     errors: list[str] = []
     for key in ("process_exited", "daemon_processes_clean", "forced_termination"):
         try:
             _require_bool(raw, key, "flutter_tray")
         except EvidenceError as error:
             errors.append(str(error))
-    if raw.get("exit_code") != 0:
-        errors.append(f"flutter_tray.exit_code must be 0, got {raw.get('exit_code')!r}")
-    if raw.get("forced_termination"):
-        errors.append("flutter release tray exit used forceful termination")
-    if not raw.get("process_exited"):
-        errors.append("flutter release tray process did not exit")
-    if not raw.get("daemon_processes_clean"):
-        errors.append("flutter release tray test left a daemon process running")
+    exit_code = raw.get("exit_code")
+    if exit_code is not None and (
+        not isinstance(exit_code, int) or isinstance(exit_code, bool)
+    ):
+        errors.append("flutter_tray.exit_code must be an integer or null")
+    dump_paths = raw.get("dump_paths")
+    if not isinstance(dump_paths, list) or any(
+        not isinstance(path, str) for path in dump_paths
+    ):
+        errors.append("flutter_tray.dump_paths must be a list of strings")
+    tray_cycles = raw.get("cycles")
+    if not isinstance(tray_cycles, list):
+        errors.append("flutter_tray.cycles must be a list")
+        tray_cycles = []
+    try:
+        attempted_cycles = _require_int(raw, "attempted_cycles", "flutter_tray")
+        successful_cycles = _require_int(raw, "successful_cycles", "flutter_tray")
+    except EvidenceError as error:
+        errors.append(str(error))
+        attempted_cycles = -1
+        successful_cycles = -1
+
+    if capability is not None and capability.get("status") == VERIFIED:
+        if attempted_cycles != 20:
+            errors.append(f"flutter_tray.attempted_cycles must be 20, got {attempted_cycles}")
+        if successful_cycles != 20:
+            errors.append(f"flutter_tray.successful_cycles must be 20, got {successful_cycles}")
+        if len(tray_cycles) != 20:
+            errors.append(f"flutter_tray.cycles must contain 20 records, got {len(tray_cycles)}")
+        if raw.get("first_failure_cycle") is not None:
+            errors.append("verified flutter_tray must not contain first_failure_cycle")
+        if raw.get("exit_code") != 0:
+            errors.append(f"flutter_tray.exit_code must be 0, got {raw.get('exit_code')!r}")
+        if raw.get("forced_termination"):
+            errors.append("flutter release tray exit used forceful termination")
+        if not raw.get("process_exited"):
+            errors.append("flutter release tray process did not exit")
+        if not raw.get("daemon_processes_clean"):
+            errors.append("flutter release tray test left a daemon process running")
+
+    for index, cycle in enumerate(tray_cycles):
+        path = f"flutter_tray.cycles[{index}]"
+        if not isinstance(cycle, dict):
+            errors.append(f"{path} must be an object")
+            continue
+        if cycle.get("status") != VERIFIED:
+            if capability is not None and capability.get("status") == VERIFIED:
+                errors.append(f"{path}.status must be verified")
+        for key in ("process_exited", "daemon_processes_clean", "forced_termination"):
+            try:
+                _require_bool(cycle, key, path)
+            except EvidenceError as error:
+                errors.append(str(error))
+        if capability is not None and capability.get("status") == VERIFIED:
+            if cycle.get("exit_code") != 0:
+                errors.append(f"{path}.exit_code must be 0")
+            if not cycle.get("process_exited"):
+                errors.append(f"{path} did not exit")
+            if not cycle.get("daemon_processes_clean"):
+                errors.append(f"{path} left a daemon process running")
+            if cycle.get("forced_termination"):
+                errors.append(f"{path} used forceful termination")
     return errors
 
 
-def validate(document: dict[str, Any]) -> dict[str, Any]:
+def _validate_handler_mapping(document: dict[str, Any]) -> list[str]:
+    raw = document.get("handler_mapping")
+    if not isinstance(raw, dict):
+        return ["handler_mapping must be an object"]
+    errors: list[str] = []
+    if raw.get("status") != VERIFIED:
+        errors.append(f"handler_mapping.status must be verified, got {raw.get('status')!r}")
+    if raw.get("live_system_delivery") != DEFERRED:
+        errors.append("handler_mapping.live_system_delivery must be deferred")
+    detail = raw.get("live_system_delivery_detail")
+    if not isinstance(detail, str) or not detail.strip():
+        errors.append("handler_mapping.live_system_delivery_detail is required")
+    for key, expected in (
+        ("console", EXPECTED_CONSOLE_MAPPING),
+        ("service", EXPECTED_SERVICE_MAPPING),
+    ):
+        value = raw.get(key)
+        if value != expected:
+            errors.append(
+                f"handler_mapping.{key} does not match the production adapter mapping"
+            )
+    for key in (
+        "idempotent_first_request_wins",
+        "no_duplicate_frees",
+        "coordinator_entered",
+        "callback_non_blocking",
+        "bounded_deadline",
+        "force_kill",
+    ):
+        try:
+            _require_bool(raw, key, "handler_mapping")
+        except EvidenceError as error:
+            errors.append(str(error))
+    if raw.get("idempotent_first_request_wins") is not True:
+        errors.append("handler mapping did not prove first-request idempotence")
+    if raw.get("no_duplicate_frees") is not True:
+        errors.append("handler mapping did not prove duplicate-free cleanup dispatch")
+    if raw.get("coordinator_entered") is not True:
+        errors.append("handler mapping did not enter the shared shutdown coordinator")
+    if raw.get("callback_non_blocking") is not True:
+        errors.append("handler mapping did not prove a non-blocking callback")
+    if raw.get("bounded_deadline") is not True:
+        errors.append("handler mapping did not prove a bounded shutdown deadline")
+    deadline_ms = raw.get("shutdown_deadline_ms")
+    if not isinstance(deadline_ms, int) or isinstance(deadline_ms, bool) or deadline_ms <= 0:
+        errors.append("handler_mapping.shutdown_deadline_ms must be a positive integer")
+    callback_elapsed_ms = raw.get("callback_elapsed_ms")
+    if (
+        not isinstance(callback_elapsed_ms, int)
+        or isinstance(callback_elapsed_ms, bool)
+        or callback_elapsed_ms < 0
+        or callback_elapsed_ms > 1_000
+    ):
+        errors.append("handler_mapping.callback_elapsed_ms must be an integer in [0, 1000]")
+    if raw.get("force_kill") is not False:
+        errors.append("handler mapping reported forceful termination")
+    coordinator = raw.get("coordinator")
+    if not isinstance(coordinator, str) or not coordinator.strip():
+        errors.append("handler_mapping.coordinator is required")
+    return errors
+
+
+def validate(
+    document: dict[str, Any],
+    expected_source_head_sha: str | None = None,
+    expected_workflow_sha: str | None = None,
+) -> dict[str, Any]:
     """Validate an evidence document and return a compact aggregate report."""
 
     if not isinstance(document, dict):
         raise EvidenceError("top-level evidence must be an object")
-    if document.get("schema_version") != SCHEMA_VERSION:
-        raise EvidenceError(f"schema_version must be {SCHEMA_VERSION}")
-    head_sha = document.get("head_sha")
-    if not isinstance(head_sha, str) or not head_sha:
-        raise EvidenceError("head_sha is required")
-    if not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
-        raise EvidenceError("head_sha must be a 40-character git SHA")
-    if document.get("runner_os") != "windows-latest":
-        raise EvidenceError("runner_os must be windows-latest")
+    source_head_sha, workflow_sha = _validate_identity(
+        document,
+        "evidence",
+        expected_source_head_sha=expected_source_head_sha,
+        expected_workflow_sha=expected_workflow_sha,
+    )
+    components = _component_map(
+        document,
+        expected_source_head_sha=expected_source_head_sha,
+        expected_workflow_sha=expected_workflow_sha,
+        document_source_head_sha=source_head_sha,
+        document_workflow_sha=workflow_sha,
+    )
     capabilities = _capability_map(document)
     cycles, cycle_errors = _validate_cycles(document)
     errors = list(cycle_errors)
+    errors.extend(_validate_handler_mapping(document))
 
     missing = [name for name in REQUIRED_CAPABILITIES if name not in capabilities]
     errors.extend(f"missing capability {name}" for name in missing)
@@ -259,6 +489,8 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
         for name in REQUIRED_CAPABILITIES
         if name in capabilities and capabilities[name]["status"] == DEFERRED
     ]
+    if document["handler_mapping"].get("live_system_delivery") == DEFERRED:
+        deferred.append("live_system_delivery")
     failed = [
         name
         for name in REQUIRED_CAPABILITIES
@@ -266,9 +498,19 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
     ]
     errors.extend(f"capability {name} is failed" for name in failed)
 
+    deferred_components = [
+        name
+        for name in EXPECTED_COMPONENTS
+        if components[name]["status"] == DEFERRED
+    ]
+    failed_components = [
+        name for name in EXPECTED_COMPONENTS if components[name]["status"] == FAILED
+    ]
+    errors.extend(f"component {name} is failed" for name in failed_components)
+
     production = [cycle for cycle in cycles if cycle.get("mode") == "production"]
-    if len(production) < 50:
-        errors.append(f"only {len(production)} production cycles; at least 50 are required")
+    if len(production) != 50:
+        errors.append(f"found {len(production)} production cycles; exactly 50 are required")
 
     entrypoints = {cycle.get("entrypoint") for cycle in production}
     for entrypoint in ("diagnostics", "cli", "ctrl_c"):
@@ -277,9 +519,9 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
 
     ui_capability = capabilities.get("ui_stop")
     ui_cycles = [cycle for cycle in cycles if cycle.get("entrypoint") == "ui"]
-    if ui_capability is not None and ui_capability.get("status") == VERIFIED and not ui_cycles:
-        errors.append("ui_stop is verified but no UI lifecycle cycle was recorded")
     if ui_capability is not None and ui_capability.get("status") == VERIFIED:
+        if len(ui_cycles) < 8:
+            errors.append(f"only {len(ui_cycles)} UI cycles; at least 8 are required")
         for index, cycle in enumerate(ui_cycles):
             if cycle.get("forced_termination"):
                 errors.append(f"ui cycle {index} used forceful termination")
@@ -288,7 +530,9 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
 
     wintun_capability = capabilities.get("wintun_ownership")
     if wintun_capability is not None and wintun_capability.get("status") == VERIFIED:
-        non_real = [cycle.get("cycle") for cycle in production if not cycle.get("real_wintun")]
+        non_real = [
+            cycle.get("cycle") for cycle in production if not cycle.get("real_wintun")
+        ]
         if non_real:
             errors.append(f"production cycles without real Wintun evidence: {non_real!r}")
 
@@ -296,24 +540,40 @@ def validate(document: dict[str, Any]) -> dict[str, Any]:
     errors.extend(_validate_service_controls(document, capabilities))
     errors.extend(_validate_flutter_tray(document, capabilities))
 
-    # A deferred capability is explicit evidence that the runner could not
-    # execute one required operation. It is never a verified pass. Any schema,
-    # cycle, or failed-capability error remains a hard failure even when some
-    # other capability is deferred; otherwise an incomplete artifact could be
-    # incorrectly downgraded to a harmless deferral.
-    overall = FAILED if errors else DEFERRED if deferred else VERIFIED
+    # A deferred capability/component is explicit evidence that the runner
+    # could not execute one required operation. It is never a verified pass.
+    # Any schema, identity, cycle, mapping, or failed-capability error remains
+    # a hard failure even when another operation is deferred.
+    overall = (
+        FAILED
+        if errors
+        else DEFERRED
+        if deferred or deferred_components
+        else VERIFIED
+    )
     report = {
         "schema_version": SCHEMA_VERSION,
-        "head_sha": head_sha,
+        "repository": REPOSITORY,
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
         "overall": overall,
         "production_cycles": len(production),
         "production_entrypoints": sorted(entrypoints),
         "deferred_capabilities": deferred,
         "failed_capabilities": failed,
+        "deferred_components": deferred_components,
+        "failed_components": failed_components,
         "error_count": len(errors),
         "errors": errors,
     }
     return report
+
+
+def _required_environment_sha(name: str) -> str:
+    value = os.environ.get(name)
+    if value is None or not SHA_RE.fullmatch(value):
+        raise EvidenceError(f"{name} must be a 40-character git SHA")
+    return value
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -323,7 +583,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         document = json.loads(args.input.read_text(encoding="utf-8-sig"))
-        report = validate(document)
+        report = validate(
+            document,
+            expected_source_head_sha=_required_environment_sha("P2WLAN_EXACT_HEAD"),
+            expected_workflow_sha=_required_environment_sha("P2WLAN_WORKFLOW_SHA"),
+        )
     except (OSError, json.JSONDecodeError, EvidenceError) as error:
         print(f"Windows lifecycle evidence rejected: {error}", file=sys.stderr)
         return 1

--- a/scripts/windows_lifecycle/test_aggregate_evidence.py
+++ b/scripts/windows_lifecycle/test_aggregate_evidence.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("aggregate_evidence.py")
+SPEC = importlib.util.spec_from_file_location("aggregate_evidence", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def capability(name, status="verified", **extra):
+    return {"name": name, "status": status, **extra}
+
+
+def cycle(number, entrypoint="diagnostics", mode="production", **extra):
+    value = {
+        "cycle": number,
+        "entrypoint": entrypoint,
+        "mode": mode,
+        "start_succeeded": True,
+        "graceful_stop": True,
+        "forced_termination": False,
+        "process_exited": True,
+        "process_exit_code": 0,
+        "children_gone": True,
+        "diagnostics_port_released": True,
+        "auth_token_removed": True,
+        "wintun_stale": False,
+        "wintun_observed": True if mode == "production" else False,
+        "real_wintun": True if mode == "production" else False,
+        "daemon_processes_clean": True,
+    }
+    value.update(extra)
+    return value
+
+
+def valid_document():
+    names = MODULE.REQUIRED_CAPABILITIES
+    cycles = [cycle(i, entrypoint=("cli" if i % 4 == 1 else "ui" if i % 4 == 2 else "ctrl_c" if i % 4 == 3 else "diagnostics")) for i in range(50)]
+    return {
+        "schema_version": 1,
+        "head_sha": "a" * 40,
+        "runner_os": "windows-latest",
+        "capabilities": [capability(name) for name in names],
+        "cycles": cycles,
+        "service_controls": [
+            {"control": "stop", "status": "verified", "process_gone": True, "wintun_observed": True, "wintun_stale": False},
+            {"control": "preshutdown", "status": "verified", "process_gone": True, "wintun_observed": True, "wintun_stale": False},
+        ],
+        "flutter_tray": {
+            "process_exited": True,
+            "exit_code": 0,
+            "daemon_processes_clean": True,
+            "forced_termination": False,
+        },
+        "wer": {"event_ids_checked": [1000, 1001], "events": []},
+    }
+
+
+class AggregateEvidenceTests(unittest.TestCase):
+    def test_accepts_fifty_graceful_production_cycles(self):
+        report = MODULE.validate(valid_document())
+        self.assertEqual(report["overall"], "verified")
+        self.assertEqual(report["production_cycles"], 50)
+        self.assertEqual(report["error_count"], 0)
+
+    def test_rejects_forceful_termination(self):
+        document = valid_document()
+        document["cycles"][7]["forced_termination"] = True
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "failed")
+        self.assertTrue(any("forceful termination" in error for error in report["errors"]))
+
+    def test_rejects_real_cycle_without_observed_wintun(self):
+        document = valid_document()
+        document["cycles"][0]["wintun_observed"] = False
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "failed")
+        self.assertTrue(any("Wintun adapter was not observed" in error for error in report["errors"]))
+
+    def test_deferred_capability_is_not_verified(self):
+        document = valid_document()
+        document["capabilities"] = [
+            capability(name, status="deferred" if name == "wintun_ownership" else "verified")
+            for name in MODULE.REQUIRED_CAPABILITIES
+        ]
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "deferred")
+        self.assertIn("wintun_ownership", report["deferred_capabilities"])
+
+    def test_missing_capability_fails_closed(self):
+        document = valid_document()
+        document["capabilities"] = document["capabilities"][1:]
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "failed")
+        self.assertTrue(any("missing capability production_start_stop" in error for error in report["errors"]))
+
+    def test_rejects_crash_events_even_when_cycles_are_clean(self):
+        document = valid_document()
+        document["wer"]["events"] = [{"id": 1000, "message": "BEX64"}]
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "failed")
+        self.assertTrue(any("crash/BEX" in error for error in report["errors"]))
+
+    def test_deferred_does_not_hide_a_hard_cycle_error(self):
+        document = valid_document()
+        document["capabilities"] = [
+            capability(name, status="deferred" if name == "wintun_ownership" else "verified")
+            for name in MODULE.REQUIRED_CAPABILITIES
+        ]
+        document["cycles"][0]["process_exited"] = False
+        report = MODULE.validate(document)
+        self.assertEqual(report["overall"], "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/windows_lifecycle/test_aggregate_evidence.py
+++ b/scripts/windows_lifecycle/test_aggregate_evidence.py
@@ -13,6 +13,10 @@ sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 
+SOURCE_SHA = "a" * 40
+WORKFLOW_SHA = "b" * 40
+
+
 def capability(name, status="verified", **extra):
     return {"name": name, "status": status, **extra}
 
@@ -39,35 +43,118 @@ def cycle(number, entrypoint="diagnostics", mode="production", **extra):
     return value
 
 
-def valid_document():
-    names = MODULE.REQUIRED_CAPABILITIES
-    cycles = [cycle(i, entrypoint=("cli" if i % 4 == 1 else "ui" if i % 4 == 2 else "ctrl_c" if i % 4 == 3 else "diagnostics")) for i in range(50)]
+def component(name, status="verified", source=SOURCE_SHA, workflow=WORKFLOW_SHA):
     return {
-        "schema_version": 1,
-        "head_sha": "a" * 40,
+        "name": name,
+        "schema_version": 2,
+        "repository": MODULE.REPOSITORY,
+        "source_head_sha": source,
+        "workflow_sha": workflow,
         "runner_os": "windows-latest",
-        "capabilities": [capability(name) for name in names],
-        "cycles": cycles,
-        "service_controls": [
-            {"control": "stop", "status": "verified", "process_gone": True, "wintun_observed": True, "wintun_stale": False},
-            {"control": "preshutdown", "status": "verified", "process_gone": True, "wintun_observed": True, "wintun_stale": False},
-        ],
-        "flutter_tray": {
+        "status": status,
+        "detail": "component evidence",
+    }
+
+
+def handler_mapping():
+    return {
+        "status": "verified",
+        "live_system_delivery": "deferred",
+        "live_system_delivery_detail": "host logoff/shutdown is deferred on GitHub-hosted runners",
+        "console": MODULE.EXPECTED_CONSOLE_MAPPING,
+        "service": MODULE.EXPECTED_SERVICE_MAPPING,
+        "idempotent_first_request_wins": True,
+        "no_duplicate_frees": True,
+        "coordinator_entered": True,
+        "callback_non_blocking": True,
+        "callback_elapsed_ms": 1,
+        "bounded_deadline": True,
+        "shutdown_deadline_ms": 10000,
+        "force_kill": False,
+        "coordinator": "wait_for_windows_lifecycle_signal -> run_daemon_inner",
+    }
+
+
+def valid_document():
+    production_cycles = [
+        cycle(
+            i,
+            entrypoint=(
+                "cli"
+                if i % 3 == 1
+                else "ctrl_c"
+                if i % 3 == 2
+                else "diagnostics"
+            ),
+        )
+        for i in range(1, 51)
+    ]
+    ui_cycles = [cycle(i, entrypoint="ui", mode="ui") for i in range(101, 109)]
+    tray_cycles = [
+        {
+            "cycle": i,
+            "status": "verified",
             "process_exited": True,
             "exit_code": 0,
             "daemon_processes_clean": True,
             "forced_termination": False,
+        }
+        for i in range(1, 21)
+    ]
+    return {
+        "schema_version": 2,
+        "repository": MODULE.REPOSITORY,
+        "source_head_sha": SOURCE_SHA,
+        "workflow_sha": WORKFLOW_SHA,
+        "runner_os": "windows-latest",
+        "components": [
+            component("production_harness"),
+            component("flutter_ui"),
+            component("handler_mapping"),
+        ],
+        "handler_mapping": handler_mapping(),
+        "capabilities": [
+            capability(name) for name in MODULE.REQUIRED_CAPABILITIES
+        ],
+        "cycles": production_cycles + ui_cycles,
+        "service_controls": [
+            {
+                "control": "stop",
+                "status": "verified",
+                "process_gone": True,
+                "wintun_observed": True,
+                "wintun_stale": False,
+            },
+            {
+                "control": "preshutdown",
+                "status": "verified",
+                "process_gone": True,
+                "wintun_observed": True,
+                "wintun_stale": False,
+            },
+        ],
+        "flutter_tray": {
+            "attempted_cycles": 20,
+            "successful_cycles": 20,
+            "first_failure_cycle": None,
+            "process_exited": True,
+            "exit_code": 0,
+            "daemon_processes_clean": True,
+            "forced_termination": False,
+            "dump_paths": [],
+            "cycles": tray_cycles,
         },
         "wer": {"event_ids_checked": [1000, 1001], "events": []},
     }
 
 
 class AggregateEvidenceTests(unittest.TestCase):
-    def test_accepts_fifty_graceful_production_cycles(self):
+    def test_accepts_fifty_graceful_production_cycles_but_preserves_deferred_delivery(self):
         report = MODULE.validate(valid_document())
-        self.assertEqual(report["overall"], "verified")
+        self.assertEqual(report["overall"], "deferred")
         self.assertEqual(report["production_cycles"], 50)
         self.assertEqual(report["error_count"], 0)
+        self.assertIn("live_system_delivery", report["deferred_capabilities"])
 
     def test_rejects_forceful_termination(self):
         document = valid_document()
@@ -81,12 +168,17 @@ class AggregateEvidenceTests(unittest.TestCase):
         document["cycles"][0]["wintun_observed"] = False
         report = MODULE.validate(document)
         self.assertEqual(report["overall"], "failed")
-        self.assertTrue(any("Wintun adapter was not observed" in error for error in report["errors"]))
+        self.assertTrue(
+            any("Wintun adapter was not observed" in error for error in report["errors"])
+        )
 
     def test_deferred_capability_is_not_verified(self):
         document = valid_document()
         document["capabilities"] = [
-            capability(name, status="deferred" if name == "wintun_ownership" else "verified")
+            capability(
+                name,
+                status="deferred" if name == "wintun_ownership" else "verified",
+            )
             for name in MODULE.REQUIRED_CAPABILITIES
         ]
         report = MODULE.validate(document)
@@ -98,7 +190,12 @@ class AggregateEvidenceTests(unittest.TestCase):
         document["capabilities"] = document["capabilities"][1:]
         report = MODULE.validate(document)
         self.assertEqual(report["overall"], "failed")
-        self.assertTrue(any("missing capability production_start_stop" in error for error in report["errors"]))
+        self.assertTrue(
+            any(
+                "missing capability production_start_stop" in error
+                for error in report["errors"]
+            )
+        )
 
     def test_rejects_crash_events_even_when_cycles_are_clean(self):
         document = valid_document()
@@ -110,12 +207,67 @@ class AggregateEvidenceTests(unittest.TestCase):
     def test_deferred_does_not_hide_a_hard_cycle_error(self):
         document = valid_document()
         document["capabilities"] = [
-            capability(name, status="deferred" if name == "wintun_ownership" else "verified")
+            capability(
+                name,
+                status="deferred" if name == "wintun_ownership" else "verified",
+            )
             for name in MODULE.REQUIRED_CAPABILITIES
         ]
         document["cycles"][0]["process_exited"] = False
         report = MODULE.validate(document)
         self.assertEqual(report["overall"], "failed")
+
+    def test_source_head_mismatch_is_rejected(self):
+        document = valid_document()
+        document["source_head_sha"] = "c" * 40
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.validate(
+                document,
+                expected_source_head_sha=SOURCE_SHA,
+                expected_workflow_sha=WORKFLOW_SHA,
+            )
+
+    def test_workflow_sha_mismatch_is_rejected(self):
+        document = valid_document()
+        document["workflow_sha"] = "d" * 40
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.validate(
+                document,
+                expected_source_head_sha=SOURCE_SHA,
+                expected_workflow_sha=WORKFLOW_SHA,
+            )
+
+    def test_merge_sha_cannot_pretend_to_be_source_head(self):
+        document = valid_document()
+        document["source_head_sha"] = WORKFLOW_SHA
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.validate(
+                document,
+                expected_source_head_sha=SOURCE_SHA,
+                expected_workflow_sha=WORKFLOW_SHA,
+            )
+
+    def test_missing_sha_is_rejected(self):
+        document = valid_document()
+        document.pop("source_head_sha")
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.validate(document)
+
+    def test_valid_dual_sha_identity_is_preserved(self):
+        report = MODULE.validate(
+            valid_document(),
+            expected_source_head_sha=SOURCE_SHA,
+            expected_workflow_sha=WORKFLOW_SHA,
+        )
+        self.assertEqual(report["source_head_sha"], SOURCE_SHA)
+        self.assertEqual(report["workflow_sha"], WORKFLOW_SHA)
+        self.assertEqual(report["overall"], "deferred")
+
+    def test_component_identity_must_match_top_level_identity(self):
+        document = valid_document()
+        document["components"][0]["workflow_sha"] = "e" * 40
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.validate(document)
 
 
 if __name__ == "__main__":

--- a/scripts/windows_lifecycle/test_aggregate_evidence.py
+++ b/scripts/windows_lifecycle/test_aggregate_evidence.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("aggregate_evidence.py")
@@ -262,6 +266,36 @@ class AggregateEvidenceTests(unittest.TestCase):
         self.assertEqual(report["source_head_sha"], SOURCE_SHA)
         self.assertEqual(report["workflow_sha"], WORKFLOW_SHA)
         self.assertEqual(report["overall"], "deferred")
+
+    def test_clean_deferred_document_is_a_successful_cli_result(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = Path(directory) / "evidence.json"
+            output_path = Path(directory) / "aggregate.json"
+            input_path.write_text(
+                json.dumps(valid_document()), encoding="utf-8"
+            )
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "P2WLAN_EXACT_HEAD": SOURCE_SHA,
+                    "P2WLAN_WORKFLOW_SHA": WORKFLOW_SHA,
+                },
+            ):
+                self.assertEqual(
+                    MODULE.main(
+                        [
+                            "--input",
+                            str(input_path),
+                            "--output",
+                            str(output_path),
+                        ]
+                    ),
+                    0,
+                )
+            self.assertEqual(
+                json.loads(output_path.read_text(encoding="utf-8"))["overall"],
+                "deferred",
+            )
 
     def test_component_identity_must_match_top_level_identity(self):
         document = valid_document()

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -240,6 +240,13 @@ public static class P2WlanLifecycleNative {
   [StructLayout(LayoutKind.Sequential)] public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread; public uint dwProcessId; public uint dwThreadId; }
   [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] static extern bool CreateProcess(string app, string cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
   [DllImport("kernel32.dll", SetLastError = true)] static extern bool CloseHandle(IntPtr handle);
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)] private delegate bool HandlerRoutine(uint ctrlType);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool SetConsoleCtrlHandler(HandlerRoutine handlerRoutine, bool add);
+  private static readonly HandlerRoutine ignoreCtrlC = IgnoreCtrlC;
+  private static bool IgnoreCtrlC(uint ctrlType) { return ctrlType == 0; }
+  public static void IgnoreCtrlCInCurrentProcess() {
+    if (!SetConsoleCtrlHandler(ignoreCtrlC, true)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+  }
   public static int StartInNewConsole(string fileName, string arguments, string cwd) {
     var si = new STARTUPINFO(); si.cb = (uint)Marshal.SizeOf(si); si.dwFlags = 0x00000001; si.wShowWindow = 0;
     PROCESS_INFORMATION pi;
@@ -254,6 +261,7 @@ public static class P2WlanLifecycleNative {
   }
 }
 '@
+    [P2WlanLifecycleNative]::IgnoreCtrlCInCurrentProcess()
 }
 
 function Send-ConsoleCtrlC {
@@ -678,6 +686,7 @@ function Invoke-ServiceCycle {
 try {
     if (-not (Test-Path -LiteralPath $DaemonPath)) { throw "daemon binary not found: $DaemonPath" }
     if (-not (Test-Path -LiteralPath $CliPath)) { throw "CLI binary not found: $CliPath" }
+    Add-ConsoleCtrlHelper
     $RealWintun = [bool]$AttemptRealWintun
     for ($cycle = 1; $cycle -le $ProductionCycles; $cycle++) {
         $entrypoint = switch (($cycle - 1) % 3) {

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -88,7 +88,7 @@ function Test-TargetWintunPresent {
 }
 
 function Wait-TargetWintunReleased {
-    param([Parameter(Mandatory = $true)][int]$TimeoutSeconds = 10)
+    param([int]$TimeoutSeconds = 10)
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     do {
         if (-not (Test-TargetWintunPresent -Snapshot (Get-WintunSnapshot))) {
@@ -126,7 +126,7 @@ function Wait-DaemonReady {
     param(
         [Parameter(Mandatory = $true)][string]$BaseUrl,
         [Parameter(Mandatory = $true)][string]$AuthPath,
-        [Parameter(Mandatory = $true)][int]$TimeoutSeconds = 20
+        [int]$TimeoutSeconds = 20
     )
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     while ([DateTime]::UtcNow -lt $deadline) {
@@ -150,7 +150,7 @@ function Wait-DaemonReady {
 function Wait-ProcessExited {
     param(
         [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
-        [Parameter(Mandatory = $true)][int]$TimeoutSeconds = 20
+        [int]$TimeoutSeconds = 20
     )
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     while ([DateTime]::UtcNow -lt $deadline) {

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -233,40 +233,82 @@ function Add-ConsoleCtrlHelper {
     if ('P2WlanLifecycleNative' -as [type]) { return }
     Add-Type @'
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 public static class P2WlanLifecycleNative {
   [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
   public struct STARTUPINFO { public uint cb; public string lpReserved; public string lpDesktop; public string lpTitle; public uint dwX; public uint dwY; public uint dwXSize; public uint dwYSize; public uint dwXCountChars; public uint dwYCountChars; public uint dwFillAttribute; public uint dwFlags; public short wShowWindow; public short cbReserved2; public IntPtr lpReserved2; public IntPtr hStdInput; public IntPtr hStdOutput; public IntPtr hStdError; }
   [StructLayout(LayoutKind.Sequential)] public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread; public uint dwProcessId; public uint dwThreadId; }
   [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] static extern bool CreateProcess(string app, string cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
-  [DllImport("kernel32.dll", SetLastError = true)] static extern bool GenerateConsoleCtrlEvent(uint type, uint group);
-  [DllImport("kernel32.dll", SetLastError = true)] static extern bool AttachConsole(uint pid);
-  [DllImport("kernel32.dll", SetLastError = true)] static extern bool FreeConsole();
   [DllImport("kernel32.dll", SetLastError = true)] static extern bool CloseHandle(IntPtr handle);
-  public static int StartInNewProcessGroup(string fileName, string arguments, string cwd) {
+  public static int StartInNewConsole(string fileName, string arguments, string cwd) {
     var si = new STARTUPINFO(); si.cb = (uint)Marshal.SizeOf(si); si.dwFlags = 0x00000001; si.wShowWindow = 0;
     PROCESS_INFORMATION pi;
-    if (!CreateProcess(fileName, "\"" + fileName + "\" " + arguments, IntPtr.Zero, IntPtr.Zero, false, 0x00000200, IntPtr.Zero, cwd, ref si, out pi)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+    // Give the daemon a console of its own. CTRL_C_EVENT is broadcast to
+    // every process attached to a console, so the injector must attach to
+    // this isolated console instead of the PowerShell job console.
+    const uint CREATE_NEW_CONSOLE = 0x00000010;
+    const uint CREATE_NEW_PROCESS_GROUP = 0x00000200;
+    if (!CreateProcess(fileName, "\"" + fileName + "\" " + arguments, IntPtr.Zero, IntPtr.Zero, false, CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP, IntPtr.Zero, cwd, ref si, out pi)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
     CloseHandle(pi.hThread); CloseHandle(pi.hProcess);
     return (int)pi.dwProcessId;
   }
-  public static void SendCtrlC(int processId) {
-    // CTRL_C_EVENT cannot be scoped to a process group. Temporarily attach
-    // this helper to the daemon's inherited console, with the PowerShell
-    // parent detached, so the event reaches only the daemon. Restore the
-    // parent console before returning to the acceptance script.
-    FreeConsole();
-    try {
-      if (!AttachConsole((uint)processId)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
-      if (!GenerateConsoleCtrlEvent(0, 0)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
-    } finally {
-      FreeConsole();
-      AttachConsole(0xffffffff);
-    }
-  }
 }
 '@
+}
+
+function Send-ConsoleCtrlC {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+    $injectorPath = Join-Path $runRoot 'send-ctrl-c.ps1'
+    if (-not (Test-Path -LiteralPath $injectorPath)) {
+        @'
+param([Parameter(Mandatory = $true)][int]$ProcessId)
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class P2WlanCtrlCInjector {
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool AttachConsole(uint pid);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool FreeConsole();
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool GenerateConsoleCtrlEvent(uint type, uint group);
+  public static void Send(int processId) {
+    FreeConsole();
+    if (!AttachConsole((uint)processId)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+    if (!GenerateConsoleCtrlEvent(0, 0)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+  }
+}
+"@
+[P2WlanCtrlCInjector]::Send($ProcessId)
+'@ | Set-Content -LiteralPath $injectorPath -Encoding utf8
+    }
+    $pwshPath = (Get-Command pwsh -CommandType Application | Select-Object -First 1).Source
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $pwshPath
+    $startInfo.WorkingDirectory = Split-Path -Parent $injectorPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    foreach ($argument in @(
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-ExecutionPolicy',
+            'Bypass',
+            '-File',
+            $injectorPath,
+            '-ProcessId',
+            $ProcessId.ToString()
+        )) {
+        $null = $startInfo.ArgumentList.Add($argument)
+    }
+    $injector = [System.Diagnostics.Process]::new()
+    $injector.StartInfo = $startInfo
+    if (-not $injector.Start()) { throw 'failed to start Ctrl+C injector' }
+    $result = Wait-ProcessExited -Process $injector -TimeoutSeconds 5
+    if (-not $result.exited) {
+        try { Stop-Process -Id $injector.Id -Force -ErrorAction SilentlyContinue } catch {}
+        throw 'Ctrl+C injector did not exit within the bounded budget'
+    }
+    # The injector is attached to the daemon console and may itself receive
+    # the broadcast CTRL_C_EVENT. Its exit code is therefore not meaningful;
+    # the daemon's graceful exit is the authoritative assertion.
 }
 
 function Invoke-ProductionCycle {
@@ -312,7 +354,7 @@ function Invoke-ProductionCycle {
         if ($Entrypoint -eq 'ctrl_c') {
             Add-ConsoleCtrlHelper
             $arguments = "--config `"$configPath`" --control http://127.0.0.1:1 --network windows-lifecycle --diagnostics-bind 127.0.0.1:$port --log-file `"$logPath`" --manual --interface p2wlan-lifecycle --address 10.20.0.1 --udp-bind 127.0.0.1:0 --stun none --socket-pool off"
-            $ctrlCProcessId = [P2WlanLifecycleNative]::StartInNewProcessGroup($DaemonPath, $arguments, (Split-Path -Parent $DaemonPath))
+            $ctrlCProcessId = [P2WlanLifecycleNative]::StartInNewConsole($DaemonPath, $arguments, (Split-Path -Parent $DaemonPath))
             $process = Get-Process -Id $ctrlCProcessId -ErrorAction Stop
         } else {
             $process = Start-ProductionDaemon -ConfigPath $configPath -LogPath $logPath -DiagnosticsBind "127.0.0.1:$port"
@@ -335,7 +377,7 @@ function Invoke-ProductionCycle {
         switch ($Entrypoint) {
             'diagnostics' { Stop-DiagnosticsDaemon -BaseUrl $baseUrl -Token $token }
             'cli' { Stop-CliDaemon -ConfigPath $configPath -StateDirectory $cycleRoot }
-            'ctrl_c' { [P2WlanLifecycleNative]::SendCtrlC($process.Id) }
+            'ctrl_c' { Send-ConsoleCtrlC -ProcessId $process.Id }
         }
         $stopRequested = $true
         if ($Entrypoint -eq 'ctrl_c') {

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -11,7 +11,9 @@ param(
 
     [string]$FlutterReleasePath,
     [string]$FlutterEvidencePath,
+    [string]$HandlerMappingPath,
     [int]$ProductionCycles = 50,
+    [int]$TrayCycles = 20,
     [switch]$AttemptRealWintun
 )
 
@@ -23,8 +25,20 @@ New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
 $records = [System.Collections.Generic.List[object]]::new()
 $capabilities = [System.Collections.Generic.List[object]]::new()
 $serviceRecords = [System.Collections.Generic.List[object]]::new()
+$components = [System.Collections.Generic.List[object]]::new()
+$handlerMapping = $null
 $previousDisableTun = $env:P2WLAN_DISABLE_TUN
 $previousStateDir = $env:P2WLAN_STATE_DIR
+$expectedSourceHeadSha = [string]$env:P2WLAN_EXACT_HEAD
+$expectedWorkflowSha = [string]$env:P2WLAN_WORKFLOW_SHA
+if ($expectedSourceHeadSha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw 'P2WLAN_EXACT_HEAD must be a 40-character git SHA'
+}
+if ($expectedWorkflowSha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw 'P2WLAN_WORKFLOW_SHA must be a 40-character git SHA'
+}
+$traceRoot = if ($env:P2WLAN_TRAY_TRACE_DIR) { $env:P2WLAN_TRAY_TRACE_DIR } else { Join-Path $runRoot 'flutter-tray-traces' }
+New-Item -ItemType Directory -Path $traceRoot -Force | Out-Null
 
 function Add-Capability {
     param(
@@ -37,6 +51,27 @@ function Add-Capability {
     }
     $capabilities.Add([ordered]@{
             name = $Name
+            status = $Status
+            detail = $Detail
+        })
+}
+
+function Add-Component {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][ValidateSet('verified', 'deferred', 'failed')][string]$Status,
+        [Parameter(Mandatory = $false)][string]$Detail = ''
+    )
+    foreach ($existing in @($components | Where-Object { $_.name -eq $Name })) {
+        [void]$components.Remove($existing)
+    }
+    $components.Add([ordered]@{
+            name = $Name
+            schema_version = 2
+            repository = 'yhan-sun/p2wlan'
+            source_head_sha = $expectedSourceHeadSha
+            workflow_sha = $expectedWorkflowSha
+            runner_os = 'windows-latest'
             status = $Status
             detail = $Detail
         })
@@ -479,7 +514,7 @@ function Invoke-ProductionCycle {
         $portReleased = Test-LoopbackPortReleased -Port $port
         $authRemoved = -not (Test-Path -LiteralPath $authPath)
         $afterWintun = Get-WintunSnapshot
-        $wintunStale = -not (Wait-TargetWintunReleased)
+        $wintunStale = if ($RealWintun) { -not (Wait-TargetWintunReleased) } else { Test-TargetWintunPresent -Snapshot $afterWintun }
         $childrenGone = Wait-ObservedChildProcessesGone -ProcessIds @($childPids)
         $daemonProcessesClean = @(
             Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
@@ -509,30 +544,36 @@ function Invoke-ProductionCycle {
     }
 }
 
-function Invoke-FlutterTrayNoAdapterExit {
-    if ([string]::IsNullOrWhiteSpace($FlutterReleasePath)) {
-        return [pscustomobject]@{
-            status = 'deferred'
-            detail = 'Flutter release executable was not supplied'
-            process_exited = $false
-            exit_code = $null
-            daemon_processes_clean = $true
-            forced_termination = $false
-        }
+function Wait-TrayDumps {
+    param(
+        [Parameter(Mandatory = $true)][string]$DumpDirectory,
+        [Parameter(Mandatory = $true)][DateTime]$SinceUtc,
+        [int]$TimeoutSeconds = 10
+    )
+    if ([string]::IsNullOrWhiteSpace($DumpDirectory) -or
+        -not (Test-Path -LiteralPath $DumpDirectory)) {
+        return @()
     }
-    if (-not (Test-Path -LiteralPath $FlutterReleasePath)) {
-        return [pscustomobject]@{
-            status = 'failed'
-            detail = "Flutter release executable not found: $FlutterReleasePath"
-            process_exited = $false
-            exit_code = $null
-            daemon_processes_clean = $false
-            forced_termination = $false
-        }
-    }
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $dumps = @(
+            Get-ChildItem -LiteralPath $DumpDirectory -Filter '*.dmp' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTimeUtc -ge $SinceUtc } |
+                Sort-Object LastWriteTimeUtc |
+                ForEach-Object { $_.FullName }
+        )
+        if ($dumps.Count -gt 0) { return $dumps }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $deadline)
+    @()
+}
 
+function Invoke-FlutterTrayNoAdapterCycle {
+    param([Parameter(Mandatory = $true)][int]$Cycle)
     $trayRoot = Join-Path $runRoot 'flutter-tray-no-adapter'
-    New-Item -ItemType Directory -Path $trayRoot -Force | Out-Null
+    $cycleRoot = Join-Path $trayRoot "cycle-$Cycle"
+    $traceCycleRoot = Join-Path $traceRoot "cycle-$Cycle"
+    New-Item -ItemType Directory -Path $cycleRoot, $traceCycleRoot -Force | Out-Null
     $beforePids = Get-ProcessIdList
     $process = $null
     $forcedTermination = $false
@@ -540,6 +581,11 @@ function Invoke-FlutterTrayNoAdapterExit {
     $stderrTask = $null
     $stdout = ''
     $stderr = ''
+    $processExited = $false
+    $exitCode = $null
+    $daemonProcessesClean = $false
+    $detail = ''
+    $startedAtUtc = [DateTime]::UtcNow
     try {
         $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
         $startInfo.FileName = [System.IO.Path]::GetFullPath($FlutterReleasePath)
@@ -552,8 +598,8 @@ function Invoke-FlutterTrayNoAdapterExit {
         $startInfo.Environment['P2WLAN_ENABLE_FLUTTER_TRAY'] = '1'
         # Keep this release run isolated from any persisted desktop settings;
         # no daemon is intentionally started for the no-adapter regression.
-        $startInfo.Environment['APPDATA'] = $trayRoot
-        $startInfo.Environment['LOCALAPPDATA'] = $trayRoot
+        $startInfo.Environment['APPDATA'] = $cycleRoot
+        $startInfo.Environment['LOCALAPPDATA'] = $cycleRoot
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo
         if (-not $process.Start()) { throw "failed to start Flutter release app" }
@@ -563,78 +609,271 @@ function Invoke-FlutterTrayNoAdapterExit {
         if (-not $result.exited) {
             try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
             $forcedTermination = $true
+            $result = Wait-ProcessExited -Process $process -TimeoutSeconds 5
             throw 'Flutter release tray app did not exit within the bounded no-adapter budget'
         }
-        $stdout = $stdoutTask.GetAwaiter().GetResult()
-        $stderr = $stderrTask.GetAwaiter().GetResult()
-        $afterPids = Get-ProcessIdList
+        $processExited = $result.exited
+        $exitCode = $result.exit_code
+        if ($stdoutTask -ne $null -and $stdoutTask.Wait(2000)) { $stdout = $stdoutTask.Result }
+        if ($stderrTask -ne $null -and $stderrTask.Wait(2000)) { $stderr = $stderrTask.Result }
         $daemonProcessesClean = @(
-            $afterPids | Where-Object { $beforePids -notcontains $_ }
+            Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
         ).Count -eq 0
         if (-not $daemonProcessesClean) {
             throw 'Flutter release tray no-adapter test left a daemon process running'
         }
-        if ($result.exit_code -ne 0) {
-            throw "Flutter release tray app exited with code $($result.exit_code)"
+        if ($exitCode -ne 0) {
+            throw "Flutter release tray app exited with code $exitCode"
         }
-        return [pscustomobject]@{
-            status = 'verified'
-            detail = 'release Flutter tray initialized and exited cleanly without a virtual adapter'
-            process_exited = $true
-            exit_code = $result.exit_code
-            daemon_processes_clean = $daemonProcessesClean
-            forced_termination = $false
-        }
+        $detail = 'release Flutter tray initialized and exited cleanly without a virtual adapter'
     } catch {
         $detail = $_.Exception.Message
-        if ($stdoutTask -ne $null) {
-            try { $stdout = $stdoutTask.GetAwaiter().GetResult() } catch {}
+        $running = $false
+        try { $running = $process -and -not $process.HasExited } catch { $running = $false }
+        if ($running) {
+            # Emergency cleanup is deliberately recorded as forceful failure;
+            # it can never make this cycle a graceful pass.
+            try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+            $forcedTermination = $true
         }
-        if ($stderrTask -ne $null) {
-            try { $stderr = $stderrTask.GetAwaiter().GetResult() } catch {}
+        if ($process) {
+            $result = Wait-ProcessExited -Process $process -TimeoutSeconds 5
+            $processExited = $result.exited
+            $exitCode = $result.exit_code
         }
+        if ($stdoutTask -ne $null -and $stdoutTask.Wait(2000)) { $stdout = $stdoutTask.Result }
+        if ($stderrTask -ne $null -and $stderrTask.Wait(2000)) { $stderr = $stderrTask.Result }
         if ($stdout -or $stderr) {
             $detail = "$detail; stdout=[$stdout]; stderr=[$stderr]"
         }
-        $daemonProcessesClean = @(
-            Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
-        ).Count -eq 0
+    }
+    $daemonProcessesClean = @(
+        Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
+    ).Count -eq 0
+    $stdoutPath = Join-Path $traceCycleRoot 'stdout.txt'
+    $stderrPath = Join-Path $traceCycleRoot 'stderr.txt'
+    Set-Content -LiteralPath $stdoutPath -Value $stdout -Encoding utf8
+    Set-Content -LiteralPath $stderrPath -Value $stderr -Encoding utf8
+    [ordered]@{
+        schema_version = 1
+        cycle = $Cycle
+        started_at_utc = $startedAtUtc.ToString('o')
+        finished_at_utc = [DateTime]::UtcNow.ToString('o')
+        pid = if ($process) { $process.Id } else { $null }
+        process_exited = $processExited
+        exit_code = $exitCode
+        forced_termination = $forcedTermination
+        daemon_processes_clean = $daemonProcessesClean
+        stdout_path = $stdoutPath
+        stderr_path = $stderrPath
+        detail = $detail
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $traceCycleRoot 'lifecycle.json') -Encoding utf8
+    [pscustomobject]@{
+        cycle = $Cycle
+        status = if ($processExited -and $exitCode -eq 0 -and -not $forcedTermination -and $daemonProcessesClean) { 'verified' } else { 'failed' }
+        started_at_utc = $startedAtUtc.ToString('o')
+        finished_at_utc = [DateTime]::UtcNow.ToString('o')
+        pid = if ($process) { $process.Id } else { $null }
+        process_exited = $processExited
+        exit_code = $exitCode
+        daemon_processes_clean = $daemonProcessesClean
+        forced_termination = $forcedTermination
+        dump_paths = @()
+        stdout_path = $stdoutPath
+        stderr_path = $stderrPath
+        detail = $detail
+    }
+}
+
+function Invoke-FlutterTrayNoAdapterExit {
+    if ([string]::IsNullOrWhiteSpace($FlutterReleasePath)) {
+        return [pscustomobject]@{
+            status = 'deferred'
+            detail = 'Flutter release executable was not supplied'
+            attempted_cycles = 0
+            successful_cycles = 0
+            first_failure_cycle = $null
+            process_exited = $false
+            exit_code = $null
+            daemon_processes_clean = $true
+            forced_termination = $false
+            dump_paths = @()
+            cycles = @()
+        }
+    }
+    if (-not (Test-Path -LiteralPath $FlutterReleasePath)) {
         return [pscustomobject]@{
             status = 'failed'
-            detail = $detail
-            process_exited = if ($process) { $process.HasExited } else { $false }
-            exit_code = if ($process -and $process.HasExited) { $process.ExitCode } else { $null }
-            daemon_processes_clean = $daemonProcessesClean
-            forced_termination = $forcedTermination
+            detail = "Flutter release executable not found: $FlutterReleasePath"
+            attempted_cycles = 0
+            successful_cycles = 0
+            first_failure_cycle = 1
+            process_exited = $false
+            exit_code = $null
+            daemon_processes_clean = $false
+            forced_termination = $false
+            dump_paths = @()
+            cycles = @()
         }
+    }
+    if ($TrayCycles -ne 20) {
+        return [pscustomobject]@{
+            status = 'failed'
+            detail = "Flutter release tray acceptance requires exactly 20 cycles, got $TrayCycles"
+            attempted_cycles = 0
+            successful_cycles = 0
+            first_failure_cycle = 1
+            process_exited = $false
+            exit_code = $null
+            daemon_processes_clean = $false
+            forced_termination = $false
+            dump_paths = @()
+            cycles = @()
+        }
+    }
+
+    $cycleRecords = [System.Collections.Generic.List[object]]::new()
+    $dumpPaths = [System.Collections.Generic.List[string]]::new()
+    for ($cycle = 1; $cycle -le $TrayCycles; $cycle++) {
+        $record = Invoke-FlutterTrayNoAdapterCycle -Cycle $cycle
+        if ($record.status -ne 'verified') {
+            $sinceUtc = [DateTime]::Parse($record.started_at_utc).ToUniversalTime()
+            foreach ($dumpPath in @(Wait-TrayDumps -DumpDirectory $env:P2WLAN_TRAY_DUMP_DIR -SinceUtc $sinceUtc)) {
+                $record.dump_paths += $dumpPath
+                if (-not $dumpPaths.Contains($dumpPath)) { $dumpPaths.Add($dumpPath) }
+            }
+        }
+        $cycleRecords.Add($record)
+        if ($record.status -ne 'verified') {
+            break
+        }
+    }
+    $attempted = $cycleRecords.Count
+    $successful = @($cycleRecords | Where-Object status -eq 'verified').Count
+    $firstFailure = @($cycleRecords | Where-Object status -ne 'verified' | Select-Object -First 1)
+    $allExited = $attempted -eq $TrayCycles -and @($cycleRecords | Where-Object { -not $_.process_exited }).Count -eq 0
+    $allClean = $attempted -gt 0 -and @($cycleRecords | Where-Object { -not $_.daemon_processes_clean }).Count -eq 0
+    $forced = @($cycleRecords | Where-Object forced_termination).Count -gt 0
+    [pscustomobject]@{
+        status = if ($attempted -eq $TrayCycles -and $successful -eq $TrayCycles -and -not $forced) { 'verified' } else { 'failed' }
+        detail = if ($firstFailure.Count -gt 0) { [string]$firstFailure[0].detail } else { 'all release Flutter tray no-adapter cycles exited cleanly' }
+        attempted_cycles = $attempted
+        successful_cycles = $successful
+        first_failure_cycle = if ($firstFailure.Count -gt 0) { $firstFailure[0].cycle } else { $null }
+        process_exited = $allExited
+        exit_code = if ($firstFailure.Count -gt 0) { $firstFailure[0].exit_code } else { 0 }
+        daemon_processes_clean = $allClean
+        forced_termination = $forced
+        dump_paths = @($dumpPaths)
+        cycles = @($cycleRecords)
     }
 }
 
 function Import-FlutterLifecycleEvidence {
-    param([Parameter(Mandatory = $true)][string]$ExpectedHeadSha)
+    param(
+        [Parameter(Mandatory = $true)][string]$ExpectedSourceHeadSha,
+        [Parameter(Mandatory = $true)][string]$ExpectedWorkflowSha
+    )
     if ([string]::IsNullOrWhiteSpace($FlutterEvidencePath)) {
         Add-Capability -Name 'ui_stop' -Status 'deferred' -Detail 'Flutter UI evidence path was not supplied'
+        Add-Component -Name 'flutter_ui' -Status 'deferred' -Detail 'Flutter UI evidence path was not supplied'
         return
     }
     if (-not (Test-Path -LiteralPath $FlutterEvidencePath)) {
-        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence was not written: $FlutterEvidencePath"
+        $detail = "Flutter UI evidence was not written: $FlutterEvidencePath"
+        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail $detail
+        Add-Component -Name 'flutter_ui' -Status 'failed' -Detail $detail
         return
     }
     try {
         $flutter = Get-Content -LiteralPath $FlutterEvidencePath -Raw | ConvertFrom-Json
-        if ($flutter.head_sha -ne $ExpectedHeadSha) {
-            Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence head_sha=$($flutter.head_sha) does not match $ExpectedHeadSha"
-            return
+        if ($flutter.schema_version -ne 2) { throw "Flutter UI evidence schema_version=$($flutter.schema_version) is not 2" }
+        if ($flutter.repository -ne 'yhan-sun/p2wlan') { throw "Flutter UI evidence repository=$($flutter.repository) is not yhan-sun/p2wlan" }
+        if ($flutter.runner_os -ne 'windows-latest') { throw "Flutter UI evidence runner_os=$($flutter.runner_os) is not windows-latest" }
+        if ($flutter.source_head_sha -ne $ExpectedSourceHeadSha) {
+            throw "Flutter UI evidence source_head_sha=$($flutter.source_head_sha) does not match $ExpectedSourceHeadSha"
+        }
+        if ($flutter.workflow_sha -ne $ExpectedWorkflowSha) {
+            throw "Flutter UI evidence workflow_sha=$($flutter.workflow_sha) does not match $ExpectedWorkflowSha"
         }
         foreach ($cycle in @($flutter.cycles)) { $records.Add($cycle) }
         $uiCapability = @($flutter.capabilities | Where-Object { $_.name -eq 'ui_stop' } | Select-Object -First 1)
         if ($uiCapability.Count -ne 1) {
-            Add-Capability -Name 'ui_stop' -Status 'failed' -Detail 'Flutter UI evidence did not contain a ui_stop capability'
-            return
+            throw 'Flutter UI evidence did not contain a ui_stop capability'
         }
         Add-Capability -Name 'ui_stop' -Status $uiCapability[0].status -Detail ([string]$uiCapability[0].detail)
+        Add-Component -Name 'flutter_ui' -Status $uiCapability[0].status -Detail ([string]$uiCapability[0].detail)
     } catch {
-        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence could not be imported: $($_.Exception.Message)"
+        $detail = "Flutter UI evidence could not be imported: $($_.Exception.Message)"
+        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail $detail
+        Add-Component -Name 'flutter_ui' -Status 'failed' -Detail $detail
+    }
+}
+
+function Import-HandlerMappingEvidence {
+    if ([string]::IsNullOrWhiteSpace($HandlerMappingPath)) {
+        $detail = 'Windows lifecycle handler mapping probe path was not supplied'
+        $script:handlerMapping = [ordered]@{
+            status = 'failed'
+            live_system_delivery = 'deferred'
+            live_system_delivery_detail = $detail
+            console = @()
+            service = @()
+            idempotent_first_request_wins = $false
+            no_duplicate_frees = $false
+            coordinator_entered = $false
+            callback_non_blocking = $false
+            callback_elapsed_ms = $null
+            bounded_deadline = $false
+            shutdown_deadline_ms = $null
+            force_kill = $false
+            coordinator = ''
+        }
+        Add-Component -Name 'handler_mapping' -Status 'failed' -Detail $detail
+        return
+    }
+    if (-not (Test-Path -LiteralPath $HandlerMappingPath)) {
+        $detail = "Windows lifecycle handler mapping probe was not written: $HandlerMappingPath"
+        $script:handlerMapping = [ordered]@{
+            status = 'failed'
+            live_system_delivery = 'deferred'
+            live_system_delivery_detail = $detail
+            console = @()
+            service = @()
+            idempotent_first_request_wins = $false
+            no_duplicate_frees = $false
+            coordinator_entered = $false
+            callback_non_blocking = $false
+            callback_elapsed_ms = $null
+            bounded_deadline = $false
+            shutdown_deadline_ms = $null
+            force_kill = $false
+            coordinator = ''
+        }
+        Add-Component -Name 'handler_mapping' -Status 'failed' -Detail $detail
+        return
+    }
+    try {
+        $probe = Get-Content -LiteralPath $HandlerMappingPath -Raw | ConvertFrom-Json
+        if ($probe.schema_version -ne 2) { throw "handler mapping schema_version=$($probe.schema_version) is not 2" }
+        if ($probe.component -ne 'handler_mapping') { throw "handler mapping component=$($probe.component) is not handler_mapping" }
+        if ($probe.repository -ne 'yhan-sun/p2wlan') { throw "handler mapping repository=$($probe.repository) is not yhan-sun/p2wlan" }
+        if ($probe.runner_os -ne 'windows-latest') { throw "handler mapping runner_os=$($probe.runner_os) is not windows-latest" }
+        if ($probe.source_head_sha -ne $expectedSourceHeadSha) { throw "handler mapping source_head_sha=$($probe.source_head_sha) does not match $expectedSourceHeadSha" }
+        if ($probe.workflow_sha -ne $expectedWorkflowSha) { throw "handler mapping workflow_sha=$($probe.workflow_sha) does not match $expectedWorkflowSha" }
+        if ($null -eq $probe.handler_mapping) { throw 'handler mapping payload was missing' }
+        $mappingStatus = [string]$probe.handler_mapping.status
+        if ($mappingStatus -notin @('verified', 'deferred', 'failed')) { throw "handler mapping status=$mappingStatus is invalid" }
+        $script:handlerMapping = $probe.handler_mapping
+        Add-Component -Name 'handler_mapping' -Status $mappingStatus -Detail 'production console/HandlerEx mapping probe'
+    } catch {
+        $detail = "Windows lifecycle handler mapping could not be imported: $($_.Exception.Message)"
+        $script:handlerMapping = [ordered]@{
+            status = 'failed'
+            live_system_delivery = 'deferred'
+            live_system_delivery_detail = $detail
+        }
+        Add-Component -Name 'handler_mapping' -Status 'failed' -Detail $detail
     }
 }
 
@@ -691,31 +930,34 @@ function Invoke-ServiceCycle {
             & sc.exe stop $serviceName | Out-Null
             if ($LASTEXITCODE -ne 0) { throw "sc.exe stop returned $LASTEXITCODE" }
         } else {
-            # PRESHUTDOWN is an SCM-delivered control. GitHub runners do not
-            # permit a job to shut down/log off the host, so only accept this
-            # as verified if the SCM actually delivers control 15.
-            & sc.exe control $serviceName 15 | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw "SCM did not deliver SERVICE_CONTROL_PRESHUTDOWN (sc.exe exit $LASTEXITCODE)" }
+            # Microsoft documents that ControlService/sc.exe cannot send
+            # SERVICE_CONTROL_PRESHUTDOWN; only the operating system can
+            # deliver it during host shutdown. The production HandlerEx
+            # mapping is covered by the injected probe, while live delivery
+            # remains explicit deferred evidence on a hosted runner.
+            $status = 'deferred'
+            $detail = 'live SERVICE_CONTROL_PRESHUTDOWN delivery deferred: only the system can send this notification; sc.exe/ControlService is unsupported'
         }
-        $deadline = [DateTime]::UtcNow.AddSeconds(25)
-        do {
-            Start-Sleep -Milliseconds 250
-            $query = (& sc.exe query $serviceName | Out-String)
-            if ($query -match 'STATE\s+:\s+1\s+STOPPED') { $status = 'verified'; break }
-        } while ([DateTime]::UtcNow -lt $deadline)
-        if ($status -ne 'verified') { throw "service did not reach STOPPED within the bounded budget" }
-        $processDeadline = [DateTime]::UtcNow.AddSeconds(10)
-        while ((Get-Process -Id $processId -ErrorAction SilentlyContinue) -and [DateTime]::UtcNow -lt $processDeadline) {
-            Start-Sleep -Milliseconds 250
+        if ($Control -eq 'stop') {
+            $deadline = [DateTime]::UtcNow.AddSeconds(25)
+            do {
+                Start-Sleep -Milliseconds 250
+                $query = (& sc.exe query $serviceName | Out-String)
+                if ($query -match 'STATE\s+:\s+1\s+STOPPED') { $status = 'verified'; break }
+            } while ([DateTime]::UtcNow -lt $deadline)
+            if ($status -ne 'verified') { throw "service did not reach STOPPED within the bounded budget" }
+            $processDeadline = [DateTime]::UtcNow.AddSeconds(10)
+            while ((Get-Process -Id $processId -ErrorAction SilentlyContinue) -and [DateTime]::UtcNow -lt $processDeadline) {
+                Start-Sleep -Milliseconds 250
+            }
+            $processGone = $null -eq (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+            if (-not $processGone) { throw "service process $processId remained after SCM $Control" }
+            $serviceLog = if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Raw } else { '' }
+            if ($serviceLog -notmatch [regex]::Escape('event SERVICE_STOP')) {
+                throw 'service log did not prove delivery of SERVICE_STOP'
+            }
+            $status = 'verified'
         }
-        $processGone = $null -eq (Get-Process -Id $processId -ErrorAction SilentlyContinue)
-        if (-not $processGone) { throw "service process $processId remained after SCM $Control" }
-        $serviceLog = if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Raw } else { '' }
-        $expectedReason = if ($Control -eq 'stop') { 'SERVICE_STOP' } else { 'SERVICE_PRESHUTDOWN' }
-        if ($serviceLog -notmatch [regex]::Escape("event $expectedReason")) {
-            throw "service log did not prove delivery of $expectedReason"
-        }
-        $status = 'verified'
     } catch {
         $detail = $_.Exception.Message
         $status = 'failed'
@@ -732,8 +974,7 @@ function Invoke-ServiceCycle {
         & sc.exe delete $serviceName | Out-Null
         if ($previousServiceDisableTun) { $env:P2WLAN_DISABLE_TUN = $previousServiceDisableTun } else { Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue }
     }
-    $afterWintun = Get-WintunSnapshot
-    $wintunStale = Test-TargetWintunPresent -Snapshot $afterWintun
+    $wintunStale = -not (Wait-TargetWintunReleased)
     $serviceRecords.Add([pscustomobject]@{
             name = $serviceName
             control = $Control
@@ -797,24 +1038,40 @@ if ($serviceRecords.Count -eq 0) {
 Add-Capability -Name 'logoff_hook' -Status 'deferred' -Detail 'GitHub-hosted job cannot log off the runner without terminating the job'
 Add-Capability -Name 'shutdown_hook' -Status 'deferred' -Detail 'GitHub-hosted job cannot shut down the runner without terminating the job'
 
-$evidenceHeadSha = if ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { 'unknown' }
-Import-FlutterLifecycleEvidence -ExpectedHeadSha $evidenceHeadSha
+$productionCapability = @($capabilities | Where-Object { $_.name -eq 'production_start_stop' } | Select-Object -First 1)
+if ($productionCapability.Count -eq 1) {
+    Add-Component -Name 'production_harness' -Status $productionCapability[0].status -Detail ([string]$productionCapability[0].detail)
+} else {
+    Add-Component -Name 'production_harness' -Status 'failed' -Detail 'production harness did not emit a production_start_stop capability'
+}
+
+Import-FlutterLifecycleEvidence -ExpectedSourceHeadSha $expectedSourceHeadSha -ExpectedWorkflowSha $expectedWorkflowSha
+Import-HandlerMappingEvidence
 $trayResult = Invoke-FlutterTrayNoAdapterExit
 Add-Capability -Name 'flutter_release_tray_no_adapter_exit' -Status $trayResult.status -Detail $trayResult.detail
 
 $evidence = [ordered]@{
-    schema_version = 1
-    head_sha = $evidenceHeadSha
+    schema_version = 2
+    repository = 'yhan-sun/p2wlan'
+    source_head_sha = $expectedSourceHeadSha
+    workflow_sha = $expectedWorkflowSha
     runner_os = 'windows-latest'
     generated_at_utc = [DateTime]::UtcNow.ToString('o')
+    components = @($components)
+    handler_mapping = $handlerMapping
     capabilities = @($capabilities)
     cycles = @($records)
     service_controls = @($serviceRecords)
     flutter_tray = [ordered]@{
+        attempted_cycles = $trayResult.attempted_cycles
+        successful_cycles = $trayResult.successful_cycles
+        first_failure_cycle = $trayResult.first_failure_cycle
         process_exited = $trayResult.process_exited
         exit_code = $trayResult.exit_code
         daemon_processes_clean = $trayResult.daemon_processes_clean
         forced_termination = $trayResult.forced_termination
+        dump_paths = @($trayResult.dump_paths)
+        cycles = @($trayResult.cycles)
         detail = $trayResult.detail
     }
     wer = [ordered]@{
@@ -825,7 +1082,7 @@ $evidence = [ordered]@{
 }
 $parent = Split-Path -Parent $EvidencePath
 if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
-$evidence | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $EvidencePath -Encoding utf8
+$evidence | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $EvidencePath -Encoding utf8
 
 if ($previousDisableTun) { $env:P2WLAN_DISABLE_TUN = $previousDisableTun } else { Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue }
 if ($previousStateDir) { $env:P2WLAN_STATE_DIR = $previousStateDir } else { Remove-Item Env:P2WLAN_STATE_DIR -ErrorAction SilentlyContinue }

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -225,7 +225,7 @@ function Stop-CliDaemon {
     $output = @(& $CliPath --config $ConfigPath down 2>&1 | Out-String)
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
-        throw "p2wlan CLI stop exited with $exitCode: $($output -join '')"
+        throw "p2wlan CLI stop exited with ${exitCode}: $($output -join '')"
     }
 }
 

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -596,6 +596,7 @@ function Invoke-FlutterTrayNoAdapterCycle {
         $startInfo.RedirectStandardError = $true
         $startInfo.Environment['P2WLAN_WINDOWS_TRAY_LIFECYCLE_TEST'] = 'no-adapter-exit'
         $startInfo.Environment['P2WLAN_ENABLE_FLUTTER_TRAY'] = '1'
+        $startInfo.Environment['P2WLAN_TRAY_TRACE_FILE'] = Join-Path $traceCycleRoot 'dart-lifecycle.log'
         # Keep this release run isolated from any persisted desktop settings;
         # no daemon is intentionally started for the no-adapter regression.
         $startInfo.Environment['APPDATA'] = $cycleRoot

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -1,0 +1,718 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DaemonPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$CliPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$EvidencePath,
+
+    [string]$FlutterReleasePath,
+    [string]$FlutterEvidencePath,
+    [int]$ProductionCycles = 50,
+    [switch]$AttemptRealWintun
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) "p2wlan-windows-lifecycle-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
+$records = [System.Collections.Generic.List[object]]::new()
+$capabilities = [System.Collections.Generic.List[object]]::new()
+$serviceRecords = [System.Collections.Generic.List[object]]::new()
+$previousDisableTun = $env:P2WLAN_DISABLE_TUN
+$previousStateDir = $env:P2WLAN_STATE_DIR
+
+function Add-Capability {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][ValidateSet('verified', 'deferred', 'failed')][string]$Status,
+        [Parameter(Mandatory = $false)][string]$Detail = ''
+    )
+    foreach ($existing in @($capabilities | Where-Object { $_.name -eq $Name })) {
+        [void]$capabilities.Remove($existing)
+    }
+    $capabilities.Add([ordered]@{
+            name = $Name
+            status = $Status
+            detail = $Detail
+        })
+}
+
+function Get-DaemonProcesses {
+    @(Get-CimInstance Win32_Process -Filter "Name = 'p2wlan-daemon.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -notmatch '(?i)(^|\s)--build-info(\s|$)' })
+}
+
+function Get-ProcessIdList {
+    @(Get-DaemonProcesses | ForEach-Object { [int]$_.ProcessId })
+}
+
+function Get-DescendantProcessIds {
+    param([Parameter(Mandatory = $true)][int]$RootPid)
+    $all = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
+    $children = [System.Collections.Generic.List[int]]::new()
+    $frontier = [System.Collections.Generic.Queue[int]]::new()
+    $frontier.Enqueue($RootPid)
+    while ($frontier.Count -gt 0) {
+        $parent = $frontier.Dequeue()
+        foreach ($process in $all | Where-Object { [int]$_.ParentProcessId -eq $parent }) {
+            $child = [int]$process.ProcessId
+            if (-not $children.Contains($child)) {
+                $children.Add($child)
+                $frontier.Enqueue($child)
+            }
+        }
+    }
+    @($children)
+}
+
+function Get-WintunSnapshot {
+    @(
+        Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.Name -match '(?i)p2wlan|wintun' -or
+                $_.InterfaceDescription -match '(?i)p2wlan|wintun'
+            } |
+            ForEach-Object { "$($_.Name)|$($_.InterfaceDescription)|$($_.Status)" } |
+            Sort-Object
+    )
+}
+
+function Test-TargetWintunPresent {
+    param([string[]]$Snapshot)
+    @($Snapshot | Where-Object { $_ -match '(?i)(^|\|)p2wlan-lifecycle(?:\||$)' }).Count -gt 0
+}
+
+function Wait-TargetWintunReleased {
+    param([Parameter(Mandatory = $true)][int]$TimeoutSeconds = 10)
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if (-not (Test-TargetWintunPresent -Snapshot (Get-WintunSnapshot))) {
+            return $true
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    $false
+}
+
+function Get-FreeLoopbackPort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        [int]$listener.LocalEndpoint.Port
+    } finally {
+        $listener.Stop()
+    }
+}
+
+function Test-LoopbackPortReleased {
+    param([Parameter(Mandatory = $true)][int]$Port)
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+    try {
+        $listener.Start()
+        $true
+    } catch {
+        $false
+    } finally {
+        $listener.Stop()
+    }
+}
+
+function Wait-DaemonReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$BaseUrl,
+        [Parameter(Mandatory = $true)][string]$AuthPath,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds = 20
+    )
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $health = Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/health" -TimeoutSec 2
+            if ($health.StatusCode -ge 200 -and $health.StatusCode -lt 300 -and (Test-Path -LiteralPath $AuthPath)) {
+                $token = (Get-Content -LiteralPath $AuthPath -Raw).Trim()
+                if ($token) {
+                    return $token
+                }
+            }
+        } catch {
+            # The daemon can be between instance-lock, diagnostics bind, and
+            # auth-file publication. Keep polling inside the bounded budget.
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    throw "daemon diagnostics did not become ready at $BaseUrl"
+}
+
+function Wait-ProcessExited {
+    param(
+        [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds = 20
+    )
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            $Process.Refresh()
+            if ($Process.HasExited) {
+                return [pscustomobject]@{ exited = $true; exit_code = $Process.ExitCode }
+            }
+        } catch {
+            return [pscustomobject]@{ exited = $true; exit_code = $null }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    [pscustomobject]@{ exited = $false; exit_code = $null }
+}
+
+function Start-ProductionDaemon {
+    param(
+        [Parameter(Mandatory = $true)][string]$ConfigPath,
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [Parameter(Mandatory = $true)][string]$DiagnosticsBind
+    )
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $DaemonPath
+    $startInfo.WorkingDirectory = Split-Path -Parent $DaemonPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in @(
+            '--config', $ConfigPath,
+            '--control', 'http://127.0.0.1:1',
+            '--network', 'windows-lifecycle',
+            '--diagnostics-bind', $DiagnosticsBind,
+            '--log-file', $LogPath,
+            '--manual',
+            '--interface', 'p2wlan-lifecycle',
+            '--address', '10.20.0.1',
+            '--udp-bind', '127.0.0.1:0',
+            '--stun', 'none',
+            '--socket-pool', 'off'
+        )) {
+        $null = $startInfo.ArgumentList.Add($argument)
+    }
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "failed to start $DaemonPath"
+    }
+    $process.BeginOutputReadLine()
+    $process.BeginErrorReadLine()
+    $process
+}
+
+function Stop-DiagnosticsDaemon {
+    param(
+        [Parameter(Mandatory = $true)][string]$BaseUrl,
+        [Parameter(Mandatory = $true)][string]$Token
+    )
+    $response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri "$BaseUrl/shutdown" -Headers @{ Authorization = "Bearer $Token" } -TimeoutSec 5
+    if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+        throw "diagnostics shutdown returned HTTP $($response.StatusCode)"
+    }
+}
+
+function Stop-CliDaemon {
+    param(
+        [Parameter(Mandatory = $true)][string]$ConfigPath,
+        [Parameter(Mandatory = $true)][string]$StateDirectory
+    )
+    $env:P2WLAN_STATE_DIR = $StateDirectory
+    $output = @(& $CliPath --config $ConfigPath down 2>&1 | Out-String)
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "p2wlan CLI stop exited with $exitCode: $($output -join '')"
+    }
+}
+
+function Add-ConsoleCtrlHelper {
+    if ('P2WlanLifecycleNative' -as [type]) { return }
+    Add-Type @'
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+public static class P2WlanLifecycleNative {
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  public struct STARTUPINFO { public uint cb; public string lpReserved; public string lpDesktop; public string lpTitle; public uint dwX; public uint dwY; public uint dwXSize; public uint dwYSize; public uint dwXCountChars; public uint dwYCountChars; public uint dwFillAttribute; public uint dwFlags; public short wShowWindow; public short cbReserved2; public IntPtr lpReserved2; public IntPtr hStdInput; public IntPtr hStdOutput; public IntPtr hStdError; }
+  [StructLayout(LayoutKind.Sequential)] public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread; public uint dwProcessId; public uint dwThreadId; }
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] static extern bool CreateProcess(string app, string cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool GenerateConsoleCtrlEvent(uint type, uint group);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool AttachConsole(uint pid);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool FreeConsole();
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool CloseHandle(IntPtr handle);
+  public static int StartInNewProcessGroup(string fileName, string arguments, string cwd) {
+    var si = new STARTUPINFO(); si.cb = (uint)Marshal.SizeOf(si); si.dwFlags = 0x00000001; si.wShowWindow = 0;
+    PROCESS_INFORMATION pi;
+    if (!CreateProcess(fileName, "\"" + fileName + "\" " + arguments, IntPtr.Zero, IntPtr.Zero, false, 0x00000200, IntPtr.Zero, cwd, ref si, out pi)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+    CloseHandle(pi.hThread); CloseHandle(pi.hProcess);
+    return (int)pi.dwProcessId;
+  }
+  public static void SendCtrlC(int processId) {
+    // CTRL_C_EVENT cannot be scoped to a process group. Temporarily attach
+    // this helper to the daemon's inherited console, with the PowerShell
+    // parent detached, so the event reaches only the daemon. Restore the
+    // parent console before returning to the acceptance script.
+    FreeConsole();
+    try {
+      if (!AttachConsole((uint)processId)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+      if (!GenerateConsoleCtrlEvent(0, 0)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+    } finally {
+      FreeConsole();
+      AttachConsole(0xffffffff);
+    }
+  }
+}
+'@
+}
+
+function Invoke-ProductionCycle {
+    param(
+        [Parameter(Mandatory = $true)][int]$Cycle,
+        [Parameter(Mandatory = $true)][ValidateSet('diagnostics', 'cli', 'ctrl_c')][string]$Entrypoint,
+        [Parameter(Mandatory = $true)][bool]$RealWintun
+    )
+    $cycleRoot = Join-Path $runRoot "cycle-$Cycle"
+    New-Item -ItemType Directory -Path $cycleRoot -Force | Out-Null
+    $configPath = Join-Path $cycleRoot 'config.json'
+    $logPath = Join-Path $cycleRoot 'daemon.log'
+    $port = Get-FreeLoopbackPort
+    $baseUrl = "http://127.0.0.1:$port"
+    $authPath = Join-Path $cycleRoot 'p2wlan-daemon.diag-auth'
+    $beforeWintun = Get-WintunSnapshot
+    $beforePids = Get-ProcessIdList
+    $process = $null
+    $ctrlCProcessId = $null
+    $startSucceeded = $false
+    $stopRequested = $false
+    $forcedTermination = $false
+    $processExited = $false
+    $exitCode = $null
+    $childrenGone = $false
+    $portReleased = $false
+    $authRemoved = $false
+    $wintunStale = $false
+    $wintunObserved = $false
+    $daemonProcessesClean = $false
+    $childPids = @()
+    $detail = ''
+
+    try {
+        if ($RealWintun -and (Test-TargetWintunPresent -Snapshot $beforeWintun)) {
+            throw 'p2wlan-lifecycle Wintun adapter was already present before the cycle'
+        }
+        if ($RealWintun) {
+            Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue
+        } else {
+            $env:P2WLAN_DISABLE_TUN = '1'
+        }
+        if ($Entrypoint -eq 'ctrl_c') {
+            Add-ConsoleCtrlHelper
+            $arguments = "--config `"$configPath`" --control http://127.0.0.1:1 --network windows-lifecycle --diagnostics-bind 127.0.0.1:$port --log-file `"$logPath`" --manual --interface p2wlan-lifecycle --address 10.20.0.1 --udp-bind 127.0.0.1:0 --stun none --socket-pool off"
+            $ctrlCProcessId = [P2WlanLifecycleNative]::StartInNewProcessGroup($DaemonPath, $arguments, (Split-Path -Parent $DaemonPath))
+            $process = Get-Process -Id $ctrlCProcessId -ErrorAction Stop
+        } else {
+            $process = Start-ProductionDaemon -ConfigPath $configPath -LogPath $logPath -DiagnosticsBind "127.0.0.1:$port"
+        }
+        $token = Wait-DaemonReady -BaseUrl $baseUrl -AuthPath $authPath
+        $startSucceeded = $true
+        $wintunDeadline = [DateTime]::UtcNow.AddSeconds(5)
+        while ($RealWintun -and [DateTime]::UtcNow -lt $wintunDeadline) {
+            $duringWintun = Get-WintunSnapshot
+            if (Test-TargetWintunPresent -Snapshot $duringWintun) {
+                $wintunObserved = $true
+                break
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if ($RealWintun -and -not $wintunObserved) {
+            throw 'daemon became ready without an observable p2wlan-lifecycle Wintun adapter'
+        }
+        $childPids = Get-DescendantProcessIds -RootPid $process.Id
+        switch ($Entrypoint) {
+            'diagnostics' { Stop-DiagnosticsDaemon -BaseUrl $baseUrl -Token $token }
+            'cli' { Stop-CliDaemon -ConfigPath $configPath -StateDirectory $cycleRoot }
+            'ctrl_c' { [P2WlanLifecycleNative]::SendCtrlC($process.Id) }
+        }
+        $stopRequested = $true
+        if ($Entrypoint -eq 'ctrl_c') {
+            $result = Wait-ProcessExited -Process $process -TimeoutSeconds 5
+        } else {
+            $result = Wait-ProcessExited -Process $process -TimeoutSeconds 20
+        }
+        $processExited = $result.exited
+        $exitCode = $result.exit_code
+        if (-not $processExited) {
+            throw "daemon did not exit after $Entrypoint"
+        }
+        if ($exitCode -ne 0) {
+            throw "daemon exited with code $exitCode after $Entrypoint"
+        }
+        $childrenAfterExit = @(Get-DescendantProcessIds -RootPid $process.Id)
+        $observedChildPids = @($childPids) + @($childrenAfterExit)
+        $observedChildPids = @($observedChildPids | Sort-Object -Unique)
+        $childrenGone = @($observedChildPids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }).Count -eq 0
+        $portReleased = Test-LoopbackPortReleased -Port $port
+        $authRemoved = -not (Test-Path -LiteralPath $authPath)
+        $afterWintun = Get-WintunSnapshot
+        $wintunStale = if ($RealWintun) { -not (Wait-TargetWintunReleased) } else { Test-TargetWintunPresent -Snapshot $afterWintun }
+        $daemonProcessesClean = @(
+            Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
+        ).Count -eq 0
+        if (-not $childrenGone) { throw "child process remained after daemon exit" }
+        if (-not $portReleased) { throw "diagnostics port $port was not released" }
+        if (-not $authRemoved) { throw "diagnostics auth file remained" }
+        if (-not $daemonProcessesClean) { throw "a new p2wlan-daemon process remained after daemon exit" }
+        if ($RealWintun -and $wintunStale) { throw "p2wlan-lifecycle Wintun adapter remained after daemon exit" }
+    } catch {
+        $detail = $_.Exception.Message
+        $running = $false
+        try { $running = $process -and -not $process.HasExited } catch { $running = $false }
+        if ($running) {
+            # Emergency cleanup is deliberately recorded as forceful failure;
+            # it can never make this cycle a graceful pass.
+            try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+            $forcedTermination = $true
+        }
+        if ($process) {
+            $result = Wait-ProcessExited -Process $process -TimeoutSeconds 5
+            $processExited = $result.exited
+            $exitCode = $result.exit_code
+        }
+        $portReleased = Test-LoopbackPortReleased -Port $port
+        $authRemoved = -not (Test-Path -LiteralPath $authPath)
+        $afterWintun = Get-WintunSnapshot
+        $wintunStale = -not (Wait-TargetWintunReleased)
+        $daemonProcessesClean = @(
+            Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
+        ).Count -eq 0
+    }
+    [pscustomobject]@{
+        cycle = $Cycle
+        entrypoint = $Entrypoint
+        mode = 'production'
+        real_wintun = $RealWintun
+        start_succeeded = $startSucceeded
+        graceful_stop = $stopRequested -and $processExited -and $exitCode -eq 0 -and -not $forcedTermination
+        forced_termination = $forcedTermination
+        process_exited = $processExited
+        process_exit_code = $exitCode
+        children_gone = $childrenGone
+        diagnostics_port_released = $portReleased
+        auth_token_removed = $authRemoved
+        wintun_stale = $wintunStale
+        wintun_observed = $wintunObserved
+        daemon_processes_clean = $daemonProcessesClean
+        pid = if ($process) { $process.Id } else { $null }
+        diagnostics_port = $port
+        detail = $detail
+        baseline_daemon_pids = @($beforePids)
+        baseline_wintun = @($beforeWintun)
+    }
+}
+
+function Invoke-FlutterTrayNoAdapterExit {
+    if ([string]::IsNullOrWhiteSpace($FlutterReleasePath)) {
+        return [pscustomobject]@{
+            status = 'deferred'
+            detail = 'Flutter release executable was not supplied'
+            process_exited = $false
+            exit_code = $null
+            daemon_processes_clean = $true
+            forced_termination = $false
+        }
+    }
+    if (-not (Test-Path -LiteralPath $FlutterReleasePath)) {
+        return [pscustomobject]@{
+            status = 'failed'
+            detail = "Flutter release executable not found: $FlutterReleasePath"
+            process_exited = $false
+            exit_code = $null
+            daemon_processes_clean = $false
+            forced_termination = $false
+        }
+    }
+
+    $trayRoot = Join-Path $runRoot 'flutter-tray-no-adapter'
+    New-Item -ItemType Directory -Path $trayRoot -Force | Out-Null
+    $beforePids = Get-ProcessIdList
+    $process = $null
+    $forcedTermination = $false
+    try {
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = [System.IO.Path]::GetFullPath($FlutterReleasePath)
+        $startInfo.WorkingDirectory = Split-Path -Parent $startInfo.FileName
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $false
+        $startInfo.Environment['P2WLAN_WINDOWS_TRAY_LIFECYCLE_TEST'] = 'no-adapter-exit'
+        $startInfo.Environment['P2WLAN_ENABLE_FLUTTER_TRAY'] = '1'
+        # Keep this release run isolated from any persisted desktop settings;
+        # no daemon is intentionally started for the no-adapter regression.
+        $startInfo.Environment['APPDATA'] = $trayRoot
+        $startInfo.Environment['LOCALAPPDATA'] = $trayRoot
+        $process = [System.Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) { throw "failed to start Flutter release app" }
+        $result = Wait-ProcessExited -Process $process -TimeoutSeconds 30
+        if (-not $result.exited) {
+            try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+            $forcedTermination = $true
+            throw 'Flutter release tray app did not exit within the bounded no-adapter budget'
+        }
+        $afterPids = Get-ProcessIdList
+        $daemonProcessesClean = @(
+            $afterPids | Where-Object { $beforePids -notcontains $_ }
+        ).Count -eq 0
+        if (-not $daemonProcessesClean) {
+            throw 'Flutter release tray no-adapter test left a daemon process running'
+        }
+        if ($result.exit_code -ne 0) {
+            throw "Flutter release tray app exited with code $($result.exit_code)"
+        }
+        return [pscustomobject]@{
+            status = 'verified'
+            detail = 'release Flutter tray initialized and exited cleanly without a virtual adapter'
+            process_exited = $true
+            exit_code = $result.exit_code
+            daemon_processes_clean = $daemonProcessesClean
+            forced_termination = $false
+        }
+    } catch {
+        $detail = $_.Exception.Message
+        $daemonProcessesClean = @(
+            Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
+        ).Count -eq 0
+        return [pscustomobject]@{
+            status = 'failed'
+            detail = $detail
+            process_exited = if ($process) { $process.HasExited } else { $false }
+            exit_code = if ($process -and $process.HasExited) { $process.ExitCode } else { $null }
+            daemon_processes_clean = $daemonProcessesClean
+            forced_termination = $forcedTermination
+        }
+    }
+}
+
+function Import-FlutterLifecycleEvidence {
+    param([Parameter(Mandatory = $true)][string]$ExpectedHeadSha)
+    if ([string]::IsNullOrWhiteSpace($FlutterEvidencePath)) {
+        Add-Capability -Name 'ui_stop' -Status 'deferred' -Detail 'Flutter UI evidence path was not supplied'
+        return
+    }
+    if (-not (Test-Path -LiteralPath $FlutterEvidencePath)) {
+        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence was not written: $FlutterEvidencePath"
+        return
+    }
+    try {
+        $flutter = Get-Content -LiteralPath $FlutterEvidencePath -Raw | ConvertFrom-Json
+        if ($flutter.head_sha -ne $ExpectedHeadSha) {
+            Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence head_sha=$($flutter.head_sha) does not match $ExpectedHeadSha"
+            return
+        }
+        foreach ($cycle in @($flutter.cycles)) { $records.Add($cycle) }
+        $uiCapability = @($flutter.capabilities | Where-Object { $_.name -eq 'ui_stop' } | Select-Object -First 1)
+        if ($uiCapability.Count -ne 1) {
+            Add-Capability -Name 'ui_stop' -Status 'failed' -Detail 'Flutter UI evidence did not contain a ui_stop capability'
+            return
+        }
+        Add-Capability -Name 'ui_stop' -Status $uiCapability[0].status -Detail ([string]$uiCapability[0].detail)
+    } catch {
+        Add-Capability -Name 'ui_stop' -Status 'failed' -Detail "Flutter UI evidence could not be imported: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-ServiceCycle {
+    param([ValidateSet('stop', 'preshutdown')][string]$Control)
+    $serviceName = "p2wlan-lifecycle-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+    $serviceRoot = Join-Path $runRoot $serviceName
+    New-Item -ItemType Directory -Path $serviceRoot -Force | Out-Null
+    $configPath = Join-Path $serviceRoot 'config.json'
+    $logPath = Join-Path $serviceRoot 'service.log'
+    $binPath = '"{0}" --windows-service --windows-service-name {1} --config "{2}" --control http://127.0.0.1:1 --network windows-lifecycle --manual --diagnostics-disable --log-file "{3}" --interface p2wlan-lifecycle --address 10.20.0.1 --udp-bind 127.0.0.1:0 --stun none --socket-pool off' -f $DaemonPath, $serviceName, $configPath, $logPath
+    $beforeWintun = Get-WintunSnapshot
+    $status = 'failed'
+    $detail = ''
+    $processId = $null
+    $processGone = $false
+    $wintunStale = $false
+    $wintunObserved = $false
+    $previousServiceDisableTun = $env:P2WLAN_DISABLE_TUN
+    try {
+        # Service control must exercise the real Wintun path even if a manual
+        # invocation of this script was configured for no-TUN production
+        # cycles. The workflow always requests real Wintun explicitly.
+        Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue
+        if (Test-TargetWintunPresent -Snapshot $beforeWintun) {
+            throw 'p2wlan-lifecycle Wintun adapter was already present before the service cycle'
+        }
+        & sc.exe create $serviceName binPath= $binPath start= demand DisplayName= 'P2WLAN lifecycle acceptance' | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "sc.exe create returned $LASTEXITCODE" }
+        & sc.exe start $serviceName | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "sc.exe start returned $LASTEXITCODE" }
+        $deadline = [DateTime]::UtcNow.AddSeconds(25)
+        do {
+            Start-Sleep -Milliseconds 250
+            $query = (& sc.exe query $serviceName | Out-String)
+            if ($query -match 'STATE\s+:\s+4\s+RUNNING') { break }
+            if ($query -match 'STATE\s+:\s+1\s+STOPPED') { throw "service stopped before reaching RUNNING" }
+        } while ([DateTime]::UtcNow -lt $deadline)
+        $queryEx = (& sc.exe queryex $serviceName | Out-String)
+        $pidMatch = [regex]::Match($queryEx, 'PID\s+\:\s+(\d+)')
+        if ($pidMatch.Success) { $processId = [int]$pidMatch.Groups[1].Value }
+        if (-not $processId) { throw 'SCM did not expose a service process id' }
+        $wintunDeadline = [DateTime]::UtcNow.AddSeconds(10)
+        while ([DateTime]::UtcNow -lt $wintunDeadline) {
+            $duringWintun = Get-WintunSnapshot
+            if (Test-TargetWintunPresent -Snapshot $duringWintun) {
+                $wintunObserved = $true
+                break
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if (-not $wintunObserved) { throw 'SCM reported RUNNING without an observable p2wlan-lifecycle Wintun adapter' }
+        if ($Control -eq 'stop') {
+            & sc.exe stop $serviceName | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "sc.exe stop returned $LASTEXITCODE" }
+        } else {
+            # PRESHUTDOWN is an SCM-delivered control. GitHub runners do not
+            # permit a job to shut down/log off the host, so only accept this
+            # as verified if the SCM actually delivers control 15.
+            & sc.exe control $serviceName 15 | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "SCM did not deliver SERVICE_CONTROL_PRESHUTDOWN (sc.exe exit $LASTEXITCODE)" }
+        }
+        $deadline = [DateTime]::UtcNow.AddSeconds(25)
+        do {
+            Start-Sleep -Milliseconds 250
+            $query = (& sc.exe query $serviceName | Out-String)
+            if ($query -match 'STATE\s+:\s+1\s+STOPPED') { $status = 'verified'; break }
+        } while ([DateTime]::UtcNow -lt $deadline)
+        if ($status -ne 'verified') { throw "service did not reach STOPPED within the bounded budget" }
+        $processDeadline = [DateTime]::UtcNow.AddSeconds(10)
+        while ((Get-Process -Id $processId -ErrorAction SilentlyContinue) -and [DateTime]::UtcNow -lt $processDeadline) {
+            Start-Sleep -Milliseconds 250
+        }
+        $processGone = $null -eq (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+        if (-not $processGone) { throw "service process $processId remained after SCM $Control" }
+        $serviceLog = if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Raw } else { '' }
+        $expectedReason = if ($Control -eq 'stop') { 'SERVICE_STOP' } else { 'SERVICE_PRESHUTDOWN' }
+        if ($serviceLog -notmatch [regex]::Escape("event $expectedReason")) {
+            throw "service log did not prove delivery of $expectedReason"
+        }
+        $status = 'verified'
+    } catch {
+        $detail = $_.Exception.Message
+        $status = 'failed'
+        if ($Control -eq 'preshutdown' -and ($detail -match 'PRESHUTDOWN|control 15|not deliver')) {
+            $status = 'deferred'
+        }
+    } finally {
+        & sc.exe stop $serviceName | Out-Null
+        $cleanupDeadline = [DateTime]::UtcNow.AddSeconds(10)
+        while ($processId -and (Get-Process -Id $processId -ErrorAction SilentlyContinue) -and [DateTime]::UtcNow -lt $cleanupDeadline) {
+            Start-Sleep -Milliseconds 250
+        }
+        $processGone = $processId -and $null -eq (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+        & sc.exe delete $serviceName | Out-Null
+        if ($previousServiceDisableTun) { $env:P2WLAN_DISABLE_TUN = $previousServiceDisableTun } else { Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue }
+    }
+    $afterWintun = Get-WintunSnapshot
+    $wintunStale = Test-TargetWintunPresent -Snapshot $afterWintun
+    $serviceRecords.Add([pscustomobject]@{
+            name = $serviceName
+            control = $Control
+            status = $status
+            detail = $detail
+            process_id = $processId
+            process_gone = [bool]$processGone -and (@((Get-DaemonProcesses)).Count -eq 0)
+            wintun_observed = $wintunObserved
+            wintun_stale = $wintunStale
+            baseline_wintun = @($beforeWintun)
+        })
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $DaemonPath)) { throw "daemon binary not found: $DaemonPath" }
+    if (-not (Test-Path -LiteralPath $CliPath)) { throw "CLI binary not found: $CliPath" }
+    $RealWintun = [bool]$AttemptRealWintun
+    for ($cycle = 1; $cycle -le $ProductionCycles; $cycle++) {
+        $entrypoint = switch (($cycle - 1) % 3) {
+            0 { 'diagnostics' }
+            1 { 'cli' }
+            default { 'ctrl_c' }
+        }
+        $record = Invoke-ProductionCycle -Cycle $cycle -Entrypoint $entrypoint -RealWintun $RealWintun
+        $records.Add($record)
+        if (-not $record.graceful_stop) {
+            throw "production cycle $cycle did not prove graceful cleanup: $($record.detail)"
+        }
+    }
+
+    Invoke-ServiceCycle -Control stop
+    Invoke-ServiceCycle -Control preshutdown
+
+    Add-Capability -Name 'production_start_stop' -Status 'verified' -Detail "$ProductionCycles production daemon cycles completed"
+    Add-Capability -Name 'diagnostics_port_release' -Status 'verified' -Detail 'every production cycle rebound the same loopback port'
+    Add-Capability -Name 'child_process_cleanup' -Status 'verified' -Detail 'every production cycle checked descendants'
+    Add-Capability -Name 'cli_stop' -Status 'verified' -Detail 'CLI stop was exercised in rotating production cycles'
+    Add-Capability -Name 'ctrl_c' -Status 'verified' -Detail 'CTRL_C_EVENT was delivered by a new-process-group helper'
+    Add-Capability -Name 'service_stop' -Status (($serviceRecords | Where-Object control -eq 'stop' | Select-Object -First 1).status) -Detail (($serviceRecords | Where-Object control -eq 'stop' | Select-Object -First 1).detail)
+    Add-Capability -Name 'service_preshutdown' -Status (($serviceRecords | Where-Object control -eq 'preshutdown' | Select-Object -First 1).status) -Detail (($serviceRecords | Where-Object control -eq 'preshutdown' | Select-Object -First 1).detail)
+    Add-Capability -Name 'wintun_ownership' -Status $(if ($RealWintun) { 'verified' } else { 'deferred' }) -Detail $(if ($RealWintun) { 'real Wintun mode checked after every production cycle' } else { 'real Wintun mode was not requested' })
+} catch {
+    Add-Capability -Name 'production_start_stop' -Status 'failed' -Detail $_.Exception.Message
+    Add-Capability -Name 'diagnostics_port_release' -Status 'failed' -Detail 'production loop aborted before all cycles completed'
+    Add-Capability -Name 'child_process_cleanup' -Status 'failed' -Detail 'production loop aborted before all cycles completed'
+    Add-Capability -Name 'cli_stop' -Status 'failed' -Detail $_.Exception.Message
+    Add-Capability -Name 'ctrl_c' -Status 'failed' -Detail $_.Exception.Message
+    Add-Capability -Name 'service_stop' -Status 'failed' -Detail $_.Exception.Message
+    Add-Capability -Name 'service_preshutdown' -Status 'deferred' -Detail 'not reached because the production loop failed'
+    Add-Capability -Name 'wintun_ownership' -Status $(if ($AttemptRealWintun) { 'failed' } else { 'deferred' }) -Detail $_.Exception.Message
+}
+
+if ($serviceRecords.Count -eq 0) {
+    Add-Capability -Name 'service_stop' -Status 'failed' -Detail 'service control cycle did not run'
+    Add-Capability -Name 'service_preshutdown' -Status 'deferred' -Detail 'service control cycle did not run'
+}
+
+# These hooks require a host logoff/shutdown and would terminate the hosted
+# job itself. Record the limitation explicitly; never emit a verified pass.
+Add-Capability -Name 'logoff_hook' -Status 'deferred' -Detail 'GitHub-hosted job cannot log off the runner without terminating the job'
+Add-Capability -Name 'shutdown_hook' -Status 'deferred' -Detail 'GitHub-hosted job cannot shut down the runner without terminating the job'
+
+$evidenceHeadSha = if ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { 'unknown' }
+Import-FlutterLifecycleEvidence -ExpectedHeadSha $evidenceHeadSha
+$trayResult = Invoke-FlutterTrayNoAdapterExit
+Add-Capability -Name 'flutter_release_tray_no_adapter_exit' -Status $trayResult.status -Detail $trayResult.detail
+
+$evidence = [ordered]@{
+    schema_version = 1
+    head_sha = $evidenceHeadSha
+    runner_os = 'windows-latest'
+    generated_at_utc = [DateTime]::UtcNow.ToString('o')
+    capabilities = @($capabilities)
+    cycles = @($records)
+    service_controls = @($serviceRecords)
+    flutter_tray = [ordered]@{
+        process_exited = $trayResult.process_exited
+        exit_code = $trayResult.exit_code
+        daemon_processes_clean = $trayResult.daemon_processes_clean
+        forced_termination = $trayResult.forced_termination
+        detail = $trayResult.detail
+    }
+    wer = [ordered]@{
+        event_ids_checked = @(1000, 1001)
+        events = @()
+        note = 'WER events are added by the workflow after this script returns.'
+    }
+}
+$parent = Split-Path -Parent $EvidencePath
+if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+$evidence | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $EvidencePath -Encoding utf8
+
+if ($previousDisableTun) { $env:P2WLAN_DISABLE_TUN = $previousDisableTun } else { Remove-Item Env:P2WLAN_DISABLE_TUN -ErrorAction SilentlyContinue }
+if ($previousStateDir) { $env:P2WLAN_STATE_DIR = $previousStateDir } else { Remove-Item Env:P2WLAN_STATE_DIR -ErrorAction SilentlyContinue }
+
+Write-Host "Windows lifecycle evidence written to $EvidencePath"

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -536,12 +536,18 @@ function Invoke-FlutterTrayNoAdapterExit {
     $beforePids = Get-ProcessIdList
     $process = $null
     $forcedTermination = $false
+    $stdoutTask = $null
+    $stderrTask = $null
+    $stdout = ''
+    $stderr = ''
     try {
         $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
         $startInfo.FileName = [System.IO.Path]::GetFullPath($FlutterReleasePath)
         $startInfo.WorkingDirectory = Split-Path -Parent $startInfo.FileName
         $startInfo.UseShellExecute = $false
         $startInfo.CreateNoWindow = $false
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
         $startInfo.Environment['P2WLAN_WINDOWS_TRAY_LIFECYCLE_TEST'] = 'no-adapter-exit'
         $startInfo.Environment['P2WLAN_ENABLE_FLUTTER_TRAY'] = '1'
         # Keep this release run isolated from any persisted desktop settings;
@@ -551,12 +557,16 @@ function Invoke-FlutterTrayNoAdapterExit {
         $process = [System.Diagnostics.Process]::new()
         $process.StartInfo = $startInfo
         if (-not $process.Start()) { throw "failed to start Flutter release app" }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
         $result = Wait-ProcessExited -Process $process -TimeoutSeconds 30
         if (-not $result.exited) {
             try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
             $forcedTermination = $true
             throw 'Flutter release tray app did not exit within the bounded no-adapter budget'
         }
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
         $afterPids = Get-ProcessIdList
         $daemonProcessesClean = @(
             $afterPids | Where-Object { $beforePids -notcontains $_ }
@@ -577,6 +587,15 @@ function Invoke-FlutterTrayNoAdapterExit {
         }
     } catch {
         $detail = $_.Exception.Message
+        if ($stdoutTask -ne $null) {
+            try { $stdout = $stdoutTask.GetAwaiter().GetResult() } catch {}
+        }
+        if ($stderrTask -ne $null) {
+            try { $stderr = $stderrTask.GetAwaiter().GetResult() } catch {}
+        }
+        if ($stdout -or $stderr) {
+            $detail = "$detail; stdout=[$stdout]; stderr=[$stderr]"
+        }
         $daemonProcessesClean = @(
             Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
         ).Count -eq 0

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -184,9 +184,10 @@ function Wait-ProcessExited {
 
 function Wait-ObservedChildProcessesGone {
     param(
-        [Parameter(Mandatory = $true)][int[]]$ProcessIds,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][int[]]$ProcessIds,
         [int]$TimeoutSeconds = 10
     )
+    if ($ProcessIds.Count -eq 0) { return $true }
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
     do {
         $alive = @($ProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })

--- a/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
+++ b/scripts/windows_lifecycle/windows_lifecycle_acceptance.ps1
@@ -157,14 +157,43 @@ function Wait-ProcessExited {
         try {
             $Process.Refresh()
             if ($Process.HasExited) {
-                return [pscustomobject]@{ exited = $true; exit_code = $Process.ExitCode }
+                $exitCode = $null
+                try { $exitCode = [int]$Process.ExitCode } catch {}
+                if ($null -eq $exitCode -and ('P2WlanLifecycleNative' -as [type])) {
+                    $nativeExitCode = 0
+                    if ([P2WlanLifecycleNative]::TryGetExitCode($Process.Id, [ref]$nativeExitCode)) {
+                        $exitCode = $nativeExitCode
+                    }
+                }
+                return [pscustomobject]@{ exited = $true; exit_code = $exitCode }
             }
         } catch {
-            return [pscustomobject]@{ exited = $true; exit_code = $null }
+            $exitCode = $null
+            if ('P2WlanLifecycleNative' -as [type]) {
+                $nativeExitCode = 0
+                if ([P2WlanLifecycleNative]::TryGetExitCode($Process.Id, [ref]$nativeExitCode)) {
+                    $exitCode = $nativeExitCode
+                }
+            }
+            return [pscustomobject]@{ exited = $true; exit_code = $exitCode }
         }
         Start-Sleep -Milliseconds 100
     }
     [pscustomobject]@{ exited = $false; exit_code = $null }
+}
+
+function Wait-ObservedChildProcessesGone {
+    param(
+        [Parameter(Mandatory = $true)][int[]]$ProcessIds,
+        [int]$TimeoutSeconds = 10
+    )
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $alive = @($ProcessIds | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+        if ($alive.Count -eq 0) { return $true }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    $false
 }
 
 function Start-ProductionDaemon {
@@ -240,12 +269,26 @@ public static class P2WlanLifecycleNative {
   [StructLayout(LayoutKind.Sequential)] public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread; public uint dwProcessId; public uint dwThreadId; }
   [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] static extern bool CreateProcess(string app, string cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string cwd, ref STARTUPINFO si, out PROCESS_INFORMATION pi);
   [DllImport("kernel32.dll", SetLastError = true)] static extern bool CloseHandle(IntPtr handle);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern IntPtr OpenProcess(uint access, bool inherit, uint processId);
+  [DllImport("kernel32.dll", SetLastError = true)] static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
   [UnmanagedFunctionPointer(CallingConvention.Winapi)] private delegate bool HandlerRoutine(uint ctrlType);
   [DllImport("kernel32.dll", SetLastError = true)] static extern bool SetConsoleCtrlHandler(HandlerRoutine handlerRoutine, bool add);
   private static readonly HandlerRoutine ignoreCtrlC = IgnoreCtrlC;
   private static bool IgnoreCtrlC(uint ctrlType) { return ctrlType == 0; }
   public static void IgnoreCtrlCInCurrentProcess() {
     if (!SetConsoleCtrlHandler(ignoreCtrlC, true)) throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+  }
+  public static bool TryGetExitCode(int processId, out int exitCode) {
+    exitCode = 0;
+    const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x00001000;
+    var process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, (uint)processId);
+    if (process == IntPtr.Zero) return false;
+    try {
+      uint raw;
+      if (!GetExitCodeProcess(process, out raw)) return false;
+      exitCode = unchecked((int)raw);
+      return true;
+    } finally { CloseHandle(process); }
   }
   public static int StartInNewConsole(string fileName, string arguments, string cwd) {
     var si = new STARTUPINFO(); si.cb = (uint)Marshal.SizeOf(si); si.dwFlags = 0x00000001; si.wShowWindow = 0;
@@ -404,7 +447,7 @@ function Invoke-ProductionCycle {
         $childrenAfterExit = @(Get-DescendantProcessIds -RootPid $process.Id)
         $observedChildPids = @($childPids) + @($childrenAfterExit)
         $observedChildPids = @($observedChildPids | Sort-Object -Unique)
-        $childrenGone = @($observedChildPids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }).Count -eq 0
+        $childrenGone = Wait-ObservedChildProcessesGone -ProcessIds $observedChildPids
         $portReleased = Test-LoopbackPortReleased -Port $port
         $authRemoved = -not (Test-Path -LiteralPath $authPath)
         $afterWintun = Get-WintunSnapshot
@@ -436,6 +479,7 @@ function Invoke-ProductionCycle {
         $authRemoved = -not (Test-Path -LiteralPath $authPath)
         $afterWintun = Get-WintunSnapshot
         $wintunStale = -not (Wait-TargetWintunReleased)
+        $childrenGone = Wait-ObservedChildProcessesGone -ProcessIds @($childPids)
         $daemonProcessesClean = @(
             Get-ProcessIdList | Where-Object { $beforePids -notcontains $_ }
         ).Count -eq 0


### PR DESCRIPTION
Refs #23

本 PR 将 Windows 生命周期验收收敛到 GitHub Actions windows-latest：

- 生产 daemon 以真实 Wintun 轮转 50 次，覆盖 diagnostics、CLI、Ctrl+C；逐轮记录 graceful/forced、退出码、子进程、diagnostics 端口、auth 文件和 Wintun 观察/释放。
- 新增真实 SCM service STOP/PRESHUTDOWN 入口和证据；daemon 对 Ctrl+C、Ctrl+Break、close、logoff、shutdown console hook 做有界、幂等 graceful drain。
- Flutter UI stop 使用真实 daemon；release tray no-adapter exit 走实际 tray bootstrap/quit path。
- WER 1000/1001 与 BEX64 扫描、结构化 evidence、fail-closed aggregate。
- 强制终止只记为 forced_termination，不会转成 graceful pass。

本机只执行允许的 Rust/Python/Flutter 非 Windows 校验；Windows 专项以该 workflow 的真实证据为准。GitHub-hosted runner 无法安全执行 host logoff/shutdown 时，证据会明确标记 deferred，不伪造 verified。