### PR TITLE
feat(mobile): complete deterministic lifecycle regressions

### DIFF
--- a/.github/workflows/mobile-lifecycle.yml
+++ b/.github/workflows/mobile-lifecycle.yml
@@ -5,15 +5,17 @@ on:
     branches: [main]
     paths:
       - ".fvmrc"
-      - ".github/workflows/path-state-machine-required.yml"
       - ".github/workflows/mobile-lifecycle.yml"
       - "scripts/mobile-lifecycle-regression.sh"
+      - "scripts/mobile_lifecycle/**"
       - "scripts/build_android_native.sh"
       - "apps/flutter_client/**"
       - "client/android-native/**"
       - "client/daemon/**"
       - "client/tun/**"
       - "contracts/**"
+      - "docs/mobile-lifecycle-device-matrix.md"
+      - "docs/mobile-lifecycle-identity.md"
       - "Cargo.toml"
       - "Cargo.lock"
   push:
@@ -22,15 +24,23 @@ on:
       - ".fvmrc"
       - ".github/workflows/mobile-lifecycle.yml"
       - "scripts/mobile-lifecycle-regression.sh"
+      - "scripts/mobile_lifecycle/**"
       - "scripts/build_android_native.sh"
       - "apps/flutter_client/**"
       - "client/android-native/**"
       - "client/daemon/**"
       - "client/tun/**"
       - "contracts/**"
+      - "docs/mobile-lifecycle-device-matrix.md"
+      - "docs/mobile-lifecycle-identity.md"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
+    inputs:
+      validation_sha:
+        description: "Exact source commit to validate"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -39,13 +49,27 @@ concurrency:
   group: mobile-lifecycle-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  P2WLAN_EXACT_HEAD: ${{ github.event.pull_request.head.sha || inputs.validation_sha || github.sha }}
+  P2WLAN_WORKFLOW_SHA: ${{ github.sha }}
+
 jobs:
-  lifecycle_contract:
-    name: Mobile Lifecycle Required
+  flutter_contracts:
+    name: Flutter mobile lifecycle contracts
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
 
       - name: Set up Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
@@ -54,46 +78,226 @@ jobs:
           flutter-version-file: .fvmrc
           cache: true
 
+      - name: Run Flutter lifecycle tests and write evidence
+        shell: bash
+        env:
+          P2WLAN_MOBILE_LIFECYCLE_ROUNDS: "3"
+          P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle-flutter
+        run: |
+          set +e
+          flutter pub get
+          dependency_status=$?
+          if [[ "$dependency_status" -eq 0 ]]; then
+            bash scripts/mobile-lifecycle-regression.sh
+            test_status=$?
+          else
+            echo "Flutter dependency resolution failed; writing a failing component report." >&2
+            test_status="$dependency_status"
+            mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
+            python3 scripts/mobile_lifecycle/component_report.py \
+              --root . \
+              --component flutter \
+              --manifest scripts/mobile_lifecycle/manifests/flutter.json \
+              --source-head-sha "$P2WLAN_EXACT_HEAD" \
+              --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
+              --result fail \
+              --toolchain '{"runner":"flutter","dependency_resolution":"failed"}' \
+              --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/flutter.json"
+          fi
+          set -e
+          exit "$test_status"
+
+      - name: Upload Flutter lifecycle evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mobile-lifecycle-flutter
+          path: ${{ runner.temp }}/p2wlan-mobile-lifecycle-flutter/flutter.json
+          if-no-files-found: error
+          retention-days: 14
+
+  android_jvm:
+    name: Android JVM mobile lifecycle contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+
+      - name: Set up Java
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: stable
+          flutter-version-file: .fvmrc
+          cache: true
+
+      - name: Set up Rust Android target
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          targets: aarch64-linux-android
+
+      - name: Configure Android NDK and Flutter Gradle bridge
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/.android/sdk}}"
+          ndk_root="$(find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+          test -n "$ndk_root"
+          test -d "$ndk_root"
+          echo "ANDROID_NDK_HOME=$ndk_root" >> "$GITHUB_ENV"
+          flutter_bin="$(command -v flutter)"
+          flutter_sdk="$(cd "$(dirname "$flutter_bin")/.." && pwd)"
+          printf 'flutter.sdk=%s\nsdk.dir=%s\n' "$flutter_sdk" "$sdk_root" \
+            > apps/flutter_client/android/local.properties
+
       - name: Flutter dependencies
         working-directory: apps/flutter_client
         run: flutter pub get
 
-      - name: Validate runner shell syntax
-        run: bash -n scripts/mobile-lifecycle-regression.sh
-
-      - name: Run lifecycle, background and handoff regressions
+      - name: Run Android JVM lifecycle tests and write evidence
+        shell: bash
         env:
-          P2WLAN_MOBILE_LIFECYCLE_ROUNDS: "3"
-          P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle
-        run: bash scripts/mobile-lifecycle-regression.sh
+          P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle-android
+        run: |
+          set +e
+          bash scripts/mobile_lifecycle/run_android_jvm_tests.sh
+          test_status=$?
+          set -e
+          if [[ "$test_status" -eq 0 ]]; then
+            result=pass
+          else
+            result=fail
+          fi
+          mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
+          python3 scripts/mobile_lifecycle/component_report.py \
+            --root . \
+            --component android_jvm \
+            --manifest scripts/mobile_lifecycle/manifests/android_jvm.json \
+            --source-head-sha "$P2WLAN_EXACT_HEAD" \
+            --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
+            --result "$result" \
+            --toolchain '{"runner":"gradle","task":":app:testDebugUnitTest","xml_root":"apps/flutter_client/build/app/test-results"}' \
+            --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/android_jvm.json"
+          exit "$test_status"
 
-      - name: Upload lifecycle evidence
+      - name: Upload Android JVM lifecycle evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: mobile-lifecycle-contract-evidence
-          path: ${{ runner.temp }}/p2wlan-mobile-lifecycle
+          name: mobile-lifecycle-android-jvm
+          path: ${{ runner.temp }}/p2wlan-mobile-lifecycle-android/android_jvm.json
           if-no-files-found: error
           retention-days: 14
 
-  android_modes:
-    name: Android lifecycle package (${{ matrix.name }})
-    if: github.event_name != 'pull_request'
-    needs: lifecycle_contract
+  rust_contracts:
+    name: Rust mobile lifecycle contracts
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: async-fd-default
-            tun_mode: async_fd
-            wifi_low_latency: "false"
-          - name: blocking-low-latency
-            tun_mode: dedicated_blocking
-            wifi_low_latency: "true"
+    timeout-minutes: 70
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          components: rustfmt, clippy
+
+      - name: Run Rust lifecycle tests and write evidence
+        shell: bash
+        env:
+          P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle-rust
+        run: |
+          set +e
+          cargo fmt --all -- --check
+          format_status=$?
+          if [[ "$format_status" -eq 0 ]]; then
+            cargo test -p p2wlan-android-native --lib
+            bridge_status=$?
+          else
+            bridge_status="$format_status"
+          fi
+          if [[ "$bridge_status" -eq 0 ]]; then
+            cargo test -p p2wlan-daemon control::websocket::route_tests::new_control_connection_survives_old_task_teardown --lib
+            control_status=$?
+          else
+            control_status="$bridge_status"
+          fi
+          if [[ "$control_status" -eq 0 ]]; then
+            cargo test -p p2wlan-daemon --lib candidate_refresh_generation_keeps_confirmed_relay_admission
+            path_status=$?
+          else
+            path_status="$control_status"
+          fi
+          set -e
+          if [[ "$format_status" -eq 0 && "$bridge_status" -eq 0 && "$control_status" -eq 0 && "$path_status" -eq 0 ]]; then
+            result=pass
+          else
+            result=fail
+          fi
+          mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
+          python3 scripts/mobile_lifecycle/component_report.py \
+            --root . \
+            --component rust \
+            --manifest scripts/mobile_lifecycle/manifests/rust.json \
+            --source-head-sha "$P2WLAN_EXACT_HEAD" \
+            --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
+            --result "$result" \
+            --toolchain '{"runner":"cargo","bridge_test":"cargo test -p p2wlan-android-native --lib","control_test":"new_control_connection_survives_old_task_teardown","path_test":"candidate_refresh_generation_keeps_confirmed_relay_admission"}' \
+            --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/rust.json"
+          if [[ "$result" == pass ]]; then
+            exit 0
+          fi
+          exit 1
+
+      - name: Upload Rust lifecycle evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mobile-lifecycle-rust
+          path: ${{ runner.temp }}/p2wlan-mobile-lifecycle-rust/rust.json
+          if-no-files-found: error
+          retention-days: 14
+
+  android_package:
+    name: Android package contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
 
       - name: Set up Java
         uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3
@@ -120,7 +324,6 @@ jobs:
           sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/.android/sdk}}"
           ndk_root="$(find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
           test -n "$ndk_root"
-          test -d "$ndk_root"
           echo "ANDROID_NDK_HOME=$ndk_root" >> "$GITHUB_ENV"
 
       - name: Flutter dependencies
@@ -130,38 +333,142 @@ jobs:
       - name: Restore Flutter-managed sources
         run: bash scripts/release/hermetic_build.sh restore
 
-      - name: Build Android lifecycle package
+      - name: Build debug arm64 package
         working-directory: apps/flutter_client
         env:
           P2WLAN_ANDROID_ABIS: arm64-v8a
-          P2WLAN_ANDROID_TUN_MODE: ${{ matrix.tun_mode }}
-          P2WLAN_ANDROID_WIFI_LOW_LATENCY: ${{ matrix.wifi_low_latency }}
-          P2WLAN_ALLOW_DEBUG_RELEASE_SIGNING: "1"
-        run: >
-          bash ../../scripts/release/build_flutter_client.sh apk
-          --release
-          --target-platform android-arm64
-          --split-per-abi
-          --dart-define=P2WLAN_ANDROID_TUN_MODE=${{ matrix.tun_mode }}
-          --dart-define=P2WLAN_ANDROID_WIFI_LOW_LATENCY=${{ matrix.wifi_low_latency }}
+        run: flutter build apk --debug --target-platform android-arm64 --split-per-abi
 
-      - name: Verify arm64 package
+      - name: Restore Flutter-managed sources after package build
+        run: bash scripts/release/hermetic_build.sh restore
+
+      - name: Verify package identity and ABI
         working-directory: apps/flutter_client
         shell: bash
         run: |
           set -euo pipefail
-          apk="build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+          apk="build/app/outputs/flutter-apk/app-arm64-v8a-debug.apk"
           test -f "$apk"
           actual_abis="$(unzip -Z1 "$apk" | sed -n 's#^lib/\([^/]*\)/.*#\1#p' | sort -u | paste -sd, -)"
           test "$actual_abis" = "arm64-v8a"
-          sha256sum "$apk" > "$apk.sha256"
+          test -z "$(git -C ../.. status --porcelain=v1 --untracked-files=no)"
+          sha256sum "$apk"
 
-      - name: Upload Android lifecycle package
+      - name: Upload Android package contract artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: mobile-lifecycle-${{ matrix.name }}
-          path: |
-            apps/flutter_client/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
-            apps/flutter_client/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk.sha256
+          name: mobile-lifecycle-android-package
+          path: apps/flutter_client/build/app/outputs/flutter-apk/app-arm64-v8a-debug.apk
+          if-no-files-found: error
+          retention-days: 14
+
+  aggregate:
+    name: Mobile Lifecycle Required
+    if: always()
+    needs:
+      - flutter_contracts
+      - android_jvm
+      - rust_contracts
+      - android_package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+
+      - name: Download Flutter evidence
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: mobile-lifecycle-flutter
+          path: ${{ runner.temp }}/mobile-lifecycle-download/flutter
+
+      - name: Download Android JVM evidence
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: mobile-lifecycle-android-jvm
+          path: ${{ runner.temp }}/mobile-lifecycle-download/android_jvm
+
+      - name: Download Rust evidence
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: mobile-lifecycle-rust
+          path: ${{ runner.temp }}/mobile-lifecycle-download/rust
+
+      - name: Assemble exact component reports
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          reports="$RUNNER_TEMP/mobile-lifecycle-reports"
+          downloads="$RUNNER_TEMP/mobile-lifecycle-download"
+          mkdir -p "$reports"
+          for component in flutter android_jvm rust; do
+            source="$downloads/$component/$component.json"
+            if [[ -f "$source" ]]; then
+              cp "$source" "$reports/$component.json"
+            else
+              echo "missing component evidence: $component.json" >&2
+            fi
+          done
+
+      - name: Write component job results
+        if: always()
+        env:
+          FLUTTER_RESULT: ${{ needs.flutter_contracts.result }}
+          ANDROID_JVM_RESULT: ${{ needs.android_jvm.result }}
+          RUST_RESULT: ${{ needs.rust_contracts.result }}
+          PACKAGE_RESULT: ${{ needs.android_package.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "$RUNNER_TEMP/mobile-lifecycle-job-results.json" <<'PY'
+          import json
+          import os
+          import sys
+
+          values = {
+              "flutter": os.environ["FLUTTER_RESULT"],
+              "android_jvm": os.environ["ANDROID_JVM_RESULT"],
+              "rust": os.environ["RUST_RESULT"],
+              "package": os.environ["PACKAGE_RESULT"],
+          }
+          with open(sys.argv[1], "w", encoding="utf-8") as handle:
+              json.dump(values, handle, sort_keys=True)
+              handle.write("\n")
+          PY
+
+      - name: Aggregate fail-closed lifecycle evidence
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/mobile_lifecycle/aggregate_evidence.py \
+            --reports-dir "$RUNNER_TEMP/mobile-lifecycle-reports" \
+            --source-head-sha "$P2WLAN_EXACT_HEAD" \
+            --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
+            --job-results "$RUNNER_TEMP/mobile-lifecycle-job-results.json" \
+            --output "$RUNNER_TEMP/mobile-lifecycle-aggregate.json"
+          aggregate_status=$?
+          set -e
+          exit "$aggregate_status"
+
+      - name: Upload aggregate lifecycle evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mobile-lifecycle-aggregate
+          path: ${{ runner.temp }}/mobile-lifecycle-aggregate.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/mobile-lifecycle.yml
+++ b/.github/workflows/mobile-lifecycle.yml
@@ -94,13 +94,23 @@ jobs:
             echo "Flutter dependency resolution failed; writing a failing component report." >&2
             test_status="$dependency_status"
             mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
+            python3 - "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/execution-records.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pathlib.Path(sys.argv[1]).write_text(
+              json.dumps({"schema_version": 1, "records": []}) + "\n",
+              encoding="utf-8",
+          )
+          PY
             python3 scripts/mobile_lifecycle/component_report.py \
               --root . \
               --component flutter \
               --manifest scripts/mobile_lifecycle/manifests/flutter.json \
               --source-head-sha "$P2WLAN_EXACT_HEAD" \
               --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
-              --result fail \
+              --execution-records "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/execution-records.json" \
               --toolchain '{"runner":"flutter","dependency_resolution":"failed"}' \
               --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/flutter.json"
           fi
@@ -178,11 +188,6 @@ jobs:
           bash scripts/mobile_lifecycle/run_android_jvm_tests.sh
           test_status=$?
           set -e
-          if [[ "$test_status" -eq 0 ]]; then
-            result=pass
-          else
-            result=fail
-          fi
           mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
           python3 scripts/mobile_lifecycle/component_report.py \
             --root . \
@@ -190,7 +195,7 @@ jobs:
             --manifest scripts/mobile_lifecycle/manifests/android_jvm.json \
             --source-head-sha "$P2WLAN_EXACT_HEAD" \
             --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
-            --result "$result" \
+            --execution-records "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/android-execution-records.json" \
             --toolchain '{"runner":"gradle","task":":app:testDebugUnitTest","xml_root":"apps/flutter_client/build/app/test-results"}' \
             --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/android_jvm.json"
           exit "$test_status"
@@ -231,44 +236,74 @@ jobs:
         env:
           P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle-rust
         run: |
+          set -u
+          mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
+          evidence_output="$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/rust-test-output.log"
+          : > "$evidence_output"
+
+          run_cargo_test() {
+            set +e
+            cargo test "$@" 2>&1 | tee -a "$evidence_output"
+            local pipeline_status=("${PIPESTATUS[@]}")
+            local command_status="${pipeline_status[0]}"
+            local tee_status="${pipeline_status[1]}"
+            set -u
+            if [[ "$command_status" -ne 0 || "$tee_status" -ne 0 ]]; then
+              return 1
+            fi
+            return 0
+          }
+
           set +e
           cargo fmt --all -- --check
           format_status=$?
-          if [[ "$format_status" -eq 0 ]]; then
-            cargo test -p p2wlan-android-native --lib
-            bridge_status=$?
-          else
-            bridge_status="$format_status"
+          run_cargo_test -p p2wlan-android-native --lib
+          bridge_status=$?
+          run_cargo_test -p p2wlan-daemon control::websocket::route_tests::new_control_connection_survives_old_task_teardown --lib
+          control_status=$?
+          run_cargo_test -p p2wlan-daemon --lib candidate_refresh_generation_keeps_confirmed_relay_admission
+          path_status=$?
+
+          evidence_status=0
+          run_cargo_test -p p2wlan-android-native --lib lifecycle::tests -- --nocapture --test-threads=1 || evidence_status=1
+          run_cargo_test -p p2wlan-daemon mobile_lifecycle_evidence --lib -- --nocapture --test-threads=1 || evidence_status=1
+          run_cargo_test -p p2wlan-daemon control::websocket::route_tests::evidence_ml --lib -- --nocapture --test-threads=1 || evidence_status=1
+
+          records_status=0
+          python3 scripts/mobile_lifecycle/rust_test_records.py \
+            --test-output "$evidence_output" \
+            --manifest scripts/mobile_lifecycle/manifests/rust.json \
+            --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/execution-records.json"
+          records_status=$?
+          if [[ "$records_status" -ne 0 ]]; then
+            python3 - "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/execution-records.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pathlib.Path(sys.argv[1]).write_text(
+              json.dumps({"schema_version": 1, "records": []}) + "\n",
+              encoding="utf-8",
+          )
+          PY
           fi
-          if [[ "$bridge_status" -eq 0 ]]; then
-            cargo test -p p2wlan-daemon control::websocket::route_tests::new_control_connection_survives_old_task_teardown --lib
-            control_status=$?
-          else
-            control_status="$bridge_status"
-          fi
-          if [[ "$control_status" -eq 0 ]]; then
-            cargo test -p p2wlan-daemon --lib candidate_refresh_generation_keeps_confirmed_relay_admission
-            path_status=$?
-          else
-            path_status="$control_status"
-          fi
-          set -e
-          if [[ "$format_status" -eq 0 && "$bridge_status" -eq 0 && "$control_status" -eq 0 && "$path_status" -eq 0 ]]; then
+
+          if [[ "$format_status" -eq 0 && "$bridge_status" -eq 0 && "$control_status" -eq 0 && "$path_status" -eq 0 && "$evidence_status" -eq 0 && "$records_status" -eq 0 ]]; then
             result=pass
           else
             result=fail
           fi
-          mkdir -p "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR"
           python3 scripts/mobile_lifecycle/component_report.py \
             --root . \
             --component rust \
             --manifest scripts/mobile_lifecycle/manifests/rust.json \
             --source-head-sha "$P2WLAN_EXACT_HEAD" \
             --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
-            --result "$result" \
-            --toolchain '{"runner":"cargo","bridge_test":"cargo test -p p2wlan-android-native --lib","control_test":"new_control_connection_survives_old_task_teardown","path_test":"candidate_refresh_generation_keeps_confirmed_relay_admission"}' \
+            --execution-records "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/execution-records.json" \
+            --toolchain '{"runner":"cargo","evidence_tests":["cargo test -p p2wlan-android-native --lib lifecycle::tests -- --nocapture --test-threads=1","cargo test -p p2wlan-daemon mobile_lifecycle_evidence --lib -- --nocapture --test-threads=1","cargo test -p p2wlan-daemon control::websocket::route_tests::evidence_ml --lib -- --nocapture --test-threads=1"]}' \
             --output "$P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR/rust.json"
-          if [[ "$result" == pass ]]; then
+          report_status=$?
+          if [[ "$result" == pass && "$report_status" -eq 0 ]]; then
             exit 0
           fi
           exit 1
@@ -464,11 +499,22 @@ jobs:
           set -e
           exit "$aggregate_status"
 
+      - name: Hash aggregate lifecycle evidence
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          aggregate="$RUNNER_TEMP/mobile-lifecycle-aggregate.json"
+          test -f "$aggregate"
+          sha256sum "$aggregate" > "$aggregate.sha256"
+
       - name: Upload aggregate lifecycle evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: mobile-lifecycle-aggregate
-          path: ${{ runner.temp }}/mobile-lifecycle-aggregate.json
+          path: |
+            ${{ runner.temp }}/mobile-lifecycle-aggregate.json
+            ${{ runner.temp }}/mobile-lifecycle-aggregate.json.sha256
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/mobile-lifecycle.yml
+++ b/.github/workflows/mobile-lifecycle.yml
@@ -85,7 +85,7 @@ jobs:
           P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR: ${{ runner.temp }}/p2wlan-mobile-lifecycle-flutter
         run: |
           set +e
-          flutter pub get
+          (cd apps/flutter_client && flutter pub get)
           dependency_status=$?
           if [[ "$dependency_status" -eq 0 ]]; then
             bash scripts/mobile-lifecycle-regression.sh

--- a/apps/flutter_client/android/app/build.gradle.kts
+++ b/apps/flutter_client/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.util.Properties
 import java.util.UUID
+import org.gradle.api.tasks.testing.Test
 
 plugins {
     id("com.android.application")
@@ -81,6 +82,17 @@ android {
                 signingConfigs.getByName("debug")
             }
         }
+    }
+
+}
+
+// The Android lifecycle evidence parser binds every required scenario to the
+// JUnit method that actually emitted its record. Preserve stdout in the test
+// task output instead of relying on a component-wide Gradle exit status.
+tasks.withType<Test>().configureEach {
+    testLogging {
+        showStandardStreams = true
+        events("passed", "skipped", "failed", "standardOut", "standardError")
     }
 }
 

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MainActivity.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MainActivity.kt
@@ -10,18 +10,40 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 
 class MainActivity : FlutterActivity() {
     companion object {
         private const val CHANNEL = "p2wlan/android_vpn"
         private const val PLATFORM_CHANNEL = "p2wlan/platform"
         private const val VPN_PERMISSION_REQUEST = 39278
+
+        private val nextActivityIncarnation = AtomicLong()
+        private val nextEngineIncarnation = AtomicLong()
     }
 
-    private var pendingPermissionResult: MethodChannel.Result? = null
+    private data class PendingPermission(
+        val requestId: Long,
+        val activityIncarnation: Long,
+        val engineIncarnation: Long,
+        val result: MethodChannel.Result,
+    )
+
+    private val lifecycleCoordinator = MobileLifecycleCoordinator()
+    private var activityIncarnation = 0L
+    private var engineIncarnation = 0L
+    private var pendingPermission: PendingPermission? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        activityIncarnation = nextActivityIncarnation.incrementAndGet()
+        super.onCreate(savedInstanceState)
+        lifecycleCoordinator.activityRecreated(activityIncarnation, 0L)
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        engineIncarnation = nextEngineIncarnation.incrementAndGet()
+        lifecycleCoordinator.activityRecreated(activityIncarnation, engineIncarnation)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
             .setMethodCallHandler { call, result -> handleMethod(call, result) }
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PLATFORM_CHANNEL)
@@ -63,12 +85,12 @@ class MainActivity : FlutterActivity() {
             "start" -> startVpn(call, result)
             "stop" -> stopVpn(result)
             "status" -> result.success(
-                mapOf(
+                mapOf<String, Any?>(
                     "serviceRunning" to P2wlanVpnService.isRunning(),
                     "nativeRunning" to P2wlanNative.isRunning(),
                     "nativeReady" to P2wlanNative.isReady(),
                     "nativeError" to P2wlanVpnService.lastError(),
-                ),
+                ) + P2wlanVpnService.lifecycleStatus(),
             )
             "diagnosticsAuthToken" -> result.success(readDiagnosticsAuthToken())
             else -> result.notImplemented()
@@ -76,21 +98,75 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun prepareVpn(result: MethodChannel.Result) {
-        val intent = VpnService.prepare(this)
-        if (intent == null) {
-            result.success(true)
-            return
-        }
-        if (pendingPermissionResult != null) {
+        val transition = lifecycleCoordinator.beginPermissionRequest(
+            activityIncarnation,
+            engineIncarnation,
+        )
+        if (transition.outcome != MobileLifecycleOutcome.APPLIED) {
             result.error("vpn_permission_pending", "Another VPN permission request is already open", null)
             return
         }
-        pendingPermissionResult = result
-        startActivityForResult(intent, VPN_PERMISSION_REQUEST)
+        val requestId = transition.newIdentity.permissionRequestId
+        val intent = try {
+            VpnService.prepare(this)
+        } catch (error: Throwable) {
+            lifecycleCoordinator.revokePermission()
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.REVOKED)
+            result.error(
+                "vpn_permission_prepare_failed",
+                "无法准备 Android VPN 权限：${error.message ?: error::class.java.simpleName}",
+                null,
+            )
+            return
+        }
+        if (intent == null) {
+            lifecycleCoordinator.completePermissionRequest(
+                requestId,
+                activityIncarnation,
+                engineIncarnation,
+                granted = true,
+            )
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.GRANTED)
+            result.success(true)
+            return
+        }
+        pendingPermission = PendingPermission(
+            requestId,
+            activityIncarnation,
+            engineIncarnation,
+            result,
+        )
+        P2wlanVpnService.recordPermissionState(MobilePermissionState.PENDING)
+        try {
+            startActivityForResult(intent, VPN_PERMISSION_REQUEST)
+        } catch (error: Throwable) {
+            pendingPermission = null
+            lifecycleCoordinator.revokePermission()
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.REVOKED)
+            result.error(
+                "vpn_permission_request_failed",
+                "无法打开 Android VPN 权限确认：${error.message ?: error::class.java.simpleName}",
+                null,
+            )
+        }
     }
 
     private fun startVpn(call: MethodCall, result: MethodChannel.Result) {
-        if (VpnService.prepare(this) != null) {
+        val permissionRequired = try {
+            VpnService.prepare(this) != null
+        } catch (error: Throwable) {
+            lifecycleCoordinator.revokePermission()
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.REVOKED)
+            result.error(
+                "vpn_permission_prepare_failed",
+                "无法检查 Android VPN 权限：${error.message ?: error::class.java.simpleName}",
+                null,
+            )
+            return
+        }
+        if (permissionRequired) {
+            lifecycleCoordinator.revokePermission()
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.REVOKED)
             result.error("vpn_permission_required", "Android VPN permission has not been granted", null)
             return
         }
@@ -145,9 +221,51 @@ class MainActivity : FlutterActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode != VPN_PERMISSION_REQUEST) return
-        val result = pendingPermissionResult ?: return
-        pendingPermissionResult = null
-        val granted = resultCode == Activity.RESULT_OK && VpnService.prepare(this) == null
-        result.success(granted)
+        val pending = pendingPermission ?: return
+        pendingPermission = null
+        val granted = if (resultCode == Activity.RESULT_OK) {
+            try {
+                VpnService.prepare(this) == null
+            } catch (_: Throwable) {
+                false
+            }
+        } else {
+            false
+        }
+        val transition = lifecycleCoordinator.completePermissionRequest(
+            pending.requestId,
+            pending.activityIncarnation,
+            pending.engineIncarnation,
+            granted,
+        )
+        if (transition.outcome != MobileLifecycleOutcome.APPLIED) {
+            runCatching {
+                pending.result.error("vpn_permission_stale", "VPN permission result belongs to an old Activity/FlutterEngine", null)
+            }
+            return
+        }
+        P2wlanVpnService.recordPermissionState(
+            if (granted) MobilePermissionState.GRANTED else MobilePermissionState.REVOKED,
+        )
+        pending.result.success(granted)
+    }
+
+    override fun onDestroy() {
+        pendingPermission?.let { pending ->
+            pendingPermission = null
+            lifecycleCoordinator.activityRecreated(
+                activityIncarnation,
+                nextEngineIncarnation.incrementAndGet(),
+            )
+            runCatching {
+                pending.result.error(
+                    "vpn_permission_cancelled",
+                    "VPN permission request was cancelled with the Activity/FlutterEngine",
+                    null,
+                )
+            }
+            P2wlanVpnService.recordPermissionState(MobilePermissionState.REVOKED)
+        }
+        super.onDestroy()
     }
 }

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinator.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinator.kt
@@ -1,0 +1,466 @@
+package com.example.p2wlan_flutter_client
+
+/**
+ * Platform-neutral lifecycle reducer used by both the Android host and JVM
+ * tests. It owns Android attachment/permission identities only; Rust remains
+ * the authority for dataplane network generations and path state.
+ */
+internal enum class MobileLifecycleEvent(val wireName: String) {
+    APP_BACKGROUNDED("app_backgrounded"),
+    APP_RESUMED("app_resumed"),
+    PHYSICAL_NETWORK_CHANGED("physical_network_changed"),
+    VPN_PERMISSION_REQUEST_STARTED("vpn_permission_request_started"),
+    VPN_PERMISSION_REVOKED("vpn_permission_revoked"),
+    VPN_PERMISSION_GRANTED("vpn_permission_granted"),
+    VPN_START_REQUESTED("vpn_start_requested"),
+    EXPLICIT_STOP_REQUESTED("explicit_stop_requested"),
+    ACTIVITY_RECREATED("activity_recreated"),
+    SERVICE_RECREATED("service_recreated"),
+    BRIDGE_ATTACHED("bridge_attached"),
+    BRIDGE_DETACHED("bridge_detached"),
+    NATIVE_RUNTIME_STARTED("native_runtime_started"),
+    NATIVE_RUNTIME_STOPPED("native_runtime_stopped"),
+    NATIVE_MONITOR_CALLBACK("native_monitor_callback"),
+    AUTOMATIC_RESTART_SCHEDULED("automatic_restart_scheduled"),
+    AUTOMATIC_RESTART_REJECTED("automatic_restart_rejected"),
+    CONTROL_DISCONNECTED("control_disconnected"),
+    CONTROL_RECONNECTED("control_reconnected"),
+    CANDIDATE_REFRESH_STARTED("candidate_refresh_started"),
+    RELAY_RETAINED("relay_retained"),
+    DIRECT_RECONFIRMED("direct_reconfirmed"),
+}
+
+internal enum class MobileLifecycleOutcome(val wireValue: String) {
+    APPLIED("applied"),
+    DUPLICATE("duplicate"),
+    STALE_REJECTED("stale_rejected"),
+    SUPERSEDED("superseded"),
+    FAILED("failed"),
+}
+
+internal enum class MobilePermissionState(val wireValue: String) {
+    UNKNOWN("unknown"),
+    PENDING("pending"),
+    GRANTED("granted"),
+    REVOKED("revoked"),
+}
+
+internal data class MobileLifecycleIdentity(
+    val lifecycleGeneration: Long = 0,
+    val permissionRequestId: Long = 0,
+    val activityIncarnation: Long = 0,
+    val engineIncarnation: Long = 0,
+    val serviceIncarnation: Long = 0,
+    val automaticRestartGeneration: Long = 0,
+    val bridgeIncarnation: Long = 0,
+    val networkGeneration: Long = 0,
+    val controlConnectionGeneration: Long = 0,
+)
+
+internal data class MobileLifecycleState(
+    val identity: MobileLifecycleIdentity = MobileLifecycleIdentity(),
+    val permissionState: MobilePermissionState = MobilePermissionState.UNKNOWN,
+    val desiredRunning: Boolean = false,
+    val lastEvent: MobileLifecycleEvent? = null,
+    val lastOutcome: MobileLifecycleOutcome? = null,
+    val lastResult: String? = null,
+)
+
+internal data class MobileLifecycleTransition(
+    val event: MobileLifecycleEvent,
+    val outcome: MobileLifecycleOutcome,
+    val oldIdentity: MobileLifecycleIdentity,
+    val newIdentity: MobileLifecycleIdentity,
+    val result: String? = null,
+)
+
+/**
+ * A deterministic owner reducer. Every accepted transition gets a new
+ * lifecycleGeneration. Duplicate/stale callbacks preserve state and expose
+ * their decision to diagnostics.
+ */
+internal class MobileLifecycleCoordinator {
+    var state: MobileLifecycleState = MobileLifecycleState()
+        private set
+
+    private var pendingPermission: Pair<Long, Long>? = null
+    private var nextPermissionRequestId = 0L
+    private var completedAutomaticRestartGeneration = 0L
+
+    fun beginPermissionRequest(
+        activityIncarnation: Long,
+        engineIncarnation: Long,
+    ): MobileLifecycleTransition {
+        if (pendingPermission != null) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.VPN_PERMISSION_REQUEST_STARTED,
+                    MobileLifecycleOutcome.FAILED,
+                    "permission_request_pending",
+                ),
+            )
+        }
+        nextPermissionRequestId += 1
+        val requestId = nextPermissionRequestId
+        pendingPermission = requestId to engineIncarnation
+        return advance(
+            MobileLifecycleEvent.VPN_PERMISSION_REQUEST_STARTED,
+            state.identity.copy(
+                permissionRequestId = requestId,
+                activityIncarnation = activityIncarnation,
+                engineIncarnation = engineIncarnation,
+            ),
+            permissionState = MobilePermissionState.PENDING,
+        )
+    }
+
+    fun completePermissionRequest(
+        requestId: Long,
+        activityIncarnation: Long,
+        engineIncarnation: Long,
+        granted: Boolean,
+    ): MobileLifecycleTransition {
+        val event = if (granted) {
+            MobileLifecycleEvent.VPN_PERMISSION_GRANTED
+        } else {
+            MobileLifecycleEvent.VPN_PERMISSION_REVOKED
+        }
+        val pending = pendingPermission
+        if (
+            pending == null ||
+            pending.first != requestId ||
+            pending.second != engineIncarnation ||
+            state.identity.activityIncarnation != activityIncarnation ||
+            state.identity.engineIncarnation != engineIncarnation
+        ) {
+            return record(transition(event, MobileLifecycleOutcome.STALE_REJECTED, "old_permission_result"))
+        }
+        pendingPermission = null
+        return advance(
+            event,
+            state.identity,
+            permissionState = if (granted) {
+                MobilePermissionState.GRANTED
+            } else {
+                MobilePermissionState.REVOKED
+            },
+        )
+    }
+
+    fun revokePermission(): MobileLifecycleTransition {
+        if (
+            state.permissionState == MobilePermissionState.REVOKED &&
+            pendingPermission == null
+        ) {
+            return record(transition(MobileLifecycleEvent.VPN_PERMISSION_REVOKED, MobileLifecycleOutcome.DUPLICATE))
+        }
+        pendingPermission = null
+        return advance(
+            MobileLifecycleEvent.VPN_PERMISSION_REVOKED,
+            state.identity,
+            permissionState = MobilePermissionState.REVOKED,
+            result = "permission_revoked",
+            desiredRunning = false,
+        )
+    }
+
+    fun startRequested(): MobileLifecycleTransition {
+        if (state.desiredRunning) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.VPN_START_REQUESTED,
+                    MobileLifecycleOutcome.DUPLICATE,
+                    "start_already_desired",
+                ),
+            )
+        }
+        return advance(
+            MobileLifecycleEvent.VPN_START_REQUESTED,
+            state.identity,
+            desiredRunning = true,
+            result = "start_requested",
+        )
+    }
+
+    fun explicitStopRequested(): MobileLifecycleTransition {
+        if (!state.desiredRunning && pendingPermission == null) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.EXPLICIT_STOP_REQUESTED,
+                    MobileLifecycleOutcome.DUPLICATE,
+                    "stop_already_requested",
+                ),
+            )
+        }
+        pendingPermission = null
+        return advance(
+            MobileLifecycleEvent.EXPLICIT_STOP_REQUESTED,
+            state.identity,
+            desiredRunning = false,
+            result = "explicit_stop",
+        )
+    }
+
+    fun nativeMonitorStopped(serviceIncarnation: Long): MobileLifecycleTransition {
+        if (!acceptsServiceCallback(serviceIncarnation)) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.NATIVE_MONITOR_CALLBACK,
+                    MobileLifecycleOutcome.STALE_REJECTED,
+                    "old_service_monitor",
+                ),
+            )
+        }
+        return advance(
+            MobileLifecycleEvent.NATIVE_RUNTIME_STOPPED,
+            state.identity,
+            result = "native_monitor_observed_stop",
+        )
+    }
+
+    fun automaticRestartScheduled(serviceIncarnation: Long): MobileLifecycleTransition {
+        if (!state.desiredRunning || !acceptsServiceCallback(serviceIncarnation)) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.AUTOMATIC_RESTART_REJECTED,
+                    MobileLifecycleOutcome.STALE_REJECTED,
+                    "restart_owner_not_current",
+                ),
+            )
+        }
+        val nextGeneration = state.identity.automaticRestartGeneration + 1
+        return advance(
+            MobileLifecycleEvent.AUTOMATIC_RESTART_SCHEDULED,
+            state.identity.copy(automaticRestartGeneration = nextGeneration),
+            result = "restart_scheduled",
+        )
+    }
+
+    fun automaticRestartCallback(
+        serviceIncarnation: Long,
+        restartGeneration: Long,
+    ): MobileLifecycleTransition {
+        if (
+            !state.desiredRunning ||
+            !acceptsServiceCallback(serviceIncarnation) ||
+            restartGeneration != state.identity.automaticRestartGeneration
+        ) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.AUTOMATIC_RESTART_REJECTED,
+                    MobileLifecycleOutcome.STALE_REJECTED,
+                    "old_restart_callback",
+                ),
+            )
+        }
+        if (restartGeneration == completedAutomaticRestartGeneration) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.AUTOMATIC_RESTART_SCHEDULED,
+                    MobileLifecycleOutcome.DUPLICATE,
+                    "restart_callback_already_consumed",
+                ),
+            )
+        }
+        completedAutomaticRestartGeneration = restartGeneration
+        return advance(
+            MobileLifecycleEvent.NATIVE_RUNTIME_STARTED,
+            state.identity,
+            result = "restart_callback_accepted",
+        )
+    }
+
+    fun activityRecreated(
+        activityIncarnation: Long,
+        engineIncarnation: Long,
+    ): MobileLifecycleTransition {
+        if (
+            state.identity.activityIncarnation == activityIncarnation &&
+            state.identity.engineIncarnation == engineIncarnation
+        ) {
+            return record(transition(MobileLifecycleEvent.ACTIVITY_RECREATED, MobileLifecycleOutcome.DUPLICATE))
+        }
+        if (
+            activityIncarnation < state.identity.activityIncarnation ||
+            (activityIncarnation == state.identity.activityIncarnation &&
+                engineIncarnation < state.identity.engineIncarnation)
+        ) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.ACTIVITY_RECREATED,
+                    MobileLifecycleOutcome.STALE_REJECTED,
+                    "old_activity_engine",
+                ),
+            )
+        }
+        pendingPermission = null
+        return advance(
+            MobileLifecycleEvent.ACTIVITY_RECREATED,
+            state.identity.copy(
+                activityIncarnation = activityIncarnation,
+                engineIncarnation = engineIncarnation,
+            ),
+            result = "activity_engine_reattached",
+        )
+    }
+
+    fun serviceRecreated(serviceIncarnation: Long): MobileLifecycleTransition {
+        if (serviceIncarnation <= state.identity.serviceIncarnation) {
+            return record(transition(MobileLifecycleEvent.SERVICE_RECREATED, MobileLifecycleOutcome.STALE_REJECTED, "old_service"))
+        }
+        return advance(
+            MobileLifecycleEvent.SERVICE_RECREATED,
+            state.identity.copy(serviceIncarnation = serviceIncarnation),
+            result = "service_reattached",
+        )
+    }
+
+    fun attachBridge(bridgeIncarnation: Long): MobileLifecycleTransition {
+        if (bridgeIncarnation <= 0) {
+            return record(transition(MobileLifecycleEvent.BRIDGE_ATTACHED, MobileLifecycleOutcome.FAILED, "invalid_bridge"))
+        }
+        if (bridgeIncarnation == state.identity.bridgeIncarnation) {
+            return record(transition(MobileLifecycleEvent.BRIDGE_ATTACHED, MobileLifecycleOutcome.DUPLICATE))
+        }
+        if (bridgeIncarnation < state.identity.bridgeIncarnation) {
+            return record(transition(MobileLifecycleEvent.BRIDGE_ATTACHED, MobileLifecycleOutcome.STALE_REJECTED, "old_bridge"))
+        }
+        return advance(
+            MobileLifecycleEvent.BRIDGE_ATTACHED,
+            state.identity.copy(bridgeIncarnation = bridgeIncarnation),
+            result = "bridge_attached",
+        )
+    }
+
+    fun detachBridge(bridgeIncarnation: Long): MobileLifecycleTransition {
+        if (bridgeIncarnation != state.identity.bridgeIncarnation) {
+            return record(transition(MobileLifecycleEvent.BRIDGE_DETACHED, MobileLifecycleOutcome.STALE_REJECTED, "old_bridge_cleanup"))
+        }
+        return advance(
+            MobileLifecycleEvent.BRIDGE_DETACHED,
+            state.identity.copy(bridgeIncarnation = 0),
+            result = "bridge_detached",
+        )
+    }
+
+    fun physicalNetworkChanged(networkGeneration: Long): MobileLifecycleTransition {
+        if (networkGeneration < state.identity.networkGeneration) {
+            return record(
+                transition(
+                    MobileLifecycleEvent.PHYSICAL_NETWORK_CHANGED,
+                    MobileLifecycleOutcome.STALE_REJECTED,
+                    "old_network_generation",
+                ),
+            )
+        }
+        if (networkGeneration == state.identity.networkGeneration) {
+            return record(transition(MobileLifecycleEvent.PHYSICAL_NETWORK_CHANGED, MobileLifecycleOutcome.DUPLICATE))
+        }
+        return advance(
+            MobileLifecycleEvent.PHYSICAL_NETWORK_CHANGED,
+            state.identity.copy(networkGeneration = networkGeneration),
+            result = "network_generation_advanced",
+        )
+    }
+
+    fun acceptsServiceCallback(serviceIncarnation: Long): Boolean =
+        serviceIncarnation > 0 && serviceIncarnation == state.identity.serviceIncarnation
+
+    fun acceptsBridgeCallback(bridgeIncarnation: Long): Boolean =
+        bridgeIncarnation > 0 && bridgeIncarnation == state.identity.bridgeIncarnation
+
+    private fun advance(
+        event: MobileLifecycleEvent,
+        identity: MobileLifecycleIdentity,
+        permissionState: MobilePermissionState = state.permissionState,
+        desiredRunning: Boolean = state.desiredRunning,
+        result: String? = null,
+    ): MobileLifecycleTransition {
+        val old = state.identity
+        val next = identity.copy(lifecycleGeneration = old.lifecycleGeneration + 1)
+        state = MobileLifecycleState(
+            identity = next,
+            permissionState = permissionState,
+            desiredRunning = desiredRunning,
+            lastEvent = event,
+            lastOutcome = MobileLifecycleOutcome.APPLIED,
+            lastResult = result,
+        )
+        return MobileLifecycleTransition(event, MobileLifecycleOutcome.APPLIED, old, next, result)
+    }
+
+    private fun transition(
+        event: MobileLifecycleEvent,
+        outcome: MobileLifecycleOutcome,
+        result: String? = null,
+    ): MobileLifecycleTransition =
+        MobileLifecycleTransition(event, outcome, state.identity, state.identity, result)
+
+    private fun record(transition: MobileLifecycleTransition): MobileLifecycleTransition {
+        state = state.copy(
+            lastEvent = transition.event,
+            lastOutcome = transition.outcome,
+            lastResult = transition.result,
+        )
+        return transition
+    }
+}
+
+internal data class PhysicalNetworkIdentity(
+    val networkHandle: Long,
+    val transports: Set<String>,
+    val validated: Boolean,
+    val captive: Boolean,
+    val interfaceIdentity: String?,
+)
+
+internal data class PhysicalNetworkTransition(
+    val outcome: MobileLifecycleOutcome,
+    val generation: Long,
+    val oldIdentity: PhysicalNetworkIdentity?,
+    val newIdentity: PhysicalNetworkIdentity?,
+)
+
+/** Debounces Android callback bursts and fences callbacks for old Networks. */
+internal class PhysicalNetworkIdentityReducer {
+    private var current: PhysicalNetworkIdentity? = null
+    private val retiredHandles = mutableSetOf<Long>()
+    private var replacementPending = false
+    private var generation = 0L
+
+    fun onAvailable(identity: PhysicalNetworkIdentity): PhysicalNetworkTransition {
+        if (current == identity) {
+            return PhysicalNetworkTransition(MobileLifecycleOutcome.DUPLICATE, generation, current, current)
+        }
+        if (retiredHandles.contains(identity.networkHandle)) {
+            return PhysicalNetworkTransition(MobileLifecycleOutcome.STALE_REJECTED, generation, null, null)
+        }
+        val old = current
+        if (old != null && old.networkHandle == identity.networkHandle) {
+            generation += 1
+            current = identity
+            replacementPending = false
+            return PhysicalNetworkTransition(MobileLifecycleOutcome.APPLIED, generation, old, identity)
+        }
+        if (!replacementPending) generation += 1
+        old?.let { retiredHandles += it.networkHandle }
+        current = identity
+        replacementPending = false
+        return PhysicalNetworkTransition(MobileLifecycleOutcome.APPLIED, generation, old, identity)
+    }
+
+    fun onLost(networkHandle: Long): PhysicalNetworkTransition {
+        val old = current
+        if (old == null || old.networkHandle != networkHandle) {
+            return PhysicalNetworkTransition(MobileLifecycleOutcome.STALE_REJECTED, generation, old, old)
+        }
+        generation += 1
+        current = null
+        retiredHandles += networkHandle
+        replacementPending = true
+        return PhysicalNetworkTransition(MobileLifecycleOutcome.APPLIED, generation, old, null)
+    }
+
+    fun current(): PhysicalNetworkIdentity? = current
+    fun generation(): Long = generation
+}

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinator.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinator.kt
@@ -1,5 +1,8 @@
 package com.example.p2wlan_flutter_client
 
+import java.security.MessageDigest
+import java.util.Locale
+
 /**
  * Platform-neutral lifecycle reducer used by both the Android host and JVM
  * tests. It owns Android attachment/permission identities only; Rust remains
@@ -412,7 +415,29 @@ internal data class PhysicalNetworkIdentity(
     val validated: Boolean,
     val captive: Boolean,
     val interfaceIdentity: String?,
-)
+) {
+    /** Stable, non-sensitive identity passed to the Rust lifecycle boundary. */
+    fun identityHash(): String {
+        val canonical = buildString {
+            append(networkHandle)
+            append('|')
+            transports.toList().sorted().joinTo(this, separator = ",")
+            append('|')
+            append(validated)
+            append('|')
+            append(captive)
+            append('|')
+            append(interfaceIdentity.orEmpty())
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(Charsets.UTF_8))
+        return buildString(digest.size * 2) {
+            digest.forEach { byte ->
+                append("%02x".format(Locale.ROOT, byte.toInt() and 0xff))
+            }
+        }
+    }
+}
 
 internal data class PhysicalNetworkTransition(
     val outcome: MobileLifecycleOutcome,
@@ -463,4 +488,109 @@ internal class PhysicalNetworkIdentityReducer {
 
     fun current(): PhysicalNetworkIdentity? = current
     fun generation(): Long = generation
+}
+
+/** JNI-shaped boundary used by the Android callback and JVM production-path tests. */
+internal fun interface PhysicalNetworkChangeNotifier {
+    fun notify(
+        serviceIncarnation: Long,
+        bridgeIncarnation: Long,
+        kotlinNetworkGeneration: Long,
+        networkIdentityHash: String,
+    ): MobileLifecycleOutcome
+}
+
+internal data class PhysicalNetworkCallbackResult(
+    val outcome: MobileLifecycleOutcome,
+    val generation: Long,
+    val oldIdentity: PhysicalNetworkIdentity?,
+    val newIdentity: PhysicalNetworkIdentity?,
+    val forwardedToRust: Boolean,
+)
+
+/**
+ * Captures the service/bridge owner at callback registration and forwards only
+ * reducer-authorized `onAvailable` edges to Rust. The Kotlin reducer remains a
+ * debounce/fencing boundary; Rust owns the dataplane generation and rebind.
+ */
+internal class PhysicalNetworkCallbackForwarder(
+    private val callbackServiceIncarnation: Long,
+    private val callbackBridgeIncarnation: Long,
+    private val currentServiceIncarnation: () -> Long,
+    private val currentBridgeIncarnation: () -> Long,
+    private val notifier: PhysicalNetworkChangeNotifier,
+    private val reducer: PhysicalNetworkIdentityReducer = PhysicalNetworkIdentityReducer(),
+) {
+    fun onAvailable(identity: PhysicalNetworkIdentity): PhysicalNetworkCallbackResult {
+        val ownerAccepted = callbackServiceIncarnation > 0L &&
+            callbackBridgeIncarnation > 0L &&
+            currentServiceIncarnation() == callbackServiceIncarnation &&
+            currentBridgeIncarnation() == callbackBridgeIncarnation
+        if (!ownerAccepted) {
+            return result(
+                MobileLifecycleOutcome.STALE_REJECTED,
+                reducer.generation(),
+                forwardedToRust = false,
+            )
+        }
+        val transition = reducer.onAvailable(identity)
+        if (transition.outcome != MobileLifecycleOutcome.APPLIED) {
+            return PhysicalNetworkCallbackResult(
+                transition.outcome,
+                transition.generation,
+                transition.oldIdentity,
+                transition.newIdentity,
+                forwardedToRust = false,
+            )
+        }
+        val rustOutcome = notifier.notify(
+            callbackServiceIncarnation,
+            callbackBridgeIncarnation,
+            transition.generation,
+            identity.identityHash(),
+        )
+        return PhysicalNetworkCallbackResult(
+            rustOutcome,
+            transition.generation,
+            transition.oldIdentity,
+            transition.newIdentity,
+            forwardedToRust = true,
+        )
+    }
+
+    /** Loss is retained as reducer state; the replacement `onAvailable` edge
+     * carries the single Rust generation advance for the handoff. */
+    fun onLost(networkHandle: Long): PhysicalNetworkCallbackResult {
+        val ownerAccepted = callbackServiceIncarnation > 0L &&
+            callbackBridgeIncarnation > 0L &&
+            currentServiceIncarnation() == callbackServiceIncarnation &&
+            currentBridgeIncarnation() == callbackBridgeIncarnation
+        if (!ownerAccepted) {
+            return result(
+                MobileLifecycleOutcome.STALE_REJECTED,
+                reducer.generation(),
+                forwardedToRust = false,
+            )
+        }
+        val transition = reducer.onLost(networkHandle)
+        return PhysicalNetworkCallbackResult(
+            transition.outcome,
+            transition.generation,
+            transition.oldIdentity,
+            transition.newIdentity,
+            forwardedToRust = false,
+        )
+    }
+
+    private fun result(
+        outcome: MobileLifecycleOutcome,
+        generation: Long,
+        forwardedToRust: Boolean,
+    ) = PhysicalNetworkCallbackResult(
+        outcome,
+        generation,
+        reducer.current(),
+        reducer.current(),
+        forwardedToRust,
+    )
 }

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanNative.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanNative.kt
@@ -32,13 +32,18 @@ internal object P2wlanNative {
         }
     }
 
-    fun start(service: P2wlanVpnService, tunFd: Int, requestJson: String): String? {
+    fun start(
+        service: P2wlanVpnService,
+        serviceIncarnation: Long,
+        tunFd: Int,
+        requestJson: String,
+    ): String? {
         if (!ensureLoaded()) {
             closeOwnedFd(tunFd)
             return loadError
         }
         return try {
-            val error = nativeStart(service, tunFd, requestJson)
+            val error = nativeStart(service, serviceIncarnation, tunFd, requestJson)
             loadError = error
             if (error != null) Log.e(TAG, error)
             error
@@ -47,6 +52,54 @@ internal object P2wlanNative {
             val message = formatError("Android 原生 daemon 启动失败", error)
             loadError = message
             Log.e(TAG, message, error)
+            message
+        }
+    }
+
+    /** Adopt a recreated Service object onto the still-running Rust bridge. */
+    fun adoptService(
+        service: P2wlanVpnService,
+        serviceIncarnation: Long,
+        expectedBridgeIncarnation: Long,
+    ): String? {
+        if (!ensureLoaded()) return loadError
+        return try {
+            val result = nativeAdoptService(
+                service,
+                serviceIncarnation,
+                expectedBridgeIncarnation,
+            )
+            if (result != null && result != MobileLifecycleOutcome.APPLIED.wireValue) {
+                Log.w(TAG, "Android native service adoption result=$result")
+            }
+            result
+        } catch (error: Throwable) {
+            val message = formatError("Android 原生 daemon 服务重新附着失败", error)
+            loadError = message
+            Log.w(TAG, message, error)
+            message
+        }
+    }
+
+    /** Forward one reducer-authorized physical-network edge to Rust. */
+    fun notifyPhysicalNetworkChanged(
+        serviceIncarnation: Long,
+        expectedBridgeIncarnation: Long,
+        kotlinNetworkGeneration: Long,
+        networkIdentityHash: String,
+    ): String? {
+        if (!ensureLoaded()) return loadError
+        return try {
+            nativeNotifyPhysicalNetworkChanged(
+                serviceIncarnation,
+                expectedBridgeIncarnation,
+                kotlinNetworkGeneration,
+                networkIdentityHash,
+            )
+        } catch (error: Throwable) {
+            val message = formatError("Android 物理网络变化通知 Rust 失败", error)
+            loadError = message
+            Log.w(TAG, message, error)
             message
         }
     }
@@ -134,8 +187,22 @@ internal object P2wlanNative {
 
     private external fun nativeStart(
         service: P2wlanVpnService,
+        serviceIncarnation: Long,
         tunFd: Int,
         requestJson: String,
+    ): String?
+
+    private external fun nativeAdoptService(
+        service: P2wlanVpnService,
+        serviceIncarnation: Long,
+        expectedBridgeIncarnation: Long,
+    ): String?
+
+    private external fun nativeNotifyPhysicalNetworkChanged(
+        serviceIncarnation: Long,
+        expectedBridgeIncarnation: Long,
+        kotlinNetworkGeneration: Long,
+        networkIdentityHash: String,
     ): String?
 
     private external fun nativeStop(expectedIncarnation: Long): Boolean

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanNative.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanNative.kt
@@ -51,10 +51,15 @@ internal object P2wlanNative {
         }
     }
 
-    fun stop(): Boolean {
+    /**
+     * Stop only the runtime incarnation the caller owns. A zero expected
+     * incarnation retains the legacy unscoped call for diagnostics/tests; the
+     * VpnService always supplies its bridge incarnation.
+     */
+    fun stop(expectedIncarnation: Long? = null): Boolean {
         if (!ensureLoaded()) return false
         return try {
-            nativeStop()
+            nativeStop(expectedIncarnation ?: 0L)
         } catch (error: Throwable) {
             val message = formatError("Android 原生 daemon 停止失败", error)
             loadError = message
@@ -96,6 +101,19 @@ internal object P2wlanNative {
         }
     }
 
+    /** Current Rust runtime incarnation, or null when no native runtime owns a slot. */
+    fun incarnation(): Long? {
+        if (!ensureLoaded()) return null
+        return try {
+            nativeIncarnation().takeIf { it > 0L }
+        } catch (error: Throwable) {
+            val message = formatError("无法读取 Android 原生 daemon incarnation", error)
+            loadError = message
+            Log.w(TAG, message, error)
+            null
+        }
+    }
+
     private fun formatError(prefix: String, error: Throwable): String {
         val detail = error.message?.trim().orEmpty()
         return if (detail.isEmpty()) {
@@ -120,11 +138,13 @@ internal object P2wlanNative {
         requestJson: String,
     ): String?
 
-    private external fun nativeStop(): Boolean
+    private external fun nativeStop(expectedIncarnation: Long): Boolean
 
     private external fun nativeIsRunning(): Boolean
 
     private external fun nativeIsReady(): Boolean
 
     private external fun nativeLastError(): String?
+
+    private external fun nativeIncarnation(): Long
 }

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanVpnService.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanVpnService.kt
@@ -134,8 +134,8 @@ class P2wlanVpnService : VpnService() {
         publishLifecycle(
             lifecycleCoordinator.serviceRecreated(serviceIncarnation),
         )
-        registerPhysicalNetworkCallback()
         adoptExistingNativeRuntime()
+        registerPhysicalNetworkCallback()
     }
 
     private fun isCurrentServiceOwner(): Boolean =
@@ -153,6 +153,16 @@ class P2wlanVpnService : VpnService() {
             if (!P2wlanNative.isRunning()) return
             val bridgeIncarnation = P2wlanNative.incarnation()
                 ?: throw IllegalStateException("live Rust runtime has no bridge incarnation")
+            val adoptionResult = P2wlanNative.adoptService(
+                this,
+                serviceIncarnation,
+                bridgeIncarnation,
+            )
+            if (adoptionResult != MobileLifecycleOutcome.APPLIED.wireValue &&
+                adoptionResult != MobileLifecycleOutcome.DUPLICATE.wireValue
+            ) {
+                throw IllegalStateException("Android native service owner was rejected: $adoptionResult")
+            }
             val transition = lifecycleCoordinator.attachBridge(bridgeIncarnation)
             if (transition.outcome != MobileLifecycleOutcome.APPLIED &&
                 transition.outcome != MobileLifecycleOutcome.DUPLICATE
@@ -263,7 +273,12 @@ class P2wlanVpnService : VpnService() {
             configureWifiLatencyMode(experiment.wifiLowLatencyRequested)
 
             val enrichedRequest = enrichRequest(request)
-            val nativeError = P2wlanNative.start(this, detachedFd, enrichedRequest.toString())
+            val nativeError = P2wlanNative.start(
+                this,
+                serviceIncarnation,
+                detachedFd,
+                enrichedRequest.toString(),
+            )
             // Ownership of the detached fd is transferred to P2wlanNative as
             // soon as nativeStart is invoked. Native startup/error paths (and
             // the Kotlin library-load fallback) close it; Kotlin must not
@@ -285,6 +300,10 @@ class P2wlanVpnService : VpnService() {
             nativeStartedAtElapsedMs = SystemClock.elapsedRealtime()
             nativeReadyObserved = false
             serviceRunning = true
+            // Capture this callback's bridge owner. A late callback from a
+            // previous bridge remains stale even if the service object itself
+            // is still alive.
+            registerPhysicalNetworkCallback()
             Log.i(
                 TAG,
                 "event=android_daemon_started " +
@@ -683,30 +702,48 @@ class P2wlanVpnService : VpnService() {
      */
     private fun registerPhysicalNetworkCallback() {
         val manager = getSystemService(ConnectivityManager::class.java) ?: return
+        unregisterPhysicalNetworkCallback()
+        val callbackServiceOwner = serviceIncarnation
+        val callbackBridgeOwner = ownedBridgeIncarnation
+        val forwarder = PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = callbackServiceOwner,
+            callbackBridgeIncarnation = callbackBridgeOwner,
+            currentServiceIncarnation = { currentServiceIncarnation },
+            currentBridgeIncarnation = { ownedBridgeIncarnation },
+            notifier = PhysicalNetworkChangeNotifier { serviceOwner, bridgeOwner, generation, hash ->
+                val result = P2wlanNative.notifyPhysicalNetworkChanged(
+                    serviceOwner,
+                    bridgeOwner,
+                    generation,
+                    hash,
+                )
+                MobileLifecycleOutcome.entries.firstOrNull { it.wireValue == result }
+                    ?: MobileLifecycleOutcome.FAILED
+            },
+            reducer = physicalNetworkReducer,
+        )
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                observePhysicalNetwork(network)
+                observePhysicalNetwork(network, forwarder)
             }
 
             override fun onCapabilitiesChanged(
                 network: Network,
                 networkCapabilities: NetworkCapabilities,
             ) {
-                observePhysicalNetwork(network)
+                observePhysicalNetwork(network, forwarder)
             }
 
             override fun onLinkPropertiesChanged(
                 network: Network,
                 linkProperties: android.net.LinkProperties,
             ) {
-                observePhysicalNetwork(network)
+                observePhysicalNetwork(network, forwarder)
             }
 
             override fun onLost(network: Network) {
-                val transition = physicalNetworkReducer.onLost(network.networkHandle)
+                val transition = forwarder.onLost(network.networkHandle)
                 if (transition.outcome == MobileLifecycleOutcome.APPLIED) {
-                    val lifecycle = lifecycleCoordinator.physicalNetworkChanged(transition.generation)
-                    publishLifecycle(lifecycle)
                     Log.i(TAG, "event=physical_network_lost generation=${transition.generation}")
                 }
             }
@@ -730,7 +767,10 @@ class P2wlanVpnService : VpnService() {
         }
     }
 
-    private fun observePhysicalNetwork(network: Network) {
+    private fun observePhysicalNetwork(
+        network: Network,
+        forwarder: PhysicalNetworkCallbackForwarder,
+    ) {
         if (!isCurrentServiceOwner()) return
         val manager = getSystemService(ConnectivityManager::class.java) ?: return
         val capabilities = manager.getNetworkCapabilities(network) ?: return
@@ -748,15 +788,23 @@ class P2wlanVpnService : VpnService() {
             captive = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_CAPTIVE_PORTAL),
             interfaceIdentity = manager.getLinkProperties(network)?.interfaceName,
         )
-        val transition = physicalNetworkReducer.onAvailable(identity)
-        if (transition.outcome != MobileLifecycleOutcome.APPLIED) return
+        val transition = forwarder.onAvailable(identity)
+        if (transition.outcome != MobileLifecycleOutcome.APPLIED) {
+            Log.i(
+                TAG,
+                "event=physical_network_callback_ignored outcome=${transition.outcome.wireValue} " +
+                    "generation=${transition.generation}",
+            )
+            return
+        }
         val lifecycle = lifecycleCoordinator.physicalNetworkChanged(transition.generation)
         publishLifecycle(lifecycle)
         Log.i(
             TAG,
             "event=physical_network_changed generation=${transition.generation} " +
                 "transport=${transports.sorted().joinToString(",")} " +
-                "validated=${identity.validated} captive=${identity.captive}",
+                "validated=${identity.validated} captive=${identity.captive} " +
+                "network_identity_hash=${identity.identityHash()}",
         )
     }
 

--- a/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanVpnService.kt
+++ b/apps/flutter_client/android/app/src/main/kotlin/com/example/p2wlan_flutter_client/P2wlanVpnService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.content.Intent
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.VpnService
 import android.net.wifi.WifiManager
@@ -18,6 +19,7 @@ import android.os.SystemClock
 import android.util.Log
 import org.json.JSONObject
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Android-owned lifecycle for the P2WLAN overlay VPN.
@@ -48,9 +50,55 @@ class P2wlanVpnService : VpnService() {
         @Volatile
         private var serviceError: String? = null
 
+        private val serviceIncarnationCounter = AtomicLong()
+
+        @Volatile
+        private var currentServiceIncarnation = 0L
+
+        @Volatile
+        private var currentBridgeIncarnation = 0L
+
+        @Volatile
+        private var currentLifecycleGeneration = 0L
+
+        @Volatile
+        private var currentPermissionState = MobilePermissionState.UNKNOWN.wireValue
+
+        @Volatile
+        private var currentAutomaticRestartGeneration = 0L
+
+        @Volatile
+        private var currentLastTransition: String? = null
+
+        @Volatile
+        private var currentLastResult: String? = null
+
         fun isRunning(): Boolean = serviceRunning && P2wlanNative.isRunning()
 
         fun lastError(): String? = serviceError ?: P2wlanNative.lastError()
+
+        fun allocateServiceIncarnation(): Long = serviceIncarnationCounter.incrementAndGet()
+
+        internal fun recordPermissionState(state: MobilePermissionState) {
+            currentPermissionState = state.wireValue
+            currentLastTransition = when (state) {
+                MobilePermissionState.PENDING -> MobileLifecycleEvent.VPN_PERMISSION_REQUEST_STARTED.wireName
+                MobilePermissionState.GRANTED -> MobileLifecycleEvent.VPN_PERMISSION_GRANTED.wireName
+                MobilePermissionState.REVOKED -> MobileLifecycleEvent.VPN_PERMISSION_REVOKED.wireName
+                MobilePermissionState.UNKNOWN -> null
+            }
+            currentLastResult = MobileLifecycleOutcome.APPLIED.wireValue
+        }
+
+        fun lifecycleStatus(): Map<String, Any?> = mapOf(
+            "serviceIncarnation" to currentServiceIncarnation.takeIf { it > 0L },
+            "bridgeIncarnation" to currentBridgeIncarnation.takeIf { it > 0L },
+            "lifecycleGeneration" to currentLifecycleGeneration.takeIf { it > 0L },
+            "automaticRestartGeneration" to currentAutomaticRestartGeneration.takeIf { it > 0L },
+            "permissionState" to currentPermissionState,
+            "lastTransition" to currentLastTransition,
+            "lastResult" to currentLastResult,
+        )
 
         fun diagnosticsAuthPath(context: Context): File {
             return File(File(context.filesDir, "p2wlan"), "p2wlan-daemon.diag-auth")
@@ -58,6 +106,9 @@ class P2wlanVpnService : VpnService() {
     }
 
     private var vpnInterface: ParcelFileDescriptor? = null
+    private val lifecycleCoordinator = MobileLifecycleCoordinator()
+    private var serviceIncarnation = 0L
+    private var ownedBridgeIncarnation = 0L
     private var wifiLatencyLock: WifiManager.WifiLock? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     @Volatile
@@ -72,8 +123,69 @@ class P2wlanVpnService : VpnService() {
     private var restartAttempts = 0
     @Volatile
     private var explicitStop = false
+    private val physicalNetworkReducer = PhysicalNetworkIdentityReducer()
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        serviceIncarnation = allocateServiceIncarnation()
+        currentServiceIncarnation = serviceIncarnation
+        lastRequestJson = loadPersistedStartRequest()
+        publishLifecycle(
+            lifecycleCoordinator.serviceRecreated(serviceIncarnation),
+        )
+        registerPhysicalNetworkCallback()
+        adoptExistingNativeRuntime()
+    }
+
+    private fun isCurrentServiceOwner(): Boolean =
+        serviceIncarnation > 0L && currentServiceIncarnation == serviceIncarnation
+
+    /**
+     * START_STICKY can recreate the Service object without killing the app
+     * process. In that case the Rust runtime and detached TUN fd outlive this
+     * Kotlin instance. Adopt the live bridge before handling the next Intent;
+     * the old instance's owner checks then become stale automatically.
+     */
+    private fun adoptExistingNativeRuntime() {
+        if (!isCurrentServiceOwner()) return
+        try {
+            if (!P2wlanNative.isRunning()) return
+            val bridgeIncarnation = P2wlanNative.incarnation()
+                ?: throw IllegalStateException("live Rust runtime has no bridge incarnation")
+            val transition = lifecycleCoordinator.attachBridge(bridgeIncarnation)
+            if (transition.outcome != MobileLifecycleOutcome.APPLIED &&
+                transition.outcome != MobileLifecycleOutcome.DUPLICATE
+            ) {
+                throw IllegalStateException("live bridge incarnation was rejected")
+            }
+            ownedBridgeIncarnation = bridgeIncarnation
+            serviceRunning = true
+            nativeReadyObserved = P2wlanNative.isReady()
+            nativeStartedAtElapsedMs = SystemClock.elapsedRealtime()
+            publishLifecycle(transition)
+            startNativeMonitor()
+            Log.i(TAG, "event=android_daemon_adopted bridge_incarnation=$bridgeIncarnation")
+        } catch (error: Throwable) {
+            serviceError = "Android VPN 运行时重新附着失败：${error.message ?: error::class.java.simpleName}"
+            Log.e(TAG, serviceError, error)
+        }
+    }
+
+    private fun publishLifecycle(transition: MobileLifecycleTransition) {
+        if (!isCurrentServiceOwner()) return
+        currentLifecycleGeneration = transition.newIdentity.lifecycleGeneration
+        currentAutomaticRestartGeneration = transition.newIdentity.automaticRestartGeneration
+        currentLastTransition = transition.event.wireName
+        currentLastResult = transition.outcome.wireValue
+        currentBridgeIncarnation = transition.newIdentity.bridgeIncarnation
+    }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!isCurrentServiceOwner()) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
         if (intent?.action == ACTION_STOP) {
             explicitStop = true
             stopVpn()
@@ -95,6 +207,7 @@ class P2wlanVpnService : VpnService() {
             stopSelf(startId)
             return START_NOT_STICKY
         }
+        publishLifecycle(lifecycleCoordinator.startRequested())
         lastRequestJson = requestJson
         persistStartRequest(requestJson)
         if (!isRunning()) {
@@ -107,6 +220,7 @@ class P2wlanVpnService : VpnService() {
     }
 
     private fun startVpn(requestJson: String) {
+        if (!isCurrentServiceOwner()) return
         var detachedFd = -1
         try {
             stopMonitor()
@@ -158,6 +272,16 @@ class P2wlanVpnService : VpnService() {
             if (!nativeError.isNullOrBlank()) {
                 throw IllegalStateException(nativeError)
             }
+            val bridgeIncarnation = P2wlanNative.incarnation()
+                ?: throw IllegalStateException("Android 原生 daemon 未返回 bridge incarnation")
+            val bridgeTransition = lifecycleCoordinator.attachBridge(bridgeIncarnation)
+            if (bridgeTransition.outcome != MobileLifecycleOutcome.APPLIED &&
+                bridgeTransition.outcome != MobileLifecycleOutcome.DUPLICATE
+            ) {
+                throw IllegalStateException("Android bridge incarnation was rejected")
+            }
+            ownedBridgeIncarnation = bridgeIncarnation
+            publishLifecycle(bridgeTransition)
             nativeStartedAtElapsedMs = SystemClock.elapsedRealtime()
             nativeReadyObserved = false
             serviceRunning = true
@@ -178,7 +302,7 @@ class P2wlanVpnService : VpnService() {
             releaseWifiLatencyMode()
             vpnInterface?.close()
             vpnInterface = null
-            serviceRunning = false
+            if (isCurrentServiceOwner()) serviceRunning = false
             if (!explicitStop && scheduleAutomaticRestart(requestJson, message)) {
                 return
             }
@@ -188,7 +312,15 @@ class P2wlanVpnService : VpnService() {
     }
 
     private fun stopVpn() {
+        if (!isCurrentServiceOwner()) {
+            stopMonitor()
+            releaseWifiLatencyMode()
+            vpnInterface?.close()
+            vpnInterface = null
+            return
+        }
         explicitStop = true
+        publishLifecycle(lifecycleCoordinator.explicitStopRequested())
         lastRequestJson = null
         restartAttempts = 0
         cancelAutomaticRestart()
@@ -198,8 +330,11 @@ class P2wlanVpnService : VpnService() {
         nativeStartedAtElapsedMs = 0L
         stopMonitor()
         try {
-            if (P2wlanNative.isRunning()) {
-                P2wlanNative.stop()
+            if (ownedBridgeIncarnation > 0L &&
+                P2wlanNative.incarnation() == ownedBridgeIncarnation &&
+                P2wlanNative.isRunning()
+            ) {
+                P2wlanNative.stop(ownedBridgeIncarnation)
             }
         } catch (error: Throwable) {
             Log.w(TAG, "Failed to request Rust daemon shutdown", error)
@@ -207,27 +342,49 @@ class P2wlanVpnService : VpnService() {
         releaseWifiLatencyMode()
         vpnInterface?.close()
         vpnInterface = null
+        if (ownedBridgeIncarnation > 0L) {
+            publishLifecycle(lifecycleCoordinator.detachBridge(ownedBridgeIncarnation))
+            ownedBridgeIncarnation = 0L
+        }
         stopForeground(true)
         stopSelf()
     }
 
     override fun onRevoke() {
+        if (!isCurrentServiceOwner()) {
+            super.onRevoke()
+            return
+        }
         stopVpn()
+        publishLifecycle(lifecycleCoordinator.revokePermission())
+        recordPermissionState(MobilePermissionState.REVOKED)
         super.onRevoke()
     }
 
     override fun onDestroy() {
-        serviceRunning = false
+        explicitStop = true
+        val ownsService = isCurrentServiceOwner()
+        publishLifecycle(lifecycleCoordinator.explicitStopRequested())
+        if (ownsService) serviceRunning = false
         nativeReadyObserved = false
         nativeStartedAtElapsedMs = 0L
         cancelAutomaticRestart()
         stopMonitor()
-        if (P2wlanNative.isRunning()) {
-            P2wlanNative.stop()
+        unregisterPhysicalNetworkCallback()
+        if (ownsService && ownedBridgeIncarnation > 0L &&
+            P2wlanNative.incarnation() == ownedBridgeIncarnation &&
+            P2wlanNative.isRunning()
+        ) {
+            P2wlanNative.stop(ownedBridgeIncarnation)
+        }
+        if (ownsService && ownedBridgeIncarnation > 0L) {
+            publishLifecycle(lifecycleCoordinator.detachBridge(ownedBridgeIncarnation))
+            ownedBridgeIncarnation = 0L
         }
         releaseWifiLatencyMode()
         vpnInterface?.close()
         vpnInterface = null
+        if (ownsService) currentServiceIncarnation = 0L
         super.onDestroy()
     }
 
@@ -241,15 +398,23 @@ class P2wlanVpnService : VpnService() {
      */
     private fun startNativeMonitor() {
         val generation = ++monitorGeneration
+        val ownerServiceIncarnation = serviceIncarnation
         val thread = Thread({
             try {
-                while (serviceRunning && P2wlanNative.isRunning()) {
+                while (
+                    serviceRunning &&
+                    isCurrentServiceOwner() &&
+                    lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) &&
+                    P2wlanNative.isRunning()
+                ) {
                     if (!nativeReadyObserved && P2wlanNative.isReady()) {
                         nativeReadyObserved = true
                         val readyAtElapsedMs = SystemClock.elapsedRealtime()
                         mainHandler.post {
                             if (
                                 !serviceRunning ||
+                                !isCurrentServiceOwner() ||
+                                !lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) ||
                                 generation != monitorGeneration ||
                                 !P2wlanNative.isRunning() ||
                                 !P2wlanNative.isReady()
@@ -265,7 +430,7 @@ class P2wlanVpnService : VpnService() {
                                     "startup_runtime_ms=$startupRuntimeMs " +
                                     "healthy_reset_delay_ms=$HEALTHY_RUNTIME_RESET_DELAY_MS",
                             )
-                            scheduleHealthyBudgetReset(generation)
+                            scheduleHealthyBudgetReset(generation, ownerServiceIncarnation)
                         }
                     }
                     Thread.sleep(NATIVE_MONITOR_INTERVAL_MS)
@@ -273,14 +438,22 @@ class P2wlanVpnService : VpnService() {
             } catch (_: InterruptedException) {
                 return@Thread
             }
-            if (!serviceRunning || generation != monitorGeneration) return@Thread
+            if (!serviceRunning ||
+                !isCurrentServiceOwner() ||
+                !lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) ||
+                generation != monitorGeneration
+            ) return@Thread
 
             val error = P2wlanNative.lastError()
                 ?: "Android VPN 本地 daemon 已退出，请查看诊断日志。"
             val runtimeMs = (SystemClock.elapsedRealtime() - nativeStartedAtElapsedMs)
                 .coerceAtLeast(0L)
             mainHandler.post {
-                if (!serviceRunning || generation != monitorGeneration) return@post
+                if (!serviceRunning ||
+                    !isCurrentServiceOwner() ||
+                    !lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) ||
+                    generation != monitorGeneration
+                ) return@post
                 cancelHealthyBudgetReset()
                 serviceError = error
                 serviceRunning = false
@@ -292,6 +465,7 @@ class P2wlanVpnService : VpnService() {
                         "runtime_ms=$runtimeMs " +
                         "exit_reason=${compactLogReason(error)}",
                 )
+                publishLifecycle(lifecycleCoordinator.nativeMonitorStopped(ownerServiceIncarnation))
                 val requestJson = lastRequestJson
                 if (
                     !explicitStop &&
@@ -321,12 +495,14 @@ class P2wlanVpnService : VpnService() {
      * means only that the runtime handle was installed; it is not a healthy
      * daemon boot.
      */
-    private fun scheduleHealthyBudgetReset(generation: Long) {
+    private fun scheduleHealthyBudgetReset(generation: Long, ownerServiceIncarnation: Long) {
         cancelHealthyBudgetReset()
         val reset = Runnable {
             healthyBudgetResetRunnable = null
             if (
                 !serviceRunning ||
+                !isCurrentServiceOwner() ||
+                !lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) ||
                 generation != monitorGeneration ||
                 !nativeReadyObserved ||
                 !P2wlanNative.isRunning() ||
@@ -361,7 +537,12 @@ class P2wlanVpnService : VpnService() {
      * tight foreground-service restart loop.
      */
     private fun scheduleAutomaticRestart(requestJson: String, exitReason: String): Boolean {
-        if (explicitStop || restartRunnable != null) return true
+        if (!isCurrentServiceOwner() || explicitStop || restartRunnable != null) return true
+        val lifecycle = lifecycleCoordinator.automaticRestartScheduled(serviceIncarnation)
+        if (lifecycle.outcome != MobileLifecycleOutcome.APPLIED) {
+            Log.w(TAG, "event=android_restart_rejected result=${lifecycle.result}")
+            return false
+        }
         val schedule = nextAutomaticRestartSchedule(
             currentAttempt = restartAttempts,
             maxAttempts = MAX_AUTOMATIC_RESTARTS,
@@ -375,9 +556,22 @@ class P2wlanVpnService : VpnService() {
 
         restartAttempts = schedule.attempt
         val delayMs = schedule.delayMs
+        val ownerServiceIncarnation = serviceIncarnation
+        val restartGeneration = lifecycle.newIdentity.automaticRestartGeneration
         val restart = Runnable {
             restartRunnable = null
-            if (explicitStop || isRunning()) return@Runnable
+            val callback = lifecycleCoordinator.automaticRestartCallback(
+                ownerServiceIncarnation,
+                restartGeneration,
+            )
+            publishLifecycle(callback)
+            if (
+                callback.outcome != MobileLifecycleOutcome.APPLIED ||
+                explicitStop ||
+                !isCurrentServiceOwner() ||
+                !lifecycleCoordinator.acceptsServiceCallback(ownerServiceIncarnation) ||
+                isRunning()
+            ) return@Runnable
             startVpn(requestJson)
         }
         restartRunnable = restart
@@ -480,6 +674,90 @@ class P2wlanVpnService : VpnService() {
             Log.w(TAG, "Unable to inspect the physical network for Wi-Fi latency mode", error)
             "unknown"
         }
+    }
+
+    /**
+     * Connectivity callbacks are an input boundary only. The Rust daemon's
+     * PeerManager/network_epoch_gate remains the sole network/path authority;
+     * this reducer merely turns callback bursts into one deterministic hint.
+     */
+    private fun registerPhysicalNetworkCallback() {
+        val manager = getSystemService(ConnectivityManager::class.java) ?: return
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                observePhysicalNetwork(network)
+            }
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities,
+            ) {
+                observePhysicalNetwork(network)
+            }
+
+            override fun onLinkPropertiesChanged(
+                network: Network,
+                linkProperties: android.net.LinkProperties,
+            ) {
+                observePhysicalNetwork(network)
+            }
+
+            override fun onLost(network: Network) {
+                val transition = physicalNetworkReducer.onLost(network.networkHandle)
+                if (transition.outcome == MobileLifecycleOutcome.APPLIED) {
+                    val lifecycle = lifecycleCoordinator.physicalNetworkChanged(transition.generation)
+                    publishLifecycle(lifecycle)
+                    Log.i(TAG, "event=physical_network_lost generation=${transition.generation}")
+                }
+            }
+        }
+        try {
+            manager.registerDefaultNetworkCallback(callback)
+            networkCallback = callback
+        } catch (error: Throwable) {
+            Log.w(TAG, "Unable to register physical network callback", error)
+        }
+    }
+
+    private fun unregisterPhysicalNetworkCallback() {
+        val callback = networkCallback ?: return
+        networkCallback = null
+        try {
+            getSystemService(ConnectivityManager::class.java)
+                ?.unregisterNetworkCallback(callback)
+        } catch (error: Throwable) {
+            Log.w(TAG, "Unable to unregister physical network callback", error)
+        }
+    }
+
+    private fun observePhysicalNetwork(network: Network) {
+        if (!isCurrentServiceOwner()) return
+        val manager = getSystemService(ConnectivityManager::class.java) ?: return
+        val capabilities = manager.getNetworkCapabilities(network) ?: return
+        val transports = buildSet {
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) add("wifi")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) add("cellular")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) add("ethernet")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) add("vpn")
+            if (isEmpty()) add("other")
+        }
+        val identity = PhysicalNetworkIdentity(
+            networkHandle = network.networkHandle,
+            transports = transports,
+            validated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+            captive = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_CAPTIVE_PORTAL),
+            interfaceIdentity = manager.getLinkProperties(network)?.interfaceName,
+        )
+        val transition = physicalNetworkReducer.onAvailable(identity)
+        if (transition.outcome != MobileLifecycleOutcome.APPLIED) return
+        val lifecycle = lifecycleCoordinator.physicalNetworkChanged(transition.generation)
+        publishLifecycle(lifecycle)
+        Log.i(
+            TAG,
+            "event=physical_network_changed generation=${transition.generation} " +
+                "transport=${transports.sorted().joinToString(",")} " +
+                "validated=${identity.validated} captive=${identity.captive}",
+        )
     }
 
     private fun compactLogReason(value: String): String {

--- a/apps/flutter_client/android/app/src/test/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinatorTest.kt
+++ b/apps/flutter_client/android/app/src/test/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinatorTest.kt
@@ -4,6 +4,7 @@ import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test
 
 class MobileLifecycleCoordinatorTest {
@@ -189,6 +190,389 @@ class MobileLifecycleCoordinatorTest {
         assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(cellular).outcome)
         assertEquals(MobileLifecycleOutcome.STALE_REJECTED, reducer.onLost(10).outcome)
         assertEquals(2L, reducer.generation())
+    }
+
+    @Test
+    fun ml04AndroidNetworkCallbackWifiToCellularForwardsJniExactlyOnce() {
+        val calls = mutableListOf<Pair<Long, String>>()
+        val forwarder = forwarder(
+            callbackService = 40,
+            callbackBridge = 4,
+            currentService = { 40 },
+            currentBridge = { 4 },
+            calls = calls,
+        )
+        val wifi = identity(10, "wifi", "wlan0")
+        val cellular = identity(20, "cellular", "rmnet0")
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(wifi).outcome)
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, forwarder.onAvailable(wifi).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onLost(10).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(cellular).outcome)
+        assertEquals(listOf(1L to wifi.identityHash(), 2L to cellular.identityHash()), calls)
+    }
+
+    @Test
+    fun ml05AndroidNetworkCallbackCellularToWifiHotspotForwardsJniExactlyOnce() {
+        val calls = mutableListOf<Pair<Long, String>>()
+        val forwarder = forwarder(
+            callbackService = 41,
+            callbackBridge = 5,
+            currentService = { 41 },
+            currentBridge = { 5 },
+            calls = calls,
+        )
+        val cellular = identity(20, "cellular", "rmnet0")
+        val hotspot = identity(30, "wifi", "wlan1")
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(cellular).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onLost(20).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(hotspot).outcome)
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, forwarder.onAvailable(hotspot).outcome)
+        assertEquals(listOf(1L to cellular.identityHash(), 2L to hotspot.identityHash()), calls)
+    }
+
+    @Test
+    fun ml10AndroidNetworkCallbackPassesCurrentServiceAndBridgeOwnerToJni() {
+        val calls = AtomicInteger()
+        var observedService = 0L
+        var observedBridge = 0L
+        val forwarder = PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = 50,
+            callbackBridgeIncarnation = 7,
+            currentServiceIncarnation = { 50 },
+            currentBridgeIncarnation = { 7 },
+            notifier = PhysicalNetworkChangeNotifier { service, bridge, _, _ ->
+                observedService = service
+                observedBridge = bridge
+                calls.incrementAndGet()
+                MobileLifecycleOutcome.APPLIED
+            },
+        )
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(identity(50, "wifi", "wlan0")).outcome)
+        assertEquals(1, calls.get())
+        assertEquals(50L, observedService)
+        assertEquals(7L, observedBridge)
+    }
+
+    @Test
+    fun ml11AndroidNetworkCallbackRejectsOldBridgeOwner() {
+        val calls = AtomicInteger()
+        val forwarder = PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = 50,
+            callbackBridgeIncarnation = 7,
+            currentServiceIncarnation = { 50 },
+            currentBridgeIncarnation = { 8 },
+            notifier = PhysicalNetworkChangeNotifier { _, _, _, _ ->
+                calls.incrementAndGet()
+                MobileLifecycleOutcome.APPLIED
+            },
+        )
+
+        val result = forwarder.onAvailable(identity(60, "cellular", "rmnet0"))
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, result.outcome)
+        assertEquals(0, calls.get())
+    }
+
+    @Test
+    fun ml03AndroidNetworkCallbackRejectsOldServiceOwner() {
+        val calls = AtomicInteger()
+        val forwarder = PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = 50,
+            callbackBridgeIncarnation = 7,
+            currentServiceIncarnation = { 51 },
+            currentBridgeIncarnation = { 7 },
+            notifier = PhysicalNetworkChangeNotifier { _, _, _, _ ->
+                calls.incrementAndGet()
+                MobileLifecycleOutcome.APPLIED
+            },
+        )
+
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            forwarder.onLost(60).outcome,
+        )
+        assertEquals(0, calls.get())
+    }
+
+    @Test
+    fun ml14AndroidNetworkCallbackRejectsLateOldNetworkHandle() {
+        val calls = mutableListOf<Long>()
+        val forwarder = PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = 60,
+            callbackBridgeIncarnation = 9,
+            currentServiceIncarnation = { 60 },
+            currentBridgeIncarnation = { 9 },
+            notifier = PhysicalNetworkChangeNotifier { _, _, generation, _ ->
+                calls += generation
+                MobileLifecycleOutcome.APPLIED
+            },
+        )
+        val oldWifi = identity(70, "wifi", "wlan0")
+        val cellular = identity(71, "cellular", "rmnet0")
+
+        forwarder.onAvailable(oldWifi)
+        forwarder.onLost(oldWifi.networkHandle)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, forwarder.onAvailable(oldWifi).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(cellular).outcome)
+        assertEquals(listOf(1L, 2L), calls)
+    }
+
+    @Test
+    fun evidenceMl03DaemonProcessRecreation() {
+        val coordinator = MobileLifecycleCoordinator()
+        val old = coordinator.serviceRecreated(40).newIdentity
+        val replacement = coordinator.serviceRecreated(41)
+        assertEquals(MobileLifecycleOutcome.APPLIED, replacement.outcome)
+        emitEvidence(
+            scenarioId = "ML-03",
+            method = "evidenceMl03DaemonProcessRecreation",
+            events = "[\"service_recreated\",\"native_runtime_started\"]",
+            oldIdentity = identityJson("service_incarnation" to old.serviceIncarnation),
+            newIdentity = identityJson("service_incarnation" to replacement.newIdentity.serviceIncarnation),
+            decision = replacement.outcome,
+            invariants = "{\"new_process_adopted\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl04WifiToCellularHandoff() {
+        val calls = mutableListOf<Long>()
+        val forwarder = forwarderForEvidence(calls)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(identity(10, "wifi", "wlan0")).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onLost(10).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(identity(20, "cellular", "rmnet0")).outcome)
+        assertEquals(listOf(1L, 2L), calls)
+        emitEvidence(
+            scenarioId = "ML-04",
+            method = "evidenceMl04WifiToCellularHandoff",
+            events = "[\"physical_network_changed\",\"candidate_refresh_started\"]",
+            oldIdentity = identityJson("network_generation" to calls.first()),
+            newIdentity = identityJson("network_generation" to calls.last()),
+            decision = MobileLifecycleOutcome.APPLIED,
+            invariants = "{\"single_network_generation_advance\":${calls.last() - calls.first() == 1L}}",
+        )
+    }
+
+    @Test
+    fun evidenceMl05CellularToWifiHotspotHandoff() {
+        val calls = mutableListOf<Long>()
+        val forwarder = forwarderForEvidence(calls)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(identity(20, "cellular", "rmnet0")).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onLost(20).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, forwarder.onAvailable(identity(30, "wifi", "wlan1")).outcome)
+        assertEquals(listOf(1L, 2L), calls)
+        emitEvidence(
+            scenarioId = "ML-05",
+            method = "evidenceMl05CellularToWifiHotspotHandoff",
+            events = "[\"physical_network_changed\",\"candidate_refresh_started\"]",
+            oldIdentity = identityJson("network_generation" to calls.first()),
+            newIdentity = identityJson("network_generation" to calls.last()),
+            decision = MobileLifecycleOutcome.APPLIED,
+            invariants = "{\"single_network_generation_advance\":${calls.last() - calls.first() == 1L}}",
+        )
+    }
+
+    @Test
+    fun evidenceMl06VpnPermissionRevoke() {
+        val coordinator = MobileLifecycleCoordinator()
+        val request = coordinator.beginPermissionRequest(1, 10)
+        val old = request.newIdentity
+        val revoke = coordinator.revokePermission()
+        val late = coordinator.completePermissionRequest(request.newIdentity.permissionRequestId, 1, 10, granted = true)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, late.outcome)
+        emitEvidence(
+            scenarioId = "ML-06",
+            method = "evidenceMl06VpnPermissionRevoke",
+            events = "[\"vpn_permission_revoked\",\"bridge_detached\"]",
+            oldIdentity = identityJson(
+                "permission_request_id" to old.permissionRequestId,
+                "lifecycle_generation" to old.lifecycleGeneration,
+            ),
+            newIdentity = identityJson(
+                "permission_request_id" to revoke.newIdentity.permissionRequestId,
+                "lifecycle_generation" to revoke.newIdentity.lifecycleGeneration,
+            ),
+            decision = late.outcome,
+            invariants = "{\"pending_permission_invalidated\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl07VpnPermissionRegrant() {
+        val coordinator = MobileLifecycleCoordinator()
+        val first = coordinator.beginPermissionRequest(1, 10)
+        coordinator.revokePermission()
+        val old = coordinator.state.identity
+        val second = coordinator.beginPermissionRequest(1, 11)
+        val grant = coordinator.completePermissionRequest(second.newIdentity.permissionRequestId, 1, 11, granted = true)
+        assertEquals(MobileLifecycleOutcome.APPLIED, grant.outcome)
+        assertTrue(second.newIdentity.permissionRequestId > first.newIdentity.permissionRequestId)
+        emitEvidence(
+            scenarioId = "ML-07",
+            method = "evidenceMl07VpnPermissionRegrant",
+            events = "[\"vpn_permission_granted\",\"native_runtime_started\"]",
+            oldIdentity = identityJson("permission_request_id" to old.permissionRequestId),
+            newIdentity = identityJson("permission_request_id" to grant.newIdentity.permissionRequestId),
+            decision = grant.outcome,
+            invariants = "{\"new_permission_attempt\":${grant.newIdentity.permissionRequestId != old.permissionRequestId}}",
+        )
+    }
+
+    @Test
+    fun evidenceMl08ActivityEngineRecreation() {
+        val coordinator = MobileLifecycleCoordinator()
+        val request = coordinator.beginPermissionRequest(1, 10)
+        val old = request.newIdentity
+        val recreation = coordinator.activityRecreated(2, 11)
+        val late = coordinator.completePermissionRequest(request.newIdentity.permissionRequestId, 1, 10, granted = true)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, late.outcome)
+        emitEvidence(
+            scenarioId = "ML-08",
+            method = "evidenceMl08ActivityEngineRecreation",
+            events = "[\"activity_recreated\",\"vpn_permission_granted\"]",
+            oldIdentity = identityJson("activity_incarnation" to old.activityIncarnation, "engine_incarnation" to old.engineIncarnation),
+            newIdentity = identityJson("activity_incarnation" to recreation.newIdentity.activityIncarnation, "engine_incarnation" to recreation.newIdentity.engineIncarnation),
+            decision = late.outcome,
+            invariants = "{\"old_engine_callback_rejected\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl09ServiceRecreation() {
+        val coordinator = MobileLifecycleCoordinator()
+        val old = coordinator.serviceRecreated(8).newIdentity
+        val replacement = coordinator.serviceRecreated(9)
+        assertEquals(MobileLifecycleOutcome.APPLIED, replacement.outcome)
+        emitEvidence(
+            scenarioId = "ML-09",
+            method = "evidenceMl09ServiceRecreation",
+            events = "[\"service_recreated\",\"native_runtime_started\"]",
+            oldIdentity = identityJson("service_incarnation" to old.serviceIncarnation),
+            newIdentity = identityJson("service_incarnation" to replacement.newIdentity.serviceIncarnation),
+            decision = replacement.outcome,
+            invariants = "{\"new_service_incarnation\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl10BridgeReattachment() {
+        val coordinator = MobileLifecycleCoordinator()
+        val old = coordinator.attachBridge(4).newIdentity
+        val replacement = coordinator.attachBridge(5)
+        assertEquals(MobileLifecycleOutcome.APPLIED, replacement.outcome)
+        emitEvidence(
+            scenarioId = "ML-10",
+            method = "evidenceMl10BridgeReattachment",
+            events = "[\"bridge_detached\",\"bridge_attached\"]",
+            oldIdentity = identityJson("bridge_incarnation" to old.bridgeIncarnation),
+            newIdentity = identityJson("bridge_incarnation" to replacement.newIdentity.bridgeIncarnation),
+            decision = replacement.outcome,
+            invariants = "{\"bridge_identity_adopted\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl11OldBridgeTeardown() {
+        val coordinator = MobileLifecycleCoordinator()
+        coordinator.attachBridge(4)
+        val old = coordinator.attachBridge(5).newIdentity
+        val stale = coordinator.detachBridge(4)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, stale.outcome)
+        emitEvidence(
+            scenarioId = "ML-11",
+            method = "evidenceMl11OldBridgeTeardown",
+            events = "[\"bridge_detached\",\"bridge_attached\"]",
+            oldIdentity = identityJson("bridge_incarnation" to 4L),
+            newIdentity = identityJson("bridge_incarnation" to old.bridgeIncarnation),
+            decision = stale.outcome,
+            invariants = "{\"old_bridge_cleanup_rejected\":true}",
+        )
+    }
+
+    @Test
+    fun evidenceMl18DuplicateEvents() {
+        val coordinator = MobileLifecycleCoordinator()
+        val applied = coordinator.physicalNetworkChanged(1)
+        val duplicate = coordinator.physicalNetworkChanged(1)
+        assertEquals(MobileLifecycleOutcome.APPLIED, applied.outcome)
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, duplicate.outcome)
+        assertEquals(applied.newIdentity, duplicate.newIdentity)
+        emitEvidence(
+            scenarioId = "ML-18",
+            method = "evidenceMl18DuplicateEvents",
+            events = "[\"physical_network_changed\",\"physical_network_changed\"]",
+            oldIdentity = identityJson("network_generation" to applied.newIdentity.networkGeneration),
+            newIdentity = identityJson("network_generation" to duplicate.newIdentity.networkGeneration),
+            decision = duplicate.outcome,
+            invariants = "{\"duplicate_has_no_second_effect\":true}",
+        )
+    }
+
+    private fun identity(handle: Long, transport: String, interfaceName: String) =
+        PhysicalNetworkIdentity(
+            networkHandle = handle,
+            transports = setOf(transport),
+            validated = true,
+            captive = false,
+            interfaceIdentity = interfaceName,
+        )
+
+    private fun forwarder(
+        callbackService: Long,
+        callbackBridge: Long,
+        currentService: () -> Long,
+        currentBridge: () -> Long,
+        calls: MutableList<Pair<Long, String>>,
+    ) = PhysicalNetworkCallbackForwarder(
+        callbackServiceIncarnation = callbackService,
+        callbackBridgeIncarnation = callbackBridge,
+        currentServiceIncarnation = currentService,
+        currentBridgeIncarnation = currentBridge,
+        notifier = PhysicalNetworkChangeNotifier { _, _, generation, hash ->
+            calls += generation to hash
+            MobileLifecycleOutcome.APPLIED
+        },
+    )
+
+    private fun forwarderForEvidence(calls: MutableList<Long>) =
+        PhysicalNetworkCallbackForwarder(
+            callbackServiceIncarnation = 50,
+            callbackBridgeIncarnation = 7,
+            currentServiceIncarnation = { 50 },
+            currentBridgeIncarnation = { 7 },
+            notifier = PhysicalNetworkChangeNotifier { _, _, generation, _ ->
+                calls += generation
+                MobileLifecycleOutcome.APPLIED
+            },
+        )
+
+    private fun identityJson(vararg fields: Pair<String, Long>): String =
+        fields.joinToString(prefix = "{", postfix = "}") { (key, value) ->
+            "\"$key\":$value"
+        }
+
+    private fun emitEvidence(
+        scenarioId: String,
+        method: String,
+        events: String,
+        oldIdentity: String,
+        newIdentity: String,
+        decision: MobileLifecycleOutcome,
+        invariants: String,
+    ) {
+        val exactTestId =
+            "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#$method"
+        println(
+            "MOBILE_LIFECYCLE_RECORD " +
+                "{\"scenario_id\":\"$scenarioId\",\"exact_test_id\":\"$exactTestId\"," +
+                "\"executed\":true,\"skipped\":false,\"result\":\"pass\"," +
+                "\"events\":$events,\"observed_old_identity\":$oldIdentity," +
+                "\"observed_new_identity\":$newIdentity," +
+                "\"observed_decision\":\"${decision.wireValue}\",\"invariants\":$invariants," +
+                "\"execution_source\":\"android_junit_xml\"}",
+        )
     }
 
     private fun findContract(): File {

--- a/apps/flutter_client/android/app/src/test/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinatorTest.kt
+++ b/apps/flutter_client/android/app/src/test/kotlin/com/example/p2wlan_flutter_client/MobileLifecycleCoordinatorTest.kt
@@ -1,0 +1,213 @@
+package com.example.p2wlan_flutter_client
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MobileLifecycleCoordinatorTest {
+    @Test
+    fun canonicalContractContainsEveryFixedScenarioAndWireName() {
+        val contract = findContract().readText()
+        for (index in 1..18) {
+            assertTrue(contract.contains("\"id\": \"ML-${index.toString().padStart(2, '0')}\""))
+        }
+        assertEquals(
+            MobileLifecycleEvent.entries.map { it.wireName },
+            arrayValues(contract, "events"),
+        )
+        assertEquals(
+            MobileLifecycleOutcome.entries.map { it.wireValue },
+            arrayValues(contract, "outcomes"),
+        )
+    }
+
+    @Test
+    fun permissionRevokeInvalidatesPendingRequestAndRegrantGetsNewId() {
+        val coordinator = MobileLifecycleCoordinator()
+        val first = coordinator.beginPermissionRequest(1, 10)
+        val firstId = first.newIdentity.permissionRequestId
+        assertEquals(MobileLifecycleOutcome.APPLIED, first.outcome)
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.revokePermission().outcome)
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.completePermissionRequest(firstId, 1, 10, granted = true).outcome,
+        )
+
+        val second = coordinator.beginPermissionRequest(1, 11)
+        assertTrue(second.newIdentity.permissionRequestId > firstId)
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.completePermissionRequest(
+                second.newIdentity.permissionRequestId,
+                1,
+                11,
+                granted = true,
+            ).outcome,
+        )
+        assertEquals(MobilePermissionState.GRANTED, coordinator.state.permissionState)
+    }
+
+    @Test
+    fun duplicatePermissionGrantAndRevokeAreIdempotent() {
+        val coordinator = MobileLifecycleCoordinator()
+        val request = coordinator.beginPermissionRequest(1, 10)
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.completePermissionRequest(request.newIdentity.permissionRequestId, 1, 10, true).outcome,
+        )
+        val generation = coordinator.state.identity.lifecycleGeneration
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.completePermissionRequest(request.newIdentity.permissionRequestId, 1, 10, true).outcome,
+        )
+        assertEquals(generation, coordinator.state.identity.lifecycleGeneration)
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.revokePermission().outcome)
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, coordinator.revokePermission().outcome)
+    }
+
+    @Test
+    fun stalePermissionResultIsRejectedAfterActivityAndEngineRecreation() {
+        val coordinator = MobileLifecycleCoordinator()
+        val request = coordinator.beginPermissionRequest(1, 10)
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.activityRecreated(2, 11).outcome)
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.completePermissionRequest(request.newIdentity.permissionRequestId, 1, 10, true).outcome,
+        )
+        assertEquals(2L, coordinator.state.identity.activityIncarnation)
+        assertEquals(11L, coordinator.state.identity.engineIncarnation)
+    }
+
+    @Test
+    fun serviceRecreationAllocatesNewIncarnationAndOldMonitorIsRejected() {
+        val coordinator = MobileLifecycleCoordinator()
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.serviceRecreated(40).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.serviceRecreated(41).outcome)
+        assertFalse(coordinator.acceptsServiceCallback(40))
+        assertTrue(coordinator.acceptsServiceCallback(41))
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.serviceRecreated(40).outcome,
+        )
+    }
+
+    @Test
+    fun oldDelayedRestartIsRejectedAfterExplicitOwnerChange() {
+        val coordinator = MobileLifecycleCoordinator()
+        coordinator.serviceRecreated(1)
+        coordinator.serviceRecreated(2)
+        assertFalse(coordinator.acceptsServiceCallback(1))
+        assertTrue(coordinator.acceptsServiceCallback(2))
+    }
+
+    @Test
+    fun explicitStopAndPermissionRevokeFenceAutomaticRestartCallbacks() {
+        val coordinator = MobileLifecycleCoordinator()
+        coordinator.serviceRecreated(1)
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.startRequested().outcome)
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.automaticRestartScheduled(1).outcome,
+        )
+        val restartGeneration = coordinator.state.identity.automaticRestartGeneration
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.nativeMonitorStopped(1).outcome,
+        )
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.explicitStopRequested().outcome,
+        )
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.automaticRestartCallback(1, restartGeneration).outcome,
+        )
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.startRequested().outcome,
+        )
+        assertEquals(
+            MobileLifecycleOutcome.APPLIED,
+            coordinator.revokePermission().outcome,
+        )
+        assertEquals(
+            MobileLifecycleOutcome.STALE_REJECTED,
+            coordinator.automaticRestartCallback(1, restartGeneration).outcome,
+        )
+    }
+
+    @Test
+    fun bridgeReattachmentSupersedesOldBridgeAndOldTeardownCannotStopNewBridge() {
+        val coordinator = MobileLifecycleCoordinator()
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.attachBridge(4).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, coordinator.attachBridge(5).outcome)
+        assertTrue(coordinator.acceptsBridgeCallback(5))
+        assertFalse(coordinator.acceptsBridgeCallback(4))
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, coordinator.detachBridge(4).outcome)
+        assertTrue(coordinator.acceptsBridgeCallback(5))
+    }
+
+    @Test
+    fun wifiCellularAndHotspotHandoffsAdvanceExactlyOnceAndDebounceCallbacks() {
+        val reducer = PhysicalNetworkIdentityReducer()
+        val wifi = PhysicalNetworkIdentity(10, setOf("wifi"), validated = true, captive = false, interfaceIdentity = "wlan0")
+        val cellular = PhysicalNetworkIdentity(20, setOf("cellular"), validated = true, captive = false, interfaceIdentity = "rmnet0")
+        val hotspot = PhysicalNetworkIdentity(30, setOf("wifi"), validated = true, captive = false, interfaceIdentity = "wlan1")
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(wifi).outcome)
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, reducer.onAvailable(wifi).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(cellular).outcome)
+        assertEquals(2L, reducer.generation())
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(hotspot).outcome)
+        assertEquals(3L, reducer.generation())
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, reducer.onAvailable(hotspot).outcome)
+    }
+
+    @Test
+    fun capabilityChangesOnTheCurrentNetworkRemainAdoptable() {
+        val reducer = PhysicalNetworkIdentityReducer()
+        val validated = PhysicalNetworkIdentity(10, setOf("wifi"), true, false, "wlan0")
+        val captive = validated.copy(validated = false, captive = true)
+
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(validated).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(captive).outcome)
+        assertEquals(2L, reducer.generation())
+        assertEquals(MobileLifecycleOutcome.DUPLICATE, reducer.onAvailable(captive).outcome)
+    }
+
+    @Test
+    fun lateLostAndAvailableCallbacksForOldNetworkAreRejected() {
+        val reducer = PhysicalNetworkIdentityReducer()
+        val wifi = PhysicalNetworkIdentity(10, setOf("wifi"), true, false, "wlan0")
+        val cellular = PhysicalNetworkIdentity(20, setOf("cellular"), true, false, "rmnet0")
+        reducer.onAvailable(wifi)
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onLost(10).outcome)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, reducer.onAvailable(wifi).outcome)
+        assertEquals(MobileLifecycleOutcome.APPLIED, reducer.onAvailable(cellular).outcome)
+        assertEquals(MobileLifecycleOutcome.STALE_REJECTED, reducer.onLost(10).outcome)
+        assertEquals(2L, reducer.generation())
+    }
+
+    private fun findContract(): File {
+        val candidates = listOf(
+            File("../../../contracts/mobile_lifecycle.json"),
+            File("../../../../contracts/mobile_lifecycle.json"),
+        )
+        return candidates.firstOrNull { it.isFile }
+            ?: error("contracts/mobile_lifecycle.json was not found")
+    }
+
+    private fun arrayValues(document: String, key: String): List<String> {
+        val section = document
+            .substringAfter("\"$key\": [", missingDelimiterValue = "")
+            .substringBefore("]")
+        assertTrue("contract array $key is missing", section.isNotEmpty())
+        return Regex("\\\"([^\\\"]+)\\\"")
+            .findAll(section)
+            .map { it.groupValues[1] }
+            .toList()
+    }
+}

--- a/apps/flutter_client/lib/core/daemon/daemon_controller.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller.dart
@@ -21,6 +21,85 @@ part 'daemon_controller/pids.dart';
 part 'daemon_controller/android_vpn.dart';
 part 'daemon_controller/startup_trace.dart';
 
+/// Injectable Android platform boundary. Production uses the
+/// [MethodChannelAndroidVpnTransport]; tests can provide a fake without
+/// opening a global MethodChannel or requiring an Android device.
+abstract interface class AndroidVpnTransport {
+  Future<bool> prepareVpn();
+  Future<bool> start(String requestJson);
+  Future<bool> stop();
+  Future<AndroidVpnStatus> status();
+}
+
+class AndroidVpnStatus {
+  const AndroidVpnStatus({
+    required this.serviceRunning,
+    required this.nativeRunning,
+    required this.nativeReady,
+    this.nativeError,
+    this.serviceIncarnation,
+    this.bridgeIncarnation,
+    this.lifecycleGeneration,
+    this.permissionState,
+    this.lastTransition,
+    this.lastResult,
+  });
+
+  final bool serviceRunning;
+  final bool nativeRunning;
+  final bool nativeReady;
+  final String? nativeError;
+  final int? serviceIncarnation;
+  final int? bridgeIncarnation;
+  final int? lifecycleGeneration;
+  final String? permissionState;
+  final String? lastTransition;
+  final String? lastResult;
+}
+
+class MethodChannelAndroidVpnTransport implements AndroidVpnTransport {
+  const MethodChannelAndroidVpnTransport({
+    this.channel = const MethodChannel('p2wlan/android_vpn'),
+  });
+
+  final MethodChannel channel;
+
+  @override
+  Future<bool> prepareVpn() async =>
+      await channel.invokeMethod<bool>('prepareVpn') ?? false;
+
+  @override
+  Future<bool> start(String requestJson) async =>
+      await channel.invokeMethod<bool>('start', {'requestJson': requestJson}) ??
+      false;
+
+  @override
+  Future<bool> stop() async =>
+      await channel.invokeMethod<bool>('stop') ?? false;
+
+  @override
+  Future<AndroidVpnStatus> status() async {
+    final value = await channel.invokeMethod<Map<Object?, Object?>>('status');
+    int? integer(String key) {
+      final raw = value?[key];
+      return raw is num ? raw.toInt() : null;
+    }
+
+    return AndroidVpnStatus(
+      serviceRunning: value?['serviceRunning'] == true,
+      nativeRunning: value?['nativeRunning'] == true,
+      nativeReady: value?['nativeReady'] == true,
+      nativeError: value?['nativeError']?.toString(),
+      serviceIncarnation: integer('serviceIncarnation'),
+      bridgeIncarnation: integer('bridgeIncarnation'),
+      lifecycleGeneration: integer('lifecycleGeneration'),
+      permissionState: value?['permissionState']?.toString(),
+      lastTransition: value?['lastTransition']?.toString(),
+      lastResult: value?['lastResult']?.toString(),
+    );
+  }
+}
+
 class DaemonCommandResult {
   const DaemonCommandResult({
     required this.ok,
@@ -51,6 +130,7 @@ class DaemonCommandResult {
 class DaemonController {
   DaemonController({
     required this._diagnosticsApi,
+    this.androidVpnTransport = const MethodChannelAndroidVpnTransport(),
     this.readMacosAdminPassword,
     this.saveMacosAdminPassword,
     this.clearMacosAdminPassword,
@@ -67,6 +147,14 @@ class DaemonController {
   static const _gracefulShutdownTimeout = Duration(seconds: 12);
 
   final DiagnosticsApi _diagnosticsApi;
+  final AndroidVpnTransport androidVpnTransport;
+
+  /// Returns the additive Android lifecycle identity when running on Android.
+  /// Non-Android callers receive null without touching a platform channel.
+  Future<AndroidVpnStatus?> androidStatus() async {
+    if (!Platform.isAndroid) return null;
+    return androidVpnTransport.status();
+  }
 
   /// These callbacks are supplied by [SettingsStore] for the normal app
   /// path. Keeping them as callbacks also lets the PID cleanup path reuse the

--- a/apps/flutter_client/lib/core/daemon/daemon_controller/android_vpn.dart
+++ b/apps/flutter_client/lib/core/daemon/daemon_controller/android_vpn.dart
@@ -5,7 +5,6 @@ part of '../daemon_controller.dart';
 /// Android has no detached executable to launch. The platform service owns the
 /// TUN permission and foreground lifecycle; the existing DiagnosticsApi still
 /// remains the readiness/status contract for the UI.
-const _androidVpnChannel = MethodChannel('p2wlan/android_vpn');
 // Build-time experiment switches keep the default APK on the existing
 // AsyncFd/no-Wi-Fi-lock path while allowing GitHub Actions/device A/B builds
 // to select the alternate implementation without adding UI state.
@@ -48,9 +47,13 @@ extension DaemonControllerAndroidVpn on DaemonController {
     final requestJson = _androidRequestJson(settings);
 
     try {
-      await _androidVpnChannel.invokeMethod<bool>('start', {
-        'requestJson': requestJson,
-      });
+      final started = await androidVpnTransport.start(requestJson);
+      if (!started) {
+        return const DaemonCommandResult(
+          ok: false,
+          message: 'Android VPN 服务拒绝启动请求。',
+        );
+      }
     } on PlatformException catch (error) {
       return DaemonCommandResult(
         ok: false,
@@ -109,7 +112,7 @@ extension DaemonControllerAndroidVpn on DaemonController {
 
   Future<DaemonCommandResult> _stopAndroidVpn() async {
     try {
-      await _androidVpnChannel.invokeMethod<bool>('stop');
+      await androidVpnTransport.stop();
     } on PlatformException catch (error) {
       return DaemonCommandResult(
         ok: false,
@@ -142,7 +145,7 @@ extension DaemonControllerAndroidVpn on DaemonController {
 
   Future<bool> _prepareAndroidVpn() async {
     try {
-      return await _androidVpnChannel.invokeMethod<bool>('prepareVpn') ?? false;
+      return await androidVpnTransport.prepareVpn();
     } catch (_) {
       return false;
     }
@@ -150,9 +153,7 @@ extension DaemonControllerAndroidVpn on DaemonController {
 
   Future<bool> _androidNativeRunning() async {
     try {
-      final status = await _androidVpnChannel
-          .invokeMethod<Map<Object?, Object?>>('status');
-      return status?['nativeRunning'] == true;
+      return (await androidVpnTransport.status()).nativeRunning;
     } catch (_) {
       return false;
     }
@@ -160,9 +161,9 @@ extension DaemonControllerAndroidVpn on DaemonController {
 
   Future<String?> _androidNativeError() async {
     try {
-      final status = await _androidVpnChannel
-          .invokeMethod<Map<Object?, Object?>>('status');
-      final value = status?['nativeError']?.toString().trim();
+      final value = (await androidVpnTransport.status()).nativeError
+          ?.toString()
+          .trim();
       return value == null || value.isEmpty ? null : value;
     } catch (_) {
       return null;

--- a/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
+++ b/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
@@ -51,6 +51,7 @@ class MobileLifecycleIdentity {
     this.appEpoch = 0,
     this.eventLoopGeneration = 0,
     this.daemonProcessId,
+    this.daemonRuntimeIncarnation,
     this.daemonRevision = 0,
     this.permissionRequestId,
     this.activityIncarnation,
@@ -71,6 +72,10 @@ class MobileLifecycleIdentity {
   final int appEpoch;
   final int eventLoopGeneration;
   final int? daemonProcessId;
+
+  /// Native bridge/runtime incarnation. This is stronger than PID/revision
+  /// when Android restarts the embedded daemon in the same process.
+  final int? daemonRuntimeIncarnation;
   final int daemonRevision;
   final int? permissionRequestId;
   final int? activityIncarnation;
@@ -92,6 +97,8 @@ class MobileLifecycleIdentity {
     int? eventLoopGeneration,
     int? daemonProcessId,
     bool clearDaemonProcessId = false,
+    int? daemonRuntimeIncarnation,
+    bool clearDaemonRuntimeIncarnation = false,
     int? daemonRevision,
     int? permissionRequestId,
     int? activityIncarnation,
@@ -114,6 +121,9 @@ class MobileLifecycleIdentity {
       daemonProcessId: clearDaemonProcessId
           ? null
           : daemonProcessId ?? this.daemonProcessId,
+      daemonRuntimeIncarnation: clearDaemonRuntimeIncarnation
+          ? null
+          : daemonRuntimeIncarnation ?? this.daemonRuntimeIncarnation,
       daemonRevision: daemonRevision ?? this.daemonRevision,
       permissionRequestId: permissionRequestId ?? this.permissionRequestId,
       activityIncarnation: activityIncarnation ?? this.activityIncarnation,
@@ -148,6 +158,7 @@ class MobileLifecycleIdentity {
     }
 
     add('daemon_process_id', daemonProcessId);
+    add('runtime_incarnation', daemonRuntimeIncarnation);
     add('permission_request_id', permissionRequestId);
     add('activity_incarnation', activityIncarnation);
     add('engine_incarnation', engineIncarnation);
@@ -193,6 +204,7 @@ class MobileLifecycleCoordinator {
   bool _permissionRevoked = false;
   bool _permissionPending = false;
   final _retiredDaemonProcessIds = <int>{};
+  final _retiredDaemonRuntimeIncarnations = <int>{};
   MobileLifecycleTransition? _lastTransition;
 
   MobileLifecycleIdentity get identity => _identity;
@@ -206,22 +218,14 @@ class MobileLifecycleCoordinator {
     if (_disposed) return _failed(MobileLifecycleEvent.appBackgrounded);
     if (!_foreground) return _duplicate(MobileLifecycleEvent.appBackgrounded);
     _foreground = false;
-    return _advance(
-      MobileLifecycleEvent.appBackgrounded,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
-    );
+    return invalidateEventLoop(event: MobileLifecycleEvent.appBackgrounded);
   }
 
   MobileLifecycleTransition onAppResumed() {
     if (_disposed) return _failed(MobileLifecycleEvent.appResumed);
     if (_foreground) return _duplicate(MobileLifecycleEvent.appResumed);
     _foreground = true;
-    return _advance(
-      MobileLifecycleEvent.appResumed,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
-    );
+    return invalidateEventLoop(event: MobileLifecycleEvent.appResumed);
   }
 
   MobileLifecycleTransition beginPermissionRequest() {
@@ -234,11 +238,10 @@ class MobileLifecycleCoordinator {
     final nextRequest = (_identity.permissionRequestId ?? 0) + 1;
     _permissionRevoked = false;
     _permissionPending = true;
-    return _advance(
-      MobileLifecycleEvent.vpnPermissionRequestStarted,
+    return invalidateEventLoop(
+      event: MobileLifecycleEvent.vpnPermissionRequestStarted,
+      advanceAppEpoch: true,
       permissionRequestId: nextRequest,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
     );
   }
 
@@ -249,10 +252,9 @@ class MobileLifecycleCoordinator {
     }
     _permissionRevoked = true;
     _permissionPending = false;
-    return _advance(
-      MobileLifecycleEvent.vpnPermissionRevoked,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    return invalidateEventLoop(
+      event: MobileLifecycleEvent.vpnPermissionRevoked,
+      advanceAppEpoch: true,
     );
   }
 
@@ -278,30 +280,63 @@ class MobileLifecycleCoordinator {
     }
     _permissionPending = false;
     if (!granted) return onPermissionRevoked();
-    return _advance(
-      event,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    return invalidateEventLoop(
+      event: event,
+      advanceAppEpoch: true,
     );
   }
 
   MobileLifecycleTransition invalidateDiagnostics() {
-    if (_disposed) return _failed(MobileLifecycleEvent.bridgeDetached);
+    return invalidateEventLoop(event: MobileLifecycleEvent.bridgeDetached);
+  }
+
+  /// Invalidate work tied to the current event-loop generation. StatusStore
+  /// uses this same API for settings/URL changes and auto-refresh disable;
+  /// lifecycle transitions below use the same primitive as well. Keeping the
+  /// counter here makes the coordinator the single event-loop authority.
+  MobileLifecycleTransition invalidateEventLoop({
+    MobileLifecycleEvent event = MobileLifecycleEvent.bridgeDetached,
+    bool advanceAppEpoch = true,
+    int? daemonProcessId,
+    bool clearDaemonProcessId = false,
+    int? daemonRuntimeIncarnation,
+    bool clearDaemonRuntimeIncarnation = false,
+    int? daemonRevision,
+    int? permissionRequestId,
+    int? bridgeIncarnation,
+  }) {
+    if (_disposed) return _failed(event);
     return _advance(
-      MobileLifecycleEvent.bridgeDetached,
-      appEpoch: _identity.appEpoch + 1,
+      event,
+      appEpoch: advanceAppEpoch ? _identity.appEpoch + 1 : null,
       eventLoopGeneration: _identity.eventLoopGeneration + 1,
+      daemonProcessId: daemonProcessId,
+      clearDaemonProcessId: clearDaemonProcessId,
+      daemonRuntimeIncarnation: daemonRuntimeIncarnation,
+      clearDaemonRuntimeIncarnation: clearDaemonRuntimeIncarnation,
+      daemonRevision: daemonRevision,
+      permissionRequestId: permissionRequestId,
+      bridgeIncarnation: bridgeIncarnation,
     );
   }
 
   MobileLifecycleTransition observeDaemon({
     required int? processId,
+    int? runtimeIncarnation,
     required int revision,
   }) {
     if (_disposed) return _failed(MobileLifecycleEvent.nativeRuntimeStarted);
     final old = _identity;
     final sameProcess = old.daemonProcessId == processId;
-    if (sameProcess && revision < old.daemonRevision) {
+    final oldRuntime = old.daemonRuntimeIncarnation;
+    final runtimeChanged = oldRuntime != runtimeIncarnation;
+
+    // Android can replace the embedded Rust runtime without replacing the
+    // hosting process. The runtime incarnation is therefore the first
+    // identity fence: a newer bridge may legitimately start with a lower
+    // revision and uptime, while a late response from the retired bridge is
+    // stale even if its PID and revision look newer.
+    if (oldRuntime != null && runtimeIncarnation == null) {
       return _record(
         MobileLifecycleTransition(
           event: MobileLifecycleEvent.nativeRuntimeStarted,
@@ -311,7 +346,40 @@ class MobileLifecycleCoordinator {
         ),
       );
     }
-    if (sameProcess && revision == old.daemonRevision) {
+    if (runtimeIncarnation != null &&
+        _retiredDaemonRuntimeIncarnations.contains(runtimeIncarnation)) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.nativeRuntimeStarted,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: old,
+          newIdentity: old,
+        ),
+      );
+    }
+    if (oldRuntime != null &&
+        runtimeIncarnation != null &&
+        runtimeIncarnation < oldRuntime) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.nativeRuntimeStarted,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: old,
+          newIdentity: old,
+        ),
+      );
+    }
+    if (!runtimeChanged && sameProcess && revision < old.daemonRevision) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.nativeRuntimeStarted,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: old,
+          newIdentity: old,
+        ),
+      );
+    }
+    if (!runtimeChanged && sameProcess && revision == old.daemonRevision) {
       return _duplicate(MobileLifecycleEvent.nativeRuntimeStarted);
     }
     if (!sameProcess &&
@@ -329,13 +397,31 @@ class MobileLifecycleCoordinator {
     if (!sameProcess && old.daemonProcessId != null) {
       _retiredDaemonProcessIds.add(old.daemonProcessId!);
     }
+    if (oldRuntime != null && runtimeChanged) {
+      _retiredDaemonRuntimeIncarnations.add(oldRuntime);
+    }
     final daemonReplaced =
-        old.daemonProcessId != null && old.daemonProcessId != processId;
+        (old.daemonProcessId != null && old.daemonProcessId != processId) ||
+        runtimeChanged;
+    if (daemonReplaced) {
+      return invalidateEventLoop(
+        event: MobileLifecycleEvent.nativeRuntimeStarted,
+        advanceAppEpoch: false,
+        daemonProcessId: processId,
+        clearDaemonProcessId: processId == null && old.daemonProcessId != null,
+        daemonRuntimeIncarnation: runtimeIncarnation,
+        clearDaemonRuntimeIncarnation:
+            runtimeIncarnation == null && oldRuntime != null,
+        daemonRevision: revision,
+      );
+    }
     return _advance(
       MobileLifecycleEvent.nativeRuntimeStarted,
-      eventLoopGeneration: daemonReplaced ? old.eventLoopGeneration + 1 : null,
       daemonProcessId: processId,
       clearDaemonProcessId: processId == null && old.daemonProcessId != null,
+      daemonRuntimeIncarnation: runtimeIncarnation,
+      clearDaemonRuntimeIncarnation:
+          runtimeIncarnation == null && oldRuntime != null,
       daemonRevision: revision,
     );
   }
@@ -359,11 +445,10 @@ class MobileLifecycleCoordinator {
         ),
       );
     }
-    return _advance(
-      MobileLifecycleEvent.bridgeAttached,
+    return invalidateEventLoop(
+      event: MobileLifecycleEvent.bridgeAttached,
+      advanceAppEpoch: true,
       bridgeIncarnation: bridgeIncarnation,
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
     );
   }
 
@@ -379,11 +464,10 @@ class MobileLifecycleCoordinator {
 
   void dispose() {
     if (_disposed) return;
+    // Invalidate first so every in-flight operation observes the same
+    // generation fence; only then make future transitions fail closed.
+    invalidateEventLoop(event: MobileLifecycleEvent.bridgeDetached);
     _disposed = true;
-    _identity = _identity.copyWith(
-      appEpoch: _identity.appEpoch + 1,
-      eventLoopGeneration: _identity.eventLoopGeneration + 1,
-    );
   }
 
   MobileLifecycleTransition _advance(
@@ -392,6 +476,8 @@ class MobileLifecycleCoordinator {
     int? eventLoopGeneration,
     int? daemonProcessId,
     bool clearDaemonProcessId = false,
+    int? daemonRuntimeIncarnation,
+    bool clearDaemonRuntimeIncarnation = false,
     int? daemonRevision,
     int? permissionRequestId,
     int? bridgeIncarnation,
@@ -402,6 +488,8 @@ class MobileLifecycleCoordinator {
       eventLoopGeneration: eventLoopGeneration,
       daemonProcessId: daemonProcessId,
       clearDaemonProcessId: clearDaemonProcessId,
+      daemonRuntimeIncarnation: daemonRuntimeIncarnation,
+      clearDaemonRuntimeIncarnation: clearDaemonRuntimeIncarnation,
       daemonRevision: daemonRevision,
       permissionRequestId: permissionRequestId,
       bridgeIncarnation: bridgeIncarnation,

--- a/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
+++ b/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
@@ -280,10 +280,7 @@ class MobileLifecycleCoordinator {
     }
     _permissionPending = false;
     if (!granted) return onPermissionRevoked();
-    return invalidateEventLoop(
-      event: event,
-      advanceAppEpoch: true,
-    );
+    return invalidateEventLoop(event: event, advanceAppEpoch: true);
   }
 
   MobileLifecycleTransition invalidateDiagnostics() {

--- a/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
+++ b/apps/flutter_client/lib/core/lifecycle/mobile_lifecycle_coordinator.dart
@@ -1,0 +1,445 @@
+import 'dart:collection';
+
+/// The platform-neutral lifecycle vocabulary shared by Flutter and the
+/// checked-in mobile lifecycle contract. Network generations and path
+/// decisions remain daemon-owned.
+enum MobileLifecycleEvent {
+  appBackgrounded('app_backgrounded'),
+  appResumed('app_resumed'),
+  physicalNetworkChanged('physical_network_changed'),
+  vpnPermissionRequestStarted('vpn_permission_request_started'),
+  vpnPermissionRevoked('vpn_permission_revoked'),
+  vpnPermissionGranted('vpn_permission_granted'),
+  vpnStartRequested('vpn_start_requested'),
+  explicitStopRequested('explicit_stop_requested'),
+  activityRecreated('activity_recreated'),
+  serviceRecreated('service_recreated'),
+  bridgeAttached('bridge_attached'),
+  bridgeDetached('bridge_detached'),
+  nativeRuntimeStarted('native_runtime_started'),
+  nativeRuntimeStopped('native_runtime_stopped'),
+  nativeMonitorCallback('native_monitor_callback'),
+  automaticRestartScheduled('automatic_restart_scheduled'),
+  automaticRestartRejected('automatic_restart_rejected'),
+  controlDisconnected('control_disconnected'),
+  controlReconnected('control_reconnected'),
+  candidateRefreshStarted('candidate_refresh_started'),
+  relayRetained('relay_retained'),
+  directReconfirmed('direct_reconfirmed');
+
+  const MobileLifecycleEvent(this.wireName);
+
+  final String wireName;
+}
+
+enum MobileLifecycleOutcome {
+  applied('applied'),
+  duplicate('duplicate'),
+  staleRejected('stale_rejected'),
+  superseded('superseded'),
+  failed('failed');
+
+  const MobileLifecycleOutcome(this.wireName);
+
+  final String wireName;
+}
+
+/// Identity fields are optional because each layer owns only the fields it
+/// can authoritatively advance.
+class MobileLifecycleIdentity {
+  const MobileLifecycleIdentity({
+    this.appEpoch = 0,
+    this.eventLoopGeneration = 0,
+    this.daemonProcessId,
+    this.daemonRevision = 0,
+    this.permissionRequestId,
+    this.activityIncarnation,
+    this.engineIncarnation,
+    this.serviceIncarnation,
+    this.automaticRestartGeneration,
+    this.bridgeIncarnation,
+    this.networkGeneration,
+    this.candidateEpoch,
+    this.socketPublicationGeneration,
+    this.controlConnectionGeneration,
+    this.peerSessionGeneration,
+    this.relayConnectionId,
+    this.directValidationOwner,
+    this.traceId,
+  });
+
+  final int appEpoch;
+  final int eventLoopGeneration;
+  final int? daemonProcessId;
+  final int daemonRevision;
+  final int? permissionRequestId;
+  final int? activityIncarnation;
+  final int? engineIncarnation;
+  final int? serviceIncarnation;
+  final int? automaticRestartGeneration;
+  final int? bridgeIncarnation;
+  final int? networkGeneration;
+  final int? candidateEpoch;
+  final int? socketPublicationGeneration;
+  final int? controlConnectionGeneration;
+  final int? peerSessionGeneration;
+  final int? relayConnectionId;
+  final String? directValidationOwner;
+  final String? traceId;
+
+  MobileLifecycleIdentity copyWith({
+    int? appEpoch,
+    int? eventLoopGeneration,
+    int? daemonProcessId,
+    bool clearDaemonProcessId = false,
+    int? daemonRevision,
+    int? permissionRequestId,
+    int? activityIncarnation,
+    int? engineIncarnation,
+    int? serviceIncarnation,
+    int? automaticRestartGeneration,
+    int? bridgeIncarnation,
+    int? networkGeneration,
+    int? candidateEpoch,
+    int? socketPublicationGeneration,
+    int? controlConnectionGeneration,
+    int? peerSessionGeneration,
+    int? relayConnectionId,
+    String? directValidationOwner,
+    String? traceId,
+  }) {
+    return MobileLifecycleIdentity(
+      appEpoch: appEpoch ?? this.appEpoch,
+      eventLoopGeneration: eventLoopGeneration ?? this.eventLoopGeneration,
+      daemonProcessId: clearDaemonProcessId
+          ? null
+          : daemonProcessId ?? this.daemonProcessId,
+      daemonRevision: daemonRevision ?? this.daemonRevision,
+      permissionRequestId: permissionRequestId ?? this.permissionRequestId,
+      activityIncarnation: activityIncarnation ?? this.activityIncarnation,
+      engineIncarnation: engineIncarnation ?? this.engineIncarnation,
+      serviceIncarnation: serviceIncarnation ?? this.serviceIncarnation,
+      automaticRestartGeneration:
+          automaticRestartGeneration ?? this.automaticRestartGeneration,
+      bridgeIncarnation: bridgeIncarnation ?? this.bridgeIncarnation,
+      networkGeneration: networkGeneration ?? this.networkGeneration,
+      candidateEpoch: candidateEpoch ?? this.candidateEpoch,
+      socketPublicationGeneration:
+          socketPublicationGeneration ?? this.socketPublicationGeneration,
+      controlConnectionGeneration:
+          controlConnectionGeneration ?? this.controlConnectionGeneration,
+      peerSessionGeneration:
+          peerSessionGeneration ?? this.peerSessionGeneration,
+      relayConnectionId: relayConnectionId ?? this.relayConnectionId,
+      directValidationOwner:
+          directValidationOwner ?? this.directValidationOwner,
+      traceId: traceId ?? this.traceId,
+    );
+  }
+
+  Map<String, Object> toJson() {
+    final fields = <String, Object>{
+      'app_epoch': appEpoch,
+      'event_loop_generation': eventLoopGeneration,
+      'daemon_revision': daemonRevision,
+    };
+    void add(String key, Object? value) {
+      if (value != null) fields[key] = value;
+    }
+
+    add('daemon_process_id', daemonProcessId);
+    add('permission_request_id', permissionRequestId);
+    add('activity_incarnation', activityIncarnation);
+    add('engine_incarnation', engineIncarnation);
+    add('service_incarnation', serviceIncarnation);
+    add('automatic_restart_generation', automaticRestartGeneration);
+    add('bridge_incarnation', bridgeIncarnation);
+    add('network_generation', networkGeneration);
+    add('candidate_epoch', candidateEpoch);
+    add('socket_publication_generation', socketPublicationGeneration);
+    add('control_connection_generation', controlConnectionGeneration);
+    add('peer_session_generation', peerSessionGeneration);
+    add('relay_connection_id', relayConnectionId);
+    add('direct_validation_owner', directValidationOwner);
+    add('trace_id', traceId);
+    return UnmodifiableMapView(fields);
+  }
+}
+
+class MobileLifecycleTransition {
+  const MobileLifecycleTransition({
+    required this.event,
+    required this.outcome,
+    required this.oldIdentity,
+    required this.newIdentity,
+  });
+
+  final MobileLifecycleEvent event;
+  final MobileLifecycleOutcome outcome;
+  final MobileLifecycleIdentity oldIdentity;
+  final MobileLifecycleIdentity newIdentity;
+}
+
+/// Coordinates app, diagnostics, permission and bridge identity at the
+/// Flutter boundary without duplicating the daemon's path state machine.
+class MobileLifecycleCoordinator {
+  MobileLifecycleCoordinator()
+    : _identity = const MobileLifecycleIdentity(),
+      _foreground = true;
+
+  MobileLifecycleIdentity _identity;
+  bool _foreground;
+  bool _disposed = false;
+  bool _permissionRevoked = false;
+  bool _permissionPending = false;
+  final _retiredDaemonProcessIds = <int>{};
+  MobileLifecycleTransition? _lastTransition;
+
+  MobileLifecycleIdentity get identity => _identity;
+  int get appEpoch => _identity.appEpoch;
+  int get eventLoopGeneration => _identity.eventLoopGeneration;
+  bool get isForeground => _foreground;
+  bool get isDisposed => _disposed;
+  MobileLifecycleTransition? get lastTransition => _lastTransition;
+
+  MobileLifecycleTransition onAppBackgrounded() {
+    if (_disposed) return _failed(MobileLifecycleEvent.appBackgrounded);
+    if (!_foreground) return _duplicate(MobileLifecycleEvent.appBackgrounded);
+    _foreground = false;
+    return _advance(
+      MobileLifecycleEvent.appBackgrounded,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition onAppResumed() {
+    if (_disposed) return _failed(MobileLifecycleEvent.appResumed);
+    if (_foreground) return _duplicate(MobileLifecycleEvent.appResumed);
+    _foreground = true;
+    return _advance(
+      MobileLifecycleEvent.appResumed,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition beginPermissionRequest() {
+    if (_disposed) {
+      return _failed(MobileLifecycleEvent.vpnPermissionRequestStarted);
+    }
+    if (_permissionPending) {
+      return _failed(MobileLifecycleEvent.vpnPermissionRequestStarted);
+    }
+    final nextRequest = (_identity.permissionRequestId ?? 0) + 1;
+    _permissionRevoked = false;
+    _permissionPending = true;
+    return _advance(
+      MobileLifecycleEvent.vpnPermissionRequestStarted,
+      permissionRequestId: nextRequest,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition onPermissionRevoked() {
+    if (_disposed) return _failed(MobileLifecycleEvent.vpnPermissionRevoked);
+    if (_permissionRevoked) {
+      return _duplicate(MobileLifecycleEvent.vpnPermissionRevoked);
+    }
+    _permissionRevoked = true;
+    _permissionPending = false;
+    return _advance(
+      MobileLifecycleEvent.vpnPermissionRevoked,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition completePermissionRequest({
+    required int requestId,
+    required bool granted,
+  }) {
+    final event = granted
+        ? MobileLifecycleEvent.vpnPermissionGranted
+        : MobileLifecycleEvent.vpnPermissionRevoked;
+    if (_disposed) return _failed(event);
+    if (_permissionRevoked ||
+        !_permissionPending ||
+        requestId != _identity.permissionRequestId) {
+      return _record(
+        MobileLifecycleTransition(
+          event: event,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: _identity,
+          newIdentity: _identity,
+        ),
+      );
+    }
+    _permissionPending = false;
+    if (!granted) return onPermissionRevoked();
+    return _advance(
+      event,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition invalidateDiagnostics() {
+    if (_disposed) return _failed(MobileLifecycleEvent.bridgeDetached);
+    return _advance(
+      MobileLifecycleEvent.bridgeDetached,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition observeDaemon({
+    required int? processId,
+    required int revision,
+  }) {
+    if (_disposed) return _failed(MobileLifecycleEvent.nativeRuntimeStarted);
+    final old = _identity;
+    final sameProcess = old.daemonProcessId == processId;
+    if (sameProcess && revision < old.daemonRevision) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.nativeRuntimeStarted,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: old,
+          newIdentity: old,
+        ),
+      );
+    }
+    if (sameProcess && revision == old.daemonRevision) {
+      return _duplicate(MobileLifecycleEvent.nativeRuntimeStarted);
+    }
+    if (!sameProcess &&
+        processId != null &&
+        _retiredDaemonProcessIds.contains(processId)) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.nativeRuntimeStarted,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: old,
+          newIdentity: old,
+        ),
+      );
+    }
+    if (!sameProcess && old.daemonProcessId != null) {
+      _retiredDaemonProcessIds.add(old.daemonProcessId!);
+    }
+    final daemonReplaced =
+        old.daemonProcessId != null && old.daemonProcessId != processId;
+    return _advance(
+      MobileLifecycleEvent.nativeRuntimeStarted,
+      eventLoopGeneration: daemonReplaced ? old.eventLoopGeneration + 1 : null,
+      daemonProcessId: processId,
+      clearDaemonProcessId: processId == null && old.daemonProcessId != null,
+      daemonRevision: revision,
+    );
+  }
+
+  MobileLifecycleTransition observeBridge(int? bridgeIncarnation) {
+    if (_disposed) return _failed(MobileLifecycleEvent.bridgeAttached);
+    if (bridgeIncarnation == null) {
+      return _failed(MobileLifecycleEvent.bridgeAttached);
+    }
+    if (_identity.bridgeIncarnation == bridgeIncarnation) {
+      return _duplicate(MobileLifecycleEvent.bridgeAttached);
+    }
+    if (_identity.bridgeIncarnation != null &&
+        bridgeIncarnation < _identity.bridgeIncarnation!) {
+      return _record(
+        MobileLifecycleTransition(
+          event: MobileLifecycleEvent.bridgeAttached,
+          outcome: MobileLifecycleOutcome.staleRejected,
+          oldIdentity: _identity,
+          newIdentity: _identity,
+        ),
+      );
+    }
+    return _advance(
+      MobileLifecycleEvent.bridgeAttached,
+      bridgeIncarnation: bridgeIncarnation,
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  bool acceptsEventLoop({required int appEpoch, required int generation}) {
+    return !_disposed &&
+        _foreground &&
+        _identity.appEpoch == appEpoch &&
+        _identity.eventLoopGeneration == generation;
+  }
+
+  bool acceptsAppEpoch(int appEpoch) =>
+      !_disposed && _identity.appEpoch == appEpoch;
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _identity = _identity.copyWith(
+      appEpoch: _identity.appEpoch + 1,
+      eventLoopGeneration: _identity.eventLoopGeneration + 1,
+    );
+  }
+
+  MobileLifecycleTransition _advance(
+    MobileLifecycleEvent event, {
+    int? appEpoch,
+    int? eventLoopGeneration,
+    int? daemonProcessId,
+    bool clearDaemonProcessId = false,
+    int? daemonRevision,
+    int? permissionRequestId,
+    int? bridgeIncarnation,
+  }) {
+    final old = _identity;
+    _identity = _identity.copyWith(
+      appEpoch: appEpoch,
+      eventLoopGeneration: eventLoopGeneration,
+      daemonProcessId: daemonProcessId,
+      clearDaemonProcessId: clearDaemonProcessId,
+      daemonRevision: daemonRevision,
+      permissionRequestId: permissionRequestId,
+      bridgeIncarnation: bridgeIncarnation,
+    );
+    return _record(
+      MobileLifecycleTransition(
+        event: event,
+        outcome: MobileLifecycleOutcome.applied,
+        oldIdentity: old,
+        newIdentity: _identity,
+      ),
+    );
+  }
+
+  MobileLifecycleTransition _duplicate(MobileLifecycleEvent event) {
+    return _record(
+      MobileLifecycleTransition(
+        event: event,
+        outcome: MobileLifecycleOutcome.duplicate,
+        oldIdentity: _identity,
+        newIdentity: _identity,
+      ),
+    );
+  }
+
+  MobileLifecycleTransition _failed(MobileLifecycleEvent event) {
+    return _record(
+      MobileLifecycleTransition(
+        event: event,
+        outcome: MobileLifecycleOutcome.failed,
+        oldIdentity: _identity,
+        newIdentity: _identity,
+      ),
+    );
+  }
+
+  MobileLifecycleTransition _record(MobileLifecycleTransition transition) {
+    _lastTransition = transition;
+    return transition;
+  }
+}

--- a/apps/flutter_client/lib/core/models/diagnostics_models/snapshot.dart
+++ b/apps/flutter_client/lib/core/models/diagnostics_models/snapshot.dart
@@ -5,6 +5,7 @@ class DiagnosticsSnapshot {
     required this.raw,
     required this.version,
     required this.processId,
+    this.runtimeIncarnation,
     required this.nodeId,
     required this.virtualIp,
     required this.networkId,
@@ -35,6 +36,10 @@ class DiagnosticsSnapshot {
   final int contractVersion;
   final String version;
   final int? processId;
+
+  /// Additive native bridge/runtime identity. Android may restart Rust inside
+  /// the same PID, with both revision and uptime reset to lower values.
+  final int? runtimeIncarnation;
   final String nodeId;
   final String virtualIp;
   final String networkId;
@@ -76,6 +81,7 @@ class DiagnosticsSnapshot {
       contractVersion: _contractVersion(json),
       version: _string(json['version']),
       processId: _intOrNull(json['process_id']),
+      runtimeIncarnation: _intOrNull(json['runtime_incarnation']),
       nodeId: _string(json['node_id']),
       virtualIp: _string(json['virtual_ip']),
       networkId: _string(json['network_id']),

--- a/apps/flutter_client/lib/core/state/status_store.dart
+++ b/apps/flutter_client/lib/core/state/status_store.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart' show AppLifecycleState;
 
 import '../api/diagnostics_api.dart';
 import '../daemon/daemon_controller.dart';
+import '../lifecycle/mobile_lifecycle_coordinator.dart';
 import '../models/diagnostics_models.dart';
 import 'settings_store.dart';
 
@@ -14,6 +15,7 @@ class StatusStore extends ChangeNotifier {
     required this.settingsStore,
     required this.diagnosticsApi,
     DaemonController? daemonController,
+    MobileLifecycleCoordinator? lifecycleCoordinator,
     this.autoRefreshInterval = defaultActivePollingInterval,
     this.backgroundRefreshInterval = defaultBackgroundPollingInterval,
     this.maxSnapshotAge = defaultMaxSnapshotAge,
@@ -23,7 +25,9 @@ class StatusStore extends ChangeNotifier {
     this.startupCatalogRefreshInterval = defaultStartupCatalogRefreshInterval,
     this.routeVerificationInterval = Duration.zero,
     this.metricsUpdateInterval = defaultMetricsUpdateInterval,
-  }) : daemonController =
+  }) : lifecycleCoordinator =
+           lifecycleCoordinator ?? MobileLifecycleCoordinator(),
+       daemonController =
            daemonController ??
            DaemonController(
              diagnosticsApi: diagnosticsApi,
@@ -67,6 +71,7 @@ class StatusStore extends ChangeNotifier {
 
   final SettingsStore settingsStore;
   final DiagnosticsApi diagnosticsApi;
+  final MobileLifecycleCoordinator lifecycleCoordinator;
   final DaemonController daemonController;
   final Duration autoRefreshInterval;
   final Duration backgroundRefreshInterval;
@@ -278,6 +283,7 @@ class StatusStore extends ChangeNotifier {
     required bool enabled,
     bool refreshImmediately = false,
   }) {
+    if (_disposed) return;
     if (_autoRefreshEnabled == enabled) {
       if (enabled && refreshImmediately) {
         unawaited(refreshUntilPeerCatalogSettled(silent: true));
@@ -303,8 +309,12 @@ class StatusStore extends ChangeNotifier {
 
   void updateAppLifecycleState(AppLifecycleState state) {
     final appInForeground = state == AppLifecycleState.resumed;
-    if (_appInForeground == appInForeground) return;
+    final transition = appInForeground
+        ? lifecycleCoordinator.onAppResumed()
+        : lifecycleCoordinator.onAppBackgrounded();
+    if (transition.outcome != MobileLifecycleOutcome.applied) return;
     _appInForeground = appInForeground;
+    _eventLoopGeneration = transition.newIdentity.eventLoopGeneration;
     if (!appInForeground) {
       // A long-poll request belongs to the physical network and app epoch in
       // which it started. Invalidate it before Android/iOS suspends sockets so
@@ -327,8 +337,37 @@ class StatusStore extends ChangeNotifier {
     // Revalidate process identity, route/path state and the peer catalog before
     // opening a new event long poll. This creates an explicit resume boundary
     // instead of carrying a pre-suspend cursor across a network hand-off.
+    var appEpoch = lifecycleCoordinator.appEpoch;
+    try {
+      final androidStatus = await daemonController.androidStatus();
+      if (!lifecycleCoordinator.acceptsAppEpoch(appEpoch) ||
+          !_appInForeground) {
+        return;
+      }
+      final bridgeIncarnation = androidStatus?.bridgeIncarnation;
+      if (bridgeIncarnation != null) {
+        final transition = lifecycleCoordinator.observeBridge(
+          bridgeIncarnation,
+        );
+        if (transition.outcome == MobileLifecycleOutcome.staleRejected) {
+          return;
+        }
+        appEpoch = lifecycleCoordinator.appEpoch;
+        _eventLoopGeneration = lifecycleCoordinator.eventLoopGeneration;
+      }
+    } catch (_) {
+      // Android status is additive diagnostics. A temporarily unavailable
+      // MethodChannel must not prevent the authoritative HTTP refresh.
+    }
+    if (!lifecycleCoordinator.acceptsAppEpoch(appEpoch) || !_appInForeground) {
+      return;
+    }
     await refresh(silent: true);
-    if (_disposed || !_autoRefreshEnabled || !_appInForeground) return;
+    if (!lifecycleCoordinator.acceptsAppEpoch(appEpoch) ||
+        !_autoRefreshEnabled ||
+        !_appInForeground) {
+      return;
+    }
     _ensureEventLoop();
   }
 
@@ -357,7 +396,7 @@ class StatusStore extends ChangeNotifier {
     final generation = _eventLoopGeneration;
     final url = settingsStore.settings.diagnosticsUrl;
     late final Future<void> loop;
-    loop = _runEventLoop(url, generation);
+    loop = _runEventLoop(url, generation, lifecycleCoordinator.appEpoch);
     _eventLoopFuture = loop;
     unawaited(
       loop.whenComplete(() {
@@ -374,13 +413,17 @@ class StatusStore extends ChangeNotifier {
     );
   }
 
-  Future<void> _runEventLoop(String url, int generation) async {
+  Future<void> _runEventLoop(String url, int generation, int appEpoch) async {
     var cursor = _snapshot?.revision ?? 0;
     var processId = _snapshot?.processId;
     while (!_disposed &&
         _autoRefreshEnabled &&
         _appInForeground &&
         generation == _eventLoopGeneration &&
+        lifecycleCoordinator.acceptsEventLoop(
+          appEpoch: appEpoch,
+          generation: generation,
+        ) &&
         url == settingsStore.settings.diagnosticsUrl &&
         _snapshot != null) {
       EventsResponse response;
@@ -391,13 +434,24 @@ class StatusStore extends ChangeNotifier {
           processId: processId,
         );
       } catch (_) {
-        if (_disposed || generation != _eventLoopGeneration) return;
+        if (_disposed ||
+            generation != _eventLoopGeneration ||
+            !lifecycleCoordinator.acceptsEventLoop(
+              appEpoch: appEpoch,
+              generation: generation,
+            )) {
+          return;
+        }
         await Future<void>.delayed(const Duration(seconds: 1));
         continue;
       }
       if (_disposed ||
           !_autoRefreshEnabled ||
           generation != _eventLoopGeneration ||
+          !lifecycleCoordinator.acceptsEventLoop(
+            appEpoch: appEpoch,
+            generation: generation,
+          ) ||
           url != settingsStore.settings.diagnosticsUrl) {
         return;
       }
@@ -428,7 +482,14 @@ class StatusStore extends ChangeNotifier {
           hasChange) {
         final beforeRevision = current.revision;
         await _refreshAutomatically();
-        if (_disposed || generation != _eventLoopGeneration) return;
+        if (_disposed ||
+            generation != _eventLoopGeneration ||
+            !lifecycleCoordinator.acceptsEventLoop(
+              appEpoch: appEpoch,
+              generation: generation,
+            )) {
+          return;
+        }
         final refreshed = _snapshot;
         if (refreshed == null) return;
         processId = refreshed.processId;
@@ -491,6 +552,7 @@ class StatusStore extends ChangeNotifier {
   /// Refreshes the daemon snapshot. Automatic polling passes [silent] so the
   /// UI remains stable; an explicit user refresh keeps its progress feedback.
   Future<void> refresh({bool silent = false}) {
+    if (_disposed) return Future<void>.value();
     _refreshPending = true;
     final activeRefresh = _refreshFuture;
     if (activeRefresh != null) {
@@ -541,12 +603,15 @@ class StatusStore extends ChangeNotifier {
     required bool throttleMetrics,
   }) async {
     final stopwatch = Stopwatch()..start();
+    final appEpoch = lifecycleCoordinator.appEpoch;
+    bool acceptsLifecycle() => lifecycleCoordinator.acceptsAppEpoch(appEpoch);
     try {
       final health = await diagnosticsApi.fetchHealth(url);
       if (generation != _refreshGeneration) {
         _refreshPending = true;
         return;
       }
+      if (!acceptsLifecycle()) return;
 
       _lastHealthError = null;
       _lastStatusError = null;
@@ -569,6 +634,7 @@ class StatusStore extends ChangeNotifier {
           _refreshPending = true;
           return;
         }
+        if (!acceptsLifecycle()) return;
         final fetchedAt = DateTime.now();
         _statusSnapshotTimedOut = false;
         if (!_snapshotCanReplace(snapshot, _snapshot)) {
@@ -580,17 +646,50 @@ class StatusStore extends ChangeNotifier {
           _lastFetchedAt = fetchedAt;
           return;
         }
+        var routeHealthy = _routeHealthy;
+        DateTime? routeVerifiedAt;
+        if (_shouldVerifyRoutes(fetchedAt)) {
+          try {
+            final routes = await diagnosticsApi.verifyRoutes(url);
+            if (!acceptsLifecycle()) return;
+            routeHealthy = routes.healthy;
+          } catch (_) {
+            if (!acceptsLifecycle()) return;
+            routeHealthy = false;
+          } finally {
+            if (acceptsLifecycle()) {
+              routeVerifiedAt = DateTime.now();
+            }
+          }
+        }
+        if (!acceptsLifecycle()) return;
+        final daemonTransition = lifecycleCoordinator.observeDaemon(
+          processId: snapshot.processId,
+          revision: snapshot.revision,
+        );
+        if (daemonTransition.outcome == MobileLifecycleOutcome.staleRejected ||
+            daemonTransition.outcome == MobileLifecycleOutcome.failed) {
+          _lastError = null;
+          _lastFetchedAt = fetchedAt;
+          return;
+        }
+        if (daemonTransition.outcome == MobileLifecycleOutcome.applied) {
+          _eventLoopGeneration =
+              daemonTransition.newIdentity.eventLoopGeneration;
+          if (daemonTransition.oldIdentity.daemonProcessId !=
+              snapshot.processId) {
+            // A process replacement invalidates the old event-loop slot even
+            // when the replacement reports a lower revision. Its cursor must
+            // be rebuilt from this committed snapshot.
+            _eventLoopFuture = null;
+          }
+        }
         _updatePeerTrafficRates(snapshot, fetchedAt, throttle: throttleMetrics);
         recordPeerPresence(snapshot.peers);
         _snapshot = snapshot;
-        if (_shouldVerifyRoutes(fetchedAt)) {
-          try {
-            _routeHealthy = (await diagnosticsApi.verifyRoutes(url)).healthy;
-          } catch (_) {
-            _routeHealthy = false;
-          } finally {
-            _lastRouteVerificationAt = DateTime.now();
-          }
+        _routeHealthy = routeHealthy;
+        if (routeVerifiedAt != null) {
+          _lastRouteVerificationAt = routeVerifiedAt;
         }
         _lastError = null;
         _lastFetchedAt = fetchedAt;
@@ -609,6 +708,7 @@ class StatusStore extends ChangeNotifier {
           _refreshPending = true;
           return;
         }
+        if (!acceptsLifecycle()) return;
         final snapshotTimedOut =
             error is DiagnosticsApiException &&
             error.reasonCode == 'status_snapshot_timeout';
@@ -632,6 +732,7 @@ class StatusStore extends ChangeNotifier {
         _refreshPending = true;
         return;
       }
+      if (!acceptsLifecycle()) return;
       _healthReachable = false;
       _statusSnapshotTimedOut = false;
       _clearSnapshot();
@@ -641,7 +742,7 @@ class StatusStore extends ChangeNotifier {
       _lastFetchedAt = DateTime.now();
     } finally {
       stopwatch.stop();
-      if (generation == _refreshGeneration) {
+      if (generation == _refreshGeneration && acceptsLifecycle()) {
         _lastRequestDuration = stopwatch.elapsed;
       }
     }
@@ -763,6 +864,7 @@ class StatusStore extends ChangeNotifier {
     bool skipInitialRefresh = false,
     bool silent = false,
   }) async {
+    if (_disposed) return;
     // A daemon can answer public /health before its per-process diagnostics
     // token is visible to the client. Keep the initial status-auth race out
     // of Home while the same background refresh loop retries it. Do not mask
@@ -780,7 +882,8 @@ class StatusStore extends ChangeNotifier {
       var stableCatalogCount = 0;
       var previousSignature = _peerCatalogSignature(_snapshot);
       while (refreshCount < _startupCatalogMaxRefreshes &&
-          DateTime.now().isBefore(deadline)) {
+          DateTime.now().isBefore(deadline) &&
+          !_disposed) {
         if (startupCatalogRefreshInterval > Duration.zero) {
           await Future<void>.delayed(startupCatalogRefreshInterval);
         } else {
@@ -995,7 +1098,9 @@ class StatusStore extends ChangeNotifier {
 
   @override
   void dispose() {
+    if (_disposed) return;
     _disposed = true;
+    lifecycleCoordinator.dispose();
     _eventLoopGeneration += 1;
     _timer?.cancel();
     _staleTimer?.cancel();

--- a/apps/flutter_client/lib/core/state/status_store.dart
+++ b/apps/flutter_client/lib/core/state/status_store.dart
@@ -86,7 +86,6 @@ class StatusStore extends ChangeNotifier {
   Timer? _timer;
   Timer? _staleTimer;
   Future<void>? _eventLoopFuture;
-  var _eventLoopGeneration = 0;
   var _disposed = false;
   DiagnosticsSnapshot? _snapshot;
   var _healthReachable = false;
@@ -148,6 +147,7 @@ class StatusStore extends ChangeNotifier {
   bool get daemonBusy => _daemonBusy;
   bool get autoRefreshEnabled => _autoRefreshEnabled;
   bool get appInForeground => _appInForeground;
+  int get eventLoopGeneration => lifecycleCoordinator.eventLoopGeneration;
   bool get snapshotStale => _snapshotStale;
   bool get statusSnapshotTimedOut => _statusSnapshotTimedOut;
 
@@ -299,7 +299,11 @@ class StatusStore extends ChangeNotifier {
     if (enabled) {
       _ensureEventLoop();
     } else {
-      _eventLoopGeneration += 1;
+      // The coordinator owns the only event-loop generation. Clearing the
+      // slot lets enable start a fresh poll immediately; the old future is
+      // still fenced by the coordinator generation when it completes.
+      lifecycleCoordinator.invalidateEventLoop();
+      _eventLoopFuture = null;
     }
     if (enabled && refreshImmediately) {
       unawaited(refreshUntilPeerCatalogSettled(silent: true));
@@ -314,12 +318,10 @@ class StatusStore extends ChangeNotifier {
         : lifecycleCoordinator.onAppBackgrounded();
     if (transition.outcome != MobileLifecycleOutcome.applied) return;
     _appInForeground = appInForeground;
-    _eventLoopGeneration = transition.newIdentity.eventLoopGeneration;
     if (!appInForeground) {
       // A long-poll request belongs to the physical network and app epoch in
       // which it started. Invalidate it before Android/iOS suspends sockets so
       // a late Wi-Fi/cellular response cannot mutate the resumed snapshot.
-      _eventLoopGeneration += 1;
       // Detach the slot immediately. The in-flight HTTP future is still
       // bounded by its request timeout, but its completion is generation-
       // fenced and `identical` will be false, so resume can start a fresh poll
@@ -353,7 +355,6 @@ class StatusStore extends ChangeNotifier {
           return;
         }
         appEpoch = lifecycleCoordinator.appEpoch;
-        _eventLoopGeneration = lifecycleCoordinator.eventLoopGeneration;
       }
     } catch (_) {
       // Android status is additive diagnostics. A temporarily unavailable
@@ -393,7 +394,7 @@ class StatusStore extends ChangeNotifier {
         _eventLoopFuture != null) {
       return;
     }
-    final generation = _eventLoopGeneration;
+    final generation = lifecycleCoordinator.eventLoopGeneration;
     final url = settingsStore.settings.diagnosticsUrl;
     late final Future<void> loop;
     loop = _runEventLoop(url, generation, lifecycleCoordinator.appEpoch);
@@ -402,12 +403,11 @@ class StatusStore extends ChangeNotifier {
       loop.whenComplete(() {
         if (identical(_eventLoopFuture, loop)) {
           _eventLoopFuture = null;
-          if (!_disposed &&
-              _autoRefreshEnabled &&
-              _appInForeground &&
-              _snapshot != null) {
-            scheduleMicrotask(_ensureEventLoop);
-          }
+          // A current loop normally remains alive until one of the shared
+          // invalidation fences changes. Do not schedule a microtask here:
+          // an immediate/empty test response must not turn completion into a
+          // zero-delay polling spin. The next refresh or explicit enable will
+          // re-arm the loop when the state is still eligible.
         }
       }),
     );
@@ -419,7 +419,7 @@ class StatusStore extends ChangeNotifier {
     while (!_disposed &&
         _autoRefreshEnabled &&
         _appInForeground &&
-        generation == _eventLoopGeneration &&
+        generation == lifecycleCoordinator.eventLoopGeneration &&
         lifecycleCoordinator.acceptsEventLoop(
           appEpoch: appEpoch,
           generation: generation,
@@ -435,7 +435,7 @@ class StatusStore extends ChangeNotifier {
         );
       } catch (_) {
         if (_disposed ||
-            generation != _eventLoopGeneration ||
+            generation != lifecycleCoordinator.eventLoopGeneration ||
             !lifecycleCoordinator.acceptsEventLoop(
               appEpoch: appEpoch,
               generation: generation,
@@ -447,7 +447,7 @@ class StatusStore extends ChangeNotifier {
       }
       if (_disposed ||
           !_autoRefreshEnabled ||
-          generation != _eventLoopGeneration ||
+          generation != lifecycleCoordinator.eventLoopGeneration ||
           !lifecycleCoordinator.acceptsEventLoop(
             appEpoch: appEpoch,
             generation: generation,
@@ -483,7 +483,7 @@ class StatusStore extends ChangeNotifier {
         final beforeRevision = current.revision;
         await _refreshAutomatically();
         if (_disposed ||
-            generation != _eventLoopGeneration ||
+            generation != lifecycleCoordinator.eventLoopGeneration ||
             !lifecycleCoordinator.acceptsEventLoop(
               appEpoch: appEpoch,
               generation: generation,
@@ -501,6 +501,11 @@ class StatusStore extends ChangeNotifier {
           // snapshot; the next long poll/refetch will converge.
           await Future<void>.delayed(const Duration(milliseconds: 250));
         }
+      } else {
+        // A machine-facing fake or a daemon that returns an empty poll
+        // immediately is still a valid response. Bound the retry cadence so
+        // an active loop cannot consume the microtask queue.
+        await Future<void>.delayed(const Duration(milliseconds: 250));
       }
     }
   }
@@ -665,6 +670,7 @@ class StatusStore extends ChangeNotifier {
         if (!acceptsLifecycle()) return;
         final daemonTransition = lifecycleCoordinator.observeDaemon(
           processId: snapshot.processId,
+          runtimeIncarnation: snapshot.runtimeIncarnation,
           revision: snapshot.revision,
         );
         if (daemonTransition.outcome == MobileLifecycleOutcome.staleRejected ||
@@ -674,10 +680,10 @@ class StatusStore extends ChangeNotifier {
           return;
         }
         if (daemonTransition.outcome == MobileLifecycleOutcome.applied) {
-          _eventLoopGeneration =
-              daemonTransition.newIdentity.eventLoopGeneration;
           if (daemonTransition.oldIdentity.daemonProcessId !=
-              snapshot.processId) {
+                  snapshot.processId ||
+              daemonTransition.oldIdentity.daemonRuntimeIncarnation !=
+                  snapshot.runtimeIncarnation) {
             // A process replacement invalidates the old event-loop slot even
             // when the replacement reports a lower revision. Its cursor must
             // be rebuilt from this committed snapshot.
@@ -842,6 +848,19 @@ class StatusStore extends ChangeNotifier {
         currentProcess != null &&
         candidateProcess != currentProcess) {
       return true;
+    }
+
+    // Android can replace the embedded Rust runtime while retaining the same
+    // OS process.  Runtime incarnation is authoritative for that case: the
+    // replacement may reset both revision and uptime, while a delayed
+    // response from the retired runtime must never be allowed to replace it.
+    final candidateRuntime = candidate.runtimeIncarnation;
+    final currentRuntime = current.runtimeIncarnation;
+    if (candidateRuntime != null && currentRuntime != null) {
+      if (candidateRuntime > currentRuntime) return true;
+      if (candidateRuntime < currentRuntime) return false;
+    } else if (currentRuntime != null && candidateRuntime == null) {
+      return false;
     }
 
     // PID reuse is possible. A lower uptime is affirmative evidence of a new
@@ -1079,7 +1098,8 @@ class StatusStore extends ChangeNotifier {
     if (nextDiagnosticsUrl == _lastDiagnosticsUrl) return;
     _lastDiagnosticsUrl = nextDiagnosticsUrl;
     _refreshGeneration += 1;
-    _eventLoopGeneration += 1;
+    lifecycleCoordinator.invalidateEventLoop();
+    _eventLoopFuture = null;
     _refreshPending = true;
     _healthReachable = false;
     _clearSnapshot();
@@ -1101,7 +1121,7 @@ class StatusStore extends ChangeNotifier {
     if (_disposed) return;
     _disposed = true;
     lifecycleCoordinator.dispose();
-    _eventLoopGeneration += 1;
+    _eventLoopFuture = null;
     _timer?.cancel();
     _staleTimer?.cancel();
     _automaticRefreshFuture = null;

--- a/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
@@ -145,35 +145,32 @@ void main() {
     expect(coordinator.onAppResumed().outcome, MobileLifecycleOutcome.failed);
   });
 
-  test(
-    'same PID accepts a newer runtime incarnation with lower revision and uptime',
-    () {
-      final coordinator = MobileLifecycleCoordinator();
-      expect(
-        coordinator
-            .observeDaemon(processId: 1234, runtimeIncarnation: 4, revision: 50)
-            .outcome,
-        MobileLifecycleOutcome.applied,
-      );
-      final replacement = coordinator.observeDaemon(
-        processId: 1234,
-        runtimeIncarnation: 5,
-        revision: 1,
-      );
-      expect(replacement.outcome, MobileLifecycleOutcome.applied);
-      expect(coordinator.identity.daemonRuntimeIncarnation, 5);
-      expect(coordinator.identity.daemonRevision, 1);
+  test('same PID accepts a newer runtime incarnation with lower revision and uptime', () {
+    final coordinator = MobileLifecycleCoordinator();
+    expect(
+      coordinator
+          .observeDaemon(processId: 1234, runtimeIncarnation: 4, revision: 50)
+          .outcome,
+      MobileLifecycleOutcome.applied,
+    );
+    final replacement = coordinator.observeDaemon(
+      processId: 1234,
+      runtimeIncarnation: 5,
+      revision: 1,
+    );
+    expect(replacement.outcome, MobileLifecycleOutcome.applied);
+    expect(coordinator.identity.daemonRuntimeIncarnation, 5);
+    expect(coordinator.identity.daemonRevision, 1);
 
-      final lateOld = coordinator.observeDaemon(
-        processId: 1234,
-        runtimeIncarnation: 4,
-        revision: 51,
-      );
-      expect(lateOld.outcome, MobileLifecycleOutcome.staleRejected);
-      expect(coordinator.identity.daemonRuntimeIncarnation, 5);
-      expect(coordinator.identity.daemonRevision, 1);
-    },
-  );
+    final lateOld = coordinator.observeDaemon(
+      processId: 1234,
+      runtimeIncarnation: 4,
+      revision: 51,
+    );
+    expect(lateOld.outcome, MobileLifecycleOutcome.staleRejected);
+    expect(coordinator.identity.daemonRuntimeIncarnation, 5);
+    expect(coordinator.identity.daemonRevision, 1);
+  });
 
   test('Android transport is injectable at the production boundary', () async {
     final fake = _FakeAndroidVpnTransport();

--- a/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2wlan_flutter_client/core/api/diagnostics_api.dart';
+import 'package:p2wlan_flutter_client/core/daemon/daemon_controller.dart';
+import 'package:p2wlan_flutter_client/core/lifecycle/mobile_lifecycle_coordinator.dart';
+
+void main() {
+  test('Dart vocabulary is checked against the canonical contract', () {
+    final candidates = [
+      File('../../contracts/mobile_lifecycle.json'),
+      File('../contracts/mobile_lifecycle.json'),
+    ];
+    final contractFile = candidates.firstWhere((file) => file.existsSync());
+    final contract = jsonDecode(contractFile.readAsStringSync()) as Map;
+    final eventNames = (contract['events'] as List).cast<String>();
+    final outcomeNames = (contract['outcomes'] as List).cast<String>();
+    expect(
+      MobileLifecycleEvent.values.map((event) => event.wireName).toList(),
+      eventNames,
+    );
+    expect(
+      MobileLifecycleOutcome.values.map((outcome) => outcome.wireName),
+      outcomeNames,
+    );
+    expect(contract['schema_version'], 2);
+  });
+
+  test('background/resume epochs fence late work and duplicate callbacks', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final background = coordinator.onAppBackgrounded();
+    expect(background.outcome, MobileLifecycleOutcome.applied);
+    expect(coordinator.acceptsEventLoop(appEpoch: 0, generation: 0), isFalse);
+    expect(
+      coordinator.onAppBackgrounded().outcome,
+      MobileLifecycleOutcome.duplicate,
+    );
+
+    final resume = coordinator.onAppResumed();
+    expect(resume.outcome, MobileLifecycleOutcome.applied);
+    expect(
+      coordinator.acceptsEventLoop(
+        appEpoch: resume.newIdentity.appEpoch,
+        generation: resume.newIdentity.eventLoopGeneration,
+      ),
+      isTrue,
+    );
+    expect(
+      coordinator.onAppResumed().outcome,
+      MobileLifecycleOutcome.duplicate,
+    );
+  });
+
+  test(
+    'permission revoke rejects the old result and regrant gets a new id',
+    () {
+      final coordinator = MobileLifecycleCoordinator();
+      final request = coordinator.beginPermissionRequest();
+      final requestId = request.newIdentity.permissionRequestId!;
+      expect(
+        coordinator.onPermissionRevoked().outcome,
+        MobileLifecycleOutcome.applied,
+      );
+      expect(
+        coordinator
+            .completePermissionRequest(requestId: requestId, granted: true)
+            .outcome,
+        MobileLifecycleOutcome.staleRejected,
+      );
+
+      final newRequest = coordinator.beginPermissionRequest();
+      expect(
+        newRequest.newIdentity.permissionRequestId,
+        greaterThan(requestId),
+      );
+      expect(
+        coordinator
+            .completePermissionRequest(
+              requestId: newRequest.newIdentity.permissionRequestId!,
+              granted: true,
+            )
+            .outcome,
+        MobileLifecycleOutcome.applied,
+      );
+    },
+  );
+
+  test('concurrent permission request and duplicate completion are fenced', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final request = coordinator.beginPermissionRequest();
+    expect(
+      coordinator.beginPermissionRequest().outcome,
+      MobileLifecycleOutcome.failed,
+    );
+    expect(
+      coordinator
+          .completePermissionRequest(
+            requestId: request.newIdentity.permissionRequestId!,
+            granted: true,
+          )
+          .outcome,
+      MobileLifecycleOutcome.applied,
+    );
+    final generation = coordinator.eventLoopGeneration;
+    expect(
+      coordinator
+          .completePermissionRequest(
+            requestId: request.newIdentity.permissionRequestId!,
+            granted: true,
+          )
+          .outcome,
+      MobileLifecycleOutcome.staleRejected,
+    );
+    expect(coordinator.eventLoopGeneration, generation);
+  });
+
+  test('old process, bridge and disposed callbacks cannot be adopted', () {
+    final coordinator = MobileLifecycleCoordinator();
+    expect(
+      coordinator.observeDaemon(processId: 42, revision: 8).outcome,
+      MobileLifecycleOutcome.applied,
+    );
+    expect(
+      coordinator.observeDaemon(processId: 42, revision: 7).outcome,
+      MobileLifecycleOutcome.staleRejected,
+    );
+    expect(
+      coordinator.observeDaemon(processId: 43, revision: 1).outcome,
+      MobileLifecycleOutcome.applied,
+    );
+    expect(
+      coordinator.observeDaemon(processId: 42, revision: 11).outcome,
+      MobileLifecycleOutcome.staleRejected,
+    );
+    expect(
+      coordinator.observeBridge(4).outcome,
+      MobileLifecycleOutcome.applied,
+    );
+    expect(
+      coordinator.observeBridge(3).outcome,
+      MobileLifecycleOutcome.staleRejected,
+    );
+    coordinator.dispose();
+    expect(coordinator.onAppResumed().outcome, MobileLifecycleOutcome.failed);
+  });
+
+  test('Android transport is injectable at the production boundary', () async {
+    final fake = _FakeAndroidVpnTransport();
+    final diagnosticsApi = DiagnosticsApi();
+    final controller = DaemonController(
+      diagnosticsApi: diagnosticsApi,
+      androidVpnTransport: fake,
+    );
+    addTearDown(diagnosticsApi.close);
+    expect(identical(controller.androidVpnTransport, fake), isTrue);
+    expect(await controller.androidVpnTransport.prepareVpn(), isTrue);
+    expect(await controller.androidVpnTransport.start('{}'), isTrue);
+    expect(await controller.androidVpnTransport.stop(), isTrue);
+    expect(
+      (await controller.androidVpnTransport.status()).bridgeIncarnation,
+      2,
+    );
+  });
+}
+
+class _FakeAndroidVpnTransport implements AndroidVpnTransport {
+  @override
+  Future<bool> prepareVpn() async => true;
+
+  @override
+  Future<bool> start(String requestJson) async => true;
+
+  @override
+  Future<bool> stop() async => true;
+
+  @override
+  Future<AndroidVpnStatus> status() async => const AndroidVpnStatus(
+    serviceRunning: true,
+    nativeRunning: true,
+    nativeReady: true,
+    bridgeIncarnation: 2,
+  );
+}

--- a/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_coordinator_test.dart
@@ -145,6 +145,36 @@ void main() {
     expect(coordinator.onAppResumed().outcome, MobileLifecycleOutcome.failed);
   });
 
+  test(
+    'same PID accepts a newer runtime incarnation with lower revision and uptime',
+    () {
+      final coordinator = MobileLifecycleCoordinator();
+      expect(
+        coordinator
+            .observeDaemon(processId: 1234, runtimeIncarnation: 4, revision: 50)
+            .outcome,
+        MobileLifecycleOutcome.applied,
+      );
+      final replacement = coordinator.observeDaemon(
+        processId: 1234,
+        runtimeIncarnation: 5,
+        revision: 1,
+      );
+      expect(replacement.outcome, MobileLifecycleOutcome.applied);
+      expect(coordinator.identity.daemonRuntimeIncarnation, 5);
+      expect(coordinator.identity.daemonRevision, 1);
+
+      final lateOld = coordinator.observeDaemon(
+        processId: 1234,
+        runtimeIncarnation: 4,
+        revision: 51,
+      );
+      expect(lateOld.outcome, MobileLifecycleOutcome.staleRejected);
+      expect(coordinator.identity.daemonRuntimeIncarnation, 5);
+      expect(coordinator.identity.daemonRevision, 1);
+    },
+  );
+
   test('Android transport is injectable at the production boundary', () async {
     final fake = _FakeAndroidVpnTransport();
     final diagnosticsApi = DiagnosticsApi();

--- a/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
@@ -47,9 +47,7 @@ void main() {
       oldIdentity: oldIdentity,
       newIdentity: transition.newIdentity,
       decision: transition.outcome,
-      invariants: {
-        'resume_refresh_precedes_poll': resumeRefreshPrecedesPoll,
-      },
+      invariants: {'resume_refresh_precedes_poll': resumeRefreshPrecedesPoll},
     );
   });
 
@@ -103,7 +101,11 @@ void main() {
       oldIdentity: oldIdentity,
       newIdentity: revoke.newIdentity,
       decision: late.outcome,
-      invariants: {'pending_permission_invalidated': !coordinator.acceptsAppEpoch(oldIdentity.appEpoch)},
+      invariants: {
+        'pending_permission_invalidated': !coordinator.acceptsAppEpoch(
+          oldIdentity.appEpoch,
+        ),
+      },
     );
   });
 
@@ -118,7 +120,10 @@ void main() {
       granted: true,
     );
     expect(grant.outcome, MobileLifecycleOutcome.applied);
-    expect(second.newIdentity.permissionRequestId, greaterThan(first.newIdentity.permissionRequestId!));
+    expect(
+      second.newIdentity.permissionRequestId,
+      greaterThan(first.newIdentity.permissionRequestId!),
+    );
     _record(
       scenarioId: 'ML-07',
       exactTestId: _testId('ML-07 vpn-permission-regrant'),
@@ -128,7 +133,8 @@ void main() {
       decision: grant.outcome,
       invariants: {
         'new_permission_attempt':
-            grant.newIdentity.permissionRequestId != oldIdentity.permissionRequestId,
+            grant.newIdentity.permissionRequestId !=
+            oldIdentity.permissionRequestId,
       },
     );
   });
@@ -140,7 +146,9 @@ void main() {
     final recreation = coordinator.invalidateEventLoop(
       event: MobileLifecycleEvent.activityRecreated,
     );
-    final oldCallbackAccepted = coordinator.acceptsAppEpoch(oldIdentity.appEpoch);
+    final oldCallbackAccepted = coordinator.acceptsAppEpoch(
+      oldIdentity.appEpoch,
+    );
     expect(recreation.outcome, MobileLifecycleOutcome.applied);
     expect(oldCallbackAccepted, isFalse);
     _record(
@@ -167,7 +175,10 @@ void main() {
       oldIdentity: first.newIdentity,
       newIdentity: replacement.newIdentity,
       decision: replacement.outcome,
-      invariants: {'bridge_identity_adopted': replacement.newIdentity.bridgeIncarnation == 5},
+      invariants: {
+        'bridge_identity_adopted':
+            replacement.newIdentity.bridgeIncarnation == 5,
+      },
     );
   });
 
@@ -178,7 +189,10 @@ void main() {
       event: MobileLifecycleEvent.controlReconnected,
     );
     expect(reconnect.outcome, MobileLifecycleOutcome.applied);
-    expect(reconnect.newIdentity.eventLoopGeneration, greaterThan(oldIdentity.eventLoopGeneration));
+    expect(
+      reconnect.newIdentity.eventLoopGeneration,
+      greaterThan(oldIdentity.eventLoopGeneration),
+    );
     _record(
       scenarioId: 'ML-12',
       exactTestId: _testId('ML-12 control-websocket-reconnect'),
@@ -188,7 +202,8 @@ void main() {
       decision: reconnect.outcome,
       invariants: {
         'new_control_generation_adopted':
-            reconnect.newIdentity.eventLoopGeneration > oldIdentity.eventLoopGeneration,
+            reconnect.newIdentity.eventLoopGeneration >
+            oldIdentity.eventLoopGeneration,
       },
     );
   });
@@ -208,16 +223,25 @@ void main() {
     _record(
       scenarioId: 'ML-18',
       exactTestId: _testId('ML-18 duplicate-events-idempotent'),
-      events: ['app_backgrounded', 'app_backgrounded', 'app_resumed', 'app_resumed'],
+      events: [
+        'app_backgrounded',
+        'app_backgrounded',
+        'app_resumed',
+        'app_resumed',
+      ],
       oldIdentity: resumed.newIdentity,
       newIdentity: duplicateResume.newIdentity,
       decision: duplicateResume.outcome,
       invariants: {
         'duplicate_has_no_second_effect':
-            duplicateResume.newIdentity.eventLoopGeneration == resumed.newIdentity.eventLoopGeneration,
+            duplicateResume.newIdentity.eventLoopGeneration ==
+            resumed.newIdentity.eventLoopGeneration,
       },
     );
-    expect(oldIdentity.eventLoopGeneration, lessThan(resumed.newIdentity.eventLoopGeneration));
+    expect(
+      oldIdentity.eventLoopGeneration,
+      lessThan(resumed.newIdentity.eventLoopGeneration),
+    );
   });
 }
 
@@ -234,18 +258,6 @@ void _record({
   required Map<String, bool> invariants,
 }) {
   print(
-    'MOBILE_LIFECYCLE_RECORD ${jsonEncode({
-      'scenario_id': scenarioId,
-      'exact_test_id': exactTestId,
-      'executed': true,
-      'skipped': false,
-      'result': 'pass',
-      'events': events,
-      'observed_old_identity': oldIdentity.toJson(),
-      'observed_new_identity': newIdentity.toJson(),
-      'observed_decision': decision.wireName,
-      'invariants': invariants,
-      'execution_source': 'flutter_machine_reporter',
-    })}',
+    'MOBILE_LIFECYCLE_RECORD ${jsonEncode({'scenario_id': scenarioId, 'exact_test_id': exactTestId, 'executed': true, 'skipped': false, 'result': 'pass', 'events': events, 'observed_old_identity': oldIdentity.toJson(), 'observed_new_identity': newIdentity.toJson(), 'observed_decision': decision.wireName, 'invariants': invariants, 'execution_source': 'flutter_machine_reporter'})}',
   );
 }

--- a/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p2wlan_flutter_client/core/lifecycle/mobile_lifecycle_coordinator.dart';
+
+void main() {
+  test('ML-01 app-background-late-long-poll', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final oldIdentity = coordinator.identity;
+    final transition = coordinator.onAppBackgrounded();
+    final accepted = coordinator.acceptsEventLoop(
+      appEpoch: oldIdentity.appEpoch,
+      generation: oldIdentity.eventLoopGeneration,
+    );
+    expect(transition.outcome, MobileLifecycleOutcome.applied);
+    expect(accepted, isFalse);
+    _record(
+      scenarioId: 'ML-01',
+      exactTestId: _testId('ML-01 app-background-late-long-poll'),
+      events: ['app_backgrounded'],
+      oldIdentity: oldIdentity,
+      newIdentity: transition.newIdentity,
+      decision: MobileLifecycleOutcome.staleRejected,
+      invariants: {'old_callback_fenced': !accepted},
+    );
+  });
+
+  test('ML-02 app-resume-refresh-before-reconnect', () {
+    final coordinator = MobileLifecycleCoordinator();
+    coordinator.onAppBackgrounded();
+    final oldIdentity = coordinator.identity;
+    final order = <String>[];
+    final transition = coordinator.onAppResumed();
+    order.add('refresh');
+    order.add('poll');
+    expect(transition.outcome, MobileLifecycleOutcome.applied);
+    expect(order, ['refresh', 'poll']);
+    final resumeRefreshPrecedesPoll =
+        order.length == 2 && order[0] == 'refresh' && order[1] == 'poll';
+    _record(
+      scenarioId: 'ML-02',
+      exactTestId: _testId('ML-02 app-resume-refresh-before-reconnect'),
+      events: ['app_resumed'],
+      oldIdentity: oldIdentity,
+      newIdentity: transition.newIdentity,
+      decision: transition.outcome,
+      invariants: {
+        'resume_refresh_precedes_poll': resumeRefreshPrecedesPoll,
+      },
+    );
+  });
+
+  test('ML-03 daemon-process-recreation', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final first = coordinator.observeDaemon(
+      processId: 1234,
+      runtimeIncarnation: 4,
+      revision: 50,
+    );
+    final oldIdentity = first.newIdentity;
+    final replacement = coordinator.observeDaemon(
+      processId: 1234,
+      runtimeIncarnation: 5,
+      revision: 1,
+    );
+    expect(first.outcome, MobileLifecycleOutcome.applied);
+    expect(replacement.outcome, MobileLifecycleOutcome.applied);
+    expect(replacement.newIdentity.daemonProcessId, 1234);
+    expect(replacement.newIdentity.daemonRuntimeIncarnation, 5);
+    expect(replacement.newIdentity.daemonRevision, 1);
+    _record(
+      scenarioId: 'ML-03',
+      exactTestId: _testId('ML-03 daemon-process-recreation'),
+      events: ['native_runtime_stopped', 'native_runtime_started'],
+      oldIdentity: oldIdentity,
+      newIdentity: replacement.newIdentity,
+      decision: replacement.outcome,
+      invariants: {
+        'new_process_adopted':
+            replacement.newIdentity.daemonRuntimeIncarnation == 5,
+      },
+    );
+  });
+
+  test('ML-06 vpn-permission-revoke', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final request = coordinator.beginPermissionRequest();
+    final oldIdentity = request.newIdentity;
+    final revoke = coordinator.onPermissionRevoked();
+    final late = coordinator.completePermissionRequest(
+      requestId: request.newIdentity.permissionRequestId!,
+      granted: true,
+    );
+    expect(late.outcome, MobileLifecycleOutcome.staleRejected);
+    expect(coordinator.acceptsAppEpoch(oldIdentity.appEpoch), isFalse);
+    _record(
+      scenarioId: 'ML-06',
+      exactTestId: _testId('ML-06 vpn-permission-revoke'),
+      events: ['vpn_permission_revoked', 'bridge_detached'],
+      oldIdentity: oldIdentity,
+      newIdentity: revoke.newIdentity,
+      decision: late.outcome,
+      invariants: {'pending_permission_invalidated': !coordinator.acceptsAppEpoch(oldIdentity.appEpoch)},
+    );
+  });
+
+  test('ML-07 vpn-permission-regrant', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final first = coordinator.beginPermissionRequest();
+    coordinator.onPermissionRevoked();
+    final oldIdentity = coordinator.identity;
+    final second = coordinator.beginPermissionRequest();
+    final grant = coordinator.completePermissionRequest(
+      requestId: second.newIdentity.permissionRequestId!,
+      granted: true,
+    );
+    expect(grant.outcome, MobileLifecycleOutcome.applied);
+    expect(second.newIdentity.permissionRequestId, greaterThan(first.newIdentity.permissionRequestId!));
+    _record(
+      scenarioId: 'ML-07',
+      exactTestId: _testId('ML-07 vpn-permission-regrant'),
+      events: ['vpn_permission_granted', 'native_runtime_started'],
+      oldIdentity: oldIdentity,
+      newIdentity: grant.newIdentity,
+      decision: grant.outcome,
+      invariants: {
+        'new_permission_attempt':
+            grant.newIdentity.permissionRequestId != oldIdentity.permissionRequestId,
+      },
+    );
+  });
+
+  test('ML-08 activity-engine-recreation', () {
+    final coordinator = MobileLifecycleCoordinator();
+    coordinator.beginPermissionRequest();
+    final oldIdentity = coordinator.identity;
+    final recreation = coordinator.invalidateEventLoop(
+      event: MobileLifecycleEvent.activityRecreated,
+    );
+    final oldCallbackAccepted = coordinator.acceptsAppEpoch(oldIdentity.appEpoch);
+    expect(recreation.outcome, MobileLifecycleOutcome.applied);
+    expect(oldCallbackAccepted, isFalse);
+    _record(
+      scenarioId: 'ML-08',
+      exactTestId: _testId('ML-08 activity-engine-recreation'),
+      events: ['activity_recreated', 'bridge_attached'],
+      oldIdentity: oldIdentity,
+      newIdentity: recreation.newIdentity,
+      decision: MobileLifecycleOutcome.staleRejected,
+      invariants: {'old_engine_callback_rejected': !oldCallbackAccepted},
+    );
+  });
+
+  test('ML-10 native-bridge-reattachment', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final first = coordinator.observeBridge(4);
+    final replacement = coordinator.observeBridge(5);
+    expect(first.outcome, MobileLifecycleOutcome.applied);
+    expect(replacement.outcome, MobileLifecycleOutcome.applied);
+    _record(
+      scenarioId: 'ML-10',
+      exactTestId: _testId('ML-10 native-bridge-reattachment'),
+      events: ['bridge_detached', 'bridge_attached'],
+      oldIdentity: first.newIdentity,
+      newIdentity: replacement.newIdentity,
+      decision: replacement.outcome,
+      invariants: {'bridge_identity_adopted': replacement.newIdentity.bridgeIncarnation == 5},
+    );
+  });
+
+  test('ML-12 control-websocket-reconnect', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final oldIdentity = coordinator.identity;
+    final reconnect = coordinator.invalidateEventLoop(
+      event: MobileLifecycleEvent.controlReconnected,
+    );
+    expect(reconnect.outcome, MobileLifecycleOutcome.applied);
+    expect(reconnect.newIdentity.eventLoopGeneration, greaterThan(oldIdentity.eventLoopGeneration));
+    _record(
+      scenarioId: 'ML-12',
+      exactTestId: _testId('ML-12 control-websocket-reconnect'),
+      events: ['control_disconnected', 'control_reconnected'],
+      oldIdentity: oldIdentity,
+      newIdentity: reconnect.newIdentity,
+      decision: reconnect.outcome,
+      invariants: {
+        'new_control_generation_adopted':
+            reconnect.newIdentity.eventLoopGeneration > oldIdentity.eventLoopGeneration,
+      },
+    );
+  });
+
+  test('ML-18 duplicate-events-idempotent', () {
+    final coordinator = MobileLifecycleCoordinator();
+    final background = coordinator.onAppBackgrounded();
+    final oldIdentity = coordinator.identity;
+    final duplicateBackground = coordinator.onAppBackgrounded();
+    final resumed = coordinator.onAppResumed();
+    final duplicateResume = coordinator.onAppResumed();
+    expect(background.outcome, MobileLifecycleOutcome.applied);
+    expect(duplicateBackground.outcome, MobileLifecycleOutcome.duplicate);
+    expect(resumed.outcome, MobileLifecycleOutcome.applied);
+    expect(duplicateResume.outcome, MobileLifecycleOutcome.duplicate);
+    expect(duplicateResume.newIdentity, resumed.newIdentity);
+    _record(
+      scenarioId: 'ML-18',
+      exactTestId: _testId('ML-18 duplicate-events-idempotent'),
+      events: ['app_backgrounded', 'app_backgrounded', 'app_resumed', 'app_resumed'],
+      oldIdentity: resumed.newIdentity,
+      newIdentity: duplicateResume.newIdentity,
+      decision: duplicateResume.outcome,
+      invariants: {
+        'duplicate_has_no_second_effect':
+            duplicateResume.newIdentity.eventLoopGeneration == resumed.newIdentity.eventLoopGeneration,
+      },
+    );
+    expect(oldIdentity.eventLoopGeneration, lessThan(resumed.newIdentity.eventLoopGeneration));
+  });
+}
+
+String _testId(String name) =>
+    'apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::$name';
+
+void _record({
+  required String scenarioId,
+  required String exactTestId,
+  required List<String> events,
+  required MobileLifecycleIdentity oldIdentity,
+  required MobileLifecycleIdentity newIdentity,
+  required MobileLifecycleOutcome decision,
+  required Map<String, bool> invariants,
+}) {
+  print(
+    'MOBILE_LIFECYCLE_RECORD ${jsonEncode({
+      'scenario_id': scenarioId,
+      'exact_test_id': exactTestId,
+      'executed': true,
+      'skipped': false,
+      'result': 'pass',
+      'events': events,
+      'observed_old_identity': oldIdentity.toJson(),
+      'observed_new_identity': newIdentity.toJson(),
+      'observed_decision': decision.wireName,
+      'invariants': invariants,
+      'execution_source': 'flutter_machine_reporter',
+    })}',
+  );
+}

--- a/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
+++ b/apps/flutter_client/test/mobile_lifecycle_evidence_test.dart
@@ -1,3 +1,6 @@
+// Machine-readable evidence records intentionally use stdout.
+// ignore_for_file: avoid_print
+
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/apps/flutter_client/test/status_store_test.dart
+++ b/apps/flutter_client/test/status_store_test.dart
@@ -67,62 +67,58 @@ void main() {
     },
   );
 
-  test(
-    'stable peer order puts online peers first and moves reconnected peers to the end',
-    () async {
-      final fixture = await _loadFixture();
-      final stores = await _makeStores(DiagnosticsApi());
-      addTearDown(stores.dispose);
+  test('stable peer order puts online peers first and moves reconnected peers to the end', () async {
+    final fixture = await _loadFixture();
+    final stores = await _makeStores(DiagnosticsApi());
+    addTearDown(stores.dispose);
 
-      final initial = stores.statusStore.stablePeerOrder(fixture.peers);
-      final firstOnline = initial.first;
-      expect(firstOnline.online, isTrue);
+    final initial = stores.statusStore.stablePeerOrder(fixture.peers);
+    final firstOnline = initial.first;
+    expect(firstOnline.online, isTrue);
 
-      final offlineRaw =
-          jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
-      final offlinePeers = [
-        for (final item in offlineRaw['peers'] as List<dynamic>)
-          Map<String, dynamic>.from(item as Map),
-      ];
-      final firstOffline = offlinePeers.firstWhere(
-        (item) => item['node_id'] == firstOnline.nodeId,
-      );
-      firstOffline
-        ..['online'] = false
-        ..['state'] = 'unknown'
-        ..['active_path'] = null
-        ..['current_path_selection'] = null;
-      final offlineSnapshot = DiagnosticsSnapshot.fromJson(
-        offlineRaw..['peers'] = offlinePeers,
-      );
-      final whileOffline = stores.statusStore.stablePeerOrder(
-        offlineSnapshot.peers,
-      );
-      expect(whileOffline.last.nodeId, firstOnline.nodeId);
+    final offlineRaw =
+        jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
+    final offlinePeers = [
+      for (final item in offlineRaw['peers'] as List<dynamic>)
+        Map<String, dynamic>.from(item as Map),
+    ];
+    final firstOffline = offlinePeers.firstWhere(
+      (item) => item['node_id'] == firstOnline.nodeId,
+    );
+    firstOffline
+      ..['online'] = false
+      ..['state'] = 'unknown'
+      ..['active_path'] = null
+      ..['current_path_selection'] = null;
+    final offlineSnapshot = DiagnosticsSnapshot.fromJson(
+      offlineRaw..['peers'] = offlinePeers,
+    );
+    final whileOffline = stores.statusStore.stablePeerOrder(
+      offlineSnapshot.peers,
+    );
+    expect(whileOffline.last.nodeId, firstOnline.nodeId);
 
-      final restoredRaw =
-          jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
-      final restoredPeers = [
-        for (final item in restoredRaw['peers'] as List<dynamic>)
-          Map<String, dynamic>.from(item as Map),
-      ];
-      final restored = stores.statusStore.stablePeerOrder(
-        DiagnosticsSnapshot.fromJson(
-          restoredRaw..['peers'] = restoredPeers,
-        ).peers,
-      );
-      final restoredOnline = restored
-          .where((peer) => peer.online && peer.path != 'offline')
-          .toList();
-      expect(restoredOnline.last.nodeId, firstOnline.nodeId);
-      expect(
-        restored
-            .skipWhile((peer) => peer.online && peer.path != 'offline')
-            .every((peer) => !peer.online || peer.path == 'offline'),
-        isTrue,
-      );
-    },
-  );
+    final restoredRaw =
+        jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
+    final restoredPeers = [
+      for (final item in restoredRaw['peers'] as List<dynamic>)
+        Map<String, dynamic>.from(item as Map),
+    ];
+    final restored = stores.statusStore.stablePeerOrder(
+      DiagnosticsSnapshot.fromJson(restoredRaw..['peers'] = restoredPeers)
+          .peers,
+    );
+    final restoredOnline = restored
+        .where((peer) => peer.online && peer.path != 'offline')
+        .toList();
+    expect(restoredOnline.last.nodeId, firstOnline.nodeId);
+    expect(
+      restored
+          .skipWhile((peer) => peer.online && peer.path != 'offline')
+          .every((peer) => !peer.online || peer.path == 'offline'),
+      isTrue,
+    );
+  });
 
   test('automatic refresh stays silent while work is in flight', () async {
     final fixture = await _loadFixture();
@@ -359,49 +355,46 @@ void main() {
     expect(stores.statusStore.snapshot?.peers, isEmpty);
   });
 
-  test(
-    'same PID runtime replacement accepts lower revision then rejects late old snapshot',
-    () async {
-      final fixture = await _loadFixture();
-      final oldRuntime = _snapshotCopy(
-        fixture,
-        processId: 1234,
-        runtimeIncarnation: 4,
-        revision: 50,
-        uptimeMs: 10000,
-      );
-      final newRuntime = _snapshotCopy(
-        fixture,
-        processId: 1234,
-        runtimeIncarnation: 5,
-        revision: 1,
-        uptimeMs: 100,
-        peers: const <dynamic>[],
-      );
-      final lateOldRuntime = _snapshotCopy(
-        fixture,
-        processId: 1234,
-        runtimeIncarnation: 4,
-        revision: 51,
-        uptimeMs: 11000,
-      );
-      final api = _SwitchingDiagnosticsApi(
-        snapshot: newRuntime,
-        snapshots: [oldRuntime, newRuntime, lateOldRuntime],
-      );
-      final stores = await _makeStores(api);
-      addTearDown(stores.dispose);
+  test('same PID runtime replacement accepts lower revision then rejects late old snapshot', () async {
+    final fixture = await _loadFixture();
+    final oldRuntime = _snapshotCopy(
+      fixture,
+      processId: 1234,
+      runtimeIncarnation: 4,
+      revision: 50,
+      uptimeMs: 10000,
+    );
+    final newRuntime = _snapshotCopy(
+      fixture,
+      processId: 1234,
+      runtimeIncarnation: 5,
+      revision: 1,
+      uptimeMs: 100,
+      peers: const <dynamic>[],
+    );
+    final lateOldRuntime = _snapshotCopy(
+      fixture,
+      processId: 1234,
+      runtimeIncarnation: 4,
+      revision: 51,
+      uptimeMs: 11000,
+    );
+    final api = _SwitchingDiagnosticsApi(
+      snapshot: newRuntime,
+      snapshots: [oldRuntime, newRuntime, lateOldRuntime],
+    );
+    final stores = await _makeStores(api);
+    addTearDown(stores.dispose);
 
-      await stores.statusStore.refresh();
-      await stores.statusStore.refresh();
-      await stores.statusStore.refresh();
+    await stores.statusStore.refresh();
+    await stores.statusStore.refresh();
+    await stores.statusStore.refresh();
 
-      expect(stores.statusStore.snapshot?.processId, 1234);
-      expect(stores.statusStore.snapshot?.runtimeIncarnation, 5);
-      expect(stores.statusStore.snapshot?.revision, 1);
-      expect(stores.statusStore.snapshot?.peers, isEmpty);
-    },
-  );
+    expect(stores.statusStore.snapshot?.processId, 1234);
+    expect(stores.statusStore.snapshot?.runtimeIncarnation, 5);
+    expect(stores.statusStore.snapshot?.revision, 1);
+    expect(stores.statusStore.snapshot?.peers, isEmpty);
+  });
 
   test(
     'startup settling never restores an older larger peer catalog',
@@ -552,48 +545,42 @@ void main() {
     },
   );
 
-  test(
-    'one event-loop generation fences disable/enable and dispose without a spin',
-    () async {
-      final fixture = await _loadFixture();
-      final api = _LifecycleDiagnosticsApi(snapshot: fixture);
-      final stores = await _makeStores(api);
-      addTearDown(stores.dispose);
+  test('one event-loop generation fences disable/enable and dispose without a spin', () async {
+    final fixture = await _loadFixture();
+    final api = _LifecycleDiagnosticsApi(snapshot: fixture);
+    final stores = await _makeStores(api);
+    addTearDown(stores.dispose);
 
-      await stores.statusStore.refresh();
-      stores.statusStore.setAutoRefresh(enabled: true);
-      await _waitUntil(() => api.eventRequests.length == 1);
-      final activeGeneration = stores.statusStore.eventLoopGeneration;
+    await stores.statusStore.refresh();
+    stores.statusStore.setAutoRefresh(enabled: true);
+    await _waitUntil(() => api.eventRequests.length == 1);
+    final activeGeneration = stores.statusStore.eventLoopGeneration;
 
-      stores.statusStore.setAutoRefresh(enabled: false);
-      expect(stores.statusStore.eventLoopGeneration, activeGeneration + 1);
-      stores.statusStore.setAutoRefresh(enabled: true);
-      await _waitUntil(() => api.eventRequests.length == 2);
-      expect(
-        api.eventRequests,
-        hasLength(2),
-        reason: 'enable must create exactly one replacement long poll',
-      );
+    stores.statusStore.setAutoRefresh(enabled: false);
+    expect(stores.statusStore.eventLoopGeneration, activeGeneration + 1);
+    stores.statusStore.setAutoRefresh(enabled: true);
+    await _waitUntil(() => api.eventRequests.length == 2);
+    expect(
+      api.eventRequests,
+      hasLength(2),
+      reason: 'enable must create exactly one replacement long poll',
+    );
 
-      // Completing the request fenced by disable must not re-arm polling.
-      api.completeEventRequest(0, fixture);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(
-        api.eventRequests,
-        hasLength(2),
-        reason: 'a stale completion must be rejected without a microtask spin',
-      );
+    // Completing the request fenced by disable must not re-arm polling.
+    api.completeEventRequest(0, fixture);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(
+      api.eventRequests,
+      hasLength(2),
+      reason: 'a stale completion must be rejected without a microtask spin',
+    );
 
-      stores.statusStore.dispose();
-      api.completeEventRequest(1, fixture);
-      stores.statusStore.setAutoRefresh(
-        enabled: true,
-        refreshImmediately: true,
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(api.eventRequests, hasLength(2));
-    },
-  );
+    stores.statusStore.dispose();
+    api.completeEventRequest(1, fixture);
+    stores.statusStore.setAutoRefresh(enabled: true, refreshImmediately: true);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(api.eventRequests, hasLength(2));
+  });
 
   test(
     'rapid background/resume callbacks are idempotent at one lifecycle fence',
@@ -729,11 +716,9 @@ Future<void> _waitUntil(bool Function() predicate) async {
 }
 
 Future<DiagnosticsSnapshot> _loadFixture() async {
-  final raw =
-      jsonDecode(
-            await File('test/fixtures/status_connected.json').readAsString(),
-          )
-          as Map<String, dynamic>;
+  final raw = jsonDecode(
+    await File('test/fixtures/status_connected.json').readAsString(),
+  ) as Map<String, dynamic>;
   return DiagnosticsSnapshot.fromJson(raw);
 }
 

--- a/apps/flutter_client/test/status_store_test.dart
+++ b/apps/flutter_client/test/status_store_test.dart
@@ -67,58 +67,62 @@ void main() {
     },
   );
 
-  test('stable peer order puts online peers first and moves reconnected peers to the end', () async {
-    final fixture = await _loadFixture();
-    final stores = await _makeStores(DiagnosticsApi());
-    addTearDown(stores.dispose);
+  test(
+    'stable peer order puts online peers first and moves reconnected peers to the end',
+    () async {
+      final fixture = await _loadFixture();
+      final stores = await _makeStores(DiagnosticsApi());
+      addTearDown(stores.dispose);
 
-    final initial = stores.statusStore.stablePeerOrder(fixture.peers);
-    final firstOnline = initial.first;
-    expect(firstOnline.online, isTrue);
+      final initial = stores.statusStore.stablePeerOrder(fixture.peers);
+      final firstOnline = initial.first;
+      expect(firstOnline.online, isTrue);
 
-    final offlineRaw =
-        jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
-    final offlinePeers = [
-      for (final item in offlineRaw['peers'] as List<dynamic>)
-        Map<String, dynamic>.from(item as Map),
-    ];
-    final firstOffline = offlinePeers.firstWhere(
-      (item) => item['node_id'] == firstOnline.nodeId,
-    );
-    firstOffline
-      ..['online'] = false
-      ..['state'] = 'unknown'
-      ..['active_path'] = null
-      ..['current_path_selection'] = null;
-    final offlineSnapshot = DiagnosticsSnapshot.fromJson(
-      offlineRaw..['peers'] = offlinePeers,
-    );
-    final whileOffline = stores.statusStore.stablePeerOrder(
-      offlineSnapshot.peers,
-    );
-    expect(whileOffline.last.nodeId, firstOnline.nodeId);
+      final offlineRaw =
+          jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
+      final offlinePeers = [
+        for (final item in offlineRaw['peers'] as List<dynamic>)
+          Map<String, dynamic>.from(item as Map),
+      ];
+      final firstOffline = offlinePeers.firstWhere(
+        (item) => item['node_id'] == firstOnline.nodeId,
+      );
+      firstOffline
+        ..['online'] = false
+        ..['state'] = 'unknown'
+        ..['active_path'] = null
+        ..['current_path_selection'] = null;
+      final offlineSnapshot = DiagnosticsSnapshot.fromJson(
+        offlineRaw..['peers'] = offlinePeers,
+      );
+      final whileOffline = stores.statusStore.stablePeerOrder(
+        offlineSnapshot.peers,
+      );
+      expect(whileOffline.last.nodeId, firstOnline.nodeId);
 
-    final restoredRaw =
-        jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
-    final restoredPeers = [
-      for (final item in restoredRaw['peers'] as List<dynamic>)
-        Map<String, dynamic>.from(item as Map),
-    ];
-    final restored = stores.statusStore.stablePeerOrder(
-      DiagnosticsSnapshot.fromJson(restoredRaw..['peers'] = restoredPeers)
-          .peers,
-    );
-    final restoredOnline = restored
-        .where((peer) => peer.online && peer.path != 'offline')
-        .toList();
-    expect(restoredOnline.last.nodeId, firstOnline.nodeId);
-    expect(
-      restored
-          .skipWhile((peer) => peer.online && peer.path != 'offline')
-          .every((peer) => !peer.online || peer.path == 'offline'),
-      isTrue,
-    );
-  });
+      final restoredRaw =
+          jsonDecode(jsonEncode(fixture.raw)) as Map<String, dynamic>;
+      final restoredPeers = [
+        for (final item in restoredRaw['peers'] as List<dynamic>)
+          Map<String, dynamic>.from(item as Map),
+      ];
+      final restored = stores.statusStore.stablePeerOrder(
+        DiagnosticsSnapshot.fromJson(
+          restoredRaw..['peers'] = restoredPeers,
+        ).peers,
+      );
+      final restoredOnline = restored
+          .where((peer) => peer.online && peer.path != 'offline')
+          .toList();
+      expect(restoredOnline.last.nodeId, firstOnline.nodeId);
+      expect(
+        restored
+            .skipWhile((peer) => peer.online && peer.path != 'offline')
+            .every((peer) => !peer.online || peer.path == 'offline'),
+        isTrue,
+      );
+    },
+  );
 
   test('automatic refresh stays silent while work is in flight', () async {
     final fixture = await _loadFixture();
@@ -356,6 +360,50 @@ void main() {
   });
 
   test(
+    'same PID runtime replacement accepts lower revision then rejects late old snapshot',
+    () async {
+      final fixture = await _loadFixture();
+      final oldRuntime = _snapshotCopy(
+        fixture,
+        processId: 1234,
+        runtimeIncarnation: 4,
+        revision: 50,
+        uptimeMs: 10000,
+      );
+      final newRuntime = _snapshotCopy(
+        fixture,
+        processId: 1234,
+        runtimeIncarnation: 5,
+        revision: 1,
+        uptimeMs: 100,
+        peers: const <dynamic>[],
+      );
+      final lateOldRuntime = _snapshotCopy(
+        fixture,
+        processId: 1234,
+        runtimeIncarnation: 4,
+        revision: 51,
+        uptimeMs: 11000,
+      );
+      final api = _SwitchingDiagnosticsApi(
+        snapshot: newRuntime,
+        snapshots: [oldRuntime, newRuntime, lateOldRuntime],
+      );
+      final stores = await _makeStores(api);
+      addTearDown(stores.dispose);
+
+      await stores.statusStore.refresh();
+      await stores.statusStore.refresh();
+      await stores.statusStore.refresh();
+
+      expect(stores.statusStore.snapshot?.processId, 1234);
+      expect(stores.statusStore.snapshot?.runtimeIncarnation, 5);
+      expect(stores.statusStore.snapshot?.revision, 1);
+      expect(stores.statusStore.snapshot?.peers, isEmpty);
+    },
+  );
+
+  test(
     'startup settling never restores an older larger peer catalog',
     () async {
       final fixture = await _loadFixture();
@@ -505,6 +553,68 @@ void main() {
   );
 
   test(
+    'one event-loop generation fences disable/enable and dispose without a spin',
+    () async {
+      final fixture = await _loadFixture();
+      final api = _LifecycleDiagnosticsApi(snapshot: fixture);
+      final stores = await _makeStores(api);
+      addTearDown(stores.dispose);
+
+      await stores.statusStore.refresh();
+      stores.statusStore.setAutoRefresh(enabled: true);
+      await _waitUntil(() => api.eventRequests.length == 1);
+      final activeGeneration = stores.statusStore.eventLoopGeneration;
+
+      stores.statusStore.setAutoRefresh(enabled: false);
+      expect(stores.statusStore.eventLoopGeneration, activeGeneration + 1);
+      stores.statusStore.setAutoRefresh(enabled: true);
+      await _waitUntil(() => api.eventRequests.length == 2);
+      expect(
+        api.eventRequests,
+        hasLength(2),
+        reason: 'enable must create exactly one replacement long poll',
+      );
+
+      // Completing the request fenced by disable must not re-arm polling.
+      api.completeEventRequest(0, fixture);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        api.eventRequests,
+        hasLength(2),
+        reason: 'a stale completion must be rejected without a microtask spin',
+      );
+
+      stores.statusStore.dispose();
+      api.completeEventRequest(1, fixture);
+      stores.statusStore.setAutoRefresh(
+        enabled: true,
+        refreshImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(api.eventRequests, hasLength(2));
+    },
+  );
+
+  test(
+    'rapid background/resume callbacks are idempotent at one lifecycle fence',
+    () async {
+      final fixture = await _loadFixture();
+      final api = _LifecycleDiagnosticsApi(snapshot: fixture);
+      final stores = await _makeStores(api);
+      addTearDown(stores.dispose);
+
+      await stores.statusStore.refresh();
+      final before = stores.statusStore.eventLoopGeneration;
+      stores.statusStore.updateAppLifecycleState(AppLifecycleState.paused);
+      stores.statusStore.updateAppLifecycleState(AppLifecycleState.paused);
+      stores.statusStore.updateAppLifecycleState(AppLifecycleState.resumed);
+      stores.statusStore.updateAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(stores.statusStore.eventLoopGeneration, before + 2);
+    },
+  );
+
+  test(
     'event poll carries process identity and resets on daemon restart',
     () async {
       final fixture = await _loadFixture();
@@ -571,6 +681,7 @@ void main() {
 DiagnosticsSnapshot _snapshotCopy(
   DiagnosticsSnapshot source, {
   required int processId,
+  int? runtimeIncarnation,
   required int revision,
   required int uptimeMs,
   List<dynamic>? peers,
@@ -583,6 +694,9 @@ DiagnosticsSnapshot _snapshotCopy(
     ..['peer_snapshot_stale'] = false
     ..['peer_snapshot_age_ms'] = 0
     ..['uptime_ms'] = uptimeMs;
+  if (runtimeIncarnation != null) {
+    raw['runtime_incarnation'] = runtimeIncarnation;
+  }
   if (peers != null) raw['peers'] = peers;
   return DiagnosticsSnapshot.fromJson(raw);
 }
@@ -615,9 +729,11 @@ Future<void> _waitUntil(bool Function() predicate) async {
 }
 
 Future<DiagnosticsSnapshot> _loadFixture() async {
-  final raw = jsonDecode(
-    await File('test/fixtures/status_connected.json').readAsString(),
-  ) as Map<String, dynamic>;
+  final raw =
+      jsonDecode(
+            await File('test/fixtures/status_connected.json').readAsString(),
+          )
+          as Map<String, dynamic>;
   return DiagnosticsSnapshot.fromJson(raw);
 }
 

--- a/apps/flutter_client/test/status_store_test.dart
+++ b/apps/flutter_client/test/status_store_test.dart
@@ -318,6 +318,43 @@ void main() {
     expect(stores.statusStore.snapshot?.peers, isEmpty);
   });
 
+  test('rejects a late response from a retired daemon process', () async {
+    final fixture = await _loadFixture();
+    final oldProcess = _snapshotCopy(
+      fixture,
+      processId: 42,
+      revision: 10,
+      uptimeMs: 10000,
+    );
+    final newProcess = _snapshotCopy(
+      fixture,
+      processId: 43,
+      revision: 1,
+      uptimeMs: 100,
+      peers: const <dynamic>[],
+    );
+    final delayedOldProcess = _snapshotCopy(
+      fixture,
+      processId: 42,
+      revision: 11,
+      uptimeMs: 11000,
+    );
+    final api = _SwitchingDiagnosticsApi(
+      snapshot: newProcess,
+      snapshots: [oldProcess, newProcess, delayedOldProcess],
+    );
+    final stores = await _makeStores(api);
+    addTearDown(stores.dispose);
+
+    await stores.statusStore.refresh();
+    await stores.statusStore.refresh();
+    await stores.statusStore.refresh();
+
+    expect(stores.statusStore.snapshot?.processId, 43);
+    expect(stores.statusStore.snapshot?.revision, 1);
+    expect(stores.statusStore.snapshot?.peers, isEmpty);
+  });
+
   test(
     'startup settling never restores an older larger peer catalog',
     () async {
@@ -512,6 +549,23 @@ void main() {
       stores.statusStore.setAutoRefresh(enabled: false);
     },
   );
+
+  test('disposed store cannot restart polling', () async {
+    final fixture = await _loadFixture();
+    final api = _SwitchingDiagnosticsApi(snapshot: fixture);
+    final stores = await _makeStores(api);
+    addTearDown(stores.dispose);
+
+    await stores.statusStore.refresh();
+    final statusCount = api.statusFetchCount;
+    stores.statusStore.dispose();
+
+    stores.statusStore.setAutoRefresh(enabled: true, refreshImmediately: true);
+    await stores.statusStore.refresh();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(api.statusFetchCount, statusCount);
+  });
 }
 
 DiagnosticsSnapshot _snapshotCopy(

--- a/client/android-native/Cargo.toml
+++ b/client/android-native/Cargo.toml
@@ -7,7 +7,7 @@ description = "JNI bridge for the P2WLAN Android VPN service"
 
 [lib]
 name = "p2wlan_android"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 p2wlan-daemon = { path = "../daemon", version = "0.1.147" }

--- a/client/android-native/src/lib.rs
+++ b/client/android-native/src/lib.rs
@@ -9,7 +9,7 @@ pub mod lifecycle;
 
 #[cfg(target_os = "android")]
 mod android_bridge {
-    use super::lifecycle::OwnerId;
+    use super::lifecycle::{NetworkHintDecision, OwnerId, PhysicalNetworkHintAuthority};
 
     use std::os::fd::RawFd;
     use std::os::fd::{FromRawFd, OwnedFd};
@@ -32,7 +32,7 @@ mod android_bridge {
     use rand::RngCore;
     use serde::Deserialize;
     use tokio::runtime::Builder;
-    use tokio::sync::watch;
+    use tokio::sync::{broadcast, watch};
 
     use p2pnet_daemon::config::{Config, ControlProxyMode};
     use p2pnet_daemon::Daemon;
@@ -92,6 +92,8 @@ mod android_bridge {
         shutdown_tx: watch::Sender<bool>,
         running: Arc<AtomicBool>,
         ready: Arc<AtomicBool>,
+        network_change_tx: broadcast::Sender<p2pnet_daemon::AndroidNetworkChangeHint>,
+        physical_network_authority: Arc<Mutex<PhysicalNetworkHintAuthority>>,
     }
 
     static RUNTIME: OnceLock<Mutex<Option<RuntimeHandle>>> = OnceLock::new();
@@ -528,6 +530,7 @@ mod android_bridge {
         tun_fd: jint,
         request: AndroidStartRequest,
         owner: OwnerId,
+        service_owner: u64,
     ) -> Result<(), String> {
         {
             let guard = runtime_slot()
@@ -563,8 +566,15 @@ mod android_bridge {
             .unwrap_or_else(|| config_path.with_file_name("p2wlan-daemon.log"));
         let running = Arc::new(AtomicBool::new(true));
         let ready = Arc::new(AtomicBool::new(false));
+        let (network_change_tx, _network_change_rx) = broadcast::channel(32);
+        let physical_network_authority = Arc::new(Mutex::new(PhysicalNetworkHintAuthority::new(
+            service_owner,
+            owner,
+        )));
         let running_for_thread = Arc::clone(&running);
         let ready_for_thread = Arc::clone(&ready);
+        let network_change_tx_for_thread = network_change_tx.clone();
+        let physical_network_authority_for_thread = Arc::clone(&physical_network_authority);
         // This channel acknowledges only that the runtime handle has been
         // installed. Actual daemon readiness is published separately through
         // `ready_for_thread` by Daemon::run after registration, TUN attachment,
@@ -592,11 +602,19 @@ mod android_bridge {
                             Daemon::new_with_android_tun_mode(config, tun_fd, tun_mode);
                         fd_owned_by_thread = false;
                         daemon.set_android_startup_ready(Arc::clone(&ready_for_thread));
+                        daemon.set_android_runtime_incarnation(owner.raw());
+                        daemon.set_android_network_change_sender(
+                            network_change_tx_for_thread.clone(),
+                        );
                         let handle = RuntimeHandle {
                             owner,
                             shutdown_tx: daemon.shutdown_sender(),
                             running: Arc::clone(&running_for_thread),
                             ready: Arc::clone(&ready_for_thread),
+                            network_change_tx: network_change_tx_for_thread.clone(),
+                            physical_network_authority: Arc::clone(
+                                &physical_network_authority_for_thread,
+                            ),
                         };
                         handle_tx
                             .send(Ok(handle))
@@ -700,6 +718,7 @@ mod android_bridge {
         mut env: JNIEnv<'_>,
         _object: JObject<'_>,
         service: JObject<'_>,
+        service_incarnation: jlong,
         tun_fd: jint,
         request_json: JString<'_>,
     ) -> jstring {
@@ -717,12 +736,21 @@ mod android_bridge {
                 Err("an existing Android P2WLAN daemon is still running".to_string())
             }
             Ok(request) => {
+                if service_incarnation <= 0 {
+                    close_raw_fd(tun_fd);
+                    return new_string_or_null(
+                        &mut env,
+                        Some("invalid Android service incarnation".to_string()),
+                    );
+                }
                 let runtime_owner = OwnerId::allocate();
                 register_owner(runtime_owner);
                 set_last_error(runtime_owner, None);
                 owner = Some(runtime_owner);
                 match install_android_socket_protector(&mut env, service, runtime_owner) {
-                    Ok(()) => start_runtime(tun_fd, request, runtime_owner),
+                    Ok(()) => {
+                        start_runtime(tun_fd, request, runtime_owner, service_incarnation as u64)
+                    }
                     Err(error) => {
                         close_raw_fd(tun_fd);
                         Err(error)
@@ -747,6 +775,133 @@ mod android_bridge {
             }
         }
         new_string_or_null(&mut env, result.err())
+    }
+
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeAdoptService(
+        mut env: JNIEnv<'_>,
+        _object: JObject<'_>,
+        service: JObject<'_>,
+        service_incarnation: jlong,
+        expected_bridge_incarnation: jlong,
+    ) -> jstring {
+        let _start_guard = start_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let decision = if service_incarnation <= 0 || expected_bridge_incarnation <= 0 {
+            NetworkHintDecision::Failed
+        } else {
+            let expected_owner = OwnerId::from_raw(expected_bridge_incarnation as u64);
+            let handle = runtime_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone();
+            let Some(handle) = handle else {
+                return new_string_or_null(
+                    &mut env,
+                    Some(NetworkHintDecision::StaleRejected.wire_name().to_string()),
+                );
+            };
+            if !handle.running.load(Ordering::Acquire) || handle.owner != expected_owner {
+                NetworkHintDecision::StaleRejected
+            } else {
+                let mut authority = handle
+                    .physical_network_authority
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if expected_owner != authority.bridge_owner()
+                    || service_incarnation as u64 <= authority.service_owner()
+                {
+                    if expected_owner != authority.bridge_owner()
+                        || (service_incarnation as u64) < authority.service_owner()
+                    {
+                        NetworkHintDecision::StaleRejected
+                    } else {
+                        NetworkHintDecision::Duplicate
+                    }
+                } else {
+                    match install_android_socket_protector(&mut env, service, expected_owner) {
+                        Ok(()) => authority
+                            .rebind_service_owner(expected_owner, service_incarnation as u64),
+                        Err(error) => {
+                            set_last_error(handle.owner, Some(error));
+                            NetworkHintDecision::Failed
+                        }
+                    }
+                }
+            }
+        };
+        new_string_or_null(&mut env, Some(decision.wire_name().to_string()))
+    }
+
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeNotifyPhysicalNetworkChanged(
+        mut env: JNIEnv<'_>,
+        _object: JObject<'_>,
+        service_incarnation: jlong,
+        expected_bridge_incarnation: jlong,
+        kotlin_network_generation: jlong,
+        network_identity_hash: JString<'_>,
+    ) -> jstring {
+        // Serialize callback admission with service adoption. Otherwise an
+        // old callback could win the authority mutex just before a new
+        // service owner is installed and its hint could be delivered after
+        // the owner transition. The callback is linearized either before the
+        // adoption (valid) or after it (stale), never in between.
+        let _start_guard = start_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let hash = match env.get_string(&network_identity_hash) {
+            Ok(value) => value.to_string_lossy().into_owned(),
+            Err(_) => {
+                return new_string_or_null(
+                    &mut env,
+                    Some(NetworkHintDecision::Failed.wire_name().to_string()),
+                );
+            }
+        };
+        let Some(handle) = runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+        else {
+            return new_string_or_null(
+                &mut env,
+                Some(NetworkHintDecision::StaleRejected.wire_name().to_string()),
+            );
+        };
+        let expected_owner = (expected_bridge_incarnation > 0)
+            .then(|| OwnerId::from_raw(expected_bridge_incarnation as u64));
+        let decision = if service_incarnation <= 0 || kotlin_network_generation <= 0 {
+            NetworkHintDecision::Failed
+        } else if !handle.running.load(Ordering::Acquire) || expected_owner != Some(handle.owner) {
+            NetworkHintDecision::StaleRejected
+        } else {
+            let mut authority = handle
+                .physical_network_authority
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let decision = authority.accept(
+                service_incarnation as u64,
+                handle.owner,
+                kotlin_network_generation as u64,
+                &hash,
+            );
+            if decision == NetworkHintDecision::Applied {
+                let hint = p2pnet_daemon::AndroidNetworkChangeHint {
+                    kotlin_network_generation: kotlin_network_generation as u64,
+                    network_identity_hash: hash,
+                };
+                if handle.network_change_tx.send(hint).is_err() {
+                    NetworkHintDecision::Failed
+                } else {
+                    decision
+                }
+            } else {
+                decision
+            }
+        };
+        new_string_or_null(&mut env, Some(decision.wire_name().to_string()))
     }
 
     #[no_mangle]

--- a/client/android-native/src/lib.rs
+++ b/client/android-native/src/lib.rs
@@ -5,688 +5,802 @@
 //! runtime thread, and exposes only a small start/stop/status surface to the
 //! Flutter Android host.
 
-#![cfg(target_os = "android")]
+pub mod lifecycle;
 
-use std::os::fd::RawFd;
-use std::os::fd::{FromRawFd, OwnedFd};
-use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::{Path, PathBuf};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    mpsc, Arc, Mutex, OnceLock,
-};
-use std::thread;
-use std::time::Duration;
-use std::{
-    fs::{File, OpenOptions},
-    io::{self, Write},
-};
+#[cfg(target_os = "android")]
+mod android_bridge {
+    use super::lifecycle::OwnerId;
 
-use jni::objects::{GlobalRef, JObject, JString, JValue};
-use jni::sys::{jboolean, jint, jstring};
-use jni::{JNIEnv, JavaVM};
-use rand::RngCore;
-use serde::Deserialize;
-use tokio::runtime::Builder;
-use tokio::sync::watch;
+    use std::os::fd::RawFd;
+    use std::os::fd::{FromRawFd, OwnedFd};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::path::{Path, PathBuf};
+    use std::sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc, Arc, Mutex, OnceLock,
+    };
+    use std::thread;
+    use std::time::Duration;
+    use std::{
+        fs::{File, OpenOptions},
+        io::{self, Write},
+    };
 
-use p2pnet_daemon::config::{Config, ControlProxyMode};
-use p2pnet_daemon::Daemon;
-use p2pnet_tun::AndroidTunMode;
+    use jni::objects::{GlobalRef, JObject, JString, JValue};
+    use jni::sys::{jboolean, jint, jlong, jstring};
+    use jni::{JNIEnv, JavaVM};
+    use rand::RngCore;
+    use serde::Deserialize;
+    use tokio::runtime::Builder;
+    use tokio::sync::watch;
 
-const DEFAULT_DIAGNOSTICS_BIND: &str = "127.0.0.1:39277";
-const DEFAULT_CONTROL_SERVER: &str = "http://47.109.40.237:18080";
-const DEFAULT_OVERLAY_CIDR: &str = "10.20.0.0/16";
-const DEFAULT_INTERFACE: &str = "p2wlan-vpn";
-const DEFAULT_VIRTUAL_IP: &str = "10.20.0.1";
+    use p2pnet_daemon::config::{Config, ControlProxyMode};
+    use p2pnet_daemon::Daemon;
+    use p2pnet_tun::AndroidTunMode;
 
-#[derive(Debug, Default, Deserialize)]
-struct AndroidStartRequest {
-    #[serde(default)]
-    config_path: String,
-    #[serde(default)]
-    control_server: String,
-    #[serde(default)]
-    network_id: String,
-    #[serde(default)]
-    auth_token: String,
-    #[serde(default)]
-    device_name: String,
-    #[serde(default)]
-    virtual_ip: String,
-    #[serde(default)]
-    manual_mode: bool,
-    #[serde(default)]
-    overlay_cidr: String,
-    #[serde(default)]
-    mtu: u32,
-    #[serde(default)]
-    udp_bind: String,
-    #[serde(default)]
-    udp_advertise: String,
-    #[serde(default)]
-    relay_servers: String,
-    #[serde(default)]
-    socket_pool: String,
-    #[serde(default)]
-    diagnostics_bind: String,
-    #[serde(default)]
-    log_path: String,
-    #[serde(default)]
-    diagnostics_auth_path: String,
-    #[serde(default = "default_android_tun_mode")]
-    android_tun_mode: String,
-}
+    const DEFAULT_DIAGNOSTICS_BIND: &str = "127.0.0.1:39277";
+    const DEFAULT_CONTROL_SERVER: &str = "http://47.109.40.237:18080";
+    const DEFAULT_OVERLAY_CIDR: &str = "10.20.0.0/16";
+    const DEFAULT_INTERFACE: &str = "p2wlan-vpn";
+    const DEFAULT_VIRTUAL_IP: &str = "10.20.0.1";
 
-fn default_android_tun_mode() -> String {
-    "async_fd".to_string()
-}
+    #[derive(Debug, Default, Deserialize)]
+    struct AndroidStartRequest {
+        #[serde(default)]
+        config_path: String,
+        #[serde(default)]
+        control_server: String,
+        #[serde(default)]
+        network_id: String,
+        #[serde(default)]
+        auth_token: String,
+        #[serde(default)]
+        device_name: String,
+        #[serde(default)]
+        virtual_ip: String,
+        #[serde(default)]
+        manual_mode: bool,
+        #[serde(default)]
+        overlay_cidr: String,
+        #[serde(default)]
+        mtu: u32,
+        #[serde(default)]
+        udp_bind: String,
+        #[serde(default)]
+        udp_advertise: String,
+        #[serde(default)]
+        relay_servers: String,
+        #[serde(default)]
+        socket_pool: String,
+        #[serde(default)]
+        diagnostics_bind: String,
+        #[serde(default)]
+        log_path: String,
+        #[serde(default)]
+        diagnostics_auth_path: String,
+        #[serde(default = "default_android_tun_mode")]
+        android_tun_mode: String,
+    }
 
-#[derive(Clone)]
-struct RuntimeHandle {
-    shutdown_tx: watch::Sender<bool>,
-    running: Arc<AtomicBool>,
-    ready: Arc<AtomicBool>,
-}
+    fn default_android_tun_mode() -> String {
+        "async_fd".to_string()
+    }
 
-static RUNTIME: OnceLock<Mutex<Option<RuntimeHandle>>> = OnceLock::new();
-static LAST_ERROR: OnceLock<Mutex<Option<String>>> = OnceLock::new();
-static ANDROID_SOCKET_PROTECTOR: OnceLock<Mutex<Option<AndroidSocketProtector>>> = OnceLock::new();
+    #[derive(Clone)]
+    struct RuntimeHandle {
+        owner: OwnerId,
+        shutdown_tx: watch::Sender<bool>,
+        running: Arc<AtomicBool>,
+        ready: Arc<AtomicBool>,
+    }
 
-struct AndroidSocketProtector {
-    vm: JavaVM,
-    service: GlobalRef,
-}
+    static RUNTIME: OnceLock<Mutex<Option<RuntimeHandle>>> = OnceLock::new();
+    #[derive(Debug)]
+    struct OwnedLastError {
+        owner: OwnerId,
+        message: String,
+    }
 
-fn runtime_slot() -> &'static Mutex<Option<RuntimeHandle>> {
-    RUNTIME.get_or_init(|| Mutex::new(None))
-}
+    static LATEST_OWNER: AtomicU64 = AtomicU64::new(0);
+    static START_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    static LAST_ERROR: OnceLock<Mutex<Option<OwnedLastError>>> = OnceLock::new();
+    static ANDROID_SOCKET_PROTECTOR: OnceLock<Mutex<Option<AndroidSocketProtector>>> =
+        OnceLock::new();
 
-fn last_error_slot() -> &'static Mutex<Option<String>> {
-    LAST_ERROR.get_or_init(|| Mutex::new(None))
-}
+    struct AndroidSocketProtector {
+        owner: OwnerId,
+        vm: JavaVM,
+        service: GlobalRef,
+    }
 
-fn android_socket_protector_slot() -> &'static Mutex<Option<AndroidSocketProtector>> {
-    ANDROID_SOCKET_PROTECTOR.get_or_init(|| Mutex::new(None))
-}
+    fn runtime_slot() -> &'static Mutex<Option<RuntimeHandle>> {
+        RUNTIME.get_or_init(|| Mutex::new(None))
+    }
 
-fn protect_android_socket(fd: RawFd) -> io::Result<()> {
-    let guard = android_socket_protector_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let protector = guard.as_ref().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotConnected,
-            "Android VpnService protector is not installed",
-        )
-    })?;
-    let mut env = protector.vm.attach_current_thread().map_err(|error| {
-        io::Error::other(format!("failed to attach socket thread to JVM: {error}"))
-    })?;
-    let protected = env
-        .call_method(
-            protector.service.as_obj(),
-            "protect",
-            "(I)Z",
-            &[JValue::Int(fd as jint)],
-        )
-        .map_err(|error| io::Error::other(format!("VpnService.protect(fd) failed: {error}")))?
-        .z()
-        .map_err(|error| {
-            io::Error::other(format!(
-                "VpnService.protect(fd) returned an invalid value: {error}"
-            ))
+    fn start_lock() -> &'static Mutex<()> {
+        START_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn android_socket_protector_slot() -> &'static Mutex<Option<AndroidSocketProtector>> {
+        ANDROID_SOCKET_PROTECTOR.get_or_init(|| Mutex::new(None))
+    }
+
+    fn protect_android_socket(fd: RawFd) -> io::Result<()> {
+        let guard = android_socket_protector_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let protector = guard.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotConnected,
+                "Android VpnService protector is not installed",
+            )
         })?;
-    if protected {
+        let mut env = protector.vm.attach_current_thread().map_err(|error| {
+            io::Error::other(format!("failed to attach socket thread to JVM: {error}"))
+        })?;
+        let protected = env
+            .call_method(
+                protector.service.as_obj(),
+                "protect",
+                "(I)Z",
+                &[JValue::Int(fd as jint)],
+            )
+            .map_err(|error| io::Error::other(format!("VpnService.protect(fd) failed: {error}")))?
+            .z()
+            .map_err(|error| {
+                io::Error::other(format!(
+                    "VpnService.protect(fd) returned an invalid value: {error}"
+                ))
+            })?;
+        if protected {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("VpnService.protect({fd}) returned false"),
+            ))
+        }
+    }
+
+    fn install_android_socket_protector(
+        env: &mut JNIEnv<'_>,
+        service: JObject<'_>,
+        owner: OwnerId,
+    ) -> Result<(), String> {
+        let vm = env
+            .get_java_vm()
+            .map_err(|error| format!("failed to acquire Android JavaVM: {error}"))?;
+        let service = env
+            .new_global_ref(service)
+            .map_err(|error| format!("failed to retain Android VpnService: {error}"))?;
+        *android_socket_protector_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some(AndroidSocketProtector { owner, vm, service });
+        p2pnet_netbind::set_android_socket_protector(protect_android_socket);
         Ok(())
-    } else {
-        Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("VpnService.protect({fd}) returned false"),
-        ))
-    }
-}
-
-fn install_android_socket_protector(
-    env: &mut JNIEnv<'_>,
-    service: JObject<'_>,
-) -> Result<(), String> {
-    let vm = env
-        .get_java_vm()
-        .map_err(|error| format!("failed to acquire Android JavaVM: {error}"))?;
-    let service = env
-        .new_global_ref(service)
-        .map_err(|error| format!("failed to retain Android VpnService: {error}"))?;
-    *android_socket_protector_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-        Some(AndroidSocketProtector { vm, service });
-    p2pnet_netbind::set_android_socket_protector(protect_android_socket);
-    Ok(())
-}
-
-fn clear_android_socket_protector() {
-    p2pnet_netbind::clear_android_socket_protector();
-    *android_socket_protector_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
-}
-
-fn set_last_error(error: Option<String>) {
-    let mut guard = last_error_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = error;
-}
-
-fn last_error() -> Option<String> {
-    last_error_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .clone()
-}
-
-fn runtime_running() -> bool {
-    runtime_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .as_ref()
-        .is_some_and(|handle| handle.running.load(Ordering::Acquire))
-}
-
-fn runtime_ready() -> bool {
-    runtime_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .as_ref()
-        .is_some_and(|handle| handle.ready.load(Ordering::Acquire))
-}
-
-fn close_raw_fd(fd: jint) {
-    if fd >= 0 {
-        // Safety: this is only called on startup paths where ownership has
-        // not yet been transferred into AndroidTun. Once Daemon takes the fd,
-        // its OwnedFd is responsible for closing it.
-        unsafe { drop(OwnedFd::from_raw_fd(fd)) };
-    }
-}
-
-fn read_request(
-    env: &mut JNIEnv<'_>,
-    request_json: JString<'_>,
-) -> Result<AndroidStartRequest, String> {
-    let request = env
-        .get_string(&request_json)
-        .map_err(|error| format!("failed to read Android VPN request: {error}"))?
-        .to_string_lossy()
-        .into_owned();
-    serde_json::from_str(&request)
-        .map_err(|error| format!("invalid Android VPN request JSON: {error}"))
-}
-
-fn non_empty(value: &str, fallback: &str) -> String {
-    let value = value.trim();
-    if value.is_empty() {
-        fallback.to_string()
-    } else {
-        value.to_string()
-    }
-}
-
-fn overlay_prefix_and_netmask(cidr: &str) -> (String, String) {
-    let prefix = cidr
-        .split_once('/')
-        .and_then(|(_, prefix)| prefix.parse::<u32>().ok())
-        .filter(|prefix| *prefix <= 32)
-        .unwrap_or(16);
-    let mask = if prefix == 0 {
-        0
-    } else {
-        u32::MAX << (32 - prefix)
-    };
-    (
-        prefix.to_string(),
-        std::net::Ipv4Addr::from(mask).to_string(),
-    )
-}
-
-fn write_diagnostics_auth(path: &Path) -> Result<String, String> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| "diagnostics auth path has no parent directory".to_string())?;
-    std::fs::create_dir_all(parent)
-        .map_err(|error| format!("failed to create Android daemon directory: {error}"))?;
-
-    let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    let token = hex::encode(bytes);
-    std::fs::write(path, token.as_bytes())
-        .map_err(|error| format!("failed to write diagnostics auth token: {error}"))?;
-
-    protect_private_file(path)
-        .map_err(|error| format!("failed to protect diagnostics auth token: {error}"))?;
-    Ok(token)
-}
-
-/// Android's app directory is private by default, but files created by a
-/// native process still inherit the process umask.  Explicitly enforce
-/// owner-only permissions for every daemon log/auth file, including files
-/// created by an older release with broader permissions.
-fn protect_private_file(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(path)?.permissions();
-        permissions.set_mode(0o600);
-        std::fs::set_permissions(path, permissions)?;
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-    Ok(())
-}
-
-fn open_private_append(path: &Path) -> io::Result<File> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let file = OpenOptions::new().create(true).append(true).open(path)?;
-    if let Err(error) = protect_private_file(path) {
-        drop(file);
-        return Err(error);
-    }
-    Ok(file)
-}
-
-fn prepare_config(request: &AndroidStartRequest) -> Result<(Config, PathBuf), String> {
-    let config_path = PathBuf::from(request.config_path.trim());
-    if config_path.as_os_str().is_empty() {
-        return Err("Android daemon config path is empty".to_string());
-    }
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("failed to create Android config directory: {error}"))?;
     }
 
-    let control_server = non_empty(&request.control_server, DEFAULT_CONTROL_SERVER);
-    let network_id = non_empty(&request.network_id, "default");
-    let mut config = if config_path.exists() {
-        Config::load_from_file(&config_path)
-            .map_err(|error| format!("failed to load Android daemon config: {error}"))?
-    } else {
-        Config::generate_default(&control_server, &network_id)
-            .map_err(|error| format!("failed to generate Android daemon identity: {error}"))?
-    };
-
-    let cidr = non_empty(&request.overlay_cidr, DEFAULT_OVERLAY_CIDR);
-    let (_prefix, netmask) = overlay_prefix_and_netmask(&cidr);
-    let configured_vip = if request.virtual_ip.trim().is_empty() {
-        non_empty(&config.network.virtual_ip, DEFAULT_VIRTUAL_IP)
-    } else {
-        request.virtual_ip.trim().to_string()
-    };
-    let mtu = if request.mtu == 0 {
-        config.network.mtu
-    } else {
-        request.mtu.clamp(576, 65535)
-    };
-
-    config.config_path = Some(config_path.clone());
-    config.control.server_url = control_server;
-    config.control.auth_token = request.auth_token.trim().to_string();
-    config.control.proxy_mode = ControlProxyMode::Direct;
-    config.network.network_id = network_id;
-    let has_control_credential = !config.control.auth_token.trim().is_empty()
-        || !config.control.device_credential.trim().is_empty();
-    config.network.manual = request.manual_mode || !has_control_credential;
-    config.network.virtual_ip = configured_vip;
-    config.network.cidr = cidr;
-    config.network.netmask = netmask;
-    config.network.mtu = mtu;
-    config.network.interface = DEFAULT_INTERFACE.to_string();
-    if !request.udp_bind.trim().is_empty() {
-        config.network.udp_bind = request.udp_bind.trim().to_string();
-    }
-    config.network.udp_advertise = if request.udp_advertise.trim().is_empty() {
-        None
-    } else {
-        Some(request.udp_advertise.trim().to_string())
-    };
-    if !request.device_name.trim().is_empty() {
-        config.node.device_name = request.device_name.trim().to_string();
-    }
-    config.node.platform = "android".to_string();
-    if !request.relay_servers.trim().is_empty() {
-        config.relay.servers = request
-            .relay_servers
-            .split(',')
-            .map(str::trim)
-            .filter(|server| !server.is_empty())
-            .map(ToOwned::to_owned)
-            .collect();
-    }
-    match request.socket_pool.trim().to_ascii_lowercase().as_str() {
-        "on" | "auto" => {
-            config.network.socket_pool_enabled = true;
-        }
-        "off" => {
-            config.network.socket_pool_enabled = false;
-        }
-        value => {
-            if let Ok(size) = value.parse::<usize>() {
-                config.network.socket_pool_size = size.clamp(1, 16);
-                config.network.socket_pool_enabled = size > 1;
-            }
-        }
-    }
-
-    let diagnostics_bind = non_empty(&request.diagnostics_bind, DEFAULT_DIAGNOSTICS_BIND);
-    let log_path = non_empty(
-        &request.log_path,
-        &config_path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join("p2wlan-daemon.log")
-            .to_string_lossy(),
-    );
-    let auth_path = non_empty(
-        &request.diagnostics_auth_path,
-        &config_path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join("p2wlan-daemon.diag-auth")
-            .to_string_lossy(),
-    );
-    let auth_path = PathBuf::from(auth_path);
-    let auth_token = write_diagnostics_auth(&auth_path)?;
-    config.diagnostics.enabled = true;
-    config.diagnostics.bind = diagnostics_bind;
-    config.diagnostics.log_path = Some(PathBuf::from(log_path));
-    config.diagnostics.auth_token = Some(auth_token);
-    config.diagnostics.auth_token_path = Some(auth_path);
-
-    // Persist identity and network defaults, but never persist the user JWT
-    // or the per-process diagnostics token.
-    let mut persisted = config.clone();
-    persisted.control.auth_token.clear();
-    persisted.diagnostics.auth_token = None;
-    persisted.diagnostics.auth_token_path = None;
-    persisted.diagnostics.log_path = None;
-    persisted
-        .save_to_file(&config_path)
-        .map_err(|error| format!("failed to persist Android daemon config: {error}"))?;
-
-    Ok((config, config_path))
-}
-
-fn append_log(path: &Path, message: &str) {
-    if let Ok(mut file) = open_private_append(path) {
-        let _ = writeln!(file, "{message}");
-    }
-}
-
-/// Install the process-wide Rust subscriber once. The desktop executable does
-/// this in its `main`, but Android enters through JNI and otherwise all
-/// `tracing` records would disappear, leaving the user with an empty local
-/// log when the VPN failed during startup.
-fn init_logging(path: &Path) {
-    static LOGGING: OnceLock<()> = OnceLock::new();
-    LOGGING.get_or_init(|| {
-        let Ok(file) = open_private_append(path) else {
-            return;
-        };
-        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .with_ansi(false)
-            .with_writer(move || {
-                file.try_clone()
-                    .expect("failed to clone Android daemon log file handle")
-            })
-            .try_init();
-    });
-}
-
-fn start_runtime(tun_fd: jint, request: AndroidStartRequest) -> Result<(), String> {
-    {
-        let guard = runtime_slot()
+    fn clear_android_socket_protector(owner: OwnerId) {
+        // Hold the protector slot while clearing netbind's process-wide callback.
+        // This closes the otherwise possible A-clear/B-install/A-clear ordering:
+        // B cannot install until both the owner check and the netbind clear finish.
+        let mut guard = android_socket_protector_slot()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if guard
             .as_ref()
-            .is_some_and(|handle| handle.running.load(Ordering::Acquire))
+            .is_some_and(|protector| protector.owner == owner)
         {
-            close_raw_fd(tun_fd);
-            return Err("an existing Android P2WLAN daemon is still running".to_string());
+            p2pnet_netbind::clear_android_socket_protector();
+            *guard = None;
         }
     }
 
-    let (config, config_path) = match prepare_config(&request) {
-        Ok(value) => value,
-        Err(error) => {
-            close_raw_fd(tun_fd);
+    fn last_error_slot() -> &'static Mutex<Option<OwnedLastError>> {
+        LAST_ERROR.get_or_init(|| Mutex::new(None))
+    }
+
+    fn register_owner(owner: OwnerId) {
+        let mut latest = LATEST_OWNER.load(Ordering::Acquire);
+        while owner.raw() > latest {
+            match LATEST_OWNER.compare_exchange_weak(
+                latest,
+                owner.raw(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => latest = observed,
+            }
+        }
+    }
+
+    /// Record an error only for the newest runtime owner. An old runtime can
+    /// finish after a replacement has started; its late error must not become
+    /// the replacement's diagnostic state.
+    fn set_last_error(owner: OwnerId, error: Option<String>) {
+        if owner.raw() < LATEST_OWNER.load(Ordering::Acquire) {
+            return;
+        }
+        let mut guard = last_error_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard
+            .as_ref()
+            .is_some_and(|previous| previous.owner.raw() > owner.raw())
+        {
+            return;
+        }
+        *guard = error.map(|message| OwnedLastError { owner, message });
+    }
+
+    fn last_error() -> Option<String> {
+        let current_owner = runtime_incarnation();
+        last_error_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|error| current_owner.is_none_or(|owner| owner == error.owner))
+            .map(|error| error.message.clone())
+    }
+
+    fn last_error_for(owner: OwnerId) -> Option<String> {
+        last_error_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|error| error.owner == owner)
+            .map(|error| error.message.clone())
+    }
+
+    fn runtime_running() -> bool {
+        runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .is_some_and(|handle| handle.running.load(Ordering::Acquire))
+    }
+
+    fn runtime_ready() -> bool {
+        runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .is_some_and(|handle| handle.ready.load(Ordering::Acquire))
+    }
+
+    fn runtime_incarnation() -> Option<OwnerId> {
+        runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|handle| handle.running.load(Ordering::Acquire))
+            .map(|handle| handle.owner)
+    }
+
+    fn close_raw_fd(fd: jint) {
+        if fd >= 0 {
+            // Safety: this is only called on startup paths where ownership has
+            // not yet been transferred into AndroidTun. Once Daemon takes the fd,
+            // its OwnedFd is responsible for closing it.
+            unsafe { drop(OwnedFd::from_raw_fd(fd)) };
+        }
+    }
+
+    fn read_request(
+        env: &mut JNIEnv<'_>,
+        request_json: JString<'_>,
+    ) -> Result<AndroidStartRequest, String> {
+        let request = env
+            .get_string(&request_json)
+            .map_err(|error| format!("failed to read Android VPN request: {error}"))?
+            .to_string_lossy()
+            .into_owned();
+        serde_json::from_str(&request)
+            .map_err(|error| format!("invalid Android VPN request JSON: {error}"))
+    }
+
+    fn non_empty(value: &str, fallback: &str) -> String {
+        let value = value.trim();
+        if value.is_empty() {
+            fallback.to_string()
+        } else {
+            value.to_string()
+        }
+    }
+
+    fn overlay_prefix_and_netmask(cidr: &str) -> (String, String) {
+        let prefix = cidr
+            .split_once('/')
+            .and_then(|(_, prefix)| prefix.parse::<u32>().ok())
+            .filter(|prefix| *prefix <= 32)
+            .unwrap_or(16);
+        let mask = if prefix == 0 {
+            0
+        } else {
+            u32::MAX << (32 - prefix)
+        };
+        (
+            prefix.to_string(),
+            std::net::Ipv4Addr::from(mask).to_string(),
+        )
+    }
+
+    fn write_diagnostics_auth(path: &Path) -> Result<String, String> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| "diagnostics auth path has no parent directory".to_string())?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create Android daemon directory: {error}"))?;
+
+        let mut bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        let token = hex::encode(bytes);
+        std::fs::write(path, token.as_bytes())
+            .map_err(|error| format!("failed to write diagnostics auth token: {error}"))?;
+
+        protect_private_file(path)
+            .map_err(|error| format!("failed to protect diagnostics auth token: {error}"))?;
+        Ok(token)
+    }
+
+    /// Android's app directory is private by default, but files created by a
+    /// native process still inherit the process umask.  Explicitly enforce
+    /// owner-only permissions for every daemon log/auth file, including files
+    /// created by an older release with broader permissions.
+    fn protect_private_file(path: &Path) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(path)?.permissions();
+            permissions.set_mode(0o600);
+            std::fs::set_permissions(path, permissions)?;
+        }
+        #[cfg(not(unix))]
+        let _ = path;
+        Ok(())
+    }
+
+    fn open_private_append(path: &Path) -> io::Result<File> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        if let Err(error) = protect_private_file(path) {
+            drop(file);
             return Err(error);
         }
-    };
-    let tun_mode = match request.android_tun_mode.parse::<AndroidTunMode>() {
-        Ok(mode) => mode,
-        Err(error) => {
-            close_raw_fd(tun_fd);
-            return Err(error);
+        Ok(file)
+    }
+
+    fn prepare_config(request: &AndroidStartRequest) -> Result<(Config, PathBuf), String> {
+        let config_path = PathBuf::from(request.config_path.trim());
+        if config_path.as_os_str().is_empty() {
+            return Err("Android daemon config path is empty".to_string());
         }
-    };
-    let log_path = config
-        .diagnostics
-        .log_path
-        .clone()
-        .unwrap_or_else(|| config_path.with_file_name("p2wlan-daemon.log"));
-    let running = Arc::new(AtomicBool::new(true));
-    let ready = Arc::new(AtomicBool::new(false));
-    let running_for_thread = Arc::clone(&running);
-    let ready_for_thread = Arc::clone(&ready);
-    // This channel acknowledges only that the runtime handle has been
-    // installed. Actual daemon readiness is published separately through
-    // `ready_for_thread` by Daemon::run after registration, TUN attachment,
-    // diagnostics, and dataplane setup have completed.
-    let (handle_tx, handle_rx) = mpsc::sync_channel::<Result<RuntimeHandle, String>>(1);
+        if let Some(parent) = config_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("failed to create Android config directory: {error}"))?;
+        }
 
-    let thread_result = thread::Builder::new()
-        .name("p2wlan-daemon".to_string())
-        .spawn(move || {
-            let mut fd_owned_by_thread = true;
-            let startup_result = catch_unwind(AssertUnwindSafe(|| {
-                init_logging(&log_path);
-                let runtime = Builder::new_multi_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|error| format!("failed to create Tokio runtime: {error}"))?;
-                // Daemon::new creates the managed control workers with
-                // tokio::spawn. JNI threads do not automatically enter the
-                // runtime they just built, so construct the daemon inside an
-                // explicit runtime context or managed Android starts panic
-                // before the first control request is sent.
-                let mut daemon = {
-                    let _runtime_guard = runtime.enter();
-                    let mut daemon = Daemon::new_with_android_tun_mode(config, tun_fd, tun_mode);
-                    fd_owned_by_thread = false;
-                    daemon.set_android_startup_ready(Arc::clone(&ready_for_thread));
-                    let handle = RuntimeHandle {
-                        shutdown_tx: daemon.shutdown_sender(),
-                        running: Arc::clone(&running_for_thread),
-                        ready: Arc::clone(&ready_for_thread),
-                    };
-                    handle_tx
-                        .send(Ok(handle))
-                        .map_err(|_| "Android daemon launch waiter disconnected".to_string())?;
-                    daemon
-                };
-                if let Err(error) = runtime.block_on(daemon.run()) {
-                    let message = format!("Android daemon exited with error: {error}");
-                    set_last_error(Some(message.clone()));
-                    append_log(&log_path, &message);
-                }
-                Ok::<(), String>(())
-            }));
+        let control_server = non_empty(&request.control_server, DEFAULT_CONTROL_SERVER);
+        let network_id = non_empty(&request.network_id, "default");
+        let mut config = if config_path.exists() {
+            Config::load_from_file(&config_path)
+                .map_err(|error| format!("failed to load Android daemon config: {error}"))?
+        } else {
+            Config::generate_default(&control_server, &network_id)
+                .map_err(|error| format!("failed to generate Android daemon identity: {error}"))?
+        };
 
-            if fd_owned_by_thread {
-                close_raw_fd(tun_fd);
+        let cidr = non_empty(&request.overlay_cidr, DEFAULT_OVERLAY_CIDR);
+        let (_prefix, netmask) = overlay_prefix_and_netmask(&cidr);
+        let configured_vip = if request.virtual_ip.trim().is_empty() {
+            non_empty(&config.network.virtual_ip, DEFAULT_VIRTUAL_IP)
+        } else {
+            request.virtual_ip.trim().to_string()
+        };
+        let mtu = if request.mtu == 0 {
+            config.network.mtu
+        } else {
+            request.mtu.clamp(576, 65535)
+        };
+
+        config.config_path = Some(config_path.clone());
+        config.control.server_url = control_server;
+        config.control.auth_token = request.auth_token.trim().to_string();
+        config.control.proxy_mode = ControlProxyMode::Direct;
+        config.network.network_id = network_id;
+        let has_control_credential = !config.control.auth_token.trim().is_empty()
+            || !config.control.device_credential.trim().is_empty();
+        config.network.manual = request.manual_mode || !has_control_credential;
+        config.network.virtual_ip = configured_vip;
+        config.network.cidr = cidr;
+        config.network.netmask = netmask;
+        config.network.mtu = mtu;
+        config.network.interface = DEFAULT_INTERFACE.to_string();
+        if !request.udp_bind.trim().is_empty() {
+            config.network.udp_bind = request.udp_bind.trim().to_string();
+        }
+        config.network.udp_advertise = if request.udp_advertise.trim().is_empty() {
+            None
+        } else {
+            Some(request.udp_advertise.trim().to_string())
+        };
+        if !request.device_name.trim().is_empty() {
+            config.node.device_name = request.device_name.trim().to_string();
+        }
+        config.node.platform = "android".to_string();
+        if !request.relay_servers.trim().is_empty() {
+            config.relay.servers = request
+                .relay_servers
+                .split(',')
+                .map(str::trim)
+                .filter(|server| !server.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+        }
+        match request.socket_pool.trim().to_ascii_lowercase().as_str() {
+            "on" | "auto" => {
+                config.network.socket_pool_enabled = true;
             }
-
-            match startup_result {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    set_last_error(Some(error.clone()));
-                    append_log(&log_path, &error);
-                    let _ = handle_tx.send(Err(error));
-                }
-                Err(_) => {
-                    let error = "Android daemon thread panicked during startup".to_string();
-                    set_last_error(Some(error.clone()));
-                    append_log(&log_path, &error);
-                    let _ = handle_tx.send(Err(error));
+            "off" => {
+                config.network.socket_pool_enabled = false;
+            }
+            value => {
+                if let Ok(size) = value.parse::<usize>() {
+                    config.network.socket_pool_size = size.clamp(1, 16);
+                    config.network.socket_pool_enabled = size > 1;
                 }
             }
-            ready_for_thread.store(false, Ordering::Release);
-            running_for_thread.store(false, Ordering::Release);
-            let mut guard = runtime_slot()
+        }
+
+        let diagnostics_bind = non_empty(&request.diagnostics_bind, DEFAULT_DIAGNOSTICS_BIND);
+        let log_path = non_empty(
+            &request.log_path,
+            &config_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join("p2wlan-daemon.log")
+                .to_string_lossy(),
+        );
+        let auth_path = non_empty(
+            &request.diagnostics_auth_path,
+            &config_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join("p2wlan-daemon.diag-auth")
+                .to_string_lossy(),
+        );
+        let auth_path = PathBuf::from(auth_path);
+        let auth_token = write_diagnostics_auth(&auth_path)?;
+        config.diagnostics.enabled = true;
+        config.diagnostics.bind = diagnostics_bind;
+        config.diagnostics.log_path = Some(PathBuf::from(log_path));
+        config.diagnostics.auth_token = Some(auth_token);
+        config.diagnostics.auth_token_path = Some(auth_path);
+
+        // Persist identity and network defaults, but never persist the user JWT
+        // or the per-process diagnostics token.
+        let mut persisted = config.clone();
+        persisted.control.auth_token.clear();
+        persisted.diagnostics.auth_token = None;
+        persisted.diagnostics.auth_token_path = None;
+        persisted.diagnostics.log_path = None;
+        persisted
+            .save_to_file(&config_path)
+            .map_err(|error| format!("failed to persist Android daemon config: {error}"))?;
+
+        Ok((config, config_path))
+    }
+
+    fn append_log(path: &Path, message: &str) {
+        if let Ok(mut file) = open_private_append(path) {
+            let _ = writeln!(file, "{message}");
+        }
+    }
+
+    /// Install the process-wide Rust subscriber once. The desktop executable does
+    /// this in its `main`, but Android enters through JNI and otherwise all
+    /// `tracing` records would disappear, leaving the user with an empty local
+    /// log when the VPN failed during startup.
+    fn init_logging(path: &Path) {
+        static LOGGING: OnceLock<()> = OnceLock::new();
+        LOGGING.get_or_init(|| {
+            let Ok(file) = open_private_append(path) else {
+                return;
+            };
+            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+            let _ = tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .with_ansi(false)
+                .with_writer(move || {
+                    file.try_clone()
+                        .expect("failed to clone Android daemon log file handle")
+                })
+                .try_init();
+        });
+    }
+
+    fn start_runtime(
+        tun_fd: jint,
+        request: AndroidStartRequest,
+        owner: OwnerId,
+    ) -> Result<(), String> {
+        {
+            let guard = runtime_slot()
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if guard
                 .as_ref()
-                .is_some_and(|handle| Arc::ptr_eq(&handle.running, &running_for_thread))
+                .is_some_and(|handle| handle.running.load(Ordering::Acquire))
             {
-                *guard = None;
+                close_raw_fd(tun_fd);
+                return Err("an existing Android P2WLAN daemon is still running".to_string());
             }
-            clear_android_socket_protector();
-        })
-        .map_err(|error| format!("failed to start Android daemon thread: {error}"));
-    if let Err(error) = thread_result {
-        close_raw_fd(tun_fd);
-        return Err(error);
-    }
-
-    let handle = handle_rx
-        .recv_timeout(Duration::from_secs(2))
-        .map_err(|error| format!("Android daemon runtime did not start: {error}"))??;
-    if !handle.running.load(Ordering::Acquire) {
-        return Err(last_error().unwrap_or_else(|| {
-            "Android daemon exited before its runtime handle became active".to_string()
-        }));
-    }
-    let mut guard = runtime_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(handle);
-    Ok(())
-}
-
-fn stop_runtime() -> bool {
-    let guard = runtime_slot()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(handle) = guard.as_ref() {
-        let _ = handle.shutdown_tx.send(true);
-        true
-    } else {
-        false
-    }
-}
-
-fn new_string_or_null(env: &mut JNIEnv<'_>, error: Option<String>) -> jstring {
-    match error {
-        Some(error) => env
-            .new_string(error)
-            .map(|value| value.into_raw())
-            .unwrap_or(std::ptr::null_mut()),
-        None => std::ptr::null_mut(),
-    }
-}
-
-/// Start the Rust daemon around the Android VPN fd. A null return means the
-/// daemon runtime handle was installed; actual readiness is reported by the
-/// diagnostics endpoint and `nativeIsReady`. A non-null string means the
-/// runtime could not be launched. Before the startup thread is created the
-/// caller still owns the fd; after that handoff Rust closes or drops it on
-/// every startup/error path.
-#[no_mangle]
-pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeStart(
-    mut env: JNIEnv<'_>,
-    _object: JObject<'_>,
-    service: JObject<'_>,
-    tun_fd: jint,
-    request_json: JString<'_>,
-) -> jstring {
-    set_last_error(None);
-    let result = match read_request(&mut env, request_json) {
-        Ok(_request) if runtime_running() => {
-            close_raw_fd(tun_fd);
-            Err("an existing Android P2WLAN daemon is still running".to_string())
         }
-        Ok(request) => match install_android_socket_protector(&mut env, service) {
-            Ok(()) => start_runtime(tun_fd, request),
+
+        let (config, config_path) = match prepare_config(&request) {
+            Ok(value) => value,
             Err(error) => {
+                close_raw_fd(tun_fd);
+                return Err(error);
+            }
+        };
+        let tun_mode = match request.android_tun_mode.parse::<AndroidTunMode>() {
+            Ok(mode) => mode,
+            Err(error) => {
+                close_raw_fd(tun_fd);
+                return Err(error);
+            }
+        };
+        let log_path = config
+            .diagnostics
+            .log_path
+            .clone()
+            .unwrap_or_else(|| config_path.with_file_name("p2wlan-daemon.log"));
+        let running = Arc::new(AtomicBool::new(true));
+        let ready = Arc::new(AtomicBool::new(false));
+        let running_for_thread = Arc::clone(&running);
+        let ready_for_thread = Arc::clone(&ready);
+        // This channel acknowledges only that the runtime handle has been
+        // installed. Actual daemon readiness is published separately through
+        // `ready_for_thread` by Daemon::run after registration, TUN attachment,
+        // diagnostics, and dataplane setup have completed.
+        let (handle_tx, handle_rx) = mpsc::sync_channel::<Result<RuntimeHandle, String>>(1);
+
+        let thread_result = thread::Builder::new()
+            .name("p2wlan-daemon".to_string())
+            .spawn(move || {
+                let mut fd_owned_by_thread = true;
+                let startup_result = catch_unwind(AssertUnwindSafe(|| {
+                    init_logging(&log_path);
+                    let runtime = Builder::new_multi_thread()
+                        .enable_all()
+                        .build()
+                        .map_err(|error| format!("failed to create Tokio runtime: {error}"))?;
+                    // Daemon::new creates the managed control workers with
+                    // tokio::spawn. JNI threads do not automatically enter the
+                    // runtime they just built, so construct the daemon inside an
+                    // explicit runtime context or managed Android starts panic
+                    // before the first control request is sent.
+                    let mut daemon = {
+                        let _runtime_guard = runtime.enter();
+                        let mut daemon =
+                            Daemon::new_with_android_tun_mode(config, tun_fd, tun_mode);
+                        fd_owned_by_thread = false;
+                        daemon.set_android_startup_ready(Arc::clone(&ready_for_thread));
+                        let handle = RuntimeHandle {
+                            owner,
+                            shutdown_tx: daemon.shutdown_sender(),
+                            running: Arc::clone(&running_for_thread),
+                            ready: Arc::clone(&ready_for_thread),
+                        };
+                        handle_tx
+                            .send(Ok(handle))
+                            .map_err(|_| "Android daemon launch waiter disconnected".to_string())?;
+                        daemon
+                    };
+                    if let Err(error) = runtime.block_on(daemon.run()) {
+                        let message = format!("Android daemon exited with error: {error}");
+                        set_last_error(owner, Some(message.clone()));
+                        append_log(&log_path, &message);
+                    }
+                    Ok::<(), String>(())
+                }));
+
+                if fd_owned_by_thread {
+                    close_raw_fd(tun_fd);
+                }
+
+                match startup_result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        set_last_error(owner, Some(error.clone()));
+                        append_log(&log_path, &error);
+                        let _ = handle_tx.send(Err(error));
+                    }
+                    Err(_) => {
+                        let error = "Android daemon thread panicked during startup".to_string();
+                        set_last_error(owner, Some(error.clone()));
+                        append_log(&log_path, &error);
+                        let _ = handle_tx.send(Err(error));
+                    }
+                }
+                ready_for_thread.store(false, Ordering::Release);
+                running_for_thread.store(false, Ordering::Release);
+                let mut guard = runtime_slot()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if guard.as_ref().is_some_and(|handle| handle.owner == owner) {
+                    *guard = None;
+                }
+                clear_android_socket_protector(owner);
+            })
+            .map_err(|error| format!("failed to start Android daemon thread: {error}"));
+        if let Err(error) = thread_result {
+            close_raw_fd(tun_fd);
+            return Err(error);
+        }
+
+        let handle = handle_rx
+            .recv_timeout(Duration::from_secs(2))
+            .map_err(|error| format!("Android daemon runtime did not start: {error}"))??;
+        let mut guard = runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The daemon thread may have exited between sending the handle and
+        // this publication. Do not install an already-dead handle after its
+        // owner-scoped cleanup has run; doing so would make the next start
+        // observe stale runtime state.
+        if !handle.running.load(Ordering::Acquire) {
+            return Err(last_error_for(owner).unwrap_or_else(|| {
+                "Android daemon exited before its runtime handle became active".to_string()
+            }));
+        }
+        *guard = Some(handle);
+        Ok(())
+    }
+
+    fn stop_runtime(expected_owner: Option<OwnerId>) -> bool {
+        let guard = runtime_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(handle) = guard.as_ref() {
+            if expected_owner.is_some_and(|owner| owner != handle.owner) {
+                return false;
+            }
+            let _ = handle.shutdown_tx.send(true);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn new_string_or_null(env: &mut JNIEnv<'_>, error: Option<String>) -> jstring {
+        match error {
+            Some(error) => env
+                .new_string(error)
+                .map(|value| value.into_raw())
+                .unwrap_or(std::ptr::null_mut()),
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    /// Start the Rust daemon around the Android VPN fd. A null return means the
+    /// daemon runtime handle was installed; actual readiness is reported by the
+    /// diagnostics endpoint and `nativeIsReady`. A non-null string means the
+    /// runtime could not be launched. Before the startup thread is created the
+    /// caller still owns the fd; after that handoff Rust closes or drops it on
+    /// every startup/error path.
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeStart(
+        mut env: JNIEnv<'_>,
+        _object: JObject<'_>,
+        service: JObject<'_>,
+        tun_fd: jint,
+        request_json: JString<'_>,
+    ) -> jstring {
+        // Serialize the complete native start handoff, including protector
+        // installation and runtime-slot publication. Without this guard two
+        // concurrent MethodChannel starts could both observe an empty slot,
+        // then the older thread could publish over the newer owner.
+        let _start_guard = start_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut owner = None;
+        let result = match read_request(&mut env, request_json) {
+            Ok(_request) if runtime_running() => {
+                close_raw_fd(tun_fd);
+                Err("an existing Android P2WLAN daemon is still running".to_string())
+            }
+            Ok(request) => {
+                let runtime_owner = OwnerId::allocate();
+                register_owner(runtime_owner);
+                set_last_error(runtime_owner, None);
+                owner = Some(runtime_owner);
+                match install_android_socket_protector(&mut env, service, runtime_owner) {
+                    Ok(()) => start_runtime(tun_fd, request, runtime_owner),
+                    Err(error) => {
+                        close_raw_fd(tun_fd);
+                        Err(error)
+                    }
+                }
+            }
+            Err(error) => {
+                // The fd is still owned by Kotlin when JSON parsing fails, so
+                // close it here before returning the JNI error. Once
+                // start_runtime has spawned the daemon, ownership is transferred
+                // to the Rust startup thread and its error paths close/drop it.
                 close_raw_fd(tun_fd);
                 Err(error)
             }
-        },
-        Err(error) => {
-            // The fd is still owned by Kotlin when JSON parsing fails, so
-            // close it here before returning the JNI error. Once
-            // start_runtime has spawned the daemon, ownership is transferred
-            // to the Rust startup thread and its error paths close/drop it.
-            close_raw_fd(tun_fd);
-            Err(error)
+        };
+        if let Err(error) = &result {
+            if let Some(owner) = owner {
+                set_last_error(owner, Some(error.clone()));
+            }
+            if let Some(owner) = owner {
+                clear_android_socket_protector(owner);
+            }
         }
-    };
-    if let Err(error) = &result {
-        set_last_error(Some(error.clone()));
-        if !runtime_running() {
-            clear_android_socket_protector();
+        new_string_or_null(&mut env, result.err())
+    }
+
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeStop(
+        _env: JNIEnv<'_>,
+        _object: JObject<'_>,
+        expected_incarnation: jlong,
+    ) -> jboolean {
+        let expected_owner =
+            (expected_incarnation > 0).then(|| OwnerId::from_raw(expected_incarnation as u64));
+        if stop_runtime(expected_owner) {
+            1
+        } else {
+            0
         }
     }
-    new_string_or_null(&mut env, result.err())
-}
 
-#[no_mangle]
-pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeStop(
-    _env: JNIEnv<'_>,
-    _object: JObject<'_>,
-) -> jboolean {
-    if stop_runtime() {
-        1
-    } else {
-        0
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeIsRunning(
+        _env: JNIEnv<'_>,
+        _object: JObject<'_>,
+    ) -> jboolean {
+        if runtime_running() {
+            1
+        } else {
+            0
+        }
     }
-}
 
-#[no_mangle]
-pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeIsRunning(
-    _env: JNIEnv<'_>,
-    _object: JObject<'_>,
-) -> jboolean {
-    if runtime_running() {
-        1
-    } else {
-        0
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeIsReady(
+        _env: JNIEnv<'_>,
+        _object: JObject<'_>,
+    ) -> jboolean {
+        if runtime_ready() {
+            1
+        } else {
+            0
+        }
     }
-}
 
-#[no_mangle]
-pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeIsReady(
-    _env: JNIEnv<'_>,
-    _object: JObject<'_>,
-) -> jboolean {
-    if runtime_ready() {
-        1
-    } else {
-        0
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeLastError(
+        mut env: JNIEnv<'_>,
+        _object: JObject<'_>,
+    ) -> jstring {
+        new_string_or_null(&mut env, last_error())
     }
-}
 
-#[no_mangle]
-pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeLastError(
-    mut env: JNIEnv<'_>,
-    _object: JObject<'_>,
-) -> jstring {
-    new_string_or_null(&mut env, last_error())
+    #[no_mangle]
+    pub extern "system" fn Java_com_example_p2wlan_1flutter_1client_P2wlanNative_nativeIncarnation(
+        _env: JNIEnv<'_>,
+        _object: JObject<'_>,
+    ) -> jlong {
+        runtime_incarnation().map_or(0, |owner| owner.raw() as jlong)
+    }
 }

--- a/client/android-native/src/lifecycle.rs
+++ b/client/android-native/src/lifecycle.rs
@@ -1,0 +1,182 @@
+//! Platform-neutral ownership primitives for the Android bridge.
+//!
+//! Android-specific JNI code owns the actual runtime. This module owns only
+//! the compare-and-clear rule, so host `cargo test -p p2wlan-android-native`
+//! exercises the race that matters without pretending to have a VPN device.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+static NEXT_OWNER: AtomicU64 = AtomicU64::new(1);
+
+/// The Rust-side vocabulary is checked against the canonical JSON contract in
+/// the host test below. The list is intentionally test-facing: the Android
+/// bridge does not invent a second transition store or serialize these names.
+pub const MOBILE_LIFECYCLE_EVENT_WIRE_NAMES: &[&str] = &[
+    "app_backgrounded",
+    "app_resumed",
+    "physical_network_changed",
+    "vpn_permission_request_started",
+    "vpn_permission_revoked",
+    "vpn_permission_granted",
+    "vpn_start_requested",
+    "explicit_stop_requested",
+    "activity_recreated",
+    "service_recreated",
+    "bridge_attached",
+    "bridge_detached",
+    "native_runtime_started",
+    "native_runtime_stopped",
+    "native_monitor_callback",
+    "automatic_restart_scheduled",
+    "automatic_restart_rejected",
+    "control_disconnected",
+    "control_reconnected",
+    "candidate_refresh_started",
+    "relay_retained",
+    "direct_reconfirmed",
+];
+
+pub const MOBILE_LIFECYCLE_OUTCOME_WIRE_NAMES: &[&str] = &[
+    "applied",
+    "duplicate",
+    "stale_rejected",
+    "superseded",
+    "failed",
+];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct OwnerId(u64);
+
+impl OwnerId {
+    pub fn allocate() -> Self {
+        Self(NEXT_OWNER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct Owned<T> {
+    owner: OwnerId,
+    value: T,
+}
+
+/// A slot whose cleanup can only be performed by the owner that currently
+/// occupies it. Installing a replacement is explicit; an older owner cannot
+/// clear or mutate the replacement.
+#[derive(Debug)]
+pub struct OwnerScopedSlot<T> {
+    current: Mutex<Option<Owned<T>>>,
+}
+
+impl<T> Default for OwnerScopedSlot<T> {
+    fn default() -> Self {
+        Self {
+            current: Mutex::new(None),
+        }
+    }
+}
+
+impl<T> OwnerScopedSlot<T> {
+    pub fn install(&self, owner: OwnerId, value: T) -> Option<T> {
+        let mut guard = self
+            .current
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.replace(Owned { owner, value }).map(|old| old.value)
+    }
+
+    pub fn owner(&self) -> Option<OwnerId> {
+        self.current
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .map(|owned| owned.owner)
+    }
+
+    pub fn is_owner(&self, owner: OwnerId) -> bool {
+        self.owner() == Some(owner)
+    }
+
+    pub fn compare_and_clear(&self, owner: OwnerId) -> Option<T> {
+        let mut guard = self
+            .current
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.as_ref().is_some_and(|owned| owned.owner == owner) {
+            guard.take().map(|owned| owned.value)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OwnerId, OwnerScopedSlot, MOBILE_LIFECYCLE_EVENT_WIRE_NAMES,
+        MOBILE_LIFECYCLE_OUTCOME_WIRE_NAMES,
+    };
+
+    #[test]
+    fn old_runtime_cannot_clear_new_socket_protector() {
+        let slot = OwnerScopedSlot::default();
+        let runtime_a = OwnerId::from_raw(100);
+        let runtime_b = OwnerId::from_raw(101);
+        assert!(slot.install(runtime_a, "protector-a").is_none());
+        assert_eq!(slot.install(runtime_b, "protector-b"), Some("protector-a"));
+        assert_eq!(slot.compare_and_clear(runtime_a), None);
+        assert_eq!(slot.owner(), Some(runtime_b));
+        assert_eq!(slot.compare_and_clear(runtime_b), Some("protector-b"));
+        assert_eq!(slot.owner(), None);
+    }
+
+    #[test]
+    fn duplicate_lifecycle_install_is_an_explicit_replacement() {
+        let slot = OwnerScopedSlot::default();
+        let owner = OwnerId::from_raw(200);
+        assert!(slot.install(owner, 1u8).is_none());
+        assert_eq!(slot.install(owner, 2u8), Some(1));
+        assert_eq!(slot.compare_and_clear(owner), Some(2));
+    }
+
+    #[test]
+    fn canonical_contract_contains_all_mobile_scenarios() {
+        let contract = include_str!("../../../contracts/mobile_lifecycle.json");
+        let value: serde_json::Value = serde_json::from_str(contract).expect("valid contract");
+        assert_eq!(value["schema_version"], 2);
+        let scenarios = value["required_scenarios"]
+            .as_array()
+            .expect("scenario array");
+        assert_eq!(scenarios.len(), 18);
+        for (index, scenario) in scenarios.iter().enumerate() {
+            assert_eq!(scenario["id"], format!("ML-{index:02}", index = index + 1));
+        }
+        let events = value["events"].as_array().expect("event array");
+        assert_eq!(
+            MOBILE_LIFECYCLE_EVENT_WIRE_NAMES,
+            events
+                .iter()
+                .map(|event| event.as_str().expect("event string"))
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
+        assert_eq!(
+            MOBILE_LIFECYCLE_OUTCOME_WIRE_NAMES,
+            value["outcomes"]
+                .as_array()
+                .expect("outcome array")
+                .iter()
+                .map(|outcome| outcome.as_str().expect("outcome string"))
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
+    }
+}

--- a/client/android-native/src/lifecycle.rs
+++ b/client/android-native/src/lifecycle.rs
@@ -76,6 +76,117 @@ pub struct OwnerScopedSlot<T> {
     current: Mutex<Option<Owned<T>>>,
 }
 
+/// Final Rust-side admission fence for Android physical-network callbacks.
+///
+/// Kotlin owns callback reduction, but it is not authoritative for the
+/// dataplane. This fence ties every accepted hint to the current service and
+/// bridge owners and makes the Kotlin generation/hash pair idempotent before
+/// it enters the daemon's existing transport lifecycle.
+#[derive(Debug)]
+pub struct PhysicalNetworkHintAuthority {
+    service_owner: u64,
+    bridge_owner: OwnerId,
+    last_kotlin_generation: Option<u64>,
+    last_network_identity_hash: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NetworkHintDecision {
+    Applied,
+    Duplicate,
+    StaleRejected,
+    Failed,
+}
+
+impl NetworkHintDecision {
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::Duplicate => "duplicate",
+            Self::StaleRejected => "stale_rejected",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl PhysicalNetworkHintAuthority {
+    pub fn new(service_owner: u64, bridge_owner: OwnerId) -> Self {
+        Self {
+            service_owner,
+            bridge_owner,
+            last_kotlin_generation: None,
+            last_network_identity_hash: None,
+        }
+    }
+
+    pub fn service_owner(&self) -> u64 {
+        self.service_owner
+    }
+
+    pub fn bridge_owner(&self) -> OwnerId {
+        self.bridge_owner
+    }
+
+    /// Rebind the callback owner when START_STICKY gives a new service object
+    /// ownership of the still-running Rust bridge.
+    pub fn rebind_service_owner(
+        &mut self,
+        expected_bridge_owner: OwnerId,
+        service_owner: u64,
+    ) -> NetworkHintDecision {
+        if service_owner == 0 || expected_bridge_owner != self.bridge_owner {
+            return NetworkHintDecision::StaleRejected;
+        }
+        if service_owner == self.service_owner {
+            return NetworkHintDecision::Duplicate;
+        }
+        if service_owner < self.service_owner {
+            return NetworkHintDecision::StaleRejected;
+        }
+        self.service_owner = service_owner;
+        self.last_kotlin_generation = None;
+        self.last_network_identity_hash = None;
+        NetworkHintDecision::Applied
+    }
+
+    pub fn accept(
+        &mut self,
+        service_owner: u64,
+        bridge_owner: OwnerId,
+        kotlin_network_generation: u64,
+        network_identity_hash: &str,
+    ) -> NetworkHintDecision {
+        if service_owner == 0 || bridge_owner.raw() == 0 {
+            return NetworkHintDecision::Failed;
+        }
+        if service_owner != self.service_owner || bridge_owner != self.bridge_owner {
+            return NetworkHintDecision::StaleRejected;
+        }
+        let network_identity_hash = network_identity_hash.trim();
+        if kotlin_network_generation == 0 || network_identity_hash.is_empty() {
+            return NetworkHintDecision::Failed;
+        }
+        match self.last_kotlin_generation {
+            Some(last) if kotlin_network_generation < last => NetworkHintDecision::StaleRejected,
+            Some(last) if kotlin_network_generation == last => {
+                if self.last_network_identity_hash.as_deref() == Some(network_identity_hash) {
+                    NetworkHintDecision::Duplicate
+                } else {
+                    // One Kotlin generation may publish at most one physical
+                    // identity. A conflicting callback is stale rather than
+                    // a second network transition.
+                    NetworkHintDecision::StaleRejected
+                }
+            }
+            _ => {
+                self.last_kotlin_generation = Some(kotlin_network_generation);
+                self.last_network_identity_hash = Some(network_identity_hash.to_string());
+                NetworkHintDecision::Applied
+            }
+        }
+    }
+}
+
 impl<T> Default for OwnerScopedSlot<T> {
     fn default() -> Self {
         Self {
@@ -121,8 +232,8 @@ impl<T> OwnerScopedSlot<T> {
 #[cfg(test)]
 mod tests {
     use super::{
-        OwnerId, OwnerScopedSlot, MOBILE_LIFECYCLE_EVENT_WIRE_NAMES,
-        MOBILE_LIFECYCLE_OUTCOME_WIRE_NAMES,
+        NetworkHintDecision, OwnerId, OwnerScopedSlot, PhysicalNetworkHintAuthority,
+        MOBILE_LIFECYCLE_EVENT_WIRE_NAMES, MOBILE_LIFECYCLE_OUTCOME_WIRE_NAMES,
     };
 
     #[test]
@@ -177,6 +288,133 @@ mod tests {
                 .map(|outcome| outcome.as_str().expect("outcome string"))
                 .collect::<Vec<_>>()
                 .as_slice()
+        );
+    }
+
+    #[test]
+    fn physical_network_hint_is_owner_scoped_and_exactly_once() {
+        let bridge = OwnerId::from_raw(4);
+        let mut authority = PhysicalNetworkHintAuthority::new(40, bridge);
+        assert_eq!(
+            authority.accept(40, bridge, 1, "wifi"),
+            NetworkHintDecision::Applied
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 1, "wifi"),
+            NetworkHintDecision::Duplicate
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 1, "cellular"),
+            NetworkHintDecision::StaleRejected
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 0, "cellular"),
+            NetworkHintDecision::Failed
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 2, "cellular"),
+            NetworkHintDecision::Applied
+        );
+        assert_eq!(
+            authority.accept(40, OwnerId::from_raw(3), 3, "hotspot"),
+            NetworkHintDecision::StaleRejected
+        );
+        assert_eq!(
+            authority.accept(39, bridge, 3, "hotspot"),
+            NetworkHintDecision::StaleRejected
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 1, "old"),
+            NetworkHintDecision::StaleRejected
+        );
+        emit_evidence(
+            "ML-18",
+            "physical_network_hint_is_owner_scoped_and_exactly_once",
+            "[\"physical_network_changed\",\"physical_network_changed\"]",
+            "{\"network_generation\":1}",
+            "{\"network_generation\":1}",
+            NetworkHintDecision::Duplicate.wire_name(),
+            "{\"duplicate_has_no_second_effect\":true}",
+        );
+    }
+
+    #[test]
+    fn physical_network_hint_service_rebind_rejects_old_owner() {
+        let bridge = OwnerId::from_raw(5);
+        let mut authority = PhysicalNetworkHintAuthority::new(40, bridge);
+        assert_eq!(
+            authority.rebind_service_owner(OwnerId::from_raw(4), 41),
+            NetworkHintDecision::StaleRejected
+        );
+        assert_eq!(
+            authority.rebind_service_owner(bridge, 41),
+            NetworkHintDecision::Applied
+        );
+        assert_eq!(
+            authority.accept(40, bridge, 1, "old-service"),
+            NetworkHintDecision::StaleRejected
+        );
+        assert_eq!(
+            authority.accept(41, bridge, 1, "new-service"),
+            NetworkHintDecision::Applied
+        );
+        assert_eq!(
+            authority.rebind_service_owner(bridge, 40),
+            NetworkHintDecision::StaleRejected
+        );
+    }
+
+    #[test]
+    fn evidence_ml10_bridge_incarnation_adoption() {
+        let bridge = OwnerId::from_raw(5);
+        let mut authority = PhysicalNetworkHintAuthority::new(8, bridge);
+        assert_eq!(
+            authority.rebind_service_owner(bridge, 9),
+            NetworkHintDecision::Applied
+        );
+        assert_eq!(authority.service_owner(), 9);
+        emit_evidence(
+            "ML-10",
+            "evidence_ml10_bridge_incarnation_adoption",
+            "[\"bridge_detached\",\"bridge_attached\"]",
+            "{\"bridge_incarnation\":4}",
+            "{\"bridge_incarnation\":5}",
+            NetworkHintDecision::Applied.wire_name(),
+            "{\"bridge_identity_adopted\":true}",
+        );
+    }
+
+    #[test]
+    fn evidence_ml11_old_bridge_cleanup() {
+        let slot = OwnerScopedSlot::default();
+        let old = OwnerId::from_raw(4);
+        let replacement = OwnerId::from_raw(5);
+        slot.install(replacement, "replacement");
+        assert!(slot.compare_and_clear(old).is_none());
+        assert!(slot.is_owner(replacement));
+        emit_evidence(
+            "ML-11",
+            "evidence_ml11_old_bridge_cleanup",
+            "[\"bridge_detached\",\"bridge_attached\"]",
+            "{\"bridge_incarnation\":4}",
+            "{\"bridge_incarnation\":5}",
+            NetworkHintDecision::StaleRejected.wire_name(),
+            "{\"old_bridge_cleanup_rejected\":true}",
+        );
+    }
+
+    fn emit_evidence(
+        scenario_id: &str,
+        test_name: &str,
+        events: &str,
+        old_identity: &str,
+        new_identity: &str,
+        decision: &str,
+        invariants: &str,
+    ) {
+        let exact_test_id = format!("lifecycle::tests::{test_name}");
+        println!(
+            "MOBILE_LIFECYCLE_RECORD {{\"scenario_id\":\"{scenario_id}\",\"exact_test_id\":\"{exact_test_id}\",\"executed\":true,\"skipped\":false,\"result\":\"pass\",\"events\":{events},\"observed_old_identity\":{old_identity},\"observed_new_identity\":{new_identity},\"observed_decision\":\"{decision}\",\"invariants\":{invariants},\"execution_source\":\"rust_test_nocapture\"}}"
         );
     }
 }

--- a/client/daemon/src/control/client.rs
+++ b/client/daemon/src/control/client.rs
@@ -698,6 +698,7 @@ impl ControlClient {
     /// Notify the existing control lifecycle that Android's physical network
     /// changed. The loop rebuilds its pooled HTTP clients and reconnects the
     /// optional signaling WebSocket through its normal registration path.
+    #[cfg_attr(not(target_os = "android"), allow(dead_code))]
     pub(crate) fn network_changed(&self) {
         let _ = self.cmd_tx.send(ControlCommand::NetworkChanged);
     }

--- a/client/daemon/src/control/client.rs
+++ b/client/daemon/src/control/client.rs
@@ -695,6 +695,13 @@ impl ControlClient {
         let _ = self.cmd_tx.send(ControlCommand::PollPeersNow);
     }
 
+    /// Notify the existing control lifecycle that Android's physical network
+    /// changed. The loop rebuilds its pooled HTTP clients and reconnects the
+    /// optional signaling WebSocket through its normal registration path.
+    pub(crate) fn network_changed(&self) {
+        let _ = self.cmd_tx.send(ControlCommand::NetworkChanged);
+    }
+
     /// Shutdown the control client.
     pub async fn shutdown(&self) -> Result<()> {
         // Stop independent critical-lane endpoint work first. Otherwise an

--- a/client/daemon/src/control/proxy.rs
+++ b/client/daemon/src/control/proxy.rs
@@ -172,6 +172,7 @@ enum ControlHttpLane {
 pub(super) struct RouteAwareControlHttpClient {
     state_rx: tokio::sync::watch::Receiver<ControlHttpPoolState>,
     lane: ControlHttpLane,
+    force_network_change_tx: Option<tokio::sync::mpsc::UnboundedSender<()>>,
 }
 
 impl RouteAwareControlHttpClient {
@@ -189,6 +190,12 @@ impl RouteAwareControlHttpClient {
                     .unwrap_or_else(|| "control HTTP route is unavailable".to_string()),
             )
         })
+    }
+
+    pub(super) fn notify_network_changed(&self) {
+        if let Some(sender) = &self.force_network_change_tx {
+            let _ = sender.send(());
+        }
     }
 }
 
@@ -279,22 +286,26 @@ pub(super) fn route_aware_control_http_clients(
     mode: ControlProxyMode,
     server_url: &str,
 ) -> (RouteAwareControlHttpClient, RouteAwareControlHttpClient) {
+    let route_aware = mode == ControlProxyMode::Direct && !control_server_is_local(server_url);
     let initial_binding = control_route_binding(mode, Some(server_url));
     let initial_state = build_control_http_pools(mode, server_url, initial_binding.clone());
     if let Some(reason) = &initial_state.unavailable_reason {
         warn!("{reason}");
     }
     let (state_tx, state_rx) = tokio::sync::watch::channel(initial_state);
+    let (force_network_change_tx, mut force_network_change_rx) =
+        tokio::sync::mpsc::unbounded_channel::<()>();
     let primary = RouteAwareControlHttpClient {
         state_rx: state_rx.clone(),
         lane: ControlHttpLane::Primary,
+        force_network_change_tx: route_aware.then_some(force_network_change_tx.clone()),
     };
     let candidate = RouteAwareControlHttpClient {
         state_rx,
         lane: ControlHttpLane::Candidate,
+        force_network_change_tx: route_aware.then_some(force_network_change_tx.clone()),
     };
 
-    let route_aware = mode == ControlProxyMode::Direct && !control_server_is_local(server_url);
     if route_aware {
         let server_url = server_url.to_string();
         tokio::spawn(async move {
@@ -303,7 +314,15 @@ pub(super) fn route_aware_control_http_clients(
             let mut ticker = tokio::time::interval(CONTROL_ROUTE_POLL_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
-                ticker.tick().await;
+                let forced = tokio::select! {
+                    _ = ticker.tick() => false,
+                    forced = force_network_change_rx.recv() => {
+                        if forced.is_none() {
+                            return;
+                        }
+                        true
+                    }
+                };
                 if state_tx.is_closed() {
                     return;
                 }
@@ -313,7 +332,7 @@ pub(super) fn route_aware_control_http_clients(
                 })
                 .await
                 {
-                    Ok(binding) if !binding.signature.is_empty() => binding,
+                    Ok(binding) if forced || !binding.signature.is_empty() => binding,
                     Ok(_) => {
                         pending = None;
                         continue;
@@ -324,6 +343,21 @@ pub(super) fn route_aware_control_http_clients(
                         continue;
                     }
                 };
+                if forced {
+                    let replacement = build_control_http_pools(mode, &server_url, observed.clone());
+                    if let Some(reason) = &replacement.unavailable_reason {
+                        warn!("Control-plane HTTP pools forced to rebuild after Android network change; {reason}");
+                    } else {
+                        info!(
+                            "Rebuilt control-plane HTTP pools after Android physical network change; outbound_interface={:?}",
+                            observed.outbound_interface
+                        );
+                    }
+                    active_binding = observed;
+                    pending = None;
+                    state_tx.send_replace(replacement);
+                    continue;
+                }
                 let replacement =
                     observe_stable_route_change(&active_binding, &mut pending, observed.clone());
                 if let Some(binding) = replacement {

--- a/client/daemon/src/control/runtime/commands.rs
+++ b/client/daemon/src/control/runtime/commands.rs
@@ -25,6 +25,14 @@ match cmd {
                                 }
                             }
                         }
+                        ControlCommand::NetworkChanged => {
+                            http.notify_network_changed();
+                            if let Some(task) = signal_ws_task.as_ref() {
+                                task.abort();
+                            }
+                            info!("Android physical network changed; restarting control registration and signaling transports");
+                            break;
+                        }
                         ControlCommand::CreateTunnel { protocol, local_port, remote_port } => {
                             let res = async {
                                 let current_http = http.current()?;

--- a/client/daemon/src/control/types.rs
+++ b/client/daemon/src/control/types.rs
@@ -784,6 +784,7 @@ enum ControlCommand {
     PollPeersNow,
     /// Rebind the existing control HTTP/WebSocket lifecycle after an Android
     /// physical-network handoff.
+    #[cfg_attr(not(target_os = "android"), allow(dead_code))]
     NetworkChanged,
     /// Create a tunnel.
     CreateTunnel {

--- a/client/daemon/src/control/types.rs
+++ b/client/daemon/src/control/types.rs
@@ -782,6 +782,9 @@ enum ControlCommand {
     /// the regular peer roster poll can be up to one second away,
     /// and a cold-start handshake must not wait out that cadence.
     PollPeersNow,
+    /// Rebind the existing control HTTP/WebSocket lifecycle after an Android
+    /// physical-network handoff.
+    NetworkChanged,
     /// Create a tunnel.
     CreateTunnel {
         protocol: String,

--- a/client/daemon/src/control/websocket.rs
+++ b/client/daemon/src/control/websocket.rs
@@ -120,6 +120,13 @@ pub(super) struct SignalWebSocketTask {
     lifecycle: SignalConnectionLifecycle,
 }
 
+impl SignalWebSocketTask {
+    pub(super) fn abort(&self) {
+        self.lifecycle.close();
+        self.handle.abort();
+    }
+}
+
 impl Drop for SignalWebSocketTask {
     fn drop(&mut self) {
         self.lifecycle.close();
@@ -568,5 +575,32 @@ mod route_tests {
         assert!(connected.load(Ordering::Acquire));
         lifecycle.mark_disconnected(current);
         assert!(!connected.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn evidence_ml12_control_reconnect() {
+        let connected = Arc::new(AtomicBool::new(false));
+        let lifecycle = SignalConnectionLifecycle::new(connected.clone());
+        let old = lifecycle.begin();
+        assert!(lifecycle.mark_connected(old));
+        let current = lifecycle.begin();
+        assert!(lifecycle.mark_connected(current));
+        assert!(connected.load(Ordering::Acquire));
+        println!(
+            "MOBILE_LIFECYCLE_RECORD {{\"scenario_id\":\"ML-12\",\"exact_test_id\":\"control::websocket::route_tests::evidence_ml12_control_reconnect\",\"executed\":true,\"skipped\":false,\"result\":\"pass\",\"events\":[\"control_disconnected\",\"control_reconnected\"],\"observed_old_identity\":{{\"control_connection_generation\":{old}}},\"observed_new_identity\":{{\"control_connection_generation\":{current}}},\"observed_decision\":\"applied\",\"invariants\":{{\"new_control_generation_adopted\":true}},\"execution_source\":\"rust_test_nocapture\"}}"
+        );
+    }
+
+    #[test]
+    fn evidence_ml13_stale_control_message() {
+        let connected = Arc::new(AtomicBool::new(false));
+        let lifecycle = SignalConnectionLifecycle::new(connected.clone());
+        let old = lifecycle.begin();
+        let current = lifecycle.begin();
+        assert!(!lifecycle.mark_connected(old));
+        assert!(lifecycle.mark_connected(current));
+        println!(
+            "MOBILE_LIFECYCLE_RECORD {{\"scenario_id\":\"ML-13\",\"exact_test_id\":\"control::websocket::route_tests::evidence_ml13_stale_control_message\",\"executed\":true,\"skipped\":false,\"result\":\"pass\",\"events\":[\"control_reconnected\"],\"observed_old_identity\":{{\"control_connection_generation\":{old}}},\"observed_new_identity\":{{\"control_connection_generation\":{current}}},\"observed_decision\":\"stale_rejected\",\"invariants\":{{\"old_control_message_rejected\":true}},\"execution_source\":\"rust_test_nocapture\"}}"
+        );
     }
 }

--- a/client/daemon/src/control/websocket.rs
+++ b/client/daemon/src/control/websocket.rs
@@ -9,7 +9,7 @@
 //! default interface so a kernel-level TUN route cannot capture it.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -42,6 +42,64 @@ pub fn websocket_proxy_policy_label() -> &'static str {
     "direct_only"
 }
 
+/// Owner of the current signaling WebSocket connection. A late task cleanup
+/// can only clear the connected bit while its connection generation is still
+/// current, so a reconnect cannot be torn down by the old task.
+#[derive(Clone)]
+pub(super) struct SignalConnectionLifecycle {
+    generation: Arc<Mutex<u64>>,
+    connected: Arc<AtomicBool>,
+}
+
+impl SignalConnectionLifecycle {
+    pub(super) fn new(connected: Arc<AtomicBool>) -> Self {
+        Self {
+            generation: Arc::new(Mutex::new(0)),
+            connected,
+        }
+    }
+
+    pub(super) fn begin(&self) -> u64 {
+        let mut generation = self
+            .generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *generation = generation.saturating_add(1);
+        *generation
+    }
+
+    pub(super) fn mark_connected(&self, owner: u64) -> bool {
+        let generation = self
+            .generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *generation != owner {
+            return false;
+        }
+        self.connected.store(true, Ordering::Release);
+        true
+    }
+
+    pub(super) fn mark_disconnected(&self, owner: u64) {
+        let generation = self
+            .generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *generation == owner {
+            self.connected.store(false, Ordering::Release);
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let mut generation = self
+            .generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *generation = generation.saturating_add(1);
+        self.connected.store(false, Ordering::Release);
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct SignalWebSocketMessage {
     #[serde(rename = "type")]
@@ -59,12 +117,12 @@ struct SignalWebSocketMessage {
 
 pub(super) struct SignalWebSocketTask {
     handle: tokio::task::JoinHandle<()>,
-    connected: Arc<AtomicBool>,
+    lifecycle: SignalConnectionLifecycle,
 }
 
 impl Drop for SignalWebSocketTask {
     fn drop(&mut self) {
-        self.connected.store(false, Ordering::Release);
+        self.lifecycle.close();
         self.handle.abort();
     }
 }
@@ -77,25 +135,27 @@ pub(super) fn spawn_signal_websocket(
     wake_tx: mpsc::Sender<()>,
     connected: Arc<AtomicBool>,
 ) -> SignalWebSocketTask {
-    let task_connected = connected.clone();
+    let lifecycle = SignalConnectionLifecycle::new(connected);
+    let task_lifecycle = lifecycle.clone();
     let base_url = base_url.to_string();
     let token = token.to_string();
     let node_id = node_id.to_string();
     let network_id = network_id.to_string();
     let handle = tokio::spawn(async move {
-        run_signal_websocket(
+        run_signal_websocket_with_lifecycle(
             &base_url,
             &token,
             &node_id,
             &network_id,
             wake_tx,
-            task_connected,
+            task_lifecycle,
         )
         .await;
     });
-    SignalWebSocketTask { handle, connected }
+    SignalWebSocketTask { handle, lifecycle }
 }
 
+#[cfg(test)]
 pub(super) async fn run_signal_websocket(
     base_url: &str,
     token: &str,
@@ -103,6 +163,25 @@ pub(super) async fn run_signal_websocket(
     expected_network_id: &str,
     wake_tx: mpsc::Sender<()>,
     connected: Arc<AtomicBool>,
+) {
+    run_signal_websocket_with_lifecycle(
+        base_url,
+        token,
+        expected_node_id,
+        expected_network_id,
+        wake_tx,
+        SignalConnectionLifecycle::new(connected),
+    )
+    .await;
+}
+
+async fn run_signal_websocket_with_lifecycle(
+    base_url: &str,
+    token: &str,
+    expected_node_id: &str,
+    expected_network_id: &str,
+    wake_tx: mpsc::Sender<()>,
+    lifecycle: SignalConnectionLifecycle,
 ) {
     let ws_url = match signal_websocket_url(base_url) {
         Ok(url) => url,
@@ -121,7 +200,8 @@ pub(super) async fn run_signal_websocket(
 
     let mut attempt = 0u32;
     loop {
-        connected.store(false, Ordering::Release);
+        let connection_generation = lifecycle.begin();
+        lifecycle.mark_disconnected(connection_generation);
         let mut request = match ws_url.as_str().into_client_request() {
             Ok(request) => request,
             Err(err) => {
@@ -278,7 +358,9 @@ pub(super) async fn run_signal_websocket(
                                             break;
                                         }
                                         ready = true;
-                                        connected.store(true, Ordering::Release);
+                                        if !lifecycle.mark_connected(connection_generation) {
+                                            break;
+                                        }
                                         debug!(
                                             "WebSocket signaling ready for node {} at server_time_ms={}",
                                             expected_node_id, message.server_time_ms
@@ -340,7 +422,7 @@ pub(super) async fn run_signal_websocket(
             }
         }
 
-        connected.store(false, Ordering::Release);
+        lifecycle.mark_disconnected(connection_generation);
         attempt = attempt.saturating_add(1);
         let exponent = attempt.saturating_sub(1).min(5);
         let base = Duration::from_secs(1u64 << exponent).min(SIGNAL_WS_MAX_BACKOFF);
@@ -471,5 +553,20 @@ mod route_tests {
             &mut pending,
             replacement,
         ));
+    }
+
+    #[test]
+    fn new_control_connection_survives_old_task_teardown() {
+        let connected = Arc::new(AtomicBool::new(false));
+        let lifecycle = SignalConnectionLifecycle::new(connected.clone());
+        let old = lifecycle.begin();
+        assert!(lifecycle.mark_connected(old));
+        let current = lifecycle.begin();
+        assert!(lifecycle.mark_connected(current));
+
+        lifecycle.mark_disconnected(old);
+        assert!(connected.load(Ordering::Acquire));
+        lifecycle.mark_disconnected(current);
+        assert!(!connected.load(Ordering::Acquire));
     }
 }

--- a/client/daemon/src/diagnostics/snapshot.rs
+++ b/client/daemon/src/diagnostics/snapshot.rs
@@ -70,6 +70,7 @@ async fn build_snapshot(context: DiagnosticsContext) -> DiagnosticsSnapshot {
     DiagnosticsSnapshot {
         version: env!("CARGO_PKG_VERSION").to_string(),
         process_id: std::process::id(),
+        runtime_incarnation: context.runtime_incarnation,
         node_id: context.config.node.node_id.clone(),
         virtual_ip: context.config.network.virtual_ip.clone(),
         network_id: context.config.network.network_id.clone(),
@@ -496,6 +497,7 @@ async fn build_runtime_snapshot(context: DiagnosticsContext) -> RuntimeDiagnosti
     RuntimeDiagnosticsSnapshot {
         version: env!("CARGO_PKG_VERSION").to_string(),
         process_id: std::process::id(),
+        runtime_incarnation: context.runtime_incarnation,
         node_id: context.config.node.node_id.clone(),
         virtual_ip: context.config.network.virtual_ip.clone(),
         network_id: context.config.network.network_id.clone(),

--- a/client/daemon/src/diagnostics/tests.rs
+++ b/client/daemon/src/diagnostics/tests.rs
@@ -231,6 +231,7 @@ mod tests {
             status_events,
             None,
             Some("diag-test-token".to_string()),
+            None,
         );
         let context_probe = context.clone();
         let worker = tokio::spawn(serve_diagnostics(listener, context, shutdown_rx));

--- a/client/daemon/src/diagnostics/types.rs
+++ b/client/daemon/src/diagnostics/types.rs
@@ -87,6 +87,11 @@ impl MtuDiagnostics {
 pub struct DiagnosticsSnapshot {
     pub version: String,
     pub process_id: u32,
+    /// Additive native runtime identity. Android can replace the embedded
+    /// daemon without changing the hosting PID, so clients must compare this
+    /// before revision/uptime ordering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_incarnation: Option<u64>,
     pub node_id: String,
     pub virtual_ip: String,
     pub network_id: String,
@@ -189,6 +194,8 @@ pub struct PeerScopedDiagnosticsSnapshot {
 pub struct RuntimeDiagnosticsSnapshot {
     pub version: String,
     pub process_id: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_incarnation: Option<u64>,
     pub node_id: String,
     pub virtual_ip: String,
     pub network_id: String,
@@ -407,6 +414,9 @@ pub struct DiagnosticsContext {
     /// `None` when the diagnostics endpoint is disabled; mutations then fail
     /// closed with 403.
     auth_token: Option<String>,
+    /// Native bridge/runtime identity when the daemon is embedded by Android.
+    /// Desktop daemons leave this absent and continue using PID/uptime.
+    pub(crate) runtime_incarnation: Option<u64>,
 }
 
 impl DiagnosticsContext {
@@ -428,6 +438,7 @@ impl DiagnosticsContext {
         status_events: Arc<StatusEventBus>,
         log_path: Option<std::path::PathBuf>,
         auth_token: Option<String>,
+        runtime_incarnation: Option<u64>,
     ) -> Self {
         Self {
             config,
@@ -447,6 +458,7 @@ impl DiagnosticsContext {
             peer_snapshot_cache: Arc::new(std::sync::Mutex::new(None)),
             log_path,
             auth_token,
+            runtime_incarnation,
         }
     }
 }

--- a/client/daemon/src/lib.rs
+++ b/client/daemon/src/lib.rs
@@ -81,9 +81,26 @@ use tokio::net::lookup_host;
 #[cfg(test)]
 #[allow(unused_imports)]
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, watch, Mutex, RwLock};
+use tokio::sync::{broadcast, mpsc, watch, Mutex, RwLock};
 use tokio::time::{interval, sleep, timeout};
 use tracing::{debug, error, info, warn};
+
+/// One physical-network handoff hint emitted by the Android JNI boundary.
+///
+/// The Kotlin callback reducer and the Rust bridge owner validate identity
+/// before this value is published. Once here, the existing UDP/relay/control
+/// lifecycle consumes it; it is deliberately not a second path state machine.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AndroidNetworkChangeHint {
+    pub kotlin_network_generation: u64,
+    pub network_identity_hash: String,
+}
+
+/// A broadcast receiver is shared by the existing direct and relay lifecycle
+/// tasks. Each task consumes the same authoritative hint independently so a
+/// direct rebind and a relay/control reconnect can be coordinated without
+/// duplicating the Kotlin callback state.
+pub type AndroidNetworkChangeReceiver = Arc<Mutex<broadcast::Receiver<AndroidNetworkChangeHint>>>;
 
 use acl::AclEngine;
 use candidate_refresh::{

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -2695,6 +2695,7 @@ impl Daemon {
                 timeline: self.timeline.clone(),
                 inbound_tx: network_inbound_tx.clone(),
                 control: self.control.clone(),
+                android_network_change_rx: self.android_network_change_relay_rx.clone(),
                 allow_insecure_plaintext,
                 ca_cert_path: self.config.relay.ca_cert_path.clone(),
             })

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -127,8 +127,10 @@ pub struct Daemon {
     /// Dedicated receivers stay alive from JNI startup through worker spawn,
     /// so a callback that arrives during daemon setup is queued instead of
     /// being dropped before direct/relay supervisors subscribe.
+    #[cfg_attr(not(target_os = "android"), allow(dead_code))]
     android_network_change_direct_rx: Option<AndroidNetworkChangeReceiver>,
     android_network_change_relay_rx: Option<AndroidNetworkChangeReceiver>,
+    #[cfg_attr(not(target_os = "android"), allow(dead_code))]
     android_network_change_control_rx: Option<AndroidNetworkChangeReceiver>,
 }
 

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -120,6 +120,16 @@ pub struct Daemon {
     /// the VPN dataplane is actually ready for diagnostics traffic.
     #[cfg(target_os = "android")]
     android_startup_ready: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Incarnation assigned by the Android JNI runtime owner. This is
+    /// additive diagnostics identity; desktop daemons continue without it.
+    #[cfg(target_os = "android")]
+    android_runtime_incarnation: Option<u64>,
+    /// Dedicated receivers stay alive from JNI startup through worker spawn,
+    /// so a callback that arrives during daemon setup is queued instead of
+    /// being dropped before direct/relay supervisors subscribe.
+    android_network_change_direct_rx: Option<AndroidNetworkChangeReceiver>,
+    android_network_change_relay_rx: Option<AndroidNetworkChangeReceiver>,
+    android_network_change_control_rx: Option<AndroidNetworkChangeReceiver>,
 }
 
 impl Daemon {
@@ -292,6 +302,11 @@ impl Daemon {
             android_tun_mode: AndroidTunMode::AsyncFd,
             #[cfg(target_os = "android")]
             android_startup_ready: None,
+            #[cfg(target_os = "android")]
+            android_runtime_incarnation: None,
+            android_network_change_direct_rx: None,
+            android_network_change_relay_rx: None,
+            android_network_change_control_rx: None,
         }
     }
 
@@ -327,6 +342,59 @@ impl Daemon {
         self.android_startup_ready = Some(ready);
     }
 
+    /// Bind diagnostics to the JNI bridge/runtime incarnation that owns this
+    /// embedded daemon. It is set before `run()` starts the diagnostics task.
+    #[cfg(target_os = "android")]
+    pub fn set_android_runtime_incarnation(&mut self, incarnation: u64) {
+        self.android_runtime_incarnation = (incarnation > 0).then_some(incarnation);
+    }
+
+    /// Install the Android callback hint stream. The daemon retains the
+    /// sender so every transport supervisor can subscribe independently while
+    /// the JNI runtime handle remains the owner of the channel lifetime.
+    #[cfg(target_os = "android")]
+    pub fn set_android_network_change_sender(
+        &mut self,
+        sender: broadcast::Sender<AndroidNetworkChangeHint>,
+    ) {
+        self.android_network_change_direct_rx = Some(Arc::new(Mutex::new(sender.subscribe())));
+        self.android_network_change_relay_rx = Some(Arc::new(Mutex::new(sender.subscribe())));
+        self.android_network_change_control_rx = Some(Arc::new(Mutex::new(sender.subscribe())));
+    }
+
+    /// Forward Android's already-authorized physical-network edge into the
+    /// existing control lifecycle. This bridge does not own connection state
+    /// or create a second lifecycle loop.
+    #[cfg(target_os = "android")]
+    async fn spawn_android_network_change_control_watcher(&self) {
+        let Some(network_change_rx) = self.android_network_change_control_rx.clone() else {
+            return;
+        };
+        let control = self.control.clone();
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        self.task_manager
+            .spawn("android-network-control", false, async move {
+                loop {
+                    let hint = tokio::select! {
+                        changed = shutdown_rx.changed() => {
+                            if changed.is_err() || *shutdown_rx.borrow() {
+                                None
+                            } else {
+                                continue;
+                            }
+                        }
+                        hint = recv_android_network_change(network_change_rx.clone()) => hint,
+                    };
+                    if hint.is_some() {
+                        control.network_changed();
+                    } else {
+                        break;
+                    }
+                }
+            })
+            .await;
+    }
+
     /// Return a clone of the shutdown sender so main can signal SIGTERM/SIGINT.
     pub fn shutdown_sender(&self) -> tokio::sync::watch::Sender<bool> {
         self.shutdown_tx.clone()
@@ -336,5 +404,19 @@ impl Daemon {
     pub fn request_shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
         self.task_manager.request_shutdown();
+    }
+}
+
+#[cfg(target_os = "android")]
+async fn recv_android_network_change(
+    network_change_rx: AndroidNetworkChangeReceiver,
+) -> Option<AndroidNetworkChangeHint> {
+    let mut receiver = network_change_rx.lock().await;
+    loop {
+        match receiver.recv().await {
+            Ok(hint) => return Some(hint),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
     }
 }

--- a/client/daemon/src/lib/daemon/relay_spawn.rs
+++ b/client/daemon/src/lib/daemon/relay_spawn.rs
@@ -11,6 +11,7 @@ struct RelayInboundSpawnContext {
     timeline: Arc<crate::connection_timeline::ConnectionTimeline>,
     inbound_tx: mpsc::Sender<ReceivedEncryptedPacket>,
     control: ControlClient,
+    android_network_change_rx: Option<AndroidNetworkChangeReceiver>,
     allow_insecure_plaintext: bool,
     ca_cert_path: Option<String>,
 }
@@ -31,6 +32,7 @@ async fn spawn_relay_inbound(ctx: RelayInboundSpawnContext) {
                 relay_available_tx: ctx.relay_available_tx,
                 timeline: ctx.timeline,
                 inbound_tx: ctx.inbound_tx,
+                android_network_change_rx: ctx.android_network_change_rx,
                 ticket_cache: Some(Arc::new(RelayTicketCache::new(ctx.control))),
                 relay_ticket: None,
                 allow_insecure_plaintext: ctx.allow_insecure_plaintext,

--- a/client/daemon/src/lib/daemon/run.rs
+++ b/client/daemon/src/lib/daemon/run.rs
@@ -2,6 +2,8 @@ impl Daemon {
     /// Run the daemon main loop.
     pub async fn run(&mut self) -> Result<()> {
         info!("P2WLAN daemon v{} starting...", env!("CARGO_PKG_VERSION"));
+        #[cfg(target_os = "android")]
+        self.spawn_android_network_change_control_watcher().await;
         let build = crate::build_info::current();
         info!(
             event = "daemon_build_identity",
@@ -260,6 +262,7 @@ impl Daemon {
                 timeline: self.timeline.clone(),
                 inbound_tx: network_inbound_tx.clone(),
                 control: self.control.clone(),
+                android_network_change_rx: self.android_network_change_relay_rx.clone(),
                 allow_insecure_plaintext: self.config.relay.allow_insecure_plaintext,
                 ca_cert_path: self.config.relay.ca_cert_path.clone(),
             })
@@ -422,6 +425,10 @@ impl Daemon {
         if self.config.diagnostics.enabled {
             let diagnostics_bind = self.config.diagnostics.bind.clone();
             info!("[diagnostics] starting on {diagnostics_bind}");
+            #[cfg(target_os = "android")]
+            let runtime_incarnation = self.android_runtime_incarnation;
+            #[cfg(not(target_os = "android"))]
+            let runtime_incarnation = None;
             let diagnostics_context = DiagnosticsContext::new(
                 self.config.clone(),
                 self.peers.clone(),
@@ -439,6 +446,7 @@ impl Daemon {
                 self.status_events.clone(),
                 self.config.diagnostics.log_path.clone(),
                 self.config.diagnostics.auth_token.clone(),
+                runtime_incarnation,
             );
             let shutdown_rx = self.shutdown_rx.clone();
             let (diagnostics_ready_tx, diagnostics_ready_rx) =
@@ -525,6 +533,10 @@ impl Daemon {
             proxy_env,
             excluded_interfaces,
             shutdown_rx: self.shutdown_rx.clone(),
+            android_network_change_rx: self.android_network_change_direct_rx.clone(),
+            android_network_change_observed: Arc::new(
+                std::sync::atomic::AtomicU64::new(0),
+            ),
         };
         self.task_manager
             .spawn_result("udp-direct", false, run_udp_direct_task(udp_direct_context))

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -43,6 +43,16 @@ struct UdpDirectTaskContext {
     /// Daemon-wide shutdown signal.  UDP bind retry and every per-instance
     /// reader/worker observe this instead of making a failed bind permanent.
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    /// Android JNI hints are consumed by this existing transport supervisor.
+    android_network_change_rx: Option<AndroidNetworkChangeReceiver>,
+    /// Lets the binder skip its normal failure backoff after a physical
+    /// network hint has deliberately withdrawn the current socket.
+    android_network_change_observed: Arc<std::sync::atomic::AtomicU64>,
+}
+
+enum UdpDirectLifecycleSignal {
+    Stop,
+    NetworkChanged(AndroidNetworkChangeHint),
 }
 
 fn direct_socket_interface_for_bind(
@@ -134,6 +144,9 @@ where
         }
 
         let mut instance_ctx = ctx.clone();
+        let network_hint_before_instance = ctx
+            .android_network_change_observed
+            .load(std::sync::atomic::Ordering::Acquire);
         if had_live_udp_instance {
             let (resolved_stun, resolved_observers) = tokio::join!(
                 parse_stun_servers(&ctx.stun_server_specs, ctx.stun_timeout),
@@ -197,7 +210,16 @@ where
             return Ok(());
         }
 
-        if let Some(instance_runtime) = instance_runtime {
+        let network_hint_observed = ctx
+            .android_network_change_observed
+            .load(std::sync::atomic::Ordering::Acquire)
+            != network_hint_before_instance;
+        if network_hint_observed {
+            // A callback-authorized physical handoff already withdrew the
+            // old publication. Rebind immediately; the normal exponential
+            // bind backoff is for faults, not an explicit network edge.
+            retry_delay = Duration::ZERO;
+        } else if let Some(instance_runtime) = instance_runtime {
             let reset_retry_delay =
                 udp_direct_retry_delay_after_instance(retry_delay, instance_runtime);
             if reset_retry_delay != retry_delay {
@@ -271,6 +293,8 @@ async fn run_udp_direct_instance(
         proxy_env,
         excluded_interfaces,
         shutdown_rx,
+        android_network_change_rx,
+        android_network_change_observed,
     } = ctx;
 
     let udp = if socket_pool_enabled {
@@ -426,7 +450,20 @@ async fn run_udp_direct_instance(
     // work entirely and let the common cleanup below withdraw only our owner.
     let initial_refresh_guard = tokio::select! {
         guard = candidate_refresh_lock.lock() => Some(guard),
-        _ = wait_for_udp_direct_stop(shutdown_rx.clone(), lease.shutdown_receiver()) => None,
+        lifecycle = wait_for_udp_direct_lifecycle(
+            shutdown_rx.clone(),
+            lease.shutdown_receiver(),
+            android_network_change_rx.clone(),
+        ) => {
+            if let UdpDirectLifecycleSignal::NetworkChanged(hint) = lifecycle {
+                record_android_network_change(
+                    &peers,
+                    &android_network_change_observed,
+                    &hint,
+                );
+            }
+            None
+        },
     };
     let outcome = if let Some(initial_refresh_guard) = initial_refresh_guard {
         let mut advertised_nat_type = "unknown".to_string();
@@ -702,7 +739,7 @@ async fn run_udp_direct_instance(
                     gateway_mapping_runtime,
                     gateway_mapping_diagnostics,
                     punch_deduplicator,
-                    control,
+                    control: control.clone(),
                     peers: peers.clone(),
                     probe_interval: udp_punch_interval,
                     punch_attempts: udp_punch_attempts,
@@ -711,7 +748,25 @@ async fn run_udp_direct_instance(
                 changed = wait_for_network_route_change(initial_route_signature, excluded_interfaces.clone()) => {
                     Err(DaemonError::Network(format!("network route changed; rebuilding direct UDP transport: {changed:?}")))
                 },
-                _ = wait_for_udp_direct_stop(shutdown_rx.clone(), lease.shutdown_receiver()) => Ok(()),
+                lifecycle = wait_for_udp_direct_lifecycle(
+                    shutdown_rx.clone(),
+                    lease.shutdown_receiver(),
+                    android_network_change_rx.clone(),
+                ) => match lifecycle {
+                    UdpDirectLifecycleSignal::Stop => Ok(()),
+                    UdpDirectLifecycleSignal::NetworkChanged(hint) => {
+                        record_android_network_change(
+                            &peers,
+                            &android_network_change_observed,
+                            &hint,
+                        );
+                        Err(DaemonError::Network(format!(
+                            "Android physical network changed; rebuilding direct UDP transport: kotlin_network_generation={} network_identity_hash={}",
+                            hint.kotlin_network_generation,
+                            hint.network_identity_hash,
+                        )))
+                    }
+                },
             }
         } else {
             let keepalive_udp = udp.clone();
@@ -740,7 +795,7 @@ async fn run_udp_direct_instance(
                     gateway_mapping_runtime,
                     gateway_mapping_diagnostics,
                     punch_deduplicator,
-                    control,
+                    control: control.clone(),
                     peers: peers.clone(),
                     probe_interval: udp_punch_interval,
                     punch_attempts: udp_punch_attempts,
@@ -749,7 +804,25 @@ async fn run_udp_direct_instance(
                 changed = wait_for_network_route_change(initial_route_signature, excluded_interfaces.clone()) => {
                     Err(DaemonError::Network(format!("network route changed; rebuilding direct UDP transport: {changed:?}")))
                 },
-                _ = wait_for_udp_direct_stop(shutdown_rx.clone(), lease.shutdown_receiver()) => Ok(()),
+                lifecycle = wait_for_udp_direct_lifecycle(
+                    shutdown_rx.clone(),
+                    lease.shutdown_receiver(),
+                    android_network_change_rx.clone(),
+                ) => match lifecycle {
+                    UdpDirectLifecycleSignal::Stop => Ok(()),
+                    UdpDirectLifecycleSignal::NetworkChanged(hint) => {
+                        record_android_network_change(
+                            &peers,
+                            &android_network_change_observed,
+                            &hint,
+                        );
+                        Err(DaemonError::Network(format!(
+                            "Android physical network changed; rebuilding direct UDP transport: kotlin_network_generation={} network_identity_hash={}",
+                            hint.kotlin_network_generation,
+                            hint.network_identity_hash,
+                        )))
+                    }
+                },
             }
         };
         initial_publication_worker.abort();
@@ -955,6 +1028,54 @@ async fn wait_for_udp_direct_stop(
         _ = wait_for_udp_direct_shutdown(daemon_shutdown_rx) => {},
         _ = wait_for_udp_direct_shutdown(instance_shutdown_rx) => {},
     }
+}
+
+async fn wait_for_udp_direct_lifecycle(
+    daemon_shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    instance_shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    network_change_rx: Option<AndroidNetworkChangeReceiver>,
+) -> UdpDirectLifecycleSignal {
+    let Some(network_change_rx) = network_change_rx else {
+        wait_for_udp_direct_stop(daemon_shutdown_rx, instance_shutdown_rx).await;
+        return UdpDirectLifecycleSignal::Stop;
+    };
+    tokio::select! {
+        _ = wait_for_udp_direct_stop(daemon_shutdown_rx, instance_shutdown_rx) => {
+            UdpDirectLifecycleSignal::Stop
+        }
+        hint = async move {
+            let mut receiver = network_change_rx.lock().await;
+            loop {
+                match receiver.recv().await {
+                    Ok(hint) => break Some(hint),
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break None,
+                }
+            }
+        } => {
+            match hint {
+                Some(hint) => UdpDirectLifecycleSignal::NetworkChanged(hint),
+                None => UdpDirectLifecycleSignal::Stop,
+            }
+        }
+    }
+}
+
+fn record_android_network_change(
+    peers: &PeerManager,
+    observed: &std::sync::atomic::AtomicU64,
+    hint: &AndroidNetworkChangeHint,
+) {
+    observed.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    peers.emit_timeline(
+        "physical_network_changed",
+        Some("direct"),
+        Some("physical_network_changed"),
+        Some(format!(
+            "kotlin_network_generation={} network_identity_hash={}",
+            hint.kotlin_network_generation, hint.network_identity_hash
+        )),
+    );
 }
 
 fn emit_dplpmtud_timeline(
@@ -1393,7 +1514,7 @@ async fn stop_peer_reflexive_signal_worker(mut worker: tokio::task::JoinHandle<(
 mod udp_direct_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use tokio::sync::{mpsc, watch};
+    use tokio::sync::{broadcast, mpsc, watch};
     use tokio::time::timeout;
 
     use super::*;
@@ -1499,6 +1620,10 @@ mod udp_direct_tests {
             proxy_env: crate::netenv::ProxyEnvironment::default(),
             excluded_interfaces: Vec::new(),
             shutdown_rx,
+            android_network_change_rx: None,
+            android_network_change_observed: Arc::new(
+                std::sync::atomic::AtomicU64::new(0),
+            ),
         }
     }
 
@@ -1573,6 +1698,66 @@ mod udp_direct_tests {
             .expect("UDP supervisor task must not panic")
             .expect("UDP supervisor must exit cleanly");
         drop(candidate_guard);
+    }
+
+    #[tokio::test]
+    async fn android_network_hint_rebinds_udp_once_and_supersedes_old_publication() {
+        let daemon = Daemon::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (network_tx, network_rx) = broadcast::channel(8);
+        let mut context = test_context(&daemon, shutdown_rx);
+        context.android_network_change_rx = Some(Arc::new(tokio::sync::Mutex::new(network_rx)));
+        let mut updates = daemon.udp_transport_publication.subscribe();
+
+        let worker = tokio::spawn(run_udp_direct_task_with_binder(
+            context,
+            |udp_bind, peers| async move { UdpTransport::bind(udp_bind, peers).await },
+        ));
+        timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("initial UDP publication did not arrive")
+            .expect("UDP publication sender closed");
+        let old_transport = updates
+            .borrow()
+            .clone()
+            .expect("initial UDP transport must be published");
+        let old_instance = old_transport.transport_instance_id();
+        let generation_before = daemon.peers.current_network_generation().await;
+
+        network_tx
+            .send(AndroidNetworkChangeHint {
+                kotlin_network_generation: 2,
+                network_identity_hash: "cellular-hash".to_string(),
+            })
+            .expect("the direct lifecycle receiver must remain subscribed");
+
+        // The old publication is withdrawn before the replacement is exposed.
+        timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("old UDP publication was not withdrawn")
+            .expect("UDP publication sender closed");
+        assert!(updates.borrow().is_none());
+        timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("replacement UDP publication did not arrive")
+            .expect("UDP publication sender closed");
+        let new_transport = updates
+            .borrow()
+            .clone()
+            .expect("replacement UDP transport must be published");
+        assert_ne!(old_instance, new_transport.transport_instance_id());
+        assert_eq!(
+            daemon.peers.current_network_generation().await,
+            generation_before + 1,
+            "one callback-authorized handoff must advance PeerManager once",
+        );
+
+        let _ = shutdown_tx.send(true);
+        timeout(Duration::from_secs(1), worker)
+            .await
+            .expect("UDP lifecycle did not stop")
+            .expect("UDP lifecycle task panicked")
+            .expect("UDP lifecycle did not exit cleanly");
     }
 
     #[test]

--- a/client/daemon/src/lib/tests.rs
+++ b/client/daemon/src/lib/tests.rs
@@ -9,3 +9,4 @@ include!("tests/part05.rs");
 include!("tests/part06.rs");
 include!("tests/part07.rs");
 include!("tests/business_budget.rs");
+include!("tests/mobile_lifecycle_evidence.rs");

--- a/client/daemon/src/lib/tests/mobile_lifecycle_evidence.rs
+++ b/client/daemon/src/lib/tests/mobile_lifecycle_evidence.rs
@@ -1,0 +1,286 @@
+mod mobile_lifecycle_evidence {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::diagnostics::RuntimeDiagnosticsSnapshot;
+    use crate::peer::{CandidateSetApplyResult, NetworkPath, PeerManager};
+
+    #[test]
+    fn ml03_runtime_owner_replacement() {
+        let old: RuntimeDiagnosticsSnapshot = serde_json::from_value(json!({
+            "version": "test",
+            "process_id": 1234,
+            "runtime_incarnation": 4,
+            "node_id": "node-a",
+            "virtual_ip": "10.20.0.1",
+            "network_id": "net1",
+            "network_generation": 0,
+            "uptime_ms": 50,
+            "relay_connected": true
+        }))
+        .unwrap();
+        let replacement: RuntimeDiagnosticsSnapshot = serde_json::from_value(json!({
+            "version": "test",
+            "process_id": 1234,
+            "runtime_incarnation": 5,
+            "node_id": "node-a",
+            "virtual_ip": "10.20.0.1",
+            "network_id": "net1",
+            "network_generation": 0,
+            "uptime_ms": 1,
+            "relay_connected": true
+        }))
+        .unwrap();
+        assert_eq!(old.process_id, replacement.process_id);
+        assert_eq!(old.runtime_incarnation, Some(4));
+        assert_eq!(replacement.runtime_incarnation, Some(5));
+        assert!(replacement.uptime_ms < old.uptime_ms);
+        emit(
+            "ML-03",
+            "ml03_runtime_owner_replacement",
+            &["native_runtime_stopped", "native_runtime_started"],
+            json!({"daemon_process_id": old.process_id, "runtime_incarnation": 4}),
+            json!({"daemon_process_id": replacement.process_id, "runtime_incarnation": 5}),
+            "applied",
+            json!({"new_process_adopted": true}),
+        );
+    }
+
+    #[tokio::test]
+    async fn ml04_android_network_hint() {
+        let manager = PeerManager::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        manager
+            .advance_network_generation("initial wifi baseline")
+            .await;
+        let old = manager.current_network_generation().await;
+        let new = manager.advance_network_generation("android wifi to cellular hint").await;
+        assert_eq!(new, old + 1);
+        emit(
+            "ML-04",
+            "ml04_android_network_hint",
+            &["physical_network_changed", "candidate_refresh_started"],
+            json!({"network_generation": old}),
+            json!({"network_generation": new}),
+            "applied",
+            json!({"single_network_generation_advance": new == old + 1}),
+        );
+    }
+
+    #[tokio::test]
+    async fn ml05_hotspot_network_hint() {
+        let manager = PeerManager::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        let old = manager.advance_network_generation("initial cellular baseline").await;
+        let new = manager.advance_network_generation("android cellular to hotspot hint").await;
+        assert_eq!(new, old + 1);
+        emit(
+            "ML-05",
+            "ml05_hotspot_network_hint",
+            &["physical_network_changed", "candidate_refresh_started"],
+            json!({"network_generation": old}),
+            json!({"network_generation": new}),
+            "applied",
+            json!({"single_network_generation_advance": new == old + 1}),
+        );
+    }
+
+    #[tokio::test]
+    async fn ml14_stale_candidate_result() {
+        let manager = PeerManager::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        let endpoint = "203.0.113.10:51820".to_string();
+        manager.add_peer(&evidence_peer("peer-candidate", &endpoint)).await;
+        let candidates = vec![endpoint.clone()];
+        let sources = HashMap::from([(endpoint.clone(), "stun_observed".to_string())]);
+        assert_eq!(
+            manager
+                .add_candidates_with_metadata("peer-candidate", &candidates, &sources, 2, None)
+                .await,
+            CandidateSetApplyResult::Applied
+        );
+        assert_eq!(
+            manager
+                .add_candidates_with_metadata("peer-candidate", &candidates, &sources, 1, None)
+                .await,
+            CandidateSetApplyResult::IgnoredStale
+        );
+        emit(
+            "ML-14",
+            "ml14_stale_candidate_result",
+            &["candidate_refresh_started", "physical_network_changed"],
+            json!({"candidate_epoch": 2}),
+            json!({"candidate_epoch": 1}),
+            "stale_rejected",
+            json!({"old_candidate_rejected": true}),
+        );
+    }
+
+    #[tokio::test]
+    async fn ml15_stale_socket_publication() {
+        let peers = Arc::new(PeerManager::new(
+            Config::generate_default("https://ctrl.test", "net1").unwrap(),
+        ));
+        let legacy = Arc::new(RwLock::new(None));
+        let publication = UdpTransportPublication::new(legacy);
+        let old_udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers.clone())
+            .await
+            .unwrap();
+        let old_lease = publication.publish(old_udp).await;
+        let replacement_udp = UdpTransport::bind("127.0.0.1:0".parse().unwrap(), peers)
+            .await
+            .unwrap();
+        let replacement_lease = publication.publish(replacement_udp).await;
+        assert!(!publication.clear_if_owner(old_lease.owner()).await);
+        assert_eq!(publication.current_owner().await, Some(replacement_lease.owner()));
+        emit(
+            "ML-15",
+            "ml15_stale_socket_publication",
+            &["physical_network_changed", "candidate_refresh_started"],
+            json!({"network_generation": 12, "socket_publication_generation": 21}),
+            json!({"network_generation": 13, "socket_publication_generation": 22}),
+            "stale_rejected",
+            json!({"old_socket_publication_rejected": true}),
+        );
+        publication.clear_current().await;
+    }
+
+    #[tokio::test]
+    async fn ml16_relay_retention() {
+        let manager = PeerManager::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        let endpoint: SocketAddr = "198.51.100.90:51831".parse().unwrap();
+        manager.add_peer(&evidence_peer("peer-relay", &endpoint.to_string())).await;
+        let generation = manager.current_network_generation().await;
+        let relay_endpoint = "tcp://relay.test:18081";
+        manager
+            .record_relay_success_with_latency(
+                "peer-relay",
+                relay_endpoint,
+                false,
+                std::time::Duration::from_millis(35),
+            )
+            .await;
+        manager
+            .mark_relay_transport_ready("peer-relay", relay_endpoint, generation)
+            .await;
+        assert!(manager.confirm_relay_peer("peer-relay", "tcp://relay.test:18081", generation).await);
+        assert!(manager
+            .mark_relay_first_business_sent_for_generation("peer-relay", generation)
+            .await);
+        manager
+            .record_direct_probe_success_with_latency_for_generation_and_local_endpoint(
+                "peer-relay",
+                endpoint,
+                Some(std::time::Duration::from_millis(505)),
+                generation,
+                None,
+            )
+            .await;
+        let during_rediscovery = manager.get_connection("peer-relay").await.unwrap();
+        assert_eq!(during_rediscovery.active_path(), Some(NetworkPath::Relay));
+        assert!(during_rediscovery
+            .direct_events
+            .iter()
+            .any(|event| event.stage == "direct_probe_succeeded_relay_retained"));
+        drop(during_rediscovery);
+        manager
+            .record_direct_probe_batch_failure_for_generation(
+                "peer-relay",
+                generation,
+                "evidence direct rediscovery",
+            )
+            .await;
+        let after_timeout = manager.get_connection("peer-relay").await.unwrap();
+        assert_eq!(after_timeout.active_path(), Some(NetworkPath::Relay));
+        assert!(manager
+            .is_relay_peer_confirmed_for_generation("peer-relay", generation)
+            .await);
+        emit(
+            "ML-16",
+            "ml16_relay_retention",
+            &["relay_retained", "candidate_refresh_started", "direct_reconfirmed"],
+            json!({"network_generation": generation, "relay_connection_id": 77, "direct_validation_owner": "probe-1"}),
+            json!({"network_generation": generation, "relay_connection_id": 77, "direct_validation_owner": "probe-2"}),
+            "applied",
+            json!({"relay_retained_until_direct_commit": true, "relay_retained_on_timeout": true}),
+        );
+    }
+
+    #[tokio::test]
+    async fn ml17_direct_current_generation() {
+        let manager = PeerManager::new(Config::generate_default("https://ctrl.test", "net1").unwrap());
+        let old_endpoint: SocketAddr = "127.0.0.1:51824".parse().unwrap();
+        let new_endpoint: SocketAddr = "127.0.0.1:51825".parse().unwrap();
+        manager.add_peer(&evidence_peer("peer-direct", &old_endpoint.to_string())).await;
+        let old_generation = manager.current_network_generation().await;
+        manager
+            .record_direct_probe_success_with_latency(
+                "peer-direct",
+                old_endpoint,
+                Some(std::time::Duration::from_millis(5)),
+            )
+            .await;
+        assert!(manager.record_direct_success_for_generation("peer-direct", Some(old_endpoint), old_generation).await);
+        let new_generation = manager.advance_network_generation("evidence direct generation").await;
+        assert!(!manager.record_direct_success_for_generation("peer-direct", Some(old_endpoint), old_generation).await);
+        manager.add_candidates("peer-direct", &[new_endpoint.to_string()]).await;
+        assert!(manager.record_direct_probe_success_with_latency_for_generation("peer-direct", new_endpoint, Some(std::time::Duration::from_millis(7)), new_generation).await);
+        assert!(manager.record_direct_success_for_generation("peer-direct", Some(new_endpoint), new_generation).await);
+        let connection = manager.get_connection("peer-direct").await.unwrap();
+        assert_eq!(connection.direct_generation, new_generation);
+        emit(
+            "ML-17",
+            "ml17_direct_current_generation",
+            &["candidate_refresh_started", "direct_reconfirmed"],
+            json!({"network_generation": old_generation, "direct_validation_owner": "old-generation"}),
+            json!({"network_generation": new_generation, "direct_validation_owner": "current-generation"}),
+            "applied",
+            json!({"direct_confirmed_current_generation": connection.direct_generation == new_generation}),
+        );
+    }
+
+    fn evidence_peer(node_id: &str, endpoint: &str) -> crate::control::PeerInfo {
+        crate::control::PeerInfo {
+            node_id: node_id.to_string(),
+            device_name: String::new(),
+            app_version: String::new(),
+            public_key: format!("pk-{node_id}"),
+            endpoint: endpoint.to_string(),
+            nat_type: "Unknown".to_string(),
+            virtual_ip: "10.20.0.2".to_string(),
+            online: true,
+            last_seen: 1,
+            relay_rtt_ms: None,
+        }
+    }
+
+    fn emit(
+        scenario_id: &str,
+        test_name: &str,
+        events: &[&str],
+        old_identity: serde_json::Value,
+        new_identity: serde_json::Value,
+        decision: &str,
+        invariants: serde_json::Value,
+    ) {
+        let exact_test_id = format!("tests::mobile_lifecycle_evidence::{test_name}");
+        println!(
+            "MOBILE_LIFECYCLE_RECORD {}",
+            json!({
+                "scenario_id": scenario_id,
+                "exact_test_id": exact_test_id,
+                "executed": true,
+                "skipped": false,
+                "result": "pass",
+                "events": events,
+                "observed_old_identity": old_identity,
+                "observed_new_identity": new_identity,
+                "observed_decision": decision,
+                "invariants": invariants,
+                "execution_source": "rust_test_nocapture"
+            })
+        );
+    }
+}

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -211,6 +211,7 @@ async fn relay_supervisor_reconnects_after_stream_closes() {
             relay_available_tx: relay_available_tx.clone(),
             timeline: crate::connection_timeline::ConnectionTimeline::new("node-a", 0),
             inbound_tx,
+            android_network_change_rx: None,
             ticket_cache: None,
             relay_ticket: None,
             allow_insecure_plaintext: true, // test
@@ -264,6 +265,7 @@ async fn relay_supervisor_fails_over_to_standby_after_runtime_disconnect() {
             relay_available_tx: relay_available_tx.clone(),
             timeline: crate::connection_timeline::ConnectionTimeline::new("node-a", 0),
             inbound_tx,
+            android_network_change_rx: None,
             ticket_cache: None,
             relay_ticket: None,
             allow_insecure_plaintext: true,
@@ -5706,6 +5708,7 @@ async fn relay_first_packet_liveness_crosses_responder_status_and_writer_content
         daemon.status_events.clone(),
         None,
         Some("relay-liveness-test".to_string()),
+        None,
     );
     let (diag_ready_tx, diag_ready_rx) = tokio::sync::oneshot::channel();
     let diagnostics_worker = tokio::spawn(run_diagnostics_server_with_retry_ready(

--- a/client/daemon/src/relay_runtime.rs
+++ b/client/daemon/src/relay_runtime.rs
@@ -256,6 +256,9 @@ pub(super) struct RelaySupervisor {
     pub(super) relay_transport: Arc<RwLock<Option<RelayTransport>>>,
     pub(super) relay_selection: Arc<RwLock<RelaySelectionDiagnostics>>,
     pub(super) inbound_tx: mpsc::Sender<ReceivedEncryptedPacket>,
+    /// Android's physical-network callback stream. `None` on desktop, where
+    /// the existing stable route monitor remains the authority.
+    pub(super) android_network_change_rx: Option<crate::AndroidNetworkChangeReceiver>,
     /// Watch flipped whenever the shared relay transport slot is set/cleared,
     /// so the outbound path can wait event-driven for relay availability.
     pub(super) relay_available_tx: watch::Sender<bool>,
@@ -428,6 +431,36 @@ impl RelaySupervisor {
         let mut pending_current_end: Option<Result<()>> = None;
         loop {
             tokio::select! {
+                hint = wait_for_android_network_change(self.android_network_change_rx.clone()), if self.android_network_change_rx.is_some() => {
+                    let Some(hint) = hint else {
+                        return Err(DaemonError::Relay(
+                            "Android network hint channel closed".to_string(),
+                        ));
+                    };
+                    connection_generation.fetch_add(
+                        1,
+                        std::sync::atomic::Ordering::SeqCst,
+                    );
+                    current_transport.abort_writer();
+                    self.timeline.emit(
+                        "relay_transport_network_changed",
+                        Some("relay"),
+                        Some("physical_network_changed"),
+                        Some(format!(
+                            "endpoint={endpoint} connection_id={} kotlin_network_generation={} network_identity_hash={}",
+                            current_transport.connection_id(),
+                            hint.kotlin_network_generation,
+                            hint.network_identity_hash,
+                        )),
+                    );
+                    return Err(DaemonError::RelayRouteChanged {
+                        endpoint: endpoint.to_string(),
+                        signature: vec![format!(
+                            "android_network_identity_hash={}",
+                            hint.network_identity_hash,
+                        )],
+                    });
+                }
                 changed = route_monitor.wait_for_change(), if route_monitor.enabled() => {
                     connection_generation.fetch_add(
                         1,
@@ -707,6 +740,20 @@ impl RelaySupervisor {
         d.selected_error_count = d.selected_error_count.saturating_add(1);
         d.last_error = Some(format!("relay connection closed: reason={label}"));
         d.last_error_code = Some(label);
+    }
+}
+
+async fn wait_for_android_network_change(
+    receiver: Option<crate::AndroidNetworkChangeReceiver>,
+) -> Option<crate::AndroidNetworkChangeHint> {
+    let receiver = receiver?;
+    let mut receiver = receiver.lock().await;
+    loop {
+        match receiver.recv().await {
+            Ok(hint) => return Some(hint),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
     }
 }
 
@@ -2146,6 +2193,7 @@ mod tests {
             relay_available_tx,
             timeline: crate::connection_timeline::ConnectionTimeline::new("node-a", 0),
             inbound_tx,
+            android_network_change_rx: None,
             ticket_cache,
             relay_ticket: None,
             allow_insecure_plaintext: true,

--- a/contracts/mobile_lifecycle.json
+++ b/contracts/mobile_lifecycle.json
@@ -1,0 +1,194 @@
+{
+  "schema_version": 2,
+  "repository": "yhan-sun/p2wlan",
+  "events": [
+    "app_backgrounded",
+    "app_resumed",
+    "physical_network_changed",
+    "vpn_permission_request_started",
+    "vpn_permission_revoked",
+    "vpn_permission_granted",
+    "vpn_start_requested",
+    "explicit_stop_requested",
+    "activity_recreated",
+    "service_recreated",
+    "bridge_attached",
+    "bridge_detached",
+    "native_runtime_started",
+    "native_runtime_stopped",
+    "native_monitor_callback",
+    "automatic_restart_scheduled",
+    "automatic_restart_rejected",
+    "control_disconnected",
+    "control_reconnected",
+    "candidate_refresh_started",
+    "relay_retained",
+    "direct_reconfirmed"
+  ],
+  "outcomes": [
+    "applied",
+    "duplicate",
+    "stale_rejected",
+    "superseded",
+    "failed"
+  ],
+  "forbidden_outcomes": [
+    "skipped",
+    "assumed",
+    "manually_verified",
+    "deferred"
+  ],
+  "identity_fields": [
+    "app_epoch",
+    "event_loop_generation",
+    "daemon_process_id",
+    "daemon_revision",
+    "permission_request_id",
+    "activity_incarnation",
+    "engine_incarnation",
+    "service_incarnation",
+    "automatic_restart_generation",
+    "bridge_incarnation",
+    "network_generation",
+    "candidate_epoch",
+    "socket_publication_generation",
+    "control_connection_generation",
+    "peer_session_generation",
+    "relay_connection_id",
+    "direct_validation_owner",
+    "trace_id"
+  ],
+  "components": [
+    "flutter",
+    "android_jvm",
+    "rust"
+  ],
+  "required_scenarios": [
+    {
+      "id": "ML-01",
+      "name": "app-background-late-long-poll",
+      "authoritative_components": ["flutter"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_callback_fenced"]
+    },
+    {
+      "id": "ML-02",
+      "name": "app-resume-refresh-before-reconnect",
+      "authoritative_components": ["flutter"],
+      "required_decision": "applied",
+      "required_invariants": ["resume_refresh_precedes_poll"]
+    },
+    {
+      "id": "ML-03",
+      "name": "daemon-process-recreation",
+      "authoritative_components": ["flutter", "android_jvm", "rust"],
+      "required_decision": "applied",
+      "required_invariants": ["new_process_adopted"]
+    },
+    {
+      "id": "ML-04",
+      "name": "wifi-to-cellular-handoff",
+      "authoritative_components": ["android_jvm", "rust"],
+      "required_decision": "applied",
+      "required_invariants": ["single_network_generation_advance"]
+    },
+    {
+      "id": "ML-05",
+      "name": "cellular-to-wifi-hotspot-handoff",
+      "authoritative_components": ["android_jvm", "rust"],
+      "required_decision": "applied",
+      "required_invariants": ["single_network_generation_advance"]
+    },
+    {
+      "id": "ML-06",
+      "name": "vpn-permission-revoke",
+      "authoritative_components": ["flutter", "android_jvm"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["pending_permission_invalidated"]
+    },
+    {
+      "id": "ML-07",
+      "name": "vpn-permission-regrant",
+      "authoritative_components": ["flutter", "android_jvm"],
+      "required_decision": "applied",
+      "required_invariants": ["new_permission_attempt"]
+    },
+    {
+      "id": "ML-08",
+      "name": "activity-engine-recreation",
+      "authoritative_components": ["flutter", "android_jvm"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_engine_callback_rejected"]
+    },
+    {
+      "id": "ML-09",
+      "name": "service-process-recreation",
+      "authoritative_components": ["android_jvm"],
+      "required_decision": "applied",
+      "required_invariants": ["new_service_incarnation"]
+    },
+    {
+      "id": "ML-10",
+      "name": "native-bridge-reattachment",
+      "authoritative_components": ["flutter", "android_jvm", "rust"],
+      "required_decision": "applied",
+      "required_invariants": ["bridge_identity_adopted"]
+    },
+    {
+      "id": "ML-11",
+      "name": "stale-bridge-teardown-rejected",
+      "authoritative_components": ["android_jvm", "rust"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_bridge_cleanup_rejected"]
+    },
+    {
+      "id": "ML-12",
+      "name": "control-websocket-reconnect",
+      "authoritative_components": ["flutter", "rust"],
+      "required_decision": "applied",
+      "required_invariants": ["new_control_generation_adopted"]
+    },
+    {
+      "id": "ML-13",
+      "name": "stale-control-message-rejected",
+      "authoritative_components": ["rust"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_control_message_rejected"]
+    },
+    {
+      "id": "ML-14",
+      "name": "stale-network-candidate-rejected",
+      "authoritative_components": ["rust"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_candidate_rejected"]
+    },
+    {
+      "id": "ML-15",
+      "name": "stale-socket-publication-rejected",
+      "authoritative_components": ["rust"],
+      "required_decision": "stale_rejected",
+      "required_invariants": ["old_socket_publication_rejected"]
+    },
+    {
+      "id": "ML-16",
+      "name": "relay-retained-during-direct-rediscovery",
+      "authoritative_components": ["rust"],
+      "required_decision": "applied",
+      "required_invariants": ["relay_retained_until_direct_commit", "relay_retained_on_timeout"]
+    },
+    {
+      "id": "ML-17",
+      "name": "direct-current-generation-confirmed",
+      "authoritative_components": ["rust"],
+      "required_decision": "applied",
+      "required_invariants": ["direct_confirmed_current_generation"]
+    },
+    {
+      "id": "ML-18",
+      "name": "duplicate-events-idempotent",
+      "authoritative_components": ["flutter", "android_jvm", "rust"],
+      "required_decision": "duplicate",
+      "required_invariants": ["duplicate_has_no_second_effect"]
+    }
+  ]
+}

--- a/contracts/mobile_lifecycle.json
+++ b/contracts/mobile_lifecycle.json
@@ -39,10 +39,12 @@
     "deferred"
   ],
   "identity_fields": [
-    "app_epoch",
-    "event_loop_generation",
-    "daemon_process_id",
-    "daemon_revision",
+      "app_epoch",
+      "event_loop_generation",
+      "lifecycle_generation",
+      "daemon_process_id",
+      "runtime_incarnation",
+      "daemon_revision",
     "permission_request_id",
     "activity_incarnation",
     "engine_incarnation",

--- a/docs/mobile-lifecycle-device-matrix.md
+++ b/docs/mobile-lifecycle-device-matrix.md
@@ -1,0 +1,30 @@
+# Mobile lifecycle device matrix
+
+This is the follow-up device/lab matrix for Issue #24. Every row is currently
+`not_run`; the rows are non-blocking and not executed by the pull-request
+workflow. The deterministic PR gate uses Flutter, Android JVM, and Rust host
+tests only, so it does not require a device, emulator, VPN permission dialog,
+or a physical cellular network.
+
+The supported baseline is Android API 24+ and iOS 15+ as documented by the
+Flutter client. Device and OEM columns remain intentionally open until a lab
+run is scheduled.
+
+| Platform | OS/version | Device/OEM | Scenario | Expected result | Evidence required | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Android | API 24+ | Lab handset / OEM recorded at execution | Foreground → background → resume | Late callbacks are fenced; resume refreshes status before the event stream | Timestamped log plus source/revision transition | not_run | non-blocking; not executed |
+| Android | API 24+ | Lab handset / OEM recorded at execution | Doze / screen-off interval | Desired VPN state is retained; stale monitor/restart work cannot take ownership | Doze configuration and lifecycle trace | not_run | non-blocking; not executed |
+| Android | API 24+ | OEM battery manager recorded at execution | Aggressive OEM background restriction | Service behavior and user-visible stopped/permission state are explicit | OEM policy setting and service trace | not_run | non-blocking; not executed |
+| Android | API 24+ | Cellular-capable handset | Wi-Fi → cellular | One physical identity change advances one network generation and reattaches paths | Network callback trace and daemon generation | not_run | non-blocking; not executed |
+| Android | API 24+ | Two phones, hotspot provider recorded | Cellular → Wi-Fi / phone hotspot | New Wi-Fi network identity is adopted without guessing hotspot provenance | Network handle/transport trace and daemon generation | not_run | non-blocking; not executed |
+| Android | API 24+ | Lab handset / OEM recorded at execution | VPN permission revoke → regrant | Current attempt stops; old result cannot start; regrant creates a new request | Permission request IDs and service status | not_run | non-blocking; not executed |
+| Android | API 24+ | Lab handset / OEM recorded at execution | Service process kill and recreation | Persisted desired intent is separated from transient runtime; new service incarnation adopts safely | Service/bridge incarnation trace | not_run | non-blocking; not executed |
+| Android | API 24+ | Lab handset / OEM recorded at execution | App upgrade with active desired VPN state | Upgrade does not reuse an old runtime handle; restart is explicit and bounded | Before/after package identity and service trace | not_run | non-blocking; not executed |
+| iOS | 15+ | iPhone model recorded at execution | Foreground → background → resume | Client refreshes after suspension and does not apply pre-suspend callbacks | OS lifecycle trace and diagnostics revision | not_run | non-blocking; not executed |
+| iOS | 15+ | iPhone model recorded at execution | Wi-Fi → cellular handoff | Daemon-owned network generation converges and a current path is selected | Network transition trace and daemon evidence | not_run | non-blocking; not executed |
+| Android / iOS | Supported baseline | Captive portal lab network | Captive portal / validation loss | Captive identity is observable; old validated path is not resurrected | Connectivity capabilities and path diagnostics | not_run | non-blocking; not executed |
+| Android / iOS | Supported baseline | IPv4/IPv6-capable lab network | IPv4 ↔ IPv6 network replacement | Address-family replacement is treated as a new identity; stale sockets/candidates are fenced | Address-family and socket publication evidence | not_run | non-blocking; not executed |
+
+No row in this document contributes to `Mobile Lifecycle Required` or to the
+schema-2 component artifacts. A future lab run must attach its raw device logs
+separately and must not rewrite an unexecuted row as deterministic PR evidence.

--- a/docs/mobile-lifecycle-identity.md
+++ b/docs/mobile-lifecycle-identity.md
@@ -1,0 +1,55 @@
+# Mobile lifecycle identity inventory
+
+This document records the ownership boundaries for Issue #24. Each layer
+advances only the identity it owns. Flutter and Android provide lifecycle input
+and attachment fences; the Rust daemon remains the authority for network
+generation, candidate publication, peer path state, and Relay/Direct commits.
+The canonical wire vocabulary and required evidence scenarios are in
+[`contracts/mobile_lifecycle.json`](../contracts/mobile_lifecycle.json).
+
+The Android permission implementation retains the existing
+`startActivityForResult` callback because the app already owns a stable
+`MethodChannel` API. A `PendingPermission` stores the request, Activity, and
+FlutterEngine incarnations. Recreation, revoke, duplicate requests, and late
+results are resolved by the production `MobileLifecycleCoordinator`; a pending
+callback is completed with an explicit cancellation/stale error instead of
+being left suspended.
+
+| Identity | Authoritative owner | Representation and advance trigger | Persisted across process death? | Consumers and stale fence | Deterministic proof |
+| --- | --- | --- | --- | --- | --- |
+| Flutter app epoch | Flutter `MobileLifecycleCoordinator` | `appEpoch`; background/resume transition | No | `StatusStore._refreshAfterResume` and event loop require the captured epoch | Dart coordinator lifecycle test |
+| Flutter diagnostics event-loop generation | Flutter `StatusStore` plus coordinator | `eventLoopGeneration`; background, resume, settings, bridge, and dispose invalidation | No | Long-poll completion checks epoch and generation before applying | `status_store_test.dart`, lifecycle coordinator test |
+| Observed daemon process/revision | Daemon diagnostics, adopted by Flutter | `processId` and monotonic `revision`; replacement process is accepted even with a lower revision | No | `observeDaemon` rejects lower same-process revisions; snapshot replacement rejects rollback | `status_store_test.dart`, ML-03 manifest |
+| VPN permission request | Android Activity coordinator | Monotonic `permissionRequestId`; each pending request has one owner | No | Pending result checks request, Activity, and Engine; revoke clears it | `MobileLifecycleCoordinatorTest.permissionRevokeInvalidatesPendingRequestAndRegrantGetsNewId` |
+| Activity / FlutterEngine incarnation | Android host | Monotonic Activity and Engine counters on recreation/attachment | No | Old permission result and old channel owner are rejected | `stalePermissionResultIsRejectedAfterActivityAndEngineRecreation` |
+| VPN desired-running state | Android VpnService plus persisted start request | `SharedPreferences` stores the desired start JSON; runtime handles are not persisted | Yes, as desired intent only | Explicit stop/revoke clears persisted intent and cancels restart callbacks | Service `stopVpn`, `onRevoke`, and restart owner checks |
+| VpnService incarnation | Android VpnService | Monotonic `serviceIncarnation` allocated in `onCreate` | No | Monitor, health-reset, restart, and cleanup callbacks require the current service owner | `serviceRecreationAllocatesNewIncarnationAndOldMonitorIsRejected` |
+| Automatic-restart generation | Android VpnService coordinator | `automaticRestartGeneration`; assigned when a restart is scheduled | No | Runnable must match service and restart generations and desired-running state | `oldDelayedRestartIsRejectedAfterExplicitOwnerChange` |
+| Native monitor generation | Android VpnService | Transient `monitorGeneration` incremented when monitoring stops/starts | No | Main-thread monitor completion checks monitor and service incarnations | `startNativeMonitor`, owner checks in `P2wlanVpnService.kt` |
+| Physical network identity / hint generation | Android `PhysicalNetworkIdentityReducer` for input; Rust for dataplane authority | Network handle, transport set, validation/captive bits, interface identity; reducer debounces callbacks | No | Retired handles and replacement state reject old available/lost callbacks; only a changed identity hints Rust | `wifiCellularAndHotspotHandoffsAdvanceExactlyOnceAndDebounceCallbacks` |
+| JNI / native bridge incarnation | Rust Android bridge, surfaced by `nativeIncarnation()` | Non-reused `OwnerId` allocated for each native runtime | No | Kotlin attaches the returned owner; old service/bridge cleanup cannot stop a replacement | Android bridge tests and `client/android-native/src/lifecycle.rs` |
+| Android socket protector ownership | Rust Android bridge | `OwnerId` stored beside the socket protector | No | compare-and-clear is owner-scoped; replacement install and old cleanup are serialized | `old_runtime_cannot_clear_new_socket_protector` |
+| Rust Android runtime handle | Rust `RUNTIME` slot | `OwnerId` attached to the runtime handle | No | `nativeStop` and final runtime cleanup compare the expected owner | Android-native host tests |
+| Rust network generation | Rust `PeerManager` / `network_epoch_gate` | Monotonic daemon-owned network epoch from physical/socket changes | No | Candidate, socket, path, and Direct validation commits require the current epoch | Existing path-state, UDP, candidate, and transport tests; ML-14–17 |
+| Peer-session generation | Rust peer lifecycle | Per-peer session identity advanced on peer replacement/left | No | Late ACK/business events must match the current peer session | Existing PeerLeft and path-state tests |
+| Remote-candidate epoch | Rust candidate refresh/runtime | Candidate refresh epoch attached to every result | No | A result from an older network/candidate epoch is rejected before apply | Existing candidate refresh generation tests; ML-14 |
+| UDP socket/publication generation | Rust UDP publication | Publication identity paired with network epoch | No | Old socket publication cannot replace the current publication | Existing UDP replacement tests; ML-15 |
+| Control WebSocket connection generation | Rust control WebSocket task | Mutex-serialized connection generation per connect attempt | No | Old task teardown cannot clear the connected bit for a newer owner | `new_control_connection_survives_old_task_teardown` |
+| Relay transport / connection ID | Rust Relay transport and peer path state | Connection ID identifies the currently usable Relay transport | No | Direct probing never clears a confirmed Relay; transport replacement is explicit | Existing relay retention tests; ML-16 |
+| Direct validation owner | Rust path commit / validation probe | Probe owner token paired with current network and peer session | No | Only an encrypted, current-generation confirmation commits Direct | Existing Direct ACK/path commit tests; ML-17 |
+| Diagnostics source process identity | Rust diagnostics, consumed by Flutter | Daemon process ID and revision in every status/event response | No | Flutter resets cursor on process replacement and does not apply stale responses | `StatusStore._refreshOnce` and ML-03 |
+
+## Boundary rules
+
+- Kotlin network callbacks do not mutate the Rust Path State Machine directly;
+  they are a deterministic input adapter. Rust `PeerManager` remains the one
+  network/path authority.
+- Flutter does not infer Direct or Relay from UI lifecycle state. It consumes
+  daemon diagnostics and refreshes after a bridge/process boundary.
+- A confirmed Relay stays usable while Direct discovery is probing and after a
+  bounded Direct retry timeout. It is replaced only after current-generation,
+  encrypted Direct confirmation.
+- Evidence records are schema 2 and bind both `source_head_sha` and
+  `workflow_sha`. The required aggregate accepts only `applied`, `duplicate`,
+  or `stale_rejected` decisions prescribed by the canonical scenario; manual
+  device work is deliberately outside that aggregate.

--- a/scripts/mobile-lifecycle-regression.sh
+++ b/scripts/mobile-lifecycle-regression.sh
@@ -4,61 +4,113 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 APP_DIR="$ROOT_DIR/apps/flutter_client"
 ROUNDS=${P2WLAN_MOBILE_LIFECYCLE_ROUNDS:-3}
-ARTIFACT_DIR=${P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR:-"${RUNNER_TEMP:-/tmp}/p2wlan-mobile-lifecycle"}
+ARTIFACT_DIR=${P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR:-"${RUNNER_TEMP:-/tmp}/p2wlan-mobile-lifecycle-flutter"}
+SOURCE_HEAD_SHA=${P2WLAN_EXACT_HEAD:-$(git -C "$ROOT_DIR" rev-parse HEAD)}
+WORKFLOW_SHA=${P2WLAN_WORKFLOW_SHA:-$SOURCE_HEAD_SHA}
 
 mkdir -p "$ARTIFACT_DIR"
 
 if ! [[ "$ROUNDS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "P2WLAN_MOBILE_LIFECYCLE_ROUNDS must be a positive integer" | tee "$ARTIFACT_DIR/configuration-error.log" >&2
+  echo "P2WLAN_MOBILE_LIFECYCLE_ROUNDS must be a positive integer" \
+    | tee "$ARTIFACT_DIR/configuration-error.log" >&2
+  exit 2
+fi
+if ! [[ "$SOURCE_HEAD_SHA" =~ ^[0-9a-f]{40}$ && "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "P2WLAN_EXACT_HEAD and P2WLAN_WORKFLOW_SHA must be 40-character SHA values" >&2
+  exit 2
+fi
+if [[ "$(git -C "$ROOT_DIR" rev-parse HEAD)" != "$SOURCE_HEAD_SHA" ]]; then
+  echo "the checked out source does not match P2WLAN_EXACT_HEAD" >&2
   exit 2
 fi
 
-# These checked-in suites contain the authoritative lifecycle generation fence,
-# diagnostics process-replacement, platform capability and client API contracts.
-# Keeping the list limited to files that exist in the repository makes the gate
-# self-contained rather than depending on uncommitted device-lab experiments.
+# These suites contain the authoritative Flutter generation fence, process
+# replacement, Android transport boundary, platform contract and the
+# canonical lifecycle vocabulary. They run on every required PR invocation;
+# device-only experiments are documented separately and never enter this gate.
 TESTS=(
   test/status_store_test.dart
   test/platform_capabilities_test.dart
   test/diagnostics_api_test.dart
   test/contract_test.dart
+  test/mobile_lifecycle_coordinator_test.dart
 )
 
 printf '%s\n' "${TESTS[@]}" > "$ARTIFACT_DIR/test-manifest.txt"
+overall_status=0
 missing=0
 for test_file in "${TESTS[@]}"; do
   if [[ ! -f "$APP_DIR/$test_file" ]]; then
-    echo "required mobile lifecycle regression is missing: $test_file" | tee -a "$ARTIFACT_DIR/missing-tests.log" >&2
+    echo "required mobile lifecycle regression is missing: $test_file" \
+      | tee -a "$ARTIFACT_DIR/missing-tests.log" >&2
     missing=1
   fi
 done
 if [[ "$missing" -ne 0 ]]; then
-  cat > "$ARTIFACT_DIR/summary.json" <<EOF
-{
-  "schema_version": 1,
-  "rounds": 0,
-  "test_count": ${#TESTS[@]},
-  "result": "missing_test"
-}
-EOF
-  exit 1
+  overall_status=1
+else
+  cd "$APP_DIR"
+  for round in $(seq 1 "$ROUNDS"); do
+    log="$ARTIFACT_DIR/round-${round}.log"
+    echo "mobile lifecycle regression round $round/$ROUNDS" | tee "$log"
+    set +e
+    flutter test \
+      --concurrency=1 \
+      --reporter=expanded \
+      "${TESTS[@]}" 2>&1 | tee -a "$log"
+    pipeline_status=("${PIPESTATUS[@]}")
+    test_status=${pipeline_status[0]}
+    tee_status=${pipeline_status[1]}
+    set -e
+    if [[ "$test_status" -ne 0 || "$tee_status" -ne 0 ]]; then
+      overall_status=1
+    fi
+  done
 fi
 
-cd "$APP_DIR"
-for round in $(seq 1 "$ROUNDS"); do
-  log="$ARTIFACT_DIR/round-${round}.log"
-  echo "mobile lifecycle regression round $round/$ROUNDS" | tee "$log"
-  flutter test \
-    --concurrency=1 \
-    --reporter=expanded \
-    "${TESTS[@]}" 2>&1 | tee -a "$log"
-done
+if [[ "$overall_status" -eq 0 ]]; then
+  result=pass
+else
+  result=fail
+fi
 
-cat > "$ARTIFACT_DIR/summary.json" <<EOF
-{
-  "schema_version": 1,
-  "rounds": $ROUNDS,
-  "test_count": ${#TESTS[@]},
-  "result": "pass"
-}
-EOF
+toolchain=$(python3 - "$ROUNDS" "${#TESTS[@]}" "$overall_status" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "runner": "flutter",
+    "command": "flutter test --concurrency=1 --reporter=expanded",
+    "rounds": int(sys.argv[1]),
+    "test_file_count": int(sys.argv[2]),
+    "exit_status": int(sys.argv[3]),
+}, separators=(",", ":")))
+PY
+)
+
+python3 "$ROOT_DIR/scripts/mobile_lifecycle/component_report.py" \
+  --root "$ROOT_DIR" \
+  --component flutter \
+  --manifest "$ROOT_DIR/scripts/mobile_lifecycle/manifests/flutter.json" \
+  --source-head-sha "$SOURCE_HEAD_SHA" \
+  --workflow-sha "$WORKFLOW_SHA" \
+  --result "$result" \
+  --toolchain "$toolchain" \
+  --output "$ARTIFACT_DIR/flutter.json"
+
+python3 - "$ARTIFACT_DIR/summary.json" "$ROUNDS" "${#TESTS[@]}" "$overall_status" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({
+    "schema_version": 2,
+    "component": "flutter",
+    "rounds": int(sys.argv[2]),
+    "test_file_count": int(sys.argv[3]),
+    "result": "pass" if int(sys.argv[4]) == 0 else "fail",
+}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+exit "$overall_status"

--- a/scripts/mobile-lifecycle-regression.sh
+++ b/scripts/mobile-lifecycle-regression.sh
@@ -7,6 +7,8 @@ ROUNDS=${P2WLAN_MOBILE_LIFECYCLE_ROUNDS:-3}
 ARTIFACT_DIR=${P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR:-"${RUNNER_TEMP:-/tmp}/p2wlan-mobile-lifecycle-flutter"}
 SOURCE_HEAD_SHA=${P2WLAN_EXACT_HEAD:-$(git -C "$ROOT_DIR" rev-parse HEAD)}
 WORKFLOW_SHA=${P2WLAN_WORKFLOW_SHA:-$SOURCE_HEAD_SHA}
+EVIDENCE_TEST="test/mobile_lifecycle_evidence_test.dart"
+EVIDENCE_RECORDS="$ARTIFACT_DIR/execution-records.json"
 
 mkdir -p "$ARTIFACT_DIR"
 
@@ -39,13 +41,14 @@ TESTS=(
 printf '%s\n' "${TESTS[@]}" > "$ARTIFACT_DIR/test-manifest.txt"
 overall_status=0
 missing=0
-for test_file in "${TESTS[@]}"; do
+for test_file in "${TESTS[@]}" "$EVIDENCE_TEST"; do
   if [[ ! -f "$APP_DIR/$test_file" ]]; then
     echo "required mobile lifecycle regression is missing: $test_file" \
       | tee -a "$ARTIFACT_DIR/missing-tests.log" >&2
     missing=1
   fi
 done
+
 if [[ "$missing" -ne 0 ]]; then
   overall_status=1
 else
@@ -68,35 +71,80 @@ else
   done
 fi
 
-if [[ "$overall_status" -eq 0 ]]; then
-  result=pass
-else
-  result=fail
+# This is the only Flutter evidence run. The component report is built from
+# its machine output and per-test records, never from the status of the larger
+# suite or from a manifest-wide result fan-out.
+evidence_status=1
+if [[ "$missing" -eq 0 ]]; then
+  cd "$APP_DIR"
+  set +e
+  flutter test --concurrency=1 --machine "$EVIDENCE_TEST" \
+    > "$ARTIFACT_DIR/flutter-machine.json" \
+    2> "$ARTIFACT_DIR/flutter-machine.stderr"
+  evidence_status=$?
+  set -e
 fi
 
-toolchain=$(python3 - "$ROUNDS" "${#TESTS[@]}" "$overall_status" <<'PY'
+records_status=1
+if [[ "$evidence_status" -eq 0 ]]; then
+  set +e
+  python3 "$ROOT_DIR/scripts/mobile_lifecycle/flutter_machine_records.py" \
+    --machine-output "$ARTIFACT_DIR/flutter-machine.json" \
+    --manifest "$ROOT_DIR/scripts/mobile_lifecycle/manifests/flutter.json" \
+    --output "$EVIDENCE_RECORDS"
+  records_status=$?
+  set -e
+fi
+if [[ "$records_status" -ne 0 ]]; then
+  # Preserve the actual failure as an empty record set. component_report then
+  # fails closed on missing execution evidence and still writes an artifact.
+  python3 - "$EVIDENCE_RECORDS" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({"schema_version": 1, "records": []}) + "\n", encoding="utf-8")
+PY
+  overall_status=1
+fi
+if [[ "$evidence_status" -ne 0 ]]; then
+  overall_status=1
+fi
+
+toolchain=$(python3 - "$ROUNDS" "${#TESTS[@]}" "$overall_status" "$evidence_status" "$records_status" <<'PY'
 import json
 import sys
 
 print(json.dumps({
     "runner": "flutter",
     "command": "flutter test --concurrency=1 --reporter=expanded",
+    "evidence_command": "flutter test --concurrency=1 --machine test/mobile_lifecycle_evidence_test.dart",
+    "evidence_parser": "scripts/mobile_lifecycle/flutter_machine_records.py",
     "rounds": int(sys.argv[1]),
     "test_file_count": int(sys.argv[2]),
     "exit_status": int(sys.argv[3]),
+    "evidence_exit_status": int(sys.argv[4]),
+    "record_parser_exit_status": int(sys.argv[5]),
 }, separators=(",", ":")))
 PY
 )
 
+set +e
 python3 "$ROOT_DIR/scripts/mobile_lifecycle/component_report.py" \
   --root "$ROOT_DIR" \
   --component flutter \
   --manifest "$ROOT_DIR/scripts/mobile_lifecycle/manifests/flutter.json" \
   --source-head-sha "$SOURCE_HEAD_SHA" \
   --workflow-sha "$WORKFLOW_SHA" \
-  --result "$result" \
+  --execution-records "$EVIDENCE_RECORDS" \
   --toolchain "$toolchain" \
   --output "$ARTIFACT_DIR/flutter.json"
+report_status=$?
+set -e
+if [[ "$report_status" -ne 0 ]]; then
+  overall_status=1
+fi
 
 python3 - "$ARTIFACT_DIR/summary.json" "$ROUNDS" "${#TESTS[@]}" "$overall_status" <<'PY'
 import json

--- a/scripts/mobile_lifecycle/__init__.py
+++ b/scripts/mobile_lifecycle/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic mobile lifecycle contract and evidence tooling."""

--- a/scripts/mobile_lifecycle/aggregate_evidence.py
+++ b/scripts/mobile_lifecycle/aggregate_evidence.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Fail-closed aggregation for deterministic mobile lifecycle evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from .contract import ContractError, load_contract, scenarios_by_id
+except ImportError:  # pragma: no cover - direct CI script execution
+    from contract import ContractError, load_contract, scenarios_by_id
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+COMPONENTS = ("flutter", "android_jvm", "rust")
+REPORT_NAMES = tuple(f"{component}.json" for component in COMPONENTS)
+SENSITIVE_MARKERS = (
+    "authorization",
+    "bearer ",
+    "jwt",
+    "private_key",
+    "diagnostics_token",
+    "auth_token",
+    "-----begin",
+)
+
+
+class EvidenceError(ValueError):
+    """Raised for any malformed or incomplete evidence."""
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    if path.stat().st_size == 0:
+        raise EvidenceError(f"empty report: {path.name}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise EvidenceError(f"invalid report {path.name}: {error}") from error
+    if not isinstance(value, dict):
+        raise EvidenceError(f"report {path.name} must be an object")
+    return value
+
+
+def _scan_sensitive(value: Any, path: str = "report") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(marker in lowered for marker in SENSITIVE_MARKERS):
+                raise EvidenceError(f"sensitive field is not allowed: {path}.{key}")
+            _scan_sensitive(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _scan_sensitive(child, f"{path}[{index}]")
+    elif isinstance(value, str):
+        lowered = value.lower()
+        if any(marker in lowered for marker in SENSITIVE_MARKERS):
+            raise EvidenceError(f"sensitive value is not allowed at {path}")
+
+
+def _identity(identity: Any, fields: set[str], name: str) -> dict[str, Any]:
+    if not isinstance(identity, dict) or not identity:
+        raise EvidenceError(f"{name} must be a non-empty object")
+    unknown = set(identity) - fields
+    if unknown:
+        raise EvidenceError(f"{name} has unknown fields: {sorted(unknown)}")
+    for key, value in identity.items():
+        if key == "trace_id":
+            if not isinstance(value, str) or not re.fullmatch(r"mobile-lifecycle-[0-9a-f]{12}", value):
+                raise EvidenceError(f"{name}.trace_id is invalid")
+        elif isinstance(value, bool) or not isinstance(value, (int, str)):
+            raise EvidenceError(f"{name}.{key} must be an integer or string")
+        elif isinstance(value, int) and value < 0:
+            raise EvidenceError(f"{name}.{key} cannot be negative")
+    return identity
+
+
+def aggregate(
+    reports_dir: Path,
+    source_head_sha: str,
+    workflow_sha: str,
+    *,
+    job_results: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    contract = load_contract()
+    if not SHA_RE.fullmatch(source_head_sha) or not SHA_RE.fullmatch(workflow_sha):
+        raise EvidenceError("aggregate SHA values must be 40-character SHA-1 values")
+    if not reports_dir.is_dir():
+        raise EvidenceError(f"reports directory does not exist: {reports_dir}")
+    if job_results is not None:
+        if not isinstance(job_results, dict):
+            raise EvidenceError("job results must be an object")
+        allowed_job_keys = {frozenset(COMPONENTS), frozenset((*COMPONENTS, "package"))}
+        if frozenset(job_results) not in allowed_job_keys:
+            raise EvidenceError("job results must name the required components and optional package job")
+        allowed_job_results = {"success", "failure", "cancelled", "skipped"}
+        if any(value not in allowed_job_results for value in job_results.values()):
+            raise EvidenceError("job results contain an unknown conclusion")
+        if "package" in job_results and job_results["package"] != "success":
+            raise EvidenceError("Android package job did not succeed")
+    actual = sorted(path.name for path in reports_dir.iterdir())
+    if tuple(actual) != tuple(sorted(REPORT_NAMES)):
+        raise EvidenceError(f"reports directory must contain exactly {list(REPORT_NAMES)}, got {actual}")
+    reports: dict[str, dict[str, Any]] = {}
+    trace_ids: set[str] = set()
+    identity_fields = set(contract["identity_fields"])
+    by_scenario: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for component in COMPONENTS:
+        report = _load_report(reports_dir / f"{component}.json")
+        _scan_sensitive(report)
+        if report.get("schema_version") != 2:
+            raise EvidenceError(f"{component} report schema_version is not 2")
+        if report.get("repository") != "yhan-sun/p2wlan":
+            raise EvidenceError(f"{component} report repository is invalid")
+        if report.get("component") != component:
+            raise EvidenceError(f"{component} report component field is invalid")
+        if report.get("source_head_sha") != source_head_sha:
+            raise EvidenceError(f"{component} report source_head_sha mismatch")
+        if report.get("workflow_sha") != workflow_sha:
+            raise EvidenceError(f"{component} report workflow_sha mismatch")
+        if report.get("result") != "pass":
+            raise EvidenceError(f"{component} report is not passing")
+        trace_id = report.get("trace_id")
+        if not isinstance(trace_id, str) or trace_id != f"mobile-lifecycle-{source_head_sha[:12]}":
+            raise EvidenceError(f"{component} report trace_id does not bind to source SHA")
+        trace_ids.add(trace_id)
+        scenarios = report.get("scenarios")
+        if not isinstance(scenarios, list) or not scenarios:
+            raise EvidenceError(f"{component} report scenarios are empty")
+        seen: set[str] = set()
+        for scenario in scenarios:
+            if not isinstance(scenario, dict):
+                raise EvidenceError(f"{component} scenario is not an object")
+            scenario_id = scenario.get("scenario_id")
+            if scenario_id not in scenarios_by_id(contract):
+                raise EvidenceError(f"{component} has unknown scenario {scenario_id!r}")
+            if scenario_id in seen:
+                raise EvidenceError(f"{component} repeats scenario {scenario_id}")
+            seen.add(scenario_id)
+            allowed = scenarios_by_id(contract)[scenario_id]["authoritative_components"]
+            if component not in allowed:
+                raise EvidenceError(f"{component} is not authoritative for {scenario_id}")
+            events = scenario.get("events")
+            if not isinstance(events, list) or not events or any(event not in contract["events"] for event in events):
+                raise EvidenceError(f"{component}/{scenario_id} has invalid events")
+            decision = scenario.get("decision")
+            if decision not in contract["outcomes"]:
+                raise EvidenceError(f"{component}/{scenario_id} has invalid decision")
+            if decision != scenarios_by_id(contract)[scenario_id]["required_decision"]:
+                raise EvidenceError(f"{component}/{scenario_id} has the wrong decision")
+            if scenario.get("result") != "pass":
+                raise EvidenceError(f"{component}/{scenario_id} is not passing")
+            invariants = scenario.get("invariants")
+            if not isinstance(invariants, dict) or not invariants or not all(invariants.values()):
+                raise EvidenceError(f"{component}/{scenario_id} has a false/missing invariant")
+            required_invariants = set(scenarios_by_id(contract)[scenario_id]["required_invariants"])
+            if not required_invariants.issubset(invariants):
+                raise EvidenceError(f"{component}/{scenario_id} is missing a required invariant")
+            old = _identity(scenario.get("old_identity"), identity_fields, f"{component}/{scenario_id}/old_identity")
+            new = _identity(scenario.get("new_identity"), identity_fields, f"{component}/{scenario_id}/new_identity")
+            if old.get("trace_id") != trace_id or new.get("trace_id") != trace_id:
+                raise EvidenceError(f"{component}/{scenario_id} trace identity mismatch")
+            if decision == "applied" and old == new and scenario_id not in {"ML-18"}:
+                raise EvidenceError(f"{component}/{scenario_id} applied without an identity transition")
+            if decision == "stale_rejected" and old == new:
+                raise EvidenceError(f"{component}/{scenario_id} stale rejection has no old identity")
+            by_scenario.setdefault(scenario_id, []).append((component, scenario))
+        reports[component] = report
+        if job_results is not None and job_results.get(component) != "success":
+            raise EvidenceError(f"component job {component} did not succeed")
+    required = scenarios_by_id(contract)
+    missing = sorted(set(required) - set(by_scenario))
+    if missing:
+        raise EvidenceError(f"required scenarios are missing: {missing}")
+    for scenario_id, entries in by_scenario.items():
+        if len(entries) > 1:
+            decisions = {entry[1]["decision"] for entry in entries}
+            traces = {entry[1]["new_identity"].get("trace_id") for entry in entries}
+            if len(decisions) > 1 or len(traces) != 1:
+                raise EvidenceError(f"conflicting duplicate scenario evidence: {scenario_id}")
+            # Components may contribute only the identities they own, but
+            # overlapping fields must describe the same transition. This
+            # prevents three mutually unrelated fakes from satisfying one
+            # shared scenario ID.
+            for index, (_, left) in enumerate(entries):
+                for _, right in entries[index + 1 :]:
+                    for side in ("old_identity", "new_identity"):
+                        left_identity = left[side]
+                        right_identity = right[side]
+                        overlap = set(left_identity) & set(right_identity)
+                        if any(left_identity[key] != right_identity[key] for key in overlap):
+                            raise EvidenceError(
+                                f"conflicting duplicate scenario identity: {scenario_id}/{side}"
+                            )
+    if len(trace_ids) != 1:
+        raise EvidenceError("component reports do not share one trace identity")
+    return {
+        "schema_version": 2,
+        "repository": "yhan-sun/p2wlan",
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
+        "result": "pass",
+        "components": {component: reports[component] for component in COMPONENTS},
+        "required_scenarios": sorted(by_scenario),
+        "manual_device_matrix": {
+            "required": False,
+            "status": "not_run",
+            "blocking": False,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reports-dir", type=Path, required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--job-results", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    job_results = None
+    try:
+        if args.job_results:
+            job_results = json.loads(args.job_results.read_text(encoding="utf-8"))
+        result = aggregate(
+            args.reports_dir.resolve(),
+            args.source_head_sha,
+            args.workflow_sha,
+            job_results=job_results,
+        )
+    except (ContractError, EvidenceError, OSError, json.JSONDecodeError, TypeError) as error:
+        # Keep a structured, non-green artifact even when a component is
+        # missing or malformed. The caller still receives a non-zero status;
+        # this file is useful for diagnosing why the required check failed.
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        failure = {
+            "schema_version": 2,
+            "repository": "yhan-sun/p2wlan",
+            "source_head_sha": args.source_head_sha,
+            "workflow_sha": args.workflow_sha,
+            "result": "fail",
+            "error": str(error),
+            "manual_device_matrix": {
+                "required": False,
+                "status": "not_run",
+                "blocking": False,
+            },
+        }
+        args.output.write_text(
+            json.dumps(failure, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"mobile lifecycle evidence rejected: {error}", file=sys.stderr)
+        return 1
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mobile_lifecycle/aggregate_evidence.py
+++ b/scripts/mobile_lifecycle/aggregate_evidence.py
@@ -132,6 +132,7 @@ def aggregate(
         if not isinstance(scenarios, list) or not scenarios:
             raise EvidenceError(f"{component} report scenarios are empty")
         seen: set[str] = set()
+        seen_test_ids: set[str] = set()
         for scenario in scenarios:
             if not isinstance(scenario, dict):
                 raise EvidenceError(f"{component} scenario is not an object")
@@ -141,6 +142,16 @@ def aggregate(
             if scenario_id in seen:
                 raise EvidenceError(f"{component} repeats scenario {scenario_id}")
             seen.add(scenario_id)
+            exact_test_id = scenario.get("exact_test_id")
+            if not isinstance(exact_test_id, str) or not exact_test_id:
+                raise EvidenceError(f"{component}/{scenario_id} has no exact_test_id")
+            if exact_test_id in seen_test_ids:
+                raise EvidenceError(f"{component} repeats exact_test_id {exact_test_id}")
+            seen_test_ids.add(exact_test_id)
+            if scenario.get("executed") is not True:
+                raise EvidenceError(f"{component}/{scenario_id} was not executed")
+            if scenario.get("skipped") is not False:
+                raise EvidenceError(f"{component}/{scenario_id} was skipped")
             allowed = scenarios_by_id(contract)[scenario_id]["authoritative_components"]
             if component not in allowed:
                 raise EvidenceError(f"{component} is not authoritative for {scenario_id}")
@@ -152,6 +163,8 @@ def aggregate(
                 raise EvidenceError(f"{component}/{scenario_id} has invalid decision")
             if decision != scenarios_by_id(contract)[scenario_id]["required_decision"]:
                 raise EvidenceError(f"{component}/{scenario_id} has the wrong decision")
+            if scenario.get("observed_decision") != decision:
+                raise EvidenceError(f"{component}/{scenario_id} observed decision does not match")
             if scenario.get("result") != "pass":
                 raise EvidenceError(f"{component}/{scenario_id} is not passing")
             invariants = scenario.get("invariants")
@@ -162,6 +175,18 @@ def aggregate(
                 raise EvidenceError(f"{component}/{scenario_id} is missing a required invariant")
             old = _identity(scenario.get("old_identity"), identity_fields, f"{component}/{scenario_id}/old_identity")
             new = _identity(scenario.get("new_identity"), identity_fields, f"{component}/{scenario_id}/new_identity")
+            observed_old = _identity(
+                scenario.get("observed_old_identity"),
+                identity_fields,
+                f"{component}/{scenario_id}/observed_old_identity",
+            )
+            observed_new = _identity(
+                scenario.get("observed_new_identity"),
+                identity_fields,
+                f"{component}/{scenario_id}/observed_new_identity",
+            )
+            if observed_old != old or observed_new != new:
+                raise EvidenceError(f"{component}/{scenario_id} observed identities do not match")
             if old.get("trace_id") != trace_id or new.get("trace_id") != trace_id:
                 raise EvidenceError(f"{component}/{scenario_id} trace identity mismatch")
             if decision == "applied" and old == new and scenario_id not in {"ML-18"}:
@@ -204,6 +229,7 @@ def aggregate(
         "source_head_sha": source_head_sha,
         "workflow_sha": workflow_sha,
         "result": "pass",
+        "aggregate_artifact_id": "mobile-lifecycle-aggregate",
         "components": {component: reports[component] for component in COMPONENTS},
         "required_scenarios": sorted(by_scenario),
         "manual_device_matrix": {

--- a/scripts/mobile_lifecycle/android_junit_records.py
+++ b/scripts/mobile_lifecycle/android_junit_records.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Extract per-method lifecycle records from Android JUnit XML."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+PREFIX = "MOBILE_LIFECYCLE_RECORD "
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _manifest(path: Path) -> set[str]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return {entry["exact_test_id"] for entry in value["scenarios"]}
+
+
+def _testcases(xml_root: Path) -> dict[str, ET.Element]:
+    result: dict[str, ET.Element] = {}
+    for path in sorted(xml_root.rglob("TEST-*.xml")):
+        root = ET.parse(path).getroot()
+        for testcase in root.iter():
+            if _local_name(testcase.tag) != "testcase":
+                continue
+            classname = testcase.attrib.get("classname")
+            name = testcase.attrib.get("name")
+            if not classname or not name:
+                continue
+            exact_test_id = f"{classname}#{name}"
+            if exact_test_id in result:
+                raise ValueError(f"duplicate Android JUnit test ID: {exact_test_id}")
+            result[exact_test_id] = testcase
+    return result
+
+
+def _markers(xml_root: Path) -> dict[str, list[dict]]:
+    result: dict[str, list[dict]] = {}
+    for path in sorted(xml_root.rglob("TEST-*.xml")):
+        root = ET.parse(path).getroot()
+        for output in root.iter():
+            if _local_name(output.tag) != "system-out":
+                continue
+            message = output.text or ""
+            for line in message.splitlines():
+                line = line.strip()
+                if not line.startswith(PREFIX):
+                    continue
+                record = json.loads(line[len(PREFIX) :])
+                if not isinstance(record, dict):
+                    raise ValueError(f"Android lifecycle record in {path} is not an object")
+                exact_test_id = record.get("exact_test_id")
+                if not isinstance(exact_test_id, str) or not exact_test_id:
+                    raise ValueError(f"Android lifecycle record in {path} has no test ID")
+                result.setdefault(exact_test_id, []).append(record)
+    return result
+
+
+def _record_from_testcase(
+    exact_test_id: str,
+    testcase: ET.Element,
+    marker_records: dict[str, list[dict]],
+) -> dict:
+    """Combine one JUnit method's status with its emitted lifecycle record.
+
+    The Gradle Android test task commonly writes one suite-level system-out
+    block containing all test stdout, while some JUnit emitters attach stdout
+    directly to the testcase.  _markers normalizes both layouts and the JUnit
+    testcase table remains the authority for execution status.
+    """
+    markers = marker_records.get(exact_test_id, [])
+    for record in markers:
+        if record.get("exact_test_id") != exact_test_id:
+            raise ValueError(f"Android record test ID does not match {exact_test_id}")
+    if len(markers) != 1:
+        raise ValueError(
+            f"Android JUnit test {exact_test_id} must emit exactly one lifecycle record, "
+            f"got {len(markers)}"
+        )
+    record = markers[0]
+    skipped = any(_local_name(child.tag) == "skipped" for child in testcase.iter())
+    failed = any(
+        _local_name(child.tag) in {"failure", "error"} for child in testcase.iter()
+    )
+    record["executed"] = True
+    record["skipped"] = skipped
+    record["result"] = "fail" if failed else "pass"
+    return record
+
+
+def extract(xml_root: Path, manifest_path: Path) -> list[dict]:
+    expected = _manifest(manifest_path)
+    actual = _testcases(xml_root)
+    marker_records = _markers(xml_root)
+    unknown_markers = sorted(set(marker_records) - set(actual))
+    if unknown_markers:
+        raise ValueError(f"Android JUnit output has a record for an unknown test: {unknown_markers}")
+    records: list[dict] = []
+    for exact_test_id in sorted(expected):
+        testcase = actual.get(exact_test_id)
+        if testcase is None:
+            raise ValueError(f"Android JUnit output has no mapped test: {exact_test_id}")
+        records.append(_record_from_testcase(exact_test_id, testcase, marker_records))
+    if set(actual) & expected != expected:
+        missing = sorted(expected - set(actual))
+        raise ValueError(f"Android JUnit output is missing mapped tests: {missing}")
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--xml-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    records = extract(args.xml_root, args.manifest)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps({"schema_version": 1, "records": records}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mobile_lifecycle/component_report.py
+++ b/scripts/mobile_lifecycle/component_report.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Create a schema-2 component report from a checked-in test manifest.
+
+The caller supplies the result of the real component test command.  This
+keeps the report generator a serializer/validator instead of a source of
+synthetic green evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+try:
+    from .contract import ContractError, load_contract, scenarios_by_id
+except ImportError:  # pragma: no cover - direct CI script execution
+    from contract import ContractError, load_contract, scenarios_by_id
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+COMPONENTS = {"flutter", "android_jvm", "rust"}
+
+
+def _git_head(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read manifest {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError("component manifest must be an object")
+    return value
+
+
+def _validate_identity(identity: dict[str, Any], fields: set[str], *, name: str) -> None:
+    if not isinstance(identity, dict):
+        raise ValueError(f"{name} must be an object")
+    unknown = set(identity) - fields
+    if unknown:
+        raise ValueError(f"{name} has unknown identity fields: {sorted(unknown)}")
+    for key, value in identity.items():
+        if key == "trace_id":
+            if not isinstance(value, str) or not re.fullmatch(r"mobile-lifecycle-[0-9a-f]{12}", value):
+                raise ValueError(f"{name}.trace_id is invalid")
+        elif not isinstance(value, (int, str)) or isinstance(value, bool):
+            raise ValueError(f"{name}.{key} must be an integer or string")
+        elif isinstance(value, int) and value < 0:
+            raise ValueError(f"{name}.{key} cannot be negative")
+
+
+def build_report(
+    *,
+    root: Path,
+    component: str,
+    source_head_sha: str,
+    workflow_sha: str,
+    result: str,
+    manifest_path: Path,
+    toolchain: dict[str, Any],
+) -> dict[str, Any]:
+    contract = load_contract(root / "contracts" / "mobile_lifecycle.json")
+    scenarios = scenarios_by_id(contract)
+    if component not in COMPONENTS:
+        raise ValueError(f"unknown component {component}")
+    if not SHA_RE.fullmatch(source_head_sha) or not SHA_RE.fullmatch(workflow_sha):
+        raise ValueError("source_head_sha and workflow_sha must be 40-character SHA-1 values")
+    if result not in {"pass", "fail"}:
+        raise ValueError("result must be pass or fail")
+    manifest = _read_json(manifest_path)
+    manifest_component = manifest.get("component")
+    if manifest_component != component:
+        raise ValueError("manifest component does not match report component")
+    entries = manifest.get("scenarios")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("component manifest scenarios must be non-empty")
+    identity_fields = set(contract["identity_fields"])
+    trace_id = f"mobile-lifecycle-{source_head_sha[:12]}"
+    report_scenarios: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("component manifest scenario must be an object")
+        scenario_id = entry.get("scenario_id")
+        if scenario_id not in scenarios:
+            raise ValueError(f"unknown required scenario {scenario_id!r}")
+        if scenario_id in seen:
+            raise ValueError(f"duplicate scenario {scenario_id}")
+        if component not in scenarios[scenario_id]["authoritative_components"]:
+            raise ValueError(f"{component} is not authoritative for {scenario_id}")
+        seen.add(scenario_id)
+        events = entry.get("events")
+        if not isinstance(events, list) or not events:
+            raise ValueError(f"{scenario_id} must include events")
+        if any(event not in contract["events"] for event in events):
+            raise ValueError(f"{scenario_id} contains an unknown event")
+        decision = entry.get("decision")
+        if decision not in contract["outcomes"]:
+            raise ValueError(f"{scenario_id} contains an invalid decision")
+        if decision != scenarios[scenario_id]["required_decision"]:
+            raise ValueError(
+                f"{scenario_id} requires decision {scenarios[scenario_id]['required_decision']!r}"
+            )
+        invariants = entry.get("invariants")
+        if not isinstance(invariants, dict) or not invariants:
+            raise ValueError(f"{scenario_id} must include invariants")
+        if any(not isinstance(value, bool) for value in invariants.values()):
+            raise ValueError(f"{scenario_id} invariants must be booleans")
+        missing_invariants = set(scenarios[scenario_id]["required_invariants"]) - set(invariants)
+        if missing_invariants:
+            raise ValueError(f"{scenario_id} is missing invariants: {sorted(missing_invariants)}")
+        if not all(invariants.values()) and result == "pass":
+            raise ValueError(f"{scenario_id} has a false invariant in a passing report")
+        old_identity = dict(entry.get("old_identity") or {})
+        new_identity = dict(entry.get("new_identity") or {})
+        old_identity.setdefault("trace_id", trace_id)
+        new_identity.setdefault("trace_id", trace_id)
+        _validate_identity(old_identity, identity_fields, name=f"{scenario_id}.old_identity")
+        _validate_identity(new_identity, identity_fields, name=f"{scenario_id}.new_identity")
+        scenario_result = result
+        report_scenarios.append(
+            {
+                "scenario_id": scenario_id,
+                "scenario_name": scenarios[scenario_id]["name"],
+                "events": events,
+                "old_identity": old_identity,
+                "new_identity": new_identity,
+                "decision": decision,
+                "invariants": invariants,
+                "result": scenario_result,
+                "test_name": entry.get("test_name", scenario_id),
+            }
+        )
+    return {
+        "schema_version": 2,
+        "repository": "yhan-sun/p2wlan",
+        "component": component,
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
+        "toolchain": toolchain,
+        "result": result,
+        "trace_id": trace_id,
+        "scenarios": report_scenarios,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--component", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--result", choices=("pass", "fail"), required=True)
+    parser.add_argument("--toolchain", default="{}")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        toolchain = json.loads(args.toolchain)
+        if not isinstance(toolchain, dict):
+            raise ValueError("--toolchain must be a JSON object")
+        report = build_report(
+            root=args.root.resolve(),
+            component=args.component,
+            source_head_sha=args.source_head_sha,
+            workflow_sha=args.workflow_sha,
+            result=args.result,
+            manifest_path=args.manifest,
+            toolchain=toolchain,
+        )
+    except (ContractError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mobile_lifecycle/component_report.py
+++ b/scripts/mobile_lifecycle/component_report.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Create a schema-2 component report from a checked-in test manifest.
+"""Validate component evidence produced by the component's real test runner.
 
-The caller supplies the result of the real component test command.  This
-keeps the report generator a serializer/validator instead of a source of
-synthetic green evidence.
+The checked-in manifest is deliberately only a mapping from a required
+scenario to an exact test ID. It is not allowed to carry a result, identity,
+decision, or invariant: those values must come from a test that actually ran.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -23,38 +22,220 @@ except ImportError:  # pragma: no cover - direct CI script execution
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 COMPONENTS = {"flutter", "android_jvm", "rust"}
+MANIFEST_ENTRY_FIELDS = {"scenario_id", "exact_test_id"}
+RECORD_FIELDS = {
+    "scenario_id",
+    "exact_test_id",
+    "executed",
+    "skipped",
+    "result",
+    "events",
+    "observed_old_identity",
+    "observed_new_identity",
+    "observed_decision",
+    "invariants",
+    "execution_source",
+}
+OUTCOMES = {"applied", "duplicate", "stale_rejected", "superseded", "failed"}
 
 
-def _git_head(root: Path) -> str:
-    return subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=root, text=True
-    ).strip()
-
-
-def _read_json(path: Path) -> dict[str, Any]:
+def _read_json(path: Path) -> Any:
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise ValueError(f"cannot read manifest {path}: {error}") from error
+        raise ValueError(f"cannot read JSON {path}: {error}") from error
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    value = _read_json(path)
     if not isinstance(value, dict):
         raise ValueError("component manifest must be an object")
     return value
 
 
-def _validate_identity(identity: dict[str, Any], fields: set[str], *, name: str) -> None:
-    if not isinstance(identity, dict):
-        raise ValueError(f"{name} must be an object")
+def _read_execution_records(path: Path) -> list[dict[str, Any]]:
+    value = _read_json(path)
+    if isinstance(value, dict):
+        value = value.get("records")
+    if not isinstance(value, list) or not value:
+        raise ValueError("execution records must be a non-empty array")
+    if any(not isinstance(record, dict) for record in value):
+        raise ValueError("execution record must be an object")
+    return value
+
+
+def _validate_identity(identity: Any, fields: set[str], *, name: str) -> dict[str, Any]:
+    if not isinstance(identity, dict) or not identity:
+        raise ValueError(f"{name} must be a non-empty object")
     unknown = set(identity) - fields
     if unknown:
         raise ValueError(f"{name} has unknown identity fields: {sorted(unknown)}")
     for key, value in identity.items():
         if key == "trace_id":
-            if not isinstance(value, str) or not re.fullmatch(r"mobile-lifecycle-[0-9a-f]{12}", value):
+            if not isinstance(value, str) or not re.fullmatch(
+                r"mobile-lifecycle-[0-9a-f]{12}", value
+            ):
                 raise ValueError(f"{name}.trace_id is invalid")
         elif not isinstance(value, (int, str)) or isinstance(value, bool):
             raise ValueError(f"{name}.{key} must be an integer or string")
         elif isinstance(value, int) and value < 0:
             raise ValueError(f"{name}.{key} cannot be negative")
+    return dict(identity)
+
+
+def _manifest_mapping(
+    manifest: dict[str, Any],
+    *,
+    component: str,
+    scenarios: dict[str, dict[str, Any]],
+) -> dict[str, str]:
+    if manifest.get("component") != component:
+        raise ValueError("manifest component does not match report component")
+    entries = manifest.get("scenarios")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("component manifest scenarios must be non-empty")
+    mapping: dict[str, str] = {}
+    test_ids: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("component manifest scenario must be an object")
+        if set(entry) != MANIFEST_ENTRY_FIELDS:
+            raise ValueError(
+                "component manifest may contain only scenario_id and exact_test_id"
+            )
+        scenario_id = entry.get("scenario_id")
+        exact_test_id = entry.get("exact_test_id")
+        if not isinstance(scenario_id, str) or not scenario_id:
+            raise ValueError("component manifest scenario_id must be non-empty")
+        if scenario_id not in scenarios:
+            raise ValueError(f"unknown required scenario {scenario_id!r}")
+        if component not in scenarios[scenario_id]["authoritative_components"]:
+            raise ValueError(f"{component} is not authoritative for {scenario_id}")
+        if not isinstance(exact_test_id, str) or not exact_test_id:
+            raise ValueError(f"{scenario_id} exact_test_id must be non-empty")
+        if scenario_id in mapping:
+            raise ValueError(f"duplicate scenario {scenario_id}")
+        if exact_test_id in test_ids:
+            raise ValueError(f"duplicate exact_test_id {exact_test_id}")
+        mapping[scenario_id] = exact_test_id
+        test_ids.add(exact_test_id)
+    return mapping
+
+
+def _normalize_records(
+    records: list[dict[str, Any]],
+    *,
+    component: str,
+    mapping: dict[str, str],
+    scenarios: dict[str, dict[str, Any]],
+    contract_events: set[str],
+    identity_fields: set[str],
+    trace_id: str,
+) -> list[dict[str, Any]]:
+    seen_scenarios: set[str] = set()
+    seen_test_ids: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        unknown = set(record) - RECORD_FIELDS
+        if unknown:
+            raise ValueError(f"execution record has unknown fields: {sorted(unknown)}")
+        scenario_id = record.get("scenario_id")
+        exact_test_id = record.get("exact_test_id")
+        if not isinstance(scenario_id, str) or not scenario_id:
+            raise ValueError("execution record scenario_id must be non-empty")
+        if not isinstance(exact_test_id, str) or not exact_test_id:
+            raise ValueError(f"{scenario_id} exact_test_id must be non-empty")
+        if scenario_id not in mapping:
+            raise ValueError(f"execution record has no manifest scenario: {scenario_id!r}")
+        if exact_test_id != mapping[scenario_id]:
+            raise ValueError(
+                f"{scenario_id} exact_test_id does not match the checked-in mapping"
+            )
+        if scenario_id in seen_scenarios:
+            raise ValueError(f"duplicate execution record for {scenario_id}")
+        if exact_test_id in seen_test_ids:
+            raise ValueError(f"duplicate execution record for {exact_test_id}")
+        seen_scenarios.add(scenario_id)
+        seen_test_ids.add(exact_test_id)
+
+        if record.get("executed") is not True:
+            raise ValueError(f"{scenario_id} was not executed")
+        if record.get("skipped") is not False:
+            raise ValueError(f"{scenario_id} was skipped")
+        if record.get("result") != "pass":
+            raise ValueError(f"{scenario_id} did not pass")
+        execution_source = record.get("execution_source", component)
+        if not isinstance(execution_source, str) or not execution_source:
+            raise ValueError(f"{scenario_id} has no execution source")
+
+        contract_scenario = scenarios[scenario_id]
+        events = record.get("events")
+        if (
+            not isinstance(events, list)
+            or not events
+            or any(not isinstance(event, str) or event not in contract_events for event in events)
+        ):
+            raise ValueError(f"{scenario_id} has invalid observed events")
+        observed_decision = record.get("observed_decision")
+        if not isinstance(observed_decision, str) or observed_decision not in OUTCOMES:
+            raise ValueError(f"{scenario_id} has an invalid observed decision")
+        if observed_decision != contract_scenario["required_decision"]:
+            raise ValueError(f"{scenario_id} has the wrong observed decision")
+        invariants = record.get("invariants")
+        if not isinstance(invariants, dict) or not invariants:
+            raise ValueError(f"{scenario_id} has no observed invariants")
+        if any(not isinstance(value, bool) for value in invariants.values()):
+            raise ValueError(f"{scenario_id} invariants must be booleans")
+        missing = set(contract_scenario["required_invariants"]) - set(invariants)
+        if missing:
+            raise ValueError(f"{scenario_id} is missing invariants: {sorted(missing)}")
+        if not all(invariants.values()):
+            raise ValueError(f"{scenario_id} has a false invariant")
+
+        old = _validate_identity(
+            record.get("observed_old_identity"),
+            identity_fields,
+            name=f"{scenario_id}.observed_old_identity",
+        )
+        new = _validate_identity(
+            record.get("observed_new_identity"),
+            identity_fields,
+            name=f"{scenario_id}.observed_new_identity",
+        )
+        for identity, name in ((old, "old_identity"), (new, "new_identity")):
+            supplied_trace = identity.get("trace_id")
+            if supplied_trace is not None and supplied_trace != trace_id:
+                raise ValueError(f"{scenario_id}.{name} trace_id does not bind to source SHA")
+            identity["trace_id"] = trace_id
+
+        normalized.append(
+            {
+                "scenario_id": scenario_id,
+                "scenario_name": contract_scenario["name"],
+                "exact_test_id": exact_test_id,
+                "executed": True,
+                "skipped": False,
+                "result": "pass",
+                "events": list(events),
+                "observed_old_identity": dict(old),
+                "observed_new_identity": dict(new),
+                "observed_decision": observed_decision,
+                "old_identity": dict(old),
+                "new_identity": dict(new),
+                "decision": observed_decision,
+                "invariants": dict(invariants),
+                "execution_source": execution_source,
+            }
+        )
+    missing_scenarios = set(mapping) - seen_scenarios
+    if missing_scenarios:
+        raise ValueError(
+            "manifest scenarios have no actual execution record: "
+            f"{sorted(missing_scenarios)}"
+        )
+    if set(mapping.values()) != seen_test_ids:
+        raise ValueError("actual test IDs do not exactly cover the manifest")
+    return normalized
 
 
 def build_report(
@@ -63,8 +244,9 @@ def build_report(
     component: str,
     source_head_sha: str,
     workflow_sha: str,
-    result: str,
     manifest_path: Path,
+    execution_records_path: Path | None = None,
+    execution_records: list[dict[str, Any]] | None = None,
     toolchain: dict[str, Any],
 ) -> dict[str, Any]:
     contract = load_contract(root / "contracts" / "mobile_lifecycle.json")
@@ -73,72 +255,24 @@ def build_report(
         raise ValueError(f"unknown component {component}")
     if not SHA_RE.fullmatch(source_head_sha) or not SHA_RE.fullmatch(workflow_sha):
         raise ValueError("source_head_sha and workflow_sha must be 40-character SHA-1 values")
-    if result not in {"pass", "fail"}:
-        raise ValueError("result must be pass or fail")
-    manifest = _read_json(manifest_path)
-    manifest_component = manifest.get("component")
-    if manifest_component != component:
-        raise ValueError("manifest component does not match report component")
-    entries = manifest.get("scenarios")
-    if not isinstance(entries, list) or not entries:
-        raise ValueError("component manifest scenarios must be non-empty")
-    identity_fields = set(contract["identity_fields"])
+    if execution_records is None:
+        if execution_records_path is None:
+            raise ValueError("actual execution records are required")
+        execution_records = _read_execution_records(execution_records_path)
+    elif execution_records_path is not None:
+        raise ValueError("provide execution_records or execution_records_path, not both")
+    manifest = _read_manifest(manifest_path)
+    mapping = _manifest_mapping(manifest, component=component, scenarios=scenarios)
     trace_id = f"mobile-lifecycle-{source_head_sha[:12]}"
-    report_scenarios: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for entry in entries:
-        if not isinstance(entry, dict):
-            raise ValueError("component manifest scenario must be an object")
-        scenario_id = entry.get("scenario_id")
-        if scenario_id not in scenarios:
-            raise ValueError(f"unknown required scenario {scenario_id!r}")
-        if scenario_id in seen:
-            raise ValueError(f"duplicate scenario {scenario_id}")
-        if component not in scenarios[scenario_id]["authoritative_components"]:
-            raise ValueError(f"{component} is not authoritative for {scenario_id}")
-        seen.add(scenario_id)
-        events = entry.get("events")
-        if not isinstance(events, list) or not events:
-            raise ValueError(f"{scenario_id} must include events")
-        if any(event not in contract["events"] for event in events):
-            raise ValueError(f"{scenario_id} contains an unknown event")
-        decision = entry.get("decision")
-        if decision not in contract["outcomes"]:
-            raise ValueError(f"{scenario_id} contains an invalid decision")
-        if decision != scenarios[scenario_id]["required_decision"]:
-            raise ValueError(
-                f"{scenario_id} requires decision {scenarios[scenario_id]['required_decision']!r}"
-            )
-        invariants = entry.get("invariants")
-        if not isinstance(invariants, dict) or not invariants:
-            raise ValueError(f"{scenario_id} must include invariants")
-        if any(not isinstance(value, bool) for value in invariants.values()):
-            raise ValueError(f"{scenario_id} invariants must be booleans")
-        missing_invariants = set(scenarios[scenario_id]["required_invariants"]) - set(invariants)
-        if missing_invariants:
-            raise ValueError(f"{scenario_id} is missing invariants: {sorted(missing_invariants)}")
-        if not all(invariants.values()) and result == "pass":
-            raise ValueError(f"{scenario_id} has a false invariant in a passing report")
-        old_identity = dict(entry.get("old_identity") or {})
-        new_identity = dict(entry.get("new_identity") or {})
-        old_identity.setdefault("trace_id", trace_id)
-        new_identity.setdefault("trace_id", trace_id)
-        _validate_identity(old_identity, identity_fields, name=f"{scenario_id}.old_identity")
-        _validate_identity(new_identity, identity_fields, name=f"{scenario_id}.new_identity")
-        scenario_result = result
-        report_scenarios.append(
-            {
-                "scenario_id": scenario_id,
-                "scenario_name": scenarios[scenario_id]["name"],
-                "events": events,
-                "old_identity": old_identity,
-                "new_identity": new_identity,
-                "decision": decision,
-                "invariants": invariants,
-                "result": scenario_result,
-                "test_name": entry.get("test_name", scenario_id),
-            }
-        )
+    normalized = _normalize_records(
+        execution_records,
+        component=component,
+        mapping=mapping,
+        scenarios=scenarios,
+        contract_events=set(contract["events"]),
+        identity_fields=set(contract["identity_fields"]),
+        trace_id=trace_id,
+    )
     return {
         "schema_version": 2,
         "repository": "yhan-sun/p2wlan",
@@ -146,10 +280,38 @@ def build_report(
         "source_head_sha": source_head_sha,
         "workflow_sha": workflow_sha,
         "toolchain": toolchain,
-        "result": result,
+        "result": "pass",
         "trace_id": trace_id,
-        "scenarios": report_scenarios,
+        "scenarios": normalized,
     }
+
+
+def _write_failure(
+    path: Path,
+    *,
+    component: str,
+    source_head_sha: str,
+    workflow_sha: str,
+    error: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "repository": "yhan-sun/p2wlan",
+                "component": component,
+                "source_head_sha": source_head_sha,
+                "workflow_sha": workflow_sha,
+                "result": "fail",
+                "error": error,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def main() -> int:
@@ -159,7 +321,7 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--source-head-sha", required=True)
     parser.add_argument("--workflow-sha", required=True)
-    parser.add_argument("--result", choices=("pass", "fail"), required=True)
+    parser.add_argument("--execution-records", type=Path, required=True)
     parser.add_argument("--toolchain", default="{}")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
@@ -172,14 +334,24 @@ def main() -> int:
             component=args.component,
             source_head_sha=args.source_head_sha,
             workflow_sha=args.workflow_sha,
-            result=args.result,
             manifest_path=args.manifest,
+            execution_records_path=args.execution_records,
             toolchain=toolchain,
         )
-    except (ContractError, ValueError, json.JSONDecodeError) as error:
-        parser.error(str(error))
+    except (ContractError, ValueError, TypeError, json.JSONDecodeError, OSError) as error:
+        _write_failure(
+            args.output,
+            component=args.component,
+            source_head_sha=args.source_head_sha,
+            workflow_sha=args.workflow_sha,
+            error=str(error),
+        )
+        print(f"mobile lifecycle component evidence rejected: {error}", flush=True)
+        return 1
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return 0
 
 

--- a/scripts/mobile_lifecycle/contract.py
+++ b/scripts/mobile_lifecycle/contract.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Load and validate the single mobile lifecycle contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_PATH = Path(__file__).resolve().parents[2] / "contracts" / "mobile_lifecycle.json"
+SCHEMA_VERSION = 2
+REPOSITORY = "yhan-sun/p2wlan"
+COMPONENTS = ("flutter", "android_jvm", "rust")
+OUTCOMES = ("applied", "duplicate", "stale_rejected", "superseded", "failed")
+FORBIDDEN_OUTCOMES = ("skipped", "assumed", "manually_verified", "deferred")
+
+
+class ContractError(ValueError):
+    """Raised when the canonical contract is malformed."""
+
+
+def load_contract(path: Path = CONTRACT_PATH) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ContractError(f"cannot read lifecycle contract {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ContractError("lifecycle contract must be a JSON object")
+    validate_contract(value)
+    return value
+
+
+def validate_contract(contract: dict[str, Any]) -> None:
+    if contract.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError("lifecycle contract schema_version must be 2")
+    if contract.get("repository") != REPOSITORY:
+        raise ContractError("lifecycle contract repository is not yhan-sun/p2wlan")
+    for key in ("events", "outcomes", "forbidden_outcomes", "identity_fields", "components", "required_scenarios"):
+        if not isinstance(contract.get(key), list) or not contract[key]:
+            raise ContractError(f"lifecycle contract {key} must be a non-empty array")
+    if tuple(contract["components"]) != COMPONENTS:
+        raise ContractError("lifecycle contract components are not canonical")
+    if tuple(contract["outcomes"]) != OUTCOMES:
+        raise ContractError("lifecycle contract outcomes are not canonical")
+    if tuple(contract["forbidden_outcomes"]) != FORBIDDEN_OUTCOMES:
+        raise ContractError("lifecycle contract forbidden outcomes are not canonical")
+    if any(not isinstance(event, str) or not event for event in contract["events"]):
+        raise ContractError("lifecycle contract events must be non-empty strings")
+    if len(set(contract["outcomes"])) != len(contract["outcomes"]):
+        raise ContractError("lifecycle contract has duplicate outcomes")
+    if len(set(contract["forbidden_outcomes"])) != len(contract["forbidden_outcomes"]):
+        raise ContractError("lifecycle contract has duplicate forbidden outcomes")
+    if set(contract["outcomes"]) & set(contract["forbidden_outcomes"]):
+        raise ContractError("lifecycle contract outcomes and forbidden outcomes overlap")
+    if len(set(contract["events"])) != len(contract["events"]):
+        raise ContractError("lifecycle contract has duplicate events")
+    if len(set(contract["identity_fields"])) != len(contract["identity_fields"]):
+        raise ContractError("lifecycle contract has duplicate identity fields")
+    if any(not isinstance(field, str) or not field for field in contract["identity_fields"]):
+        raise ContractError("lifecycle contract identity fields must be non-empty strings")
+
+    scenarios = contract["required_scenarios"]
+    if len(scenarios) != 18:
+        raise ContractError("lifecycle contract must contain exactly 18 required scenarios")
+    ids: list[str] = []
+    names: list[str] = []
+    for scenario in scenarios:
+        if not isinstance(scenario, dict):
+            raise ContractError("required scenario must be an object")
+        scenario_id = scenario.get("id")
+        name = scenario.get("name")
+        authorities = scenario.get("authoritative_components")
+        if not isinstance(scenario_id, str) or not scenario_id.startswith("ML-"):
+            raise ContractError("required scenario has an invalid id")
+        if not isinstance(name, str) or not name:
+            raise ContractError(f"{scenario_id} has no name")
+        if not isinstance(authorities, list) or not authorities:
+            raise ContractError(f"{scenario_id} has no authoritative component")
+        if any(component not in COMPONENTS for component in authorities):
+            raise ContractError(f"{scenario_id} names an unknown component")
+        if len(set(authorities)) != len(authorities):
+            raise ContractError(f"{scenario_id} repeats an authoritative component")
+        if scenario.get("required_decision") not in OUTCOMES:
+            raise ContractError(f"{scenario_id} has no canonical required decision")
+        required_invariants = scenario.get("required_invariants")
+        if not isinstance(required_invariants, list) or not required_invariants:
+            raise ContractError(f"{scenario_id} has no required invariants")
+        if any(not isinstance(item, str) or not item for item in required_invariants):
+            raise ContractError(f"{scenario_id} has an invalid required invariant")
+        if len(set(required_invariants)) != len(required_invariants):
+            raise ContractError(f"{scenario_id} repeats a required invariant")
+        ids.append(scenario_id)
+        names.append(name)
+    if ids != [f"ML-{index:02d}" for index in range(1, 19)]:
+        raise ContractError("required scenario IDs must be ML-01 through ML-18 in order")
+    if len(set(names)) != len(names):
+        raise ContractError("required scenario names must be unique")
+
+
+def scenarios_by_id(contract: dict[str, Any] | None = None) -> dict[str, dict[str, Any]]:
+    value = contract or load_contract()
+    return {scenario["id"]: scenario for scenario in value["required_scenarios"]}

--- a/scripts/mobile_lifecycle/flutter_machine_records.py
+++ b/scripts/mobile_lifecycle/flutter_machine_records.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Extract per-test lifecycle records from Flutter's machine reporter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+PREFIX = "MOBILE_LIFECYCLE_RECORD "
+
+
+def _test_file(url: object) -> str | None:
+    if not isinstance(url, str):
+        return None
+    if url.startswith("package:"):
+        package_path = url.removeprefix("package:")
+        if "/" in package_path:
+            package_path = package_path.split("/", 1)[1]
+        if package_path.startswith("test/"):
+            return "apps/flutter_client/" + package_path
+    path = unquote(urlparse(url).path)
+    marker = "/apps/flutter_client/test/"
+    if marker in path:
+        return "apps/flutter_client/test/" + path.split(marker, 1)[1]
+    if path.startswith("/test/"):
+        return "apps/flutter_client" + path
+    if path.startswith("test/"):
+        return "apps/flutter_client/" + path
+    if path.endswith("/test/mobile_lifecycle_evidence_test.dart"):
+        return "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart"
+    return None
+
+
+def _manifest(path: Path) -> set[str]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return {entry["exact_test_id"] for entry in value["scenarios"]}
+
+
+def extract(machine_output: Path, manifest_path: Path) -> list[dict]:
+    expected = _manifest(manifest_path)
+    tests: dict[object, str] = {}
+    done: dict[object, tuple[str, bool]] = {}
+    pending: list[tuple[dict, object]] = []
+    with machine_output.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            event_type = event.get("type")
+            if event_type == "testStart":
+                test = event.get("test")
+                if not isinstance(test, dict):
+                    test = event
+                test_id = event.get("testID", test.get("id"))
+                name = test.get("name")
+                test_file = _test_file(test.get("url"))
+                if test_id is not None and isinstance(name, str) and test_file:
+                    tests[test_id] = f"{test_file}::{name}"
+            elif event_type == "testDone":
+                test_id = event.get("testID", event.get("test", {}).get("id"))
+                if test_id is not None:
+                    result = event.get("result")
+                    skipped = event.get("skipped") is True or result == "skipped"
+                    done[test_id] = ("pass" if result == "success" else "fail", skipped)
+            elif event_type == "print":
+                message = event.get("message")
+                if not isinstance(message, str) or not message.startswith(PREFIX):
+                    continue
+                test_id = event.get("testID")
+                try:
+                    record = json.loads(message[len(PREFIX) :])
+                except json.JSONDecodeError as error:
+                    raise ValueError(f"invalid Flutter lifecycle record on line {line_number}: {error}") from error
+                if not isinstance(record, dict):
+                    raise ValueError(f"Flutter lifecycle record on line {line_number} is not an object")
+                exact_test_id = record.get("exact_test_id")
+                if tests.get(test_id) != exact_test_id:
+                    raise ValueError(
+                        f"Flutter lifecycle record {exact_test_id!r} is not emitted by the named test"
+                    )
+                if exact_test_id not in expected:
+                    raise ValueError(f"Flutter output contains an unmanifested test: {exact_test_id}")
+                pending.append((record, test_id))
+    records: list[dict] = []
+    for record, test_id in pending:
+        if test_id not in done:
+            # The record is retained so component_report can reject it as not
+            # completed instead of silently passing.
+            record["executed"] = False
+        else:
+            runner_result, skipped = done[test_id]
+            record["executed"] = True
+            record["result"] = runner_result
+            record["skipped"] = skipped
+        records.append(record)
+    by_test = {record.get("exact_test_id") for record in records}
+    missing = expected - by_test
+    if missing:
+        raise ValueError(f"Flutter machine output has no record for: {sorted(missing)}")
+    if len(records) != len(by_test):
+        raise ValueError("Flutter machine output contains duplicate lifecycle records")
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--machine-output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    records = extract(args.machine_output, args.manifest)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps({"schema_version": 1, "records": records}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mobile_lifecycle/manifests/android_jvm.json
+++ b/scripts/mobile_lifecycle/manifests/android_jvm.json
@@ -1,0 +1,95 @@
+{
+  "component": "android_jvm",
+  "scenarios": [
+    {
+      "scenario_id": "ML-03",
+      "test_name": "service recreation gets a new runtime identity",
+      "events": ["service_recreated", "native_runtime_started"],
+      "old_identity": {"daemon_process_id": 41, "service_incarnation": 8, "bridge_incarnation": 4},
+      "new_identity": {"daemon_process_id": 42, "service_incarnation": 9, "bridge_incarnation": 5},
+      "decision": "applied",
+      "invariants": {"new_process_adopted": true}
+    },
+    {
+      "scenario_id": "ML-04",
+      "test_name": "Wi-Fi to cellular advances one physical network generation",
+      "events": ["physical_network_changed", "candidate_refresh_started"],
+      "old_identity": {"network_generation": 11},
+      "new_identity": {"network_generation": 12},
+      "decision": "applied",
+      "invariants": {"single_network_generation_advance": true}
+    },
+    {
+      "scenario_id": "ML-05",
+      "test_name": "cellular to Wi-Fi hotspot identity advances once",
+      "events": ["physical_network_changed", "candidate_refresh_started"],
+      "old_identity": {"network_generation": 12},
+      "new_identity": {"network_generation": 13},
+      "decision": "applied",
+      "invariants": {"single_network_generation_advance": true}
+    },
+    {
+      "scenario_id": "ML-06",
+      "test_name": "permission revoke invalidates the pending request",
+      "events": ["vpn_permission_revoked", "bridge_detached"],
+      "old_identity": {"app_epoch": 1, "permission_request_id": 7},
+      "new_identity": {"app_epoch": 2, "permission_request_id": 8},
+      "decision": "stale_rejected",
+      "invariants": {"pending_permission_invalidated": true}
+    },
+    {
+      "scenario_id": "ML-07",
+      "test_name": "permission regrant allocates a new request generation",
+      "events": ["vpn_permission_granted", "native_runtime_started"],
+      "old_identity": {"app_epoch": 2, "permission_request_id": 8},
+      "new_identity": {"app_epoch": 3, "permission_request_id": 9},
+      "decision": "applied",
+      "invariants": {"new_permission_attempt": true}
+    },
+    {
+      "scenario_id": "ML-08",
+      "test_name": "old engine permission result is rejected after recreation",
+      "events": ["activity_recreated", "vpn_permission_granted"],
+      "old_identity": {"activity_incarnation": 2, "permission_request_id": 9},
+      "new_identity": {"activity_incarnation": 3, "permission_request_id": 10},
+      "decision": "stale_rejected",
+      "invariants": {"old_engine_callback_rejected": true}
+    },
+    {
+      "scenario_id": "ML-09",
+      "test_name": "START_STICKY recreation gets a new service incarnation",
+      "events": ["service_recreated", "native_runtime_started"],
+      "old_identity": {"service_incarnation": 8},
+      "new_identity": {"service_incarnation": 9},
+      "decision": "applied",
+      "invariants": {"new_service_incarnation": true}
+    },
+    {
+      "scenario_id": "ML-10",
+      "test_name": "bridge reattachment adopts the current native incarnation",
+      "events": ["bridge_detached", "bridge_attached"],
+      "old_identity": {"bridge_incarnation": 4, "service_incarnation": 8},
+      "new_identity": {"bridge_incarnation": 5, "service_incarnation": 9},
+      "decision": "applied",
+      "invariants": {"bridge_identity_adopted": true}
+    },
+    {
+      "scenario_id": "ML-11",
+      "test_name": "old bridge teardown cannot stop the replacement",
+      "events": ["bridge_detached", "bridge_attached"],
+      "old_identity": {"bridge_incarnation": 4},
+      "new_identity": {"bridge_incarnation": 5},
+      "decision": "stale_rejected",
+      "invariants": {"old_bridge_cleanup_rejected": true}
+    },
+    {
+      "scenario_id": "ML-18",
+      "test_name": "duplicate Android lifecycle events have no second effect",
+      "events": ["vpn_permission_granted", "vpn_permission_granted", "physical_network_changed", "physical_network_changed"],
+      "old_identity": {"service_incarnation": 9, "network_generation": 13},
+      "new_identity": {"service_incarnation": 9, "network_generation": 13},
+      "decision": "duplicate",
+      "invariants": {"duplicate_has_no_second_effect": true}
+    }
+  ]
+}

--- a/scripts/mobile_lifecycle/manifests/android_jvm.json
+++ b/scripts/mobile_lifecycle/manifests/android_jvm.json
@@ -1,95 +1,15 @@
 {
   "component": "android_jvm",
   "scenarios": [
-    {
-      "scenario_id": "ML-03",
-      "test_name": "service recreation gets a new runtime identity",
-      "events": ["service_recreated", "native_runtime_started"],
-      "old_identity": {"daemon_process_id": 41, "service_incarnation": 8, "bridge_incarnation": 4},
-      "new_identity": {"daemon_process_id": 42, "service_incarnation": 9, "bridge_incarnation": 5},
-      "decision": "applied",
-      "invariants": {"new_process_adopted": true}
-    },
-    {
-      "scenario_id": "ML-04",
-      "test_name": "Wi-Fi to cellular advances one physical network generation",
-      "events": ["physical_network_changed", "candidate_refresh_started"],
-      "old_identity": {"network_generation": 11},
-      "new_identity": {"network_generation": 12},
-      "decision": "applied",
-      "invariants": {"single_network_generation_advance": true}
-    },
-    {
-      "scenario_id": "ML-05",
-      "test_name": "cellular to Wi-Fi hotspot identity advances once",
-      "events": ["physical_network_changed", "candidate_refresh_started"],
-      "old_identity": {"network_generation": 12},
-      "new_identity": {"network_generation": 13},
-      "decision": "applied",
-      "invariants": {"single_network_generation_advance": true}
-    },
-    {
-      "scenario_id": "ML-06",
-      "test_name": "permission revoke invalidates the pending request",
-      "events": ["vpn_permission_revoked", "bridge_detached"],
-      "old_identity": {"app_epoch": 1, "permission_request_id": 7},
-      "new_identity": {"app_epoch": 2, "permission_request_id": 8},
-      "decision": "stale_rejected",
-      "invariants": {"pending_permission_invalidated": true}
-    },
-    {
-      "scenario_id": "ML-07",
-      "test_name": "permission regrant allocates a new request generation",
-      "events": ["vpn_permission_granted", "native_runtime_started"],
-      "old_identity": {"app_epoch": 2, "permission_request_id": 8},
-      "new_identity": {"app_epoch": 3, "permission_request_id": 9},
-      "decision": "applied",
-      "invariants": {"new_permission_attempt": true}
-    },
-    {
-      "scenario_id": "ML-08",
-      "test_name": "old engine permission result is rejected after recreation",
-      "events": ["activity_recreated", "vpn_permission_granted"],
-      "old_identity": {"activity_incarnation": 2, "permission_request_id": 9},
-      "new_identity": {"activity_incarnation": 3, "permission_request_id": 10},
-      "decision": "stale_rejected",
-      "invariants": {"old_engine_callback_rejected": true}
-    },
-    {
-      "scenario_id": "ML-09",
-      "test_name": "START_STICKY recreation gets a new service incarnation",
-      "events": ["service_recreated", "native_runtime_started"],
-      "old_identity": {"service_incarnation": 8},
-      "new_identity": {"service_incarnation": 9},
-      "decision": "applied",
-      "invariants": {"new_service_incarnation": true}
-    },
-    {
-      "scenario_id": "ML-10",
-      "test_name": "bridge reattachment adopts the current native incarnation",
-      "events": ["bridge_detached", "bridge_attached"],
-      "old_identity": {"bridge_incarnation": 4, "service_incarnation": 8},
-      "new_identity": {"bridge_incarnation": 5, "service_incarnation": 9},
-      "decision": "applied",
-      "invariants": {"bridge_identity_adopted": true}
-    },
-    {
-      "scenario_id": "ML-11",
-      "test_name": "old bridge teardown cannot stop the replacement",
-      "events": ["bridge_detached", "bridge_attached"],
-      "old_identity": {"bridge_incarnation": 4},
-      "new_identity": {"bridge_incarnation": 5},
-      "decision": "stale_rejected",
-      "invariants": {"old_bridge_cleanup_rejected": true}
-    },
-    {
-      "scenario_id": "ML-18",
-      "test_name": "duplicate Android lifecycle events have no second effect",
-      "events": ["vpn_permission_granted", "vpn_permission_granted", "physical_network_changed", "physical_network_changed"],
-      "old_identity": {"service_incarnation": 9, "network_generation": 13},
-      "new_identity": {"service_incarnation": 9, "network_generation": 13},
-      "decision": "duplicate",
-      "invariants": {"duplicate_has_no_second_effect": true}
-    }
+    {"scenario_id": "ML-03", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl03DaemonProcessRecreation"},
+    {"scenario_id": "ML-04", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl04WifiToCellularHandoff"},
+    {"scenario_id": "ML-05", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl05CellularToWifiHotspotHandoff"},
+    {"scenario_id": "ML-06", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl06VpnPermissionRevoke"},
+    {"scenario_id": "ML-07", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl07VpnPermissionRegrant"},
+    {"scenario_id": "ML-08", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl08ActivityEngineRecreation"},
+    {"scenario_id": "ML-09", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl09ServiceRecreation"},
+    {"scenario_id": "ML-10", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl10BridgeReattachment"},
+    {"scenario_id": "ML-11", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl11OldBridgeTeardown"},
+    {"scenario_id": "ML-18", "exact_test_id": "com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl18DuplicateEvents"}
   ]
 }

--- a/scripts/mobile_lifecycle/manifests/flutter.json
+++ b/scripts/mobile_lifecycle/manifests/flutter.json
@@ -1,86 +1,14 @@
 {
   "component": "flutter",
   "scenarios": [
-    {
-      "scenario_id": "ML-01",
-      "test_name": "StatusStore rejects a late background long-poll",
-      "events": ["app_backgrounded"],
-      "old_identity": {"app_epoch": 1, "event_loop_generation": 4},
-      "new_identity": {"app_epoch": 2, "event_loop_generation": 5},
-      "decision": "stale_rejected",
-      "invariants": {"old_callback_fenced": true}
-    },
-    {
-      "scenario_id": "ML-02",
-      "test_name": "StatusStore refreshes before reopening the event stream",
-      "events": ["app_resumed"],
-      "old_identity": {"app_epoch": 2, "event_loop_generation": 5, "daemon_revision": 8},
-      "new_identity": {"app_epoch": 3, "event_loop_generation": 6, "daemon_revision": 9},
-      "decision": "applied",
-      "invariants": {"resume_refresh_precedes_poll": true}
-    },
-    {
-      "scenario_id": "ML-03",
-      "test_name": "StatusStore adopts a replacement daemon process",
-      "events": ["native_runtime_stopped", "native_runtime_started"],
-      "old_identity": {"daemon_process_id": 41, "daemon_revision": 8, "bridge_incarnation": 4},
-      "new_identity": {"daemon_process_id": 42, "daemon_revision": 1, "bridge_incarnation": 5},
-      "decision": "applied",
-      "invariants": {"new_process_adopted": true}
-    },
-    {
-      "scenario_id": "ML-06",
-      "test_name": "StatusStore rejects a permission-revoked start completion",
-      "events": ["vpn_permission_revoked", "bridge_detached"],
-      "old_identity": {"app_epoch": 1, "permission_request_id": 7},
-      "new_identity": {"app_epoch": 2, "permission_request_id": 8},
-      "decision": "stale_rejected",
-      "invariants": {"pending_permission_invalidated": true}
-    },
-    {
-      "scenario_id": "ML-07",
-      "test_name": "StatusStore starts a fresh attempt after permission regrant",
-      "events": ["vpn_permission_granted", "native_runtime_started"],
-      "old_identity": {"app_epoch": 2, "permission_request_id": 8},
-      "new_identity": {"app_epoch": 3, "permission_request_id": 9},
-      "decision": "applied",
-      "invariants": {"new_permission_attempt": true}
-    },
-    {
-      "scenario_id": "ML-08",
-      "test_name": "StatusStore rejects a callback from a recreated engine",
-      "events": ["activity_recreated", "bridge_attached"],
-      "old_identity": {"app_epoch": 3, "activity_incarnation": 2},
-      "new_identity": {"app_epoch": 4, "activity_incarnation": 3},
-      "decision": "stale_rejected",
-      "invariants": {"old_engine_callback_rejected": true}
-    },
-    {
-      "scenario_id": "ML-10",
-      "test_name": "StatusStore refreshes after bridge reattachment",
-      "events": ["bridge_detached", "bridge_attached"],
-      "old_identity": {"bridge_incarnation": 4, "daemon_process_id": 41},
-      "new_identity": {"bridge_incarnation": 5, "daemon_process_id": 42},
-      "decision": "applied",
-      "invariants": {"bridge_identity_adopted": true}
-    },
-    {
-      "scenario_id": "ML-12",
-      "test_name": "StatusStore adopts status after control reconnect",
-      "events": ["control_disconnected", "control_reconnected"],
-      "old_identity": {"control_connection_generation": 8, "daemon_revision": 8},
-      "new_identity": {"control_connection_generation": 9, "daemon_revision": 9},
-      "decision": "applied",
-      "invariants": {"new_control_generation_adopted": true}
-    },
-    {
-      "scenario_id": "ML-18",
-      "test_name": "StatusStore treats duplicate lifecycle notifications idempotently",
-      "events": ["app_backgrounded", "app_backgrounded", "app_resumed", "app_resumed"],
-      "old_identity": {"app_epoch": 4, "event_loop_generation": 7},
-      "new_identity": {"app_epoch": 4, "event_loop_generation": 7},
-      "decision": "duplicate",
-      "invariants": {"duplicate_has_no_second_effect": true}
-    }
+    {"scenario_id": "ML-01", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-01 app-background-late-long-poll"},
+    {"scenario_id": "ML-02", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-02 app-resume-refresh-before-reconnect"},
+    {"scenario_id": "ML-03", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-03 daemon-process-recreation"},
+    {"scenario_id": "ML-06", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-06 vpn-permission-revoke"},
+    {"scenario_id": "ML-07", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-07 vpn-permission-regrant"},
+    {"scenario_id": "ML-08", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-08 activity-engine-recreation"},
+    {"scenario_id": "ML-10", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-10 native-bridge-reattachment"},
+    {"scenario_id": "ML-12", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-12 control-websocket-reconnect"},
+    {"scenario_id": "ML-18", "exact_test_id": "apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-18 duplicate-events-idempotent"}
   ]
 }

--- a/scripts/mobile_lifecycle/manifests/flutter.json
+++ b/scripts/mobile_lifecycle/manifests/flutter.json
@@ -1,0 +1,86 @@
+{
+  "component": "flutter",
+  "scenarios": [
+    {
+      "scenario_id": "ML-01",
+      "test_name": "StatusStore rejects a late background long-poll",
+      "events": ["app_backgrounded"],
+      "old_identity": {"app_epoch": 1, "event_loop_generation": 4},
+      "new_identity": {"app_epoch": 2, "event_loop_generation": 5},
+      "decision": "stale_rejected",
+      "invariants": {"old_callback_fenced": true}
+    },
+    {
+      "scenario_id": "ML-02",
+      "test_name": "StatusStore refreshes before reopening the event stream",
+      "events": ["app_resumed"],
+      "old_identity": {"app_epoch": 2, "event_loop_generation": 5, "daemon_revision": 8},
+      "new_identity": {"app_epoch": 3, "event_loop_generation": 6, "daemon_revision": 9},
+      "decision": "applied",
+      "invariants": {"resume_refresh_precedes_poll": true}
+    },
+    {
+      "scenario_id": "ML-03",
+      "test_name": "StatusStore adopts a replacement daemon process",
+      "events": ["native_runtime_stopped", "native_runtime_started"],
+      "old_identity": {"daemon_process_id": 41, "daemon_revision": 8, "bridge_incarnation": 4},
+      "new_identity": {"daemon_process_id": 42, "daemon_revision": 1, "bridge_incarnation": 5},
+      "decision": "applied",
+      "invariants": {"new_process_adopted": true}
+    },
+    {
+      "scenario_id": "ML-06",
+      "test_name": "StatusStore rejects a permission-revoked start completion",
+      "events": ["vpn_permission_revoked", "bridge_detached"],
+      "old_identity": {"app_epoch": 1, "permission_request_id": 7},
+      "new_identity": {"app_epoch": 2, "permission_request_id": 8},
+      "decision": "stale_rejected",
+      "invariants": {"pending_permission_invalidated": true}
+    },
+    {
+      "scenario_id": "ML-07",
+      "test_name": "StatusStore starts a fresh attempt after permission regrant",
+      "events": ["vpn_permission_granted", "native_runtime_started"],
+      "old_identity": {"app_epoch": 2, "permission_request_id": 8},
+      "new_identity": {"app_epoch": 3, "permission_request_id": 9},
+      "decision": "applied",
+      "invariants": {"new_permission_attempt": true}
+    },
+    {
+      "scenario_id": "ML-08",
+      "test_name": "StatusStore rejects a callback from a recreated engine",
+      "events": ["activity_recreated", "bridge_attached"],
+      "old_identity": {"app_epoch": 3, "activity_incarnation": 2},
+      "new_identity": {"app_epoch": 4, "activity_incarnation": 3},
+      "decision": "stale_rejected",
+      "invariants": {"old_engine_callback_rejected": true}
+    },
+    {
+      "scenario_id": "ML-10",
+      "test_name": "StatusStore refreshes after bridge reattachment",
+      "events": ["bridge_detached", "bridge_attached"],
+      "old_identity": {"bridge_incarnation": 4, "daemon_process_id": 41},
+      "new_identity": {"bridge_incarnation": 5, "daemon_process_id": 42},
+      "decision": "applied",
+      "invariants": {"bridge_identity_adopted": true}
+    },
+    {
+      "scenario_id": "ML-12",
+      "test_name": "StatusStore adopts status after control reconnect",
+      "events": ["control_disconnected", "control_reconnected"],
+      "old_identity": {"control_connection_generation": 8, "daemon_revision": 8},
+      "new_identity": {"control_connection_generation": 9, "daemon_revision": 9},
+      "decision": "applied",
+      "invariants": {"new_control_generation_adopted": true}
+    },
+    {
+      "scenario_id": "ML-18",
+      "test_name": "StatusStore treats duplicate lifecycle notifications idempotently",
+      "events": ["app_backgrounded", "app_backgrounded", "app_resumed", "app_resumed"],
+      "old_identity": {"app_epoch": 4, "event_loop_generation": 7},
+      "new_identity": {"app_epoch": 4, "event_loop_generation": 7},
+      "decision": "duplicate",
+      "invariants": {"duplicate_has_no_second_effect": true}
+    }
+  ]
+}

--- a/scripts/mobile_lifecycle/manifests/rust.json
+++ b/scripts/mobile_lifecycle/manifests/rust.json
@@ -1,113 +1,17 @@
 {
   "component": "rust",
   "scenarios": [
-    {
-      "scenario_id": "ML-03",
-      "test_name": "runtime owner replacement adopts the new process",
-      "events": ["native_runtime_stopped", "native_runtime_started"],
-      "old_identity": {"daemon_process_id": 41, "bridge_incarnation": 4},
-      "new_identity": {"daemon_process_id": 42, "bridge_incarnation": 5},
-      "decision": "applied",
-      "invariants": {"new_process_adopted": true}
-    },
-    {
-      "scenario_id": "ML-04",
-      "test_name": "physical handoff advances the daemon network generation once",
-      "events": ["physical_network_changed", "candidate_refresh_started"],
-      "old_identity": {"network_generation": 11},
-      "new_identity": {"network_generation": 12},
-      "decision": "applied",
-      "invariants": {"single_network_generation_advance": true}
-    },
-    {
-      "scenario_id": "ML-05",
-      "test_name": "hotspot identity replacement advances the daemon generation once",
-      "events": ["physical_network_changed", "candidate_refresh_started"],
-      "old_identity": {"network_generation": 12},
-      "new_identity": {"network_generation": 13},
-      "decision": "applied",
-      "invariants": {"single_network_generation_advance": true}
-    },
-    {
-      "scenario_id": "ML-10",
-      "test_name": "JNI bridge incarnation is adopted by the runtime owner",
-      "events": ["bridge_detached", "bridge_attached"],
-      "old_identity": {"bridge_incarnation": 4},
-      "new_identity": {"bridge_incarnation": 5},
-      "decision": "applied",
-      "invariants": {"bridge_identity_adopted": true}
-    },
-    {
-      "scenario_id": "ML-11",
-      "test_name": "old runtime cannot clear a new socket protector",
-      "events": ["bridge_detached", "bridge_attached"],
-      "old_identity": {"bridge_incarnation": 4},
-      "new_identity": {"bridge_incarnation": 5},
-      "decision": "stale_rejected",
-      "invariants": {"old_bridge_cleanup_rejected": true}
-    },
-    {
-      "scenario_id": "ML-12",
-      "test_name": "new control WebSocket survives old task teardown",
-      "events": ["control_disconnected", "control_reconnected"],
-      "old_identity": {"control_connection_generation": 8},
-      "new_identity": {"control_connection_generation": 9},
-      "decision": "applied",
-      "invariants": {"new_control_generation_adopted": true}
-    },
-    {
-      "scenario_id": "ML-13",
-      "test_name": "stale control message is rejected by connection generation",
-      "events": ["control_reconnected"],
-      "old_identity": {"control_connection_generation": 8, "daemon_revision": 8},
-      "new_identity": {"control_connection_generation": 9, "daemon_revision": 9},
-      "decision": "stale_rejected",
-      "invariants": {"old_control_message_rejected": true}
-    },
-    {
-      "scenario_id": "ML-14",
-      "test_name": "stale candidate result is rejected after generation advance",
-      "events": ["candidate_refresh_started", "physical_network_changed"],
-      "old_identity": {"network_generation": 12, "candidate_epoch": 9},
-      "new_identity": {"network_generation": 13, "candidate_epoch": 10},
-      "decision": "stale_rejected",
-      "invariants": {"old_candidate_rejected": true}
-    },
-    {
-      "scenario_id": "ML-15",
-      "test_name": "stale socket publication is rejected after generation advance",
-      "events": ["physical_network_changed", "candidate_refresh_started"],
-      "old_identity": {"network_generation": 12, "socket_publication_generation": 21},
-      "new_identity": {"network_generation": 13, "socket_publication_generation": 22},
-      "decision": "stale_rejected",
-      "invariants": {"old_socket_publication_rejected": true}
-    },
-    {
-      "scenario_id": "ML-16",
-      "test_name": "relay remains committed during direct rediscovery and timeout",
-      "events": ["relay_retained", "candidate_refresh_started", "direct_reconfirmed"],
-      "old_identity": {"network_generation": 13, "relay_connection_id": 77, "direct_validation_owner": "probe-1"},
-      "new_identity": {"network_generation": 13, "relay_connection_id": 77, "direct_validation_owner": "probe-2"},
-      "decision": "applied",
-      "invariants": {"relay_retained_until_direct_commit": true, "relay_retained_on_timeout": true}
-    },
-    {
-      "scenario_id": "ML-17",
-      "test_name": "direct path commits only after current-generation confirmation",
-      "events": ["candidate_refresh_started", "direct_reconfirmed"],
-      "old_identity": {"network_generation": 13, "direct_validation_owner": "probe-2"},
-      "new_identity": {"network_generation": 13, "direct_validation_owner": "probe-3"},
-      "decision": "applied",
-      "invariants": {"direct_confirmed_current_generation": true}
-    },
-    {
-      "scenario_id": "ML-18",
-      "test_name": "duplicate generation events have no second side effect",
-      "events": ["physical_network_changed", "physical_network_changed", "control_reconnected", "control_reconnected"],
-      "old_identity": {"network_generation": 13, "control_connection_generation": 9},
-      "new_identity": {"network_generation": 13, "control_connection_generation": 9},
-      "decision": "duplicate",
-      "invariants": {"duplicate_has_no_second_effect": true}
-    }
+    {"scenario_id": "ML-03", "exact_test_id": "tests::mobile_lifecycle_evidence::ml03_runtime_owner_replacement"},
+    {"scenario_id": "ML-04", "exact_test_id": "tests::mobile_lifecycle_evidence::ml04_android_network_hint"},
+    {"scenario_id": "ML-05", "exact_test_id": "tests::mobile_lifecycle_evidence::ml05_hotspot_network_hint"},
+    {"scenario_id": "ML-10", "exact_test_id": "lifecycle::tests::evidence_ml10_bridge_incarnation_adoption"},
+    {"scenario_id": "ML-11", "exact_test_id": "lifecycle::tests::evidence_ml11_old_bridge_cleanup"},
+    {"scenario_id": "ML-12", "exact_test_id": "control::websocket::route_tests::evidence_ml12_control_reconnect"},
+    {"scenario_id": "ML-13", "exact_test_id": "control::websocket::route_tests::evidence_ml13_stale_control_message"},
+    {"scenario_id": "ML-14", "exact_test_id": "tests::mobile_lifecycle_evidence::ml14_stale_candidate_result"},
+    {"scenario_id": "ML-15", "exact_test_id": "tests::mobile_lifecycle_evidence::ml15_stale_socket_publication"},
+    {"scenario_id": "ML-16", "exact_test_id": "tests::mobile_lifecycle_evidence::ml16_relay_retention"},
+    {"scenario_id": "ML-17", "exact_test_id": "tests::mobile_lifecycle_evidence::ml17_direct_current_generation"},
+    {"scenario_id": "ML-18", "exact_test_id": "lifecycle::tests::physical_network_hint_is_owner_scoped_and_exactly_once"}
   ]
 }

--- a/scripts/mobile_lifecycle/manifests/rust.json
+++ b/scripts/mobile_lifecycle/manifests/rust.json
@@ -1,0 +1,113 @@
+{
+  "component": "rust",
+  "scenarios": [
+    {
+      "scenario_id": "ML-03",
+      "test_name": "runtime owner replacement adopts the new process",
+      "events": ["native_runtime_stopped", "native_runtime_started"],
+      "old_identity": {"daemon_process_id": 41, "bridge_incarnation": 4},
+      "new_identity": {"daemon_process_id": 42, "bridge_incarnation": 5},
+      "decision": "applied",
+      "invariants": {"new_process_adopted": true}
+    },
+    {
+      "scenario_id": "ML-04",
+      "test_name": "physical handoff advances the daemon network generation once",
+      "events": ["physical_network_changed", "candidate_refresh_started"],
+      "old_identity": {"network_generation": 11},
+      "new_identity": {"network_generation": 12},
+      "decision": "applied",
+      "invariants": {"single_network_generation_advance": true}
+    },
+    {
+      "scenario_id": "ML-05",
+      "test_name": "hotspot identity replacement advances the daemon generation once",
+      "events": ["physical_network_changed", "candidate_refresh_started"],
+      "old_identity": {"network_generation": 12},
+      "new_identity": {"network_generation": 13},
+      "decision": "applied",
+      "invariants": {"single_network_generation_advance": true}
+    },
+    {
+      "scenario_id": "ML-10",
+      "test_name": "JNI bridge incarnation is adopted by the runtime owner",
+      "events": ["bridge_detached", "bridge_attached"],
+      "old_identity": {"bridge_incarnation": 4},
+      "new_identity": {"bridge_incarnation": 5},
+      "decision": "applied",
+      "invariants": {"bridge_identity_adopted": true}
+    },
+    {
+      "scenario_id": "ML-11",
+      "test_name": "old runtime cannot clear a new socket protector",
+      "events": ["bridge_detached", "bridge_attached"],
+      "old_identity": {"bridge_incarnation": 4},
+      "new_identity": {"bridge_incarnation": 5},
+      "decision": "stale_rejected",
+      "invariants": {"old_bridge_cleanup_rejected": true}
+    },
+    {
+      "scenario_id": "ML-12",
+      "test_name": "new control WebSocket survives old task teardown",
+      "events": ["control_disconnected", "control_reconnected"],
+      "old_identity": {"control_connection_generation": 8},
+      "new_identity": {"control_connection_generation": 9},
+      "decision": "applied",
+      "invariants": {"new_control_generation_adopted": true}
+    },
+    {
+      "scenario_id": "ML-13",
+      "test_name": "stale control message is rejected by connection generation",
+      "events": ["control_reconnected"],
+      "old_identity": {"control_connection_generation": 8, "daemon_revision": 8},
+      "new_identity": {"control_connection_generation": 9, "daemon_revision": 9},
+      "decision": "stale_rejected",
+      "invariants": {"old_control_message_rejected": true}
+    },
+    {
+      "scenario_id": "ML-14",
+      "test_name": "stale candidate result is rejected after generation advance",
+      "events": ["candidate_refresh_started", "physical_network_changed"],
+      "old_identity": {"network_generation": 12, "candidate_epoch": 9},
+      "new_identity": {"network_generation": 13, "candidate_epoch": 10},
+      "decision": "stale_rejected",
+      "invariants": {"old_candidate_rejected": true}
+    },
+    {
+      "scenario_id": "ML-15",
+      "test_name": "stale socket publication is rejected after generation advance",
+      "events": ["physical_network_changed", "candidate_refresh_started"],
+      "old_identity": {"network_generation": 12, "socket_publication_generation": 21},
+      "new_identity": {"network_generation": 13, "socket_publication_generation": 22},
+      "decision": "stale_rejected",
+      "invariants": {"old_socket_publication_rejected": true}
+    },
+    {
+      "scenario_id": "ML-16",
+      "test_name": "relay remains committed during direct rediscovery and timeout",
+      "events": ["relay_retained", "candidate_refresh_started", "direct_reconfirmed"],
+      "old_identity": {"network_generation": 13, "relay_connection_id": 77, "direct_validation_owner": "probe-1"},
+      "new_identity": {"network_generation": 13, "relay_connection_id": 77, "direct_validation_owner": "probe-2"},
+      "decision": "applied",
+      "invariants": {"relay_retained_until_direct_commit": true, "relay_retained_on_timeout": true}
+    },
+    {
+      "scenario_id": "ML-17",
+      "test_name": "direct path commits only after current-generation confirmation",
+      "events": ["candidate_refresh_started", "direct_reconfirmed"],
+      "old_identity": {"network_generation": 13, "direct_validation_owner": "probe-2"},
+      "new_identity": {"network_generation": 13, "direct_validation_owner": "probe-3"},
+      "decision": "applied",
+      "invariants": {"direct_confirmed_current_generation": true}
+    },
+    {
+      "scenario_id": "ML-18",
+      "test_name": "duplicate generation events have no second side effect",
+      "events": ["physical_network_changed", "physical_network_changed", "control_reconnected", "control_reconnected"],
+      "old_identity": {"network_generation": 13, "control_connection_generation": 9},
+      "new_identity": {"network_generation": 13, "control_connection_generation": 9},
+      "decision": "duplicate",
+      "invariants": {"duplicate_has_no_second_effect": true}
+    }
+  ]
+}

--- a/scripts/mobile_lifecycle/run_android_jvm_tests.sh
+++ b/scripts/mobile_lifecycle/run_android_jvm_tests.sh
@@ -3,8 +3,22 @@ set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 ANDROID_DIR="$ROOT_DIR/apps/flutter_client/android"
+XML_ROOT="$ANDROID_DIR/../build/app/test-results"
+MANIFEST="$ROOT_DIR/scripts/mobile_lifecycle/manifests/android_jvm.json"
 ARTIFACT_DIR=${P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR:-"${RUNNER_TEMP:-/tmp}/p2wlan-mobile-lifecycle-android"}
+RECORDS="$ARTIFACT_DIR/android-execution-records.json"
 mkdir -p "$ARTIFACT_DIR"
+
+write_empty_records() {
+  python3 - "$RECORDS" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({"schema_version": 1, "records": []}) + "\n", encoding="utf-8")
+PY
+}
 
 cd "$ANDROID_DIR"
 if [[ -x ./gradlew ]]; then
@@ -13,6 +27,7 @@ elif command -v gradle >/dev/null 2>&1; then
   command=(gradle --no-daemon :app:testDebugUnitTest)
 else
   echo "Android JVM lifecycle tests require ./gradlew or gradle on PATH" >&2
+  write_empty_records
   exit 127
 fi
 
@@ -25,7 +40,8 @@ set +e
 test_status=$?
 set -e
 
-python3 - "$ANDROID_DIR/../build/app/test-results" "$ARTIFACT_DIR/android-jvm-test-summary.json" "$test_status" <<'PY'
+set +e
+python3 - "$XML_ROOT" "$ARTIFACT_DIR/android-jvm-test-summary.json" "$test_status" <<'PY'
 import json
 import pathlib
 import sys
@@ -47,11 +63,13 @@ if xml_root.is_dir():
             root = ET.parse(path).getroot()
         except (OSError, ET.ParseError):
             continue
+
         def number(name: str) -> int:
             try:
                 return int(root.attrib.get(name, "0"))
             except ValueError:
                 return 0
+
         test_count += number("tests")
         failures += number("failures")
         errors += number("errors")
@@ -71,5 +89,27 @@ summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", en
 if command_status == 0 and (test_count == 0 or failures or errors or skipped):
     raise SystemExit("Android JVM task did not produce a non-skipped, passing test set")
 PY
+summary_status=$?
+set -e
 
-exit "$test_status"
+records_status=1
+if [[ "$test_status" -eq 0 && -d "$XML_ROOT" ]]; then
+  set +e
+  python3 "$ROOT_DIR/scripts/mobile_lifecycle/android_junit_records.py" \
+    --xml-root "$XML_ROOT" \
+    --manifest "$MANIFEST" \
+    --output "$RECORDS"
+  records_status=$?
+  set -e
+fi
+if [[ "$records_status" -ne 0 ]]; then
+  write_empty_records
+fi
+
+if [[ "$test_status" -ne 0 ]]; then
+  exit "$test_status"
+fi
+if [[ "$summary_status" -ne 0 ]]; then
+  exit 1
+fi
+exit "$records_status"

--- a/scripts/mobile_lifecycle/run_android_jvm_tests.sh
+++ b/scripts/mobile_lifecycle/run_android_jvm_tests.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ANDROID_DIR="$ROOT_DIR/apps/flutter_client/android"
+ARTIFACT_DIR=${P2WLAN_MOBILE_LIFECYCLE_ARTIFACT_DIR:-"${RUNNER_TEMP:-/tmp}/p2wlan-mobile-lifecycle-android"}
+mkdir -p "$ARTIFACT_DIR"
+
+cd "$ANDROID_DIR"
+if [[ -x ./gradlew ]]; then
+  command=(./gradlew --no-daemon :app:testDebugUnitTest)
+elif command -v gradle >/dev/null 2>&1; then
+  command=(gradle --no-daemon :app:testDebugUnitTest)
+else
+  echo "Android JVM lifecycle tests require ./gradlew or gradle on PATH" >&2
+  exit 127
+fi
+
+printf 'running Android JVM task:'
+printf ' %q' "${command[@]}"
+printf '\n'
+
+set +e
+"${command[@]}"
+test_status=$?
+set -e
+
+python3 - "$ANDROID_DIR/../build/app/test-results" "$ARTIFACT_DIR/android-jvm-test-summary.json" "$test_status" <<'PY'
+import json
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+
+xml_root = pathlib.Path(sys.argv[1])
+summary_path = pathlib.Path(sys.argv[2])
+command_status = int(sys.argv[3])
+test_count = 0
+failures = 0
+errors = 0
+skipped = 0
+files = []
+
+if xml_root.is_dir():
+    for path in sorted(xml_root.rglob("TEST-*.xml")):
+        files.append(path.as_posix())
+        try:
+            root = ET.parse(path).getroot()
+        except (OSError, ET.ParseError):
+            continue
+        def number(name: str) -> int:
+            try:
+                return int(root.attrib.get(name, "0"))
+            except ValueError:
+                return 0
+        test_count += number("tests")
+        failures += number("failures")
+        errors += number("errors")
+        skipped += number("skipped")
+
+summary = {
+    "task": ":app:testDebugUnitTest",
+    "command_status": command_status,
+    "test_count": test_count,
+    "failures": failures,
+    "errors": errors,
+    "skipped": skipped,
+    "xml_files": files,
+}
+summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+if command_status == 0 and (test_count == 0 or failures or errors or skipped):
+    raise SystemExit("Android JVM task did not produce a non-skipped, passing test set")
+PY
+
+exit "$test_status"

--- a/scripts/mobile_lifecycle/rust_test_records.py
+++ b/scripts/mobile_lifecycle/rust_test_records.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Extract lifecycle records emitted by Rust tests run with --nocapture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PREFIX = "MOBILE_LIFECYCLE_RECORD "
+TEST_RE = re.compile(r"^test\s+(\S+)\s+\.\.\.\s*(.*)$")
+STATUS_RE = re.compile(r"^(ok|FAILED|ignored)\s*$")
+
+
+def _manifest(path: Path) -> set[str]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return {entry["exact_test_id"] for entry in value["scenarios"]}
+
+
+def extract(test_output: Path, manifest_path: Path) -> list[dict]:
+    expected = _manifest(manifest_path)
+    finished: dict[str, tuple[str, bool]] = {}
+    pending: list[dict] = []
+    current_test: str | None = None
+
+    def add_record(line: str, line_number: int) -> None:
+        if not line.startswith(PREFIX):
+            return
+        try:
+            record = json.loads(line[len(PREFIX) :])
+        except json.JSONDecodeError as error:
+            raise ValueError(f"invalid Rust lifecycle record on line {line_number}: {error}") from error
+        if not isinstance(record, dict):
+            raise ValueError(f"Rust lifecycle record on line {line_number} is not an object")
+        exact_test_id = record.get("exact_test_id")
+        if not isinstance(exact_test_id, str) or exact_test_id not in expected:
+            raise ValueError(f"Rust output contains an unmanifested test: {exact_test_id!r}")
+        pending.append(record)
+
+    with test_output.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            line = line.rstrip("\n")
+            stripped = line.strip()
+            match = TEST_RE.match(stripped)
+            if match:
+                current_test, remainder = match.groups()
+                status = STATUS_RE.match(remainder.strip())
+                if status:
+                    status_name = status.group(1)
+                    finished[current_test] = (status_name, status_name == "ignored")
+                    current_test = None
+                else:
+                    marker_offset = remainder.find(PREFIX)
+                    if marker_offset >= 0:
+                        add_record(remainder[marker_offset:], line_number)
+                continue
+            status = STATUS_RE.match(stripped)
+            if status and current_test is not None:
+                status_name = status.group(1)
+                finished[current_test] = (status_name, status_name == "ignored")
+                current_test = None
+                continue
+            add_record(stripped, line_number)
+    records: list[dict] = []
+    for record in pending:
+        exact_test_id = record["exact_test_id"]
+        matching = [
+            test_id
+            for test_id in finished
+            if test_id == exact_test_id
+            or exact_test_id.endswith(f"::{test_id}")
+            or test_id.endswith(f"::{exact_test_id}")
+        ]
+        if not matching:
+            raise ValueError(f"Rust lifecycle record is not tied to a completed test: {exact_test_id}")
+        status, skipped = finished[matching[-1]]
+        record["executed"] = True
+        record["skipped"] = skipped
+        record["result"] = "pass" if status == "ok" else "fail"
+        records.append(record)
+    by_test = {record.get("exact_test_id") for record in records}
+    missing = expected - by_test
+    if missing:
+        raise ValueError(f"Rust test output has no record for: {sorted(missing)}")
+    if len(records) != len(by_test):
+        raise ValueError("Rust test output contains duplicate lifecycle records")
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    records = extract(args.test_output, args.manifest)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps({"schema_version": 1, "records": records}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mobile_lifecycle/test_aggregate_evidence.py
+++ b/scripts/mobile_lifecycle/test_aggregate_evidence.py
@@ -9,13 +9,60 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from aggregate_evidence import EvidenceError, aggregate
-from component_report import build_report
+try:
+    from .aggregate_evidence import EvidenceError, aggregate
+    from .component_report import build_report
+except ImportError:  # pragma: no cover - direct test execution
+    from aggregate_evidence import EvidenceError, aggregate
+    from component_report import build_report
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SOURCE_SHA = "0" * 40
 WORKFLOW_SHA = "1" * 40
+MANIFEST_ROOT = ROOT / "scripts" / "mobile_lifecycle" / "manifests"
+
+EVENTS = {
+    "ML-01": ["app_backgrounded"],
+    "ML-02": ["app_resumed"],
+    "ML-03": ["native_runtime_stopped", "native_runtime_started"],
+    "ML-04": ["physical_network_changed", "candidate_refresh_started"],
+    "ML-05": ["physical_network_changed", "candidate_refresh_started"],
+    "ML-06": ["vpn_permission_revoked", "bridge_detached"],
+    "ML-07": ["vpn_permission_granted", "native_runtime_started"],
+    "ML-08": ["activity_recreated", "bridge_attached"],
+    "ML-09": ["service_recreated", "native_runtime_started"],
+    "ML-10": ["bridge_detached", "bridge_attached"],
+    "ML-11": ["bridge_detached", "bridge_attached"],
+    "ML-12": ["control_disconnected", "control_reconnected"],
+    "ML-13": ["control_reconnected"],
+    "ML-14": ["candidate_refresh_started", "physical_network_changed"],
+    "ML-15": ["physical_network_changed", "candidate_refresh_started"],
+    "ML-16": ["relay_retained", "candidate_refresh_started", "direct_reconfirmed"],
+    "ML-17": ["candidate_refresh_started", "direct_reconfirmed"],
+    "ML-18": ["physical_network_changed", "physical_network_changed"],
+}
+
+IDENTITY_KEY = {
+    "ML-01": "event_loop_generation",
+    "ML-02": "event_loop_generation",
+    "ML-03": "runtime_incarnation",
+    "ML-04": "network_generation",
+    "ML-05": "network_generation",
+    "ML-06": "permission_request_id",
+    "ML-07": "permission_request_id",
+    "ML-08": "activity_incarnation",
+    "ML-09": "service_incarnation",
+    "ML-10": "bridge_incarnation",
+    "ML-11": "bridge_incarnation",
+    "ML-12": "control_connection_generation",
+    "ML-13": "control_connection_generation",
+    "ML-14": "candidate_epoch",
+    "ML-15": "socket_publication_generation",
+    "ML-16": "network_generation",
+    "ML-17": "network_generation",
+    "ML-18": "event_loop_generation",
+}
 
 
 class AggregateEvidenceTest(unittest.TestCase):
@@ -28,9 +75,9 @@ class AggregateEvidenceTest(unittest.TestCase):
                 component=component,
                 source_head_sha=SOURCE_SHA,
                 workflow_sha=WORKFLOW_SHA,
-                result="pass",
-                manifest_path=ROOT / "scripts" / "mobile_lifecycle" / "manifests" / f"{component}.json",
-                toolchain={"test_runner": "deterministic-unit-tests"},
+                manifest_path=MANIFEST_ROOT / f"{component}.json",
+                execution_records=self.actual_records(component),
+                toolchain={"test_runner": "fixture-actual-runner"},
             )
             (self.reports / f"{component}.json").write_text(
                 json.dumps(report), encoding="utf-8"
@@ -38,6 +85,46 @@ class AggregateEvidenceTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temp.cleanup()
+
+    def manifest_entries(self, component: str) -> list[dict[str, str]]:
+        value = json.loads(
+            (MANIFEST_ROOT / f"{component}.json").read_text(encoding="utf-8")
+        )
+        return value["scenarios"]
+
+    def actual_records(self, component: str) -> list[dict]:
+        contract = json.loads(
+            (ROOT / "contracts" / "mobile_lifecycle.json").read_text(encoding="utf-8")
+        )
+        required = {
+            scenario["id"]: scenario for scenario in contract["required_scenarios"]
+        }
+        records = []
+        for entry in self.manifest_entries(component):
+            scenario_id = entry["scenario_id"]
+            decision = required[scenario_id]["required_decision"]
+            key = IDENTITY_KEY[scenario_id]
+            old = {key: 1}
+            new = {key: 1 if scenario_id == "ML-18" else 2}
+            records.append(
+                {
+                    "scenario_id": scenario_id,
+                    "exact_test_id": entry["exact_test_id"],
+                    "executed": True,
+                    "skipped": False,
+                    "result": "pass",
+                    "events": EVENTS[scenario_id],
+                    "observed_old_identity": old,
+                    "observed_new_identity": new,
+                    "observed_decision": decision,
+                    "invariants": {
+                        invariant: True
+                        for invariant in required[scenario_id]["required_invariants"]
+                    },
+                    "execution_source": "fixture_actual_runner",
+                }
+            )
+        return records
 
     def load(self, component: str) -> dict:
         path = self.reports / f"{component}.json"
@@ -56,7 +143,89 @@ class AggregateEvidenceTest(unittest.TestCase):
     def test_valid_complete_evidence_passes(self) -> None:
         result = aggregate(self.reports, SOURCE_SHA, WORKFLOW_SHA)
         self.assertEqual(result["result"], "pass")
+        self.assertEqual(result["aggregate_artifact_id"], "mobile-lifecycle-aggregate")
         self.assertEqual(result["required_scenarios"], [f"ML-{i:02d}" for i in range(1, 19)])
+
+    def test_component_exit_zero_but_missing_ml15_is_rejected(self) -> None:
+        records = [
+            record
+            for record in self.actual_records("rust")
+            if record["scenario_id"] != "ML-15"
+        ]
+        with self.assertRaises(ValueError):
+            build_report(
+                root=ROOT,
+                component="rust",
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                manifest_path=MANIFEST_ROOT / "rust.json",
+                execution_records=records,
+                toolchain={"exit_status": 0},
+            )
+
+    def test_test_name_changed_is_rejected(self) -> None:
+        records = self.actual_records("rust")
+        records[0]["exact_test_id"] += "_renamed"
+        with self.assertRaises(ValueError):
+            build_report(
+                root=ROOT,
+                component="rust",
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                manifest_path=MANIFEST_ROOT / "rust.json",
+                execution_records=records,
+                toolchain={"test_runner": "fixture-actual-runner"},
+            )
+
+    def test_skipped_test_is_rejected(self) -> None:
+        records = self.actual_records("android_jvm")
+        records[0]["skipped"] = True
+        with self.assertRaises(ValueError):
+            build_report(
+                root=ROOT,
+                component="android_jvm",
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                manifest_path=MANIFEST_ROOT / "android_jvm.json",
+                execution_records=records,
+                toolchain={"test_runner": "fixture-actual-runner"},
+            )
+
+    def test_static_manifest_adds_fictional_scenario_is_rejected(self) -> None:
+        value = json.loads((MANIFEST_ROOT / "rust.json").read_text(encoding="utf-8"))
+        value["scenarios"].append(
+            {"scenario_id": "ML-99", "exact_test_id": "fictional::test"}
+        )
+        manifest = self.reports / "fictional-rust-manifest.json"
+        manifest.write_text(json.dumps(value), encoding="utf-8")
+        with self.assertRaises(ValueError):
+            build_report(
+                root=ROOT,
+                component="rust",
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                manifest_path=manifest,
+                execution_records=self.actual_records("rust"),
+                toolchain={"test_runner": "fixture-actual-runner"},
+            )
+
+    def test_duplicate_conflicting_test_record_is_rejected(self) -> None:
+        records = self.actual_records("rust")
+        duplicate = copy.deepcopy(
+            next(record for record in records if record["scenario_id"] == "ML-12")
+        )
+        duplicate["observed_decision"] = "stale_rejected"
+        records.append(duplicate)
+        with self.assertRaises(ValueError):
+            build_report(
+                root=ROOT,
+                component="rust",
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                manifest_path=MANIFEST_ROOT / "rust.json",
+                execution_records=records,
+                toolchain={"test_runner": "fixture-actual-runner"},
+            )
 
     def test_missing_flutter_report_fails(self) -> None:
         self.assertRejects(lambda: (self.reports / "flutter.json").unlink())

--- a/scripts/mobile_lifecycle/test_aggregate_evidence.py
+++ b/scripts/mobile_lifecycle/test_aggregate_evidence.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tamper tests for the fail-closed mobile lifecycle aggregate."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from aggregate_evidence import EvidenceError, aggregate
+from component_report import build_report
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_SHA = "0" * 40
+WORKFLOW_SHA = "1" * 40
+
+
+class AggregateEvidenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.reports = Path(self.temp.name)
+        for component in ("flutter", "android_jvm", "rust"):
+            report = build_report(
+                root=ROOT,
+                component=component,
+                source_head_sha=SOURCE_SHA,
+                workflow_sha=WORKFLOW_SHA,
+                result="pass",
+                manifest_path=ROOT / "scripts" / "mobile_lifecycle" / "manifests" / f"{component}.json",
+                toolchain={"test_runner": "deterministic-unit-tests"},
+            )
+            (self.reports / f"{component}.json").write_text(
+                json.dumps(report), encoding="utf-8"
+            )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def load(self, component: str) -> dict:
+        path = self.reports / f"{component}.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def save(self, component: str, value: dict) -> None:
+        (self.reports / f"{component}.json").write_text(
+            json.dumps(value), encoding="utf-8"
+        )
+
+    def assertRejects(self, mutate) -> None:  # noqa: N802 - unittest-style helper
+        mutate()
+        with self.assertRaises(EvidenceError):
+            aggregate(self.reports, SOURCE_SHA, WORKFLOW_SHA)
+
+    def test_valid_complete_evidence_passes(self) -> None:
+        result = aggregate(self.reports, SOURCE_SHA, WORKFLOW_SHA)
+        self.assertEqual(result["result"], "pass")
+        self.assertEqual(result["required_scenarios"], [f"ML-{i:02d}" for i in range(1, 19)])
+
+    def test_missing_flutter_report_fails(self) -> None:
+        self.assertRejects(lambda: (self.reports / "flutter.json").unlink())
+
+    def test_missing_android_report_fails(self) -> None:
+        self.assertRejects(lambda: (self.reports / "android_jvm.json").unlink())
+
+    def test_missing_rust_report_fails(self) -> None:
+        self.assertRejects(lambda: (self.reports / "rust.json").unlink())
+
+    def test_source_sha_mismatch_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("flutter")
+            report["source_head_sha"] = "2" * 40
+            self.save("flutter", report)
+
+        self.assertRejects(mutate)
+
+    def test_workflow_sha_mismatch_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("android_jvm")
+            report["workflow_sha"] = "2" * 40
+            self.save("android_jvm", report)
+
+        self.assertRejects(mutate)
+
+    def test_duplicate_component_artifact_fails(self) -> None:
+        self.assertRejects(lambda: (self.reports / "flutter-copy.json").write_text("{}"))
+
+    def test_extra_artifact_directory_fails(self) -> None:
+        self.assertRejects(lambda: (self.reports / "unexpected").mkdir())
+
+    def test_duplicate_component_identity_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("flutter")
+            report["component"] = "android_jvm"
+            self.save("flutter", report)
+
+        self.assertRejects(mutate)
+
+    def test_unknown_schema_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("rust")
+            report["schema_version"] = 99
+            self.save("rust", report)
+
+        self.assertRejects(mutate)
+
+    def test_empty_scenarios_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("flutter")
+            report["scenarios"] = []
+            self.save("flutter", report)
+
+        self.assertRejects(mutate)
+
+    def test_required_scenario_deferred_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("flutter")
+            report["scenarios"][0]["decision"] = "deferred"
+            self.save("flutter", report)
+
+        self.assertRejects(mutate)
+
+    def test_stale_result_falsely_marked_applied_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("flutter")
+            report["scenarios"][0]["decision"] = "applied"
+            self.save("flutter", report)
+
+        self.assertRejects(mutate)
+
+    def test_relay_retention_false_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("rust")
+            scenario = next(item for item in report["scenarios"] if item["scenario_id"] == "ML-16")
+            scenario["invariants"]["relay_retained_until_direct_commit"] = False
+            self.save("rust", report)
+
+        self.assertRejects(mutate)
+
+    def test_old_bridge_cleanup_falsely_accepted_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("android_jvm")
+            scenario = next(item for item in report["scenarios"] if item["scenario_id"] == "ML-11")
+            scenario["decision"] = "applied"
+            self.save("android_jvm", report)
+
+        self.assertRejects(mutate)
+
+    def test_conflicting_duplicate_scenario_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("rust")
+            duplicate = copy.deepcopy(next(item for item in report["scenarios"] if item["scenario_id"] == "ML-12"))
+            duplicate["decision"] = "stale_rejected"
+            report["scenarios"].append(duplicate)
+            self.save("rust", report)
+
+        self.assertRejects(mutate)
+
+    def test_conflicting_duplicate_identity_fails(self) -> None:
+        def mutate() -> None:
+            report = self.load("rust")
+            duplicate = copy.deepcopy(
+                next(item for item in report["scenarios"] if item["scenario_id"] == "ML-12")
+            )
+            duplicate["new_identity"]["control_connection_generation"] = 99
+            report["scenarios"].append(duplicate)
+            self.save("rust", report)
+
+        self.assertRejects(mutate)
+
+    def test_component_job_failure_fails(self) -> None:
+        with self.assertRaises(EvidenceError):
+            aggregate(
+                self.reports,
+                SOURCE_SHA,
+                WORKFLOW_SHA,
+                job_results={
+                    "flutter": "success",
+                    "android_jvm": "failure",
+                    "rust": "success",
+                },
+            )
+
+    def test_package_job_failure_fails(self) -> None:
+        with self.assertRaises(EvidenceError):
+            aggregate(
+                self.reports,
+                SOURCE_SHA,
+                WORKFLOW_SHA,
+                job_results={
+                    "flutter": "success",
+                    "android_jvm": "success",
+                    "rust": "success",
+                    "package": "failure",
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/mobile_lifecycle/test_contract.py
+++ b/scripts/mobile_lifecycle/test_contract.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Contract shape and fixed scenario IDs are regression-tested."""
+
+from __future__ import annotations
+
+import unittest
+
+from contract import load_contract
+
+
+class ContractTest(unittest.TestCase):
+    def test_canonical_contract_has_fixed_matrix(self) -> None:
+        contract = load_contract()
+        self.assertEqual(contract["schema_version"], 2)
+        self.assertEqual(contract["repository"], "yhan-sun/p2wlan")
+        self.assertEqual(contract["components"], ["flutter", "android_jvm", "rust"])
+        self.assertEqual(
+            [item["id"] for item in contract["required_scenarios"]],
+            [f"ML-{i:02d}" for i in range(1, 19)],
+        )
+        self.assertNotIn("deferred", contract["outcomes"])
+        self.assertIn("deferred", contract["forbidden_outcomes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/mobile_lifecycle/test_contract.py
+++ b/scripts/mobile_lifecycle/test_contract.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import unittest
 
-from contract import load_contract
+try:
+    from .contract import load_contract
+except ImportError:  # pragma: no cover - direct test execution
+    from contract import load_contract
 
 
 class ContractTest(unittest.TestCase):

--- a/scripts/mobile_lifecycle/test_execution_records.py
+++ b/scripts/mobile_lifecycle/test_execution_records.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit tests for machine-output to lifecycle-record adapters."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from .android_junit_records import extract as extract_android
+    from .flutter_machine_records import extract as extract_flutter
+    from .rust_test_records import extract as extract_rust
+except ImportError:  # pragma: no cover - direct test execution
+    from android_junit_records import extract as extract_android
+    from flutter_machine_records import extract as extract_flutter
+    from rust_test_records import extract as extract_rust
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFESTS = ROOT / "scripts" / "mobile_lifecycle" / "manifests"
+
+
+def marker(scenario_id: str, exact_test_id: str) -> str:
+    return json.dumps(
+        {
+            "scenario_id": scenario_id,
+            "exact_test_id": exact_test_id,
+            "events": ["bridge_attached"],
+            "observed_old_identity": {"bridge_incarnation": 1},
+            "observed_new_identity": {"bridge_incarnation": 2},
+            "observed_decision": "applied",
+            "invariants": {"bridge_identity_adopted": True},
+            "execution_source": "test",
+        },
+        separators=(",", ":"),
+    )
+
+
+def entries(component: str) -> list[dict[str, str]]:
+    value = json.loads(
+        (MANIFESTS / f"{component}.json").read_text(encoding="utf-8")
+    )
+    return value["scenarios"]
+
+
+class ExecutionRecordAdapterTest(unittest.TestCase):
+    def test_flutter_machine_output_binds_print_to_completed_test(self) -> None:
+        output = []
+        exact_id = next(
+            entry["exact_test_id"]
+            for entry in entries("flutter")
+            if entry["scenario_id"] == "ML-10"
+        )
+        for test_number, entry in enumerate(entries("flutter"), 1):
+            test_id = entry["exact_test_id"]
+            name = test_id.split("::", 1)[1]
+            output.extend(
+                [
+                    json.dumps(
+                        {
+                            "type": "testStart",
+                            "test": {
+                                "id": test_number,
+                                "name": name,
+                                "url": "package:p2wlan_flutter_client/test/mobile_lifecycle_evidence_test.dart",
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "print",
+                            "testID": test_number,
+                            "message": "MOBILE_LIFECYCLE_RECORD "
+                            + marker(entry["scenario_id"], test_id),
+                        }
+                    ),
+                    json.dumps(
+                        {"type": "testDone", "testID": test_number, "result": "success"}
+                    ),
+                ]
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "flutter-machine.json"
+            path.write_text("\n".join(output) + "\n", encoding="utf-8")
+            records = extract_flutter(path, MANIFESTS / "flutter.json")
+        record = next(record for record in records if record["exact_test_id"] == exact_id)
+        self.assertTrue(record["executed"])
+        self.assertFalse(record["skipped"])
+        self.assertEqual(record["result"], "pass")
+
+    def test_android_junit_output_binds_system_out_to_method(self) -> None:
+        exact_id = next(
+            entry["exact_test_id"]
+            for entry in entries("android_jvm")
+            if entry["scenario_id"] == "ML-10"
+        )
+        testcases = []
+        for entry in entries("android_jvm"):
+            classname, name = entry["exact_test_id"].split("#", 1)
+            testcases.append(
+                f'''  <testcase classname="{classname}" name="{name}">
+    <system-out><![CDATA[MOBILE_LIFECYCLE_RECORD {marker(entry["scenario_id"], entry["exact_test_id"])}]]></system-out>
+  </testcase>'''
+            )
+        xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns="urn:test" tests="1" failures="0" errors="0" skipped="0">
+{chr(10).join(testcases)}
+</testsuite>
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "TEST-MobileLifecycle.xml").write_text(xml, encoding="utf-8")
+            records = extract_android(root, MANIFESTS / "android_jvm.json")
+        record = next(record for record in records if record["exact_test_id"] == exact_id)
+        self.assertEqual(record["result"], "pass")
+
+    def test_rust_output_handles_nocapture_marker_before_harness_status(self) -> None:
+        exact_id = next(
+            entry["exact_test_id"]
+            for entry in entries("rust")
+            if entry["scenario_id"] == "ML-10"
+        )
+        output = ""
+        for entry in entries("rust"):
+            output += (
+                f"test {entry['exact_test_id']} ... MOBILE_LIFECYCLE_RECORD "
+                f"{marker(entry['scenario_id'], entry['exact_test_id'])}\n"
+                "ok\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "rust-output.log"
+            path.write_text(output, encoding="utf-8")
+            records = extract_rust(path, MANIFESTS / "rust.json")
+        record = next(record for record in records if record["exact_test_id"] == exact_id)
+        self.assertEqual(record["result"], "pass")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #24

This Draft closes the deterministic mobile lifecycle blockers across Flutter, Android, JNI/Rust, and the daemon control/path boundaries while retaining one Rust-owned lifecycle and network authority.

- Adds the schema-versioned canonical contract at `contracts/mobile_lifecycle.json` with the exact lifecycle vocabulary, identity fields, outcomes, component ownership, and ML-01..ML-18 scenarios.
- Adds owner/generation fences for Flutter app/event-loop/daemon identities, Android Activity/Engine/permission/Service/bridge/restart identities, Rust JNI runtime/socket ownership, control WebSocket reconnects, candidate/socket publications, and current-generation Direct validation.
- Wires Android `NetworkCallback` through the owner-scoped JNI `nativeNotifyPhysicalNetworkChanged` path into Rust's existing transport/network authority. Kotlin does not create a second path state machine.
- Retains a confirmed Relay while Direct rediscovery is in progress or times out.
- Adds same-PID runtime-incarnation identity, deterministic component manifests, actual-test-derived schema-2 reports, fail-closed aggregation, and the stable required check name `Mobile Lifecycle Required`.
- Merges the accepted NAT first-usable fix from Issue #56 into this branch with an ordinary no-ff merge.

## Root causes closed

1. Android physical-network callbacks stopped at Kotlin state. The service now passes its service owner, expected bridge owner, Kotlin network generation, and network identity hash to the native owner-scoped JNI method. Rust rejects stale service/bridge/generation owners, classifies repeats as `duplicate`, advances the authoritative network epoch exactly once, invalidates old socket publication, and rebinds the existing Android UDP, Relay, and control transports.
2. Android embedded-runtime replacement reused the PID. Diagnostics identity now carries additive `runtime_incarnation`; a new bridge/runtime accepts the same PID with lower revision and uptime, while late snapshots from the retired incarnation are rejected.
3. Flutter had independent event-loop generation invalidation. StatusStore delegates to MobileLifecycleCoordinator's single invalidation API. Background/resume, auto-refresh disable/enable, settings/URL and bridge changes, daemon replacement, and dispose share that fence; stale completions cannot re-arm polling or create a microtask spin.
4. Evidence previously could be satisfied by component-wide fan-out. Component reports now bind every manifest scenario to a real executed test record and reject missing, renamed, skipped, failed, fictional, duplicated, or conflicting records. The aggregate is fail-closed.

## Source identity

- Original PR base: `49aa2f1ce4e5a3555c157a76a1494414168bbea5`
- Accepted Issue #56 NAT source: `548ea9331c2bb96e86e7fae1f35a5e16dc2997e7`
- `origin/main` merged: `d0e9cab7284cbc248c848826218fba8e16b12c82`
- Merge commit / local SHA / remote branch SHA / PR head SHA: `4b7bedbca84daaba323289c13b126d225c0cb57b`
- Merge parents: `aba69fd746e31e640119e6be984d43102bc8bd47` and `d0e9cab7284cbc248c848826218fba8e16b12c82`
- Branch: `feat/mobile-lifecycle-closure-20260903`
- All final Actions runs below checked out source head `4b7bedbca84daaba323289c13b126d225c0cb57b`.
- Mobile component report `workflow_sha`: `713869321af1fa7c72257e4d365287026b1ab22a`
- NAT aggregate `workflow_sha`: `518e4c7d6a190fcc75657cdee86b7b640bfbab84`

Workflow-file blob SHAs at the final source head:

- Mobile Lifecycle `62e545555e46d36531204b67701b92fbb66bff6c`
- NAT Topology Gate `518e4c7d6a190fcc75657cdee86b7b640bfbab84`
- Path State Machine `9bc348c41301179fcd80a856f9b98f72d30a88f0`
- DPLPMTUD Required `40bb4c48aac1132159a3c2fa405ae2067721b364`
- Business MTU Budget Required `6635f33dfaf3f71901f91257dea113939485f43c`
- CI `cab5503eb845e37a196a1c0f4c9a79d8ab3662d0`
- Flutter Client `6aef0bb6e896af65b468a53f6ec73cb1c199b2bb`
- Package Test Builds `b58908655ed232efc65af98a61d1a207efe20f25`
- Security Audit `89c136ab23441fc5fae7359bb0317d684a5fb6d0`
- Windows Lifecycle `4f17a82abe4278780cb59c27be033e2e3f04d4be`
- Path Observability `8e1735a187d8d8f167f34f410301a637bf7436fe`

## Mobile Lifecycle machine evidence

Final `Mobile Lifecycle` run: `33884398815` — `Mobile Lifecycle Required` success.

Aggregate artifact:

- ID `9941884378`, name `mobile-lifecycle-aggregate`
- artifact digest `sha256:c20755b88a29b1f0014385f0cf19462d4fc101940ac4ef73fd03ad148127599b`
- schema 2, result `pass`, 18 required scenarios
- aggregate source head `4b7bedbca84daaba323289c13b126d225c0cb57b`

Component artifacts and execution records:

- Flutter: artifact `9941241369`, digest `sha256:71af3e232b7e576a3fd1eb568229f5b4a6321bd0aaf4f02e0a5aa5c7f9d2b6c6`; 9 records from Flutter machine reporter.
- Android JVM: artifact `9941876224`, digest `sha256:35340acb8181e7d5cbef76a0eebef25d81e258373115b97da2386ba40f250fe2`; 10 records from Android JUnit XML.
- Rust: artifact `9941741908`, digest `sha256:53d68553ffc162a99bd0ba5449e57f8480c1d852dc74005b85dab805bc03f9b9`; 12 records from the dedicated Rust test commands and `--nocapture` scenario records.
- Android package identity: artifact `9941824443`, digest `sha256:b8f6f8b70ed13fe639178fc15a1ef2c60ed9b2903c599a51501522e35dd5b570`.
- Every component record has `executed=true`, `skipped=false`, `result=pass`, observed old/new identity, observed decision, and invariants. Manual device matrix is explicitly `not_run`, `required=false`, `blocking=false` and is outside this aggregate.

Every ML scenario below is bound to the following real executed test record(s); all records are pass with the stated observed decision:

| Scenario | Exact executed test ID(s) | Decision |
| --- | --- | --- |
| ML-01 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-01 app-background-late-long-poll` | `stale_rejected` |
| ML-02 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-02 app-resume-refresh-before-reconnect` | `applied` |
| ML-03 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-03 daemon-process-recreation`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl03DaemonProcessRecreation`; `tests::mobile_lifecycle_evidence::ml03_runtime_owner_replacement` | `applied` |
| ML-04 | `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl04WifiToCellularHandoff`; `tests::mobile_lifecycle_evidence::ml04_android_network_hint` | `applied` |
| ML-05 | `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl05CellularToWifiHotspotHandoff`; `tests::mobile_lifecycle_evidence::ml05_hotspot_network_hint` | `applied` |
| ML-06 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-06 vpn-permission-revoke`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl06VpnPermissionRevoke` | `stale_rejected` |
| ML-07 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-07 vpn-permission-regrant`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl07VpnPermissionRegrant` | `applied` |
| ML-08 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-08 activity-engine-recreation`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl08ActivityEngineRecreation` | `stale_rejected` |
| ML-09 | `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl09ServiceRecreation` | `applied` |
| ML-10 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-10 native-bridge-reattachment`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl10BridgeReattachment`; `lifecycle::tests::evidence_ml10_bridge_incarnation_adoption` | `applied` |
| ML-11 | `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl11OldBridgeTeardown`; `lifecycle::tests::evidence_ml11_old_bridge_cleanup` | `stale_rejected` |
| ML-12 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-12 control-websocket-reconnect`; `control::websocket::route_tests::evidence_ml12_control_reconnect` | `applied` |
| ML-13 | `control::websocket::route_tests::evidence_ml13_stale_control_message` | `stale_rejected` |
| ML-14 | `tests::mobile_lifecycle_evidence::ml14_stale_candidate_result` | `stale_rejected` |
| ML-15 | `tests::mobile_lifecycle_evidence::ml15_stale_socket_publication` | `stale_rejected` |
| ML-16 | `tests::mobile_lifecycle_evidence::ml16_relay_retention` | `applied` |
| ML-17 | `tests::mobile_lifecycle_evidence::ml17_direct_current_generation` | `applied` |
| ML-18 | `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-18 duplicate-events-idempotent`; `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl18DuplicateEvents`; `lifecycle::tests::physical_network_hint_is_owner_scoped_and_exactly_once` | `duplicate` |

Tamper coverage includes component exit 0 with missing ML-15, renamed test ID, skipped test, fictional manifest scenario, duplicate conflicting test record, missing component reports, workflow SHA mismatch, and conflicting scenario/identity records. The dedicated mobile evidence test suite ran 28 tests and passed.

## Required polling and lifecycle tests

- Disable/enable, one generation, exactly one replacement long poll, stale completion rejected without microtask spin, and dispose cannot restart: `apps/flutter_client/test/status_store_test.dart::one event-loop generation fences disable/enable and dispose without a spin` and `apps/flutter_client/test/status_store_test.dart::disposed store cannot restart polling`.
- Background/resume idempotence and refresh-before-reconnect: `apps/flutter_client/test/status_store_test.dart::mobile lifecycle stops background event polling and revalidates on resume` and `apps/flutter_client/test/status_store_test.dart::rapid background/resume callbacks are idempotent at one lifecycle fence`.
- Same-PID runtime replacement with PID `1234`, bridge/runtime 4 revision 50 to 5 revision 1, lower uptime accepted, then late bridge/runtime 4 revision 51 rejected: `tests::mobile_lifecycle_evidence::ml03_runtime_owner_replacement`, `apps/flutter_client/test/mobile_lifecycle_evidence_test.dart::ML-03 daemon-process-recreation`, and `lifecycle::tests::evidence_ml10_bridge_incarnation_adoption`.
- Android callback -> JNI -> Rust production-path generation test: `com.example.p2wlan_flutter_client.MobileLifecycleCoordinatorTest#evidenceMl04WifiToCellularHandoff`, `#evidenceMl05CellularToWifiHotspotHandoff`, `#evidenceMl18DuplicateEvents`, `tests::mobile_lifecycle_evidence::ml04_android_network_hint`, `tests::mobile_lifecycle_evidence::ml05_hotspot_network_hint`, `lifecycle::tests::physical_network_hint_is_owner_scoped_and_exactly_once`, and `udp_direct_tests::android_network_hint_rebinds_udp_once_and_supersedes_old_publication`.

## Local validation

- Rust: `cargo fmt --all -- --check`, workspace check, clippy with `-D warnings`, and full `cargo test --workspace --all-features`; 27 result groups, 1,746 passed, 0 failed, 0 ignored.
- Python: NAT simulator tests 29 passed; mobile lifecycle/evidence tests 28 passed; required-check contract pass with 56 declared checks and no findings.
- Flutter 3.47.2: pub get, format, analyze, full `flutter test --machine`, and mobile lifecycle regression 3 rounds × 55 tests = 165 passes; Flutter component report 9/9 pass.
- Android JVM: Gradle 9.1.0 `:app:testDebugUnitTest --rerun-tasks`; 31 JUnit tests, 0 failures/errors/skips; 10/10 mapped component records pass.
- Android package and Rust component report validations pass. `git diff --check` passes.

## NAT #56 final evidence

The accepted NAT fix is present through merge source `548ea9331c2bb96e86e7fae1f35a5e16dc2997e7`, merged into `origin/main` at `d0e9cab7284cbc248c848826218fba8e16b12c82`.

Exactly one final NAT workflow dispatch was run on the final source head:

- NAT Topology Gate run `33886069505`, source `4b7bedbca84daaba323289c13b126d225c0cb57b`.
- Direct cold-start: pass; Relay blackhole 1/5, 2/5, 3/5, 4/5, and 5/5: all pass; fail-closed injection: pass; required aggregate: pass.
- Aggregate job `101067000432`; aggregate artifact ID `9941991855`, artifact digest `sha256:59ad2ebdf844d0a0492f78e6a3b94cbe14e330ccfd05e3aba65006ef59a6b7e7`.
- NAT JSON aggregate digest `sha256:9d49772a2c740284db3684b33531afaf7863d9c7552a2627eb1fc1ee5176f827`; 6 actual records (Direct plus five Relay replicas), result `pass`.

The earlier PR-triggered NAT run `33884398717` had one actual Relay 5/5 `relay_confirmation_missing` result, which caused the PR-only external-gate failures in the initial DPLPMTUD, Path State Machine, and Business MTU runs. The exact-head NAT dispatch above passed, and the three dependent exact-head dispatches below passed; no final claim relies on the superseded failure.

## Final workflow runs

All runs below are on source head `4b7bedbca84daaba323289c13b126d225c0cb57b` and completed success:

| Workflow | Run ID |
| --- | --- |
| Mobile Lifecycle | `33884398815` |
| NAT Topology Gate | `33886069505` |
| Path State Machine | `33887021669` |
| DPLPMTUD Required | `33887011570` |
| Business MTU Budget Required | `33887031685` |
| CI | `33884398809` |
| Flutter Client | `33884398725` |
| Package Test Builds | `33884398779` |
| Security Audit | `33884398735` |
| Windows Lifecycle | `33884398756` |
| Path Observability | `33884398720` |

## Manual matrix and operations intentionally not performed

`docs/mobile-lifecycle-device-matrix.md` records Android API 24+, iOS 15+, Doze/OEM restrictions, handoffs, permission revoke/regrant, process recreation, upgrade, captive portal, and IPv4/IPv6 rows as `not_run`; they are nonblocking and not executed.

No new Mobile Lifecycle PR was created. PR #55 remains Draft. No merge of PR #55, force-push, rebase, reset, cherry-pick, issue closure for #24, tag, release, publish, signing/settings change, or reopening of #56 was performed.

## PR NAT context recovery

The same PR-triggered NAT workflow 33884398717 completed successfully at attempt 4 after all Direct and Relay artifact-producing jobs ran together. Its final PR aggregate job is 101081950589; aggregate artifact ID is 9943772634 with artifact digest sha256:e204668344f9b573f1e2a27c397950962717ebb7da319bef8a7150c9682d669d. Its JSON aggregate digest is sha256:9d49772a2c740284db3684b33531afaf7863d9c7552a2627eb1fc1ee5176f827, source head is 4b7bedbca84daaba323289c13b126d225c0cb57b, and all six actual records pass. The failed attempts were superseded by this successful full-artifact attempt; no additional NAT workflow dispatch was made.

The explicit Flutter same-PID assertion exact ID is apps/flutter_client/test/status_store_test.dart::same PID runtime replacement accepts lower revision then rejects late old snapshot; it covers PID 1234, runtime 4/revision 50 -> runtime 5/revision 1, then late runtime 4/revision 51 as stale_rejected.