### PR TITLE
fix: stabilize NAT first-usable relay evidence

### DIFF
--- a/.github/workflows/nat-topology-gate.yml
+++ b/.github/workflows/nat-topology-gate.yml
@@ -68,6 +68,10 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
+          # The component record is consumed by the exact-head aggregate.
+          # Do not let pull_request's synthetic merge ref become its source
+          # identity.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.26.6"
@@ -77,6 +81,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
       - name: Run deterministic Direct topology
+        env:
+          NAT_TOPOLOGY_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: bash scripts/nat-sim/run-ci-topology.sh direct
       - name: Upload Direct evidence
         if: always()
@@ -173,10 +179,79 @@ jobs:
     if: always()
     needs: [unit, direct, relay]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Enforce required topology results
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify exact aggregate source head
+        id: identity
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          test "${{ needs.unit.result }}" = "success"
-          test "${{ needs.direct.result }}" = "success"
-          test "${{ needs.relay.result }}" = "success"
-          echo "all required NAT topology profiles succeeded"
+          set -euo pipefail
+          actual_head_sha="$(git rev-parse HEAD)"
+          test "$actual_head_sha" = "$EXPECTED_HEAD_SHA"
+          workflow_sha="$(git rev-parse "$actual_head_sha:.github/workflows/nat-topology-gate.yml")"
+          {
+            echo "source_head_sha=$actual_head_sha"
+            echo "workflow_sha=$workflow_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download Direct component evidence
+        id: download_direct
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: nat-topology-direct-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/nat-topology-evidence/direct
+          merge-multiple: false
+
+      - name: Download Relay component evidence
+        id: download_relay
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}-*-of-5
+          path: ${{ runner.temp }}/nat-topology-evidence/relay
+          merge-multiple: false
+
+      - name: Build actual-execution NAT aggregate
+        id: aggregate
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 scripts/nat-sim/aggregate_evidence.py \
+            --input-root "$RUNNER_TEMP/nat-topology-evidence" \
+            --source-head-sha "${{ steps.identity.outputs.source_head_sha }}" \
+            --workflow-sha "${{ steps.identity.outputs.workflow_sha }}" \
+            --output "$RUNNER_TEMP/nat-topology-aggregate.json"
+
+      - name: Upload actual-execution NAT aggregate
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: nat-topology-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/nat-topology-aggregate.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Enforce required topology results and aggregate
+        env:
+          UNIT_RESULT: ${{ needs.unit.result }}
+          DIRECT_RESULT: ${{ needs.direct.result }}
+          RELAY_RESULT: ${{ needs.relay.result }}
+          DOWNLOAD_DIRECT_OUTCOME: ${{ steps.download_direct.outcome }}
+          DOWNLOAD_RELAY_OUTCOME: ${{ steps.download_relay.outcome }}
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+        run: |
+          set -euo pipefail
+          test "$UNIT_RESULT" = "success"
+          test "$DIRECT_RESULT" = "success"
+          test "$RELAY_RESULT" = "success"
+          test "$DOWNLOAD_DIRECT_OUTCOME" = "success"
+          test "$DOWNLOAD_RELAY_OUTCOME" = "success"
+          test "$AGGREGATE_OUTCOME" = "success"
+          echo "all required NAT topology profiles and actual-execution evidence passed"

--- a/client/daemon/src/connection_timeline.rs
+++ b/client/daemon/src/connection_timeline.rs
@@ -20,7 +20,7 @@
 //!   TCP connect, writer completion, nor metrics is business evidence;
 //! - `direct_promoted` still requires the existing encrypted validation chain.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -34,6 +34,13 @@ use tracing::{debug, info};
 /// though the structured counters still retained them. Keep the ring bounded,
 /// but large enough to correlate a burst, handshake, retries, and teardown.
 pub const TIMELINE_MAX_EVENTS: usize = 512;
+
+/// Additive schema for the durable first-usable evidence ledger. The ordinary
+/// timeline is intentionally a bounded ring and may evict the transition that
+/// proved usability; this summary remains available to `/status` after that
+/// eviction and carries the status revision fence used by the NAT harness.
+pub const FIRST_USABLE_SUMMARY_SCHEMA_VERSION: u32 = 1;
+pub const FIRST_USABLE_SUMMARY_MAX_ENTRIES: usize = 1024;
 
 /// One recorded timeline event (serializable, bounded).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,6 +69,55 @@ pub struct ConnectionTimelineEvent {
     pub relay_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relay_region: Option<String>,
+    /// The monotonic status-event sequence assigned at the same commit. A
+    /// missing value means this timeline is running without a status event bus
+    /// (standalone/unit mode), never that a production transition has an
+    /// unknown revision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_revision: Option<u64>,
+}
+
+/// Persistent, per-peer/per-network-generation first-usable commit summary.
+///
+/// This is written only after the authoritative peer state has accepted a
+/// real authenticated business ingress. Relay confirmation, socket readiness,
+/// queue acceptance, and writer completion are represented separately and
+/// cannot create one of these records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstUsableEvidenceSummary {
+    pub schema_version: u32,
+    pub peer_id: String,
+    pub path: String,
+    pub network_generation: u64,
+    pub first_usable_at_ms: u64,
+    /// Status-event revision assigned to the `first_usable_path` commit. Zero
+    /// means the timeline is used without an attached status event bus (unit
+    /// tests and standalone diagnostics fixtures).
+    #[serde(default)]
+    pub transition_revision: u64,
+    /// The closest same-peer/same-generation relay-ready commit known to the
+    /// process-local timeline. It is optional because a long-running daemon
+    /// may have evicted the ready event before the first-usable commit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_ready_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_usable_delta_ms: Option<u64>,
+    /// Business evidence dimensions are explicit so a collector cannot treat
+    /// `relay_connected` or `relay_peer_confirmed` as first usability.
+    #[serde(default)]
+    pub business_sent: bool,
+    #[serde(default)]
+    pub business_received: bool,
+    #[serde(default)]
+    pub business_exchange: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_connection_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
+    /// Stable producer label; kept additive for machine evidence audits.
+    pub source: String,
 }
 
 /// Bounded, serializable snapshot exposed by diagnostics `/status`.
@@ -71,6 +127,10 @@ pub struct ConnectionTimelineDiagnostics {
     pub run_id: Option<String>,
     pub correlation_id: String,
     pub events: Vec<ConnectionTimelineEvent>,
+    /// Persistent first-usable summaries are not subject to the event-ring
+    /// eviction window.
+    #[serde(default)]
+    pub first_usable_summaries: Vec<FirstUsableEvidenceSummary>,
 }
 
 /// Structured INFO timeline emitter shared across daemon subsystems.
@@ -79,6 +139,10 @@ pub struct ConnectionTimeline {
     correlation_id: String,
     started_at: Instant,
     events: Mutex<VecDeque<ConnectionTimelineEvent>>,
+    first_usable_summaries: Mutex<VecDeque<FirstUsableEvidenceSummary>>,
+    /// Same-peer/same-generation relay-ready times used to compute a local
+    /// delta even when the ready event later leaves the bounded event ring.
+    relay_ready_at_ms: Mutex<HashMap<(String, u64), u64>>,
     /// Events that must be emitted at most once per scope.  The scope is a
     /// stable string (`""` for process-level milestones, `peer:<id>:<generation>`
     /// for per-peer + generation milestones), so a first-milestone can never be
@@ -115,6 +179,8 @@ impl ConnectionTimeline {
             correlation_id,
             started_at: Instant::now(),
             events: Mutex::new(VecDeque::new()),
+            first_usable_summaries: Mutex::new(VecDeque::new()),
+            relay_ready_at_ms: Mutex::new(HashMap::new()),
             first_events: Mutex::new(HashSet::new()),
             status_events: Mutex::new(None),
             control_registration_count: AtomicU64::new(0),
@@ -151,7 +217,7 @@ impl ConnectionTimeline {
         path: Option<&str>,
         reason_code: Option<&str>,
         detail: Option<String>,
-    ) -> u64 {
+    ) -> (u64, u64) {
         let at_ms = self.started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
         if event == "control_registered" {
             self.control_registration_count
@@ -161,43 +227,67 @@ impl ConnectionTimeline {
             .as_deref()
             .map(parse_detail_fields)
             .unwrap_or_default();
-        // Captured before `fields.peer_id` is moved into the timeline event, so
-        // the diagnostics mirror below can use it without a use-after-move.
-        let mirror_peer_id = fields.peer_id.clone();
-        {
-            let mut events = self
-                .events
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            events.push_back(ConnectionTimelineEvent {
-                run_id: self.run_id.clone(),
-                event: event.to_string(),
-                at_ms,
-                path: path.map(str::to_string),
-                reason_code: reason_code.map(str::to_string),
-                detail: detail.clone(),
-                peer_id: fields.peer_id,
-                connection_generation: fields.connection_generation,
-                path_id: fields.path_id.or_else(|| path.map(str::to_string)),
-                relay_id: fields.relay_id,
-                relay_region: fields.relay_region,
-            });
-            while events.len() > TIMELINE_MAX_EVENTS {
-                events.pop_front();
+        if event == "relay_transport_ready_peer" {
+            if let (Some(peer_id), Some(generation)) =
+                (fields.peer_id.as_ref(), fields.connection_generation)
+            {
+                let mut ready_times = self
+                    .relay_ready_at_ms
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                ready_times.insert((peer_id.clone(), generation), at_ms);
+                while ready_times.len() > FIRST_USABLE_SUMMARY_MAX_ENTRIES {
+                    let Some(oldest_key) = ready_times
+                        .iter()
+                        .min_by_key(|(_, timestamp)| **timestamp)
+                        .map(|(key, _)| key.clone())
+                    else {
+                        break;
+                    };
+                    ready_times.remove(&oldest_key);
+                }
             }
         }
-        // Mirror to the diagnostics status event bus (single choke point that
-        // covers all timeline emits). Best-effort: a detached timeline (no bus)
-        // or a transient lock failure must never break the dataplane.
-        if let Some(bus) = self
+        // Hold the event-ring lock while assigning the status sequence so
+        // concurrent producers cannot make the ring order disagree with the
+        // `/events` cursor order.
+        let mirror_peer_id = fields.peer_id.clone();
+        let mut events = self
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let revision = if let Some(bus) = self
             .status_events
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .as_ref()
         {
-            bus.record(event, at_ms, path, reason_code, mirror_peer_id.as_deref());
+            bus.record(event, at_ms, path, reason_code, mirror_peer_id.as_deref())
+        } else {
+            0
+        };
+        events.push_back(ConnectionTimelineEvent {
+            run_id: self.run_id.clone(),
+            event: event.to_string(),
+            at_ms,
+            path: path.map(str::to_string),
+            reason_code: reason_code.map(str::to_string),
+            detail: detail.clone(),
+            peer_id: fields.peer_id,
+            connection_generation: fields.connection_generation,
+            path_id: fields.path_id.or_else(|| path.map(str::to_string)),
+            relay_id: fields.relay_id,
+            relay_region: fields.relay_region,
+            transition_revision: (revision != 0).then_some(revision),
+        });
+        while events.len() > TIMELINE_MAX_EVENTS {
+            events.pop_front();
         }
-        at_ms
+        drop(events);
+        // A detached timeline (no bus) intentionally returns revision zero;
+        // that value is omitted from the serialized event in standalone/unit
+        // mode rather than being mistaken for a production cursor.
+        (at_ms, revision)
     }
 
     /// Number of control-plane reconnects observed after the initial
@@ -219,7 +309,7 @@ impl ConnectionTimeline {
         reason_code: Option<&str>,
         detail: Option<String>,
     ) {
-        let at_ms = self.record_event(event, path, reason_code, detail.clone());
+        let (at_ms, _) = self.record_event(event, path, reason_code, detail.clone());
         info!(
             event = event,
             run_id = ?self.run_id,
@@ -331,6 +421,103 @@ impl ConnectionTimeline {
         self.emit_first_scoped("", event, path, reason_code, detail)
     }
 
+    /// Record the durable first-usable summary and its event-ring milestone as
+    /// one deduplicated commit. Callers must invoke this only after the
+    /// authoritative PeerConnection state transition returned `true`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn emit_first_usable(
+        &self,
+        peer_id: &str,
+        generation: u64,
+        path: &str,
+        reason_code: Option<&str>,
+        detail: Option<String>,
+        business_sent: bool,
+        business_received: bool,
+        business_exchange: bool,
+        relay_id: Option<&str>,
+        relay_connection_id: Option<u64>,
+    ) -> bool {
+        let scope = format!("peer:{peer_id}:{generation}");
+        let mut firsts = self
+            .first_events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !firsts.insert((scope, "first_usable_path:first_usable_path".to_string())) {
+            return false;
+        }
+        drop(firsts);
+
+        let fields = detail
+            .as_deref()
+            .map(parse_detail_fields)
+            .unwrap_or_default();
+        let (at_ms, transition_revision) =
+            self.record_event("first_usable_path", Some(path), reason_code, detail.clone());
+        let ready_key = (peer_id.to_string(), generation);
+        let relay_ready_at_ms = self
+            .relay_ready_at_ms
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&ready_key)
+            .copied();
+        let first_usable_delta_ms = relay_ready_at_ms
+            .filter(|ready_at_ms| at_ms >= *ready_at_ms)
+            .map(|ready_at_ms| at_ms.saturating_sub(ready_at_ms));
+        let summary = FirstUsableEvidenceSummary {
+            schema_version: FIRST_USABLE_SUMMARY_SCHEMA_VERSION,
+            peer_id: peer_id.to_string(),
+            path: path.to_string(),
+            network_generation: generation,
+            first_usable_at_ms: at_ms,
+            transition_revision,
+            relay_ready_at_ms,
+            first_usable_delta_ms,
+            business_sent,
+            business_received,
+            business_exchange,
+            relay_id: relay_id.map(str::to_string).or(fields.relay_id),
+            relay_connection_id,
+            reason_code: reason_code.map(str::to_string),
+            source: "authoritative_business_ingress_commit".to_string(),
+        };
+        let mut summaries = self
+            .first_usable_summaries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        summaries.push_back(summary);
+        while summaries.len() > FIRST_USABLE_SUMMARY_MAX_ENTRIES {
+            summaries.pop_front();
+        }
+        drop(summaries);
+        info!(
+            event = "first_usable_path",
+            run_id = ?self.run_id,
+            corr_id = %self.correlation_id,
+            t_ms = at_ms,
+            path = path,
+            reason_code = reason_code,
+            peer_id = peer_id,
+            generation,
+            transition_revision,
+            business_sent,
+            business_received,
+            business_exchange,
+            "first_usable_path run_id={:?} corr_id={} t_ms={} peer_id={} generation={} path={} transition_revision={} business_sent={} business_received={} business_exchange={}",
+            self.run_id,
+            self.correlation_id,
+            at_ms,
+            peer_id,
+            generation,
+            path,
+            transition_revision,
+            business_sent,
+            business_received,
+            business_exchange,
+        );
+        true
+    }
+
     /// Serialize the bounded event ring for diagnostics.
     pub fn snapshot(&self) -> ConnectionTimelineDiagnostics {
         let events = self
@@ -344,6 +531,13 @@ impl ConnectionTimeline {
             run_id: self.run_id.clone(),
             correlation_id: self.correlation_id.clone(),
             events,
+            first_usable_summaries: self
+                .first_usable_summaries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .cloned()
+                .collect(),
         }
     }
 }
@@ -544,6 +738,99 @@ mod tests {
         assert_eq!(observed[0].path.as_deref(), Some("direct"));
         assert_eq!(observed[1].path.as_deref(), Some("relay"));
         assert_eq!(observed[1].relay_id.as_deref(), Some("relay.test"));
+    }
+
+    #[test]
+    fn first_usable_summary_is_revision_fenced_and_deduplicated() {
+        let timeline = ConnectionTimeline::new("node-a", 0);
+        timeline.set_status_event_bus(crate::diagnostics::StatusEventBus::new());
+        timeline.emit(
+            "relay_transport_ready_peer",
+            Some("relay"),
+            None,
+            Some(
+                "peer=node-b generation=7 relay_endpoint=relay.test relay_connection_id=12"
+                    .to_string(),
+            ),
+        );
+        assert!(timeline.emit_first_usable(
+            "node-b",
+            7,
+            "relay",
+            None,
+            Some("peer=node-b generation=7 ingress=relay:relay.test".to_string()),
+            true,
+            true,
+            true,
+            Some("relay.test"),
+            Some(12),
+        ));
+        assert!(!timeline.emit_first_usable(
+            "node-b",
+            7,
+            "relay",
+            None,
+            None,
+            true,
+            true,
+            true,
+            Some("relay.test"),
+            Some(12),
+        ));
+        let snapshot = timeline.snapshot();
+        assert_eq!(snapshot.first_usable_summaries.len(), 1);
+        let summary = &snapshot.first_usable_summaries[0];
+        assert_eq!(summary.schema_version, FIRST_USABLE_SUMMARY_SCHEMA_VERSION);
+        assert_eq!(summary.transition_revision, 2);
+        assert_eq!(
+            snapshot
+                .events
+                .iter()
+                .find(|event| event.event == "first_usable_path")
+                .and_then(|event| event.transition_revision),
+            Some(2)
+        );
+        let relay_ready_at_ms = summary.relay_ready_at_ms.expect("relay ready timestamp");
+        assert!(summary.first_usable_at_ms >= relay_ready_at_ms);
+        assert_eq!(
+            summary.first_usable_delta_ms,
+            Some(summary.first_usable_at_ms - relay_ready_at_ms)
+        );
+        assert!(summary.business_sent && summary.business_received && summary.business_exchange);
+    }
+
+    #[test]
+    fn first_usable_summary_survives_event_ring_eviction() {
+        let timeline = ConnectionTimeline::new("node-a", 0);
+        timeline.emit(
+            "relay_transport_ready_peer",
+            Some("relay"),
+            None,
+            Some("peer=node-b generation=9 relay_endpoint=relay.test".to_string()),
+        );
+        assert!(timeline.emit_first_usable(
+            "node-b",
+            9,
+            "relay",
+            None,
+            Some("peer=node-b generation=9 ingress=relay:relay.test".to_string()),
+            false,
+            true,
+            false,
+            Some("relay.test"),
+            None,
+        ));
+        for _ in 0..(TIMELINE_MAX_EVENTS + 8) {
+            timeline.emit("diagnostic_noise", None, None, None);
+        }
+        let snapshot = timeline.snapshot();
+        assert!(!snapshot
+            .events
+            .iter()
+            .any(|event| event.event == "first_usable_path"));
+        assert_eq!(snapshot.first_usable_summaries.len(), 1);
+        assert_eq!(snapshot.first_usable_summaries[0].peer_id, "node-b");
+        assert_eq!(snapshot.first_usable_summaries[0].network_generation, 9);
     }
 
     #[test]

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -10,6 +10,12 @@ use std::pin::Pin;
 type ControlEventWork<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
 const MAX_CONTROL_EVENT_SLOW_WORK: usize = 64;
+/// Initiator publication retries are latency-critical evidence producers. Keep
+/// them in a separate bounded cooperative lane so a roster burst of unrelated
+/// STUN/HTTP work cannot occupy every general slow-work slot until the retry
+/// ledger expires. This is still the existing control-event loop and the
+/// existing per-peer reservation/ledger; it is only a fairness boundary.
+const MAX_INITIATOR_RETRY_WORK: usize = 16;
 /// A roster burst may contain more peers than the cooperative slow-work lane
 /// can admit at once.  Do not silently lose the initiator handshake for the
 /// peers after that boundary: retain one newest-wins entry per peer and drain
@@ -2507,12 +2513,12 @@ impl Daemon {
     /// polled as part of the existing bounded slow-work lane.
     fn drain_initiator_retry_ledger<'a>(
         &'a self,
-        slow_work: &mut FuturesUnordered<ControlEventWork<'a>>,
+        retry_work: &mut FuturesUnordered<ControlEventWork<'a>>,
     ) {
         self.pending_handshakes
             .lock()
             .expire_initiator_retries(Instant::now());
-        while slow_work.len() < MAX_CONTROL_EVENT_SLOW_WORK {
+        while retry_work.len() < MAX_INITIATOR_RETRY_WORK {
             let claimed = self
                 .pending_handshakes
                 .lock()
@@ -2520,8 +2526,23 @@ impl Daemon {
             let Some((identity, reservation)) = claimed else {
                 break;
             };
+            self.timeline.emit(
+                "initiator_handshake_retry_claimed",
+                None,
+                None,
+                Some(format!(
+                    "peer={} owner={} generation={} peer_session_generation={} phase={} attempt={} cancellation_generation={}",
+                    identity.peer_id,
+                    identity.reservation_owner,
+                    identity.network_generation,
+                    identity.peer_session_generation.value(),
+                    identity.phase.as_str(),
+                    identity.attempt,
+                    identity.cancellation_generation,
+                )),
+            );
             let daemon = self;
-            slow_work.push(Box::pin(async move {
+            retry_work.push(Box::pin(async move {
                 daemon
                     .run_claimed_initiator_retry(identity, reservation)
                     .await;
@@ -2543,6 +2564,10 @@ impl Daemon {
         let mut control_rx = std::mem::replace(&mut self.control_rx, replacement_rx);
         let daemon: &Daemon = &*self;
         let mut slow_work: FuturesUnordered<ControlEventWork<'_>> = FuturesUnordered::new();
+        // Retries have a distinct bounded lane. A full general slow-work lane
+        // must never turn an already-prepared initiation into a lost first
+        // usable attempt.
+        let mut retry_work: FuturesUnordered<ControlEventWork<'_>> = FuturesUnordered::new();
         let mut deferred_initiators: InitiatorQueue<control::PeerInfo> = InitiatorQueue::new();
         // Keep responder answers out of the general slow-work budget. A
         // blocked candidate refresh or peer-reflexive HTTP task must not
@@ -2576,7 +2601,19 @@ impl Daemon {
                         // Completion frees a bounded slot. Admit the oldest still
                         // live deferred peer immediately instead of waiting for a
                         // later control poll.
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
+                        daemon
+                            .drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            );
+                    }
+                    _ = retry_work.next(), if !retry_work.is_empty() => {
+                        // A retry completion frees the exact prepared
+                        // initiation owner. Revisit both the retry ledger and
+                        // any deferred roster edge without waiting for an
+                        // unrelated control signal.
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -2589,7 +2626,7 @@ impl Daemon {
                         // completion can also free a pending initiator's
                         // reservation, so retry deferred roster work here even
                         // when the general slow-work lane is otherwise idle.
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -2597,7 +2634,7 @@ impl Daemon {
                             );
                     }
                     _ = candidate_work.next(), if !candidate_work.is_empty() => {
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -2609,7 +2646,7 @@ impl Daemon {
                             break;
                         }
                         handshake_retry_kick_rx.borrow_and_update();
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -2617,7 +2654,7 @@ impl Daemon {
                             );
                     }
                     _ = handshake_retry_tick.tick() => {
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -3733,7 +3770,7 @@ impl Daemon {
                         // in either cooperative lane. Revisit the newest
                         // deferred roster edge before waiting for another
                         // unrelated event.
-                        daemon.drain_initiator_retry_ledger(&mut slow_work);
+                        daemon.drain_initiator_retry_ledger(&mut retry_work);
                         daemon
                             .drain_deferred_initiator_handshakes(
                                 &mut slow_work,
@@ -3746,6 +3783,7 @@ impl Daemon {
         // Dropping these futures also releases any STUN/HTTP wait promptly on
         // daemon shutdown rather than leaving detached work behind.
         drop(slow_work);
+        drop(retry_work);
         drop(responder_work);
         drop(candidate_work);
         self.control_rx = control_rx;

--- a/client/daemon/src/lib/daemon/overlay_validate.rs
+++ b/client/daemon/src/lib/daemon/overlay_validate.rs
@@ -609,6 +609,19 @@ async fn send_overlay_payloads(
         }
         let virtual_ip = peer.virtual_ip.clone();
         let peer_id = peer.peer_id.clone();
+        // The strict Direct acceptance profile is a make-before-break proof:
+        // its first Direct business packet must not race ahead of the forced
+        // encrypted Relay confirmation.  This is an authoritative manager
+        // read, not a second path state machine and not a timing sleep.  The
+        // Relay-availability profile intentionally allows Relay immediately.
+        if !overlay_any_path
+            && peer.active_path() == Some(crate::peer::NetworkPath::Direct)
+            && !peers
+                .is_relay_peer_confirmed_for_generation(&peer_id, generation)
+                .await
+        {
+            continue;
+        }
         *next_nonce = next_nonce.wrapping_add(1);
         *next_seq = next_seq.wrapping_add(1);
         let payload = build_overlay_payload(OVERLAY_DIRECTION_REQUEST, *next_nonce, *next_seq);

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -312,6 +312,45 @@ impl PeerManager {
         }
     }
 
+    /// Record the first-usable milestone and the persistent machine-readable
+    /// summary at the same authoritative business-ingress commit. The caller
+    /// supplies the already-validated business dimensions; transport readiness
+    /// and relay confirmation alone cannot create this record.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn emit_timeline_first_usable(
+        &self,
+        peer_id: &str,
+        generation: u64,
+        path: &str,
+        reason_code: Option<&str>,
+        detail: Option<String>,
+        business_sent: bool,
+        business_received: bool,
+        business_exchange: bool,
+        relay_id: Option<&str>,
+        relay_connection_id: Option<u64>,
+    ) -> bool {
+        let timeline = self
+            .timeline
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        timeline.is_some_and(|timeline| {
+            timeline.emit_first_usable(
+                peer_id,
+                generation,
+                path,
+                reason_code,
+                detail,
+                business_sent,
+                business_received,
+                business_exchange,
+                relay_id,
+                relay_connection_id,
+            )
+        })
+    }
+
     /// Record dropped outbound business packets for a stable reason code so
     /// `/status` can report queue/startup-wait loss structurally.  Terminal
     /// loss only: a packet that was handed to a transport (even if the remote

--- a/client/daemon/src/peer/manager/relay.rs
+++ b/client/daemon/src/peer/manager/relay.rs
@@ -781,7 +781,15 @@ impl PeerManager {
                 )
             })
         });
-        let (confirmation_changed, pending_committed, exchange_confirmed, first_usable_recorded) = {
+        let (
+            confirmation_changed,
+            pending_committed,
+            exchange_confirmed,
+            first_usable_recorded,
+            first_business_sent,
+            first_business_received,
+            first_business_exchange,
+        ) = {
             let epoch_gate = self.network_epoch_gate();
             let Ok(_epoch_guard) = epoch_gate.try_lock() else {
                 self.emit_timeline_first(
@@ -909,7 +917,7 @@ impl PeerManager {
                 let pending_is_current = pending_evidence.as_ref().is_some_and(|evidence| {
                     self.pending_relay_business_evidence_is_exact(evidence, Instant::now())
                 });
-                let mut result = (false, false, false, false);
+                let mut result = (false, false, false, false, false, false, false);
                 let outcome = conn.commit_path_transition(
                     PathEvent::RelayPeerConfirmed {
                         relay: relay_identity,
@@ -997,11 +1005,20 @@ impl PeerManager {
                             first_usable_recorded =
                                 conn.record_first_usable(NetworkPath::Relay, generation);
                         }
+                        let first_business_sent = first_usable_recorded
+                            && conn.relay_first.business_sent_generation == Some(generation);
+                        let first_business_received = first_usable_recorded
+                            && conn.relay_first.business_received_generation == Some(generation);
+                        let first_business_exchange = first_usable_recorded
+                            && conn.relay_first.business_exchange_generation == Some(generation);
                         result = (
                             changed,
                             pending_committed,
                             exchange_confirmed,
                             first_usable_recorded,
+                            first_business_sent,
+                            first_business_received,
+                            first_business_exchange,
                         );
                         if changed {
                             // Keep the synchronous waiter mirror in the same critical
@@ -1068,15 +1085,19 @@ impl PeerManager {
             );
         }
         if first_usable_recorded {
-            self.emit_timeline_first(
+            self.emit_timeline_first_usable(
                 node_id,
                 generation,
-                "first_usable_path",
-                Some("relay"),
+                "relay",
                 None,
                 Some(format!(
                     "peer={node_id} generation={generation} ingress=relay:{relay_endpoint} retained_preconfirmation_business=true"
                 )),
+                first_business_sent,
+                first_business_received,
+                first_business_exchange,
+                Some(relay_endpoint),
+                relay_connection_id,
             );
             self.emit_timeline(
                 "relay_first_business_evidence_promoted",
@@ -1242,15 +1263,19 @@ impl PeerManager {
                     )),
                 );
             }
-            self.emit_timeline_first(
+            self.emit_timeline_first_usable(
                 node_id,
                 generation,
-                "first_usable_path",
-                Some("direct"),
+                "direct",
                 fallback_reason,
                 Some(format!(
                     "peer={node_id} generation={generation} ingress=direct"
                 )),
+                false,
+                true,
+                false,
+                None,
+                None,
             );
         }
         recorded
@@ -1381,18 +1406,22 @@ impl PeerManager {
                     )),
                 );
             }
-            self.emit_timeline_first(
+            self.emit_timeline_first_usable(
                 node_id,
                 generation,
-                "first_usable_path",
-                Some(match path {
+                match path {
                     NetworkPath::Direct => "direct",
                     NetworkPath::Relay => "relay",
-                }),
+                },
                 fallback_reason,
                 Some(format!(
                     "peer={node_id} generation={generation} ingress={ingress_label}"
                 )),
+                false,
+                true,
+                false,
+                ingress_label.strip_prefix("relay:"),
+                None,
             );
         }
         recorded
@@ -2510,6 +2539,9 @@ impl PeerManager {
         let mut first_receive = false;
         let mut exchange_confirmed = false;
         let mut first_usable_recorded = false;
+        let mut first_business_sent = false;
+        let mut first_business_received = false;
+        let mut first_business_exchange = false;
         let outcome = conn.commit_path_transition(
             PathEvent::RelayBusinessUsable {
                 relay: relay_identity,
@@ -2528,6 +2560,12 @@ impl PeerManager {
                     conn.relay_first.business_gate_completed_generation = Some(generation);
                 }
                 first_usable_recorded = conn.record_first_usable(NetworkPath::Relay, generation);
+                first_business_sent = first_usable_recorded
+                    && conn.relay_first.business_sent_generation == Some(generation);
+                first_business_received = first_usable_recorded
+                    && conn.relay_first.business_received_generation == Some(generation);
+                first_business_exchange = first_usable_recorded
+                    && conn.relay_first.business_exchange_generation == Some(generation);
             },
         );
         if !outcome.accepted() {
@@ -2559,15 +2597,19 @@ impl PeerManager {
             );
         }
         if first_usable_recorded {
-            self.emit_timeline_first(
+            self.emit_timeline_first_usable(
                 node_id,
                 generation,
-                "first_usable_path",
-                Some("relay"),
+                "relay",
                 None,
                 Some(format!(
                     "peer={node_id} generation={generation} ingress=relay:{relay_endpoint}"
                 )),
+                first_business_sent,
+                first_business_received,
+                first_business_exchange,
+                Some(relay_endpoint),
+                relay_connection_id,
             );
         }
         finish(if first_receive || exchange_confirmed || first_usable_recorded {

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -97,7 +97,8 @@
   "control_proxy_consults_env": false,
   "connection_timeline": {
     "correlation_id": "node-a-boot0",
-    "events": []
+    "events": [],
+    "first_usable_summaries": []
   },
   "traversal_history": {
     "sources": []

--- a/scripts/nat-sim/aggregate_evidence.py
+++ b/scripts/nat-sim/aggregate_evidence.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Aggregate only actually executed NAT replica evidence.
+
+The expected scenario set is generated here from the component contract. It is
+not read from a user-controlled manifest, and no one record can fan out to
+other scenarios. Every JSON record must identify its exact test invocation and
+must independently satisfy the first-usable and revision-fence invariants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+REPOSITORY = "yhan-sun/p2wlan"
+EXPECTED_TOPOLOGIES = {
+    "direct-cold-start": {1},
+    "relay-blackhole": {1, 2, 3, 4, 5},
+}
+EXPECTED_TEST_ID = re.compile(
+    r"^nat-sim-smoke\.sh::(direct-cold-start|relay-blackhole)::replica-([1-5])::round-1$"
+)
+SHA1 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _read_records(root: Path) -> list[tuple[Path, dict[str, Any]]]:
+    records: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(root.rglob("nat-evidence.json")):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"invalid_record_json:{path}:{exc}") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"record_not_object:{path}")
+        records.append((path, value))
+    return records
+
+
+def _require_bool(value: Any, name: str) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name}_must_be_boolean")
+
+
+def _require_pass_side(
+    observed: Any,
+    collector: Any,
+    invariants: Any,
+    label: str,
+    expected_path: str,
+) -> None:
+    if not isinstance(observed, dict) or not isinstance(collector, dict) or not isinstance(invariants, dict):
+        raise ValueError(f"{label}_missing")
+    first = observed.get("first_usable")
+    if not isinstance(first, dict):
+        raise ValueError(f"{label}_first_usable_missing")
+    process_identity = observed.get("process_identity")
+    if not isinstance(process_identity, dict):
+        raise ValueError(f"{label}_process_identity_missing")
+    baseline_identity = process_identity.get("baseline")
+    final_identity = process_identity.get("final")
+    if not isinstance(baseline_identity, dict) or not isinstance(final_identity, dict):
+        raise ValueError(f"{label}_process_identity_shape_invalid")
+    if not isinstance(baseline_identity.get("process_id"), int):
+        raise ValueError(f"{label}_baseline_process_identity_missing")
+    if not isinstance(final_identity.get("process_id"), int):
+        raise ValueError(f"{label}_final_process_identity_missing")
+    if baseline_identity["process_id"] != final_identity["process_id"]:
+        raise ValueError(f"{label}_process_identity_changed")
+    if not isinstance(final_identity.get("revision"), int):
+        raise ValueError(f"{label}_final_revision_missing")
+    if final_identity.get("captured_revision") != final_identity.get("revision"):
+        raise ValueError(f"{label}_final_revision_not_captured")
+    if final_identity.get("peer_snapshot_stale") is not False:
+        raise ValueError(f"{label}_peer_snapshot_stale")
+    if first.get("path") != expected_path:
+        raise ValueError(f"{label}_first_usable_path_mismatch")
+    for field in ("first_usable_at_ms", "transition_revision", "delta_ms"):
+        if not isinstance(first.get(field), int) or first[field] < 0:
+            raise ValueError(f"{label}_{field}_missing")
+    if first["transition_revision"] == 0:
+        raise ValueError(f"{label}_transition_revision_missing")
+    if first["delta_ms"] > 3000:
+        raise ValueError(f"{label}_delta_exceeded")
+    if first.get("source") not in {"persistent_summary", "event"}:
+        raise ValueError(f"{label}_collector_source_invalid")
+    if not isinstance(first.get("baseline_after_transition"), bool):
+        raise ValueError(f"{label}_baseline_order_missing")
+    if first.get("baseline_after_transition") is True and first.get("source") != "persistent_summary":
+        raise ValueError(f"{label}_baseline_after_transition_without_summary")
+    if collector.get("revision_converged") is not True:
+        raise ValueError(f"{label}_revision_not_converged")
+    if collector.get("invalid_summary_present") is not False:
+        raise ValueError(f"{label}_invalid_summary_present")
+    if expected_path == "relay" and observed.get("relay_connected") is not True:
+        raise ValueError(f"{label}_relay_not_connected")
+    if expected_path == "relay":
+        if observed.get("relay_peer_confirmed") is not True:
+            raise ValueError(f"{label}_relay_peer_not_confirmed")
+        if observed.get("first_business_received") is not True:
+            raise ValueError(f"{label}_first_business_not_received")
+        if not (observed.get("first_business_sent") is True or observed.get("first_business_exchange") is True):
+            raise ValueError(f"{label}_first_business_send_missing")
+    else:
+        if not isinstance(observed.get("direct_promoted"), int) or observed["direct_promoted"] < 1:
+            raise ValueError(f"{label}_direct_promotion_missing")
+    if not isinstance(observed.get("overlay_verified"), int) or observed["overlay_verified"] < 1:
+        raise ValueError(f"{label}_overlay_verification_missing")
+    if observed.get("outbound_drop_packets") != 0:
+        raise ValueError(f"{label}_outbound_drop")
+    if observed.get("replay_rejected") != 0 or observed.get("overlay_invalid") != 0:
+        raise ValueError(f"{label}_invalid_or_replay")
+    for name, value in invariants.items():
+        if value is not True:
+            raise ValueError(f"{label}_invariant_failed:{name}")
+
+
+def validate_record(
+    record: dict[str, Any],
+    source_head_sha: str,
+    workflow_sha: str,
+) -> tuple[str, str, int]:
+    if not isinstance(source_head_sha, str) or SHA1.fullmatch(source_head_sha) is None:
+        raise ValueError("source_head_sha_invalid")
+    if not isinstance(workflow_sha, str) or SHA1.fullmatch(workflow_sha) is None:
+        raise ValueError("workflow_sha_invalid")
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unknown_schema_version")
+    if record.get("repository") != REPOSITORY:
+        raise ValueError("repository_mismatch")
+    if record.get("source_head_sha") != source_head_sha:
+        raise ValueError("source_head_sha_mismatch")
+    if record.get("workflow_sha") != workflow_sha:
+        raise ValueError("workflow_sha_mismatch")
+    _require_bool(record.get("executed"), "executed")
+    _require_bool(record.get("skipped"), "skipped")
+    if record.get("executed") is not True:
+        raise ValueError("test_not_executed")
+    if record.get("skipped") is not False:
+        raise ValueError("test_skipped")
+    if record.get("result") != "pass":
+        raise ValueError("record_not_pass")
+
+    topology = record.get("topology")
+    replica = record.get("replica")
+    round_number = record.get("round")
+    if topology not in EXPECTED_TOPOLOGIES or not isinstance(replica, int) or not isinstance(round_number, int):
+        raise ValueError("scenario_identity_invalid")
+    if replica not in EXPECTED_TOPOLOGIES[topology] or round_number != 1:
+        raise ValueError("scenario_not_expected")
+    expected_scenario = f"{topology}:replica-{replica}:round-1"
+    if record.get("scenario_id") != expected_scenario:
+        raise ValueError("scenario_id_mismatch")
+    exact_test_id = record.get("exact_test_id")
+    match = EXPECTED_TEST_ID.fullmatch(exact_test_id) if isinstance(exact_test_id, str) else None
+    if match is None:
+        raise ValueError("exact_test_id_invalid")
+    if match.group(1) != topology or int(match.group(2)) != replica:
+        raise ValueError("exact_test_id_scenario_mismatch")
+
+    observed = record.get("observed")
+    collector = record.get("collector")
+    invariants = record.get("invariants")
+    if not isinstance(observed, dict) or not isinstance(collector, dict) or not isinstance(invariants, dict):
+        raise ValueError("record_evidence_shape_invalid")
+    expected_path = "relay" if topology == "relay-blackhole" else "direct"
+    _require_pass_side(
+        observed.get("a"),
+        collector.get("a"),
+        invariants.get("a"),
+        "a",
+        expected_path,
+    )
+    _require_pass_side(
+        observed.get("b"),
+        collector.get("b"),
+        invariants.get("b"),
+        "b",
+        expected_path,
+    )
+    if collector.get("revision_converged") is not True:
+        raise ValueError("aggregate_revision_not_converged")
+    if invariants.get("same_source_head") is not True or invariants.get("same_workflow_sha") is not True:
+        raise ValueError("record_identity_invariant_failed")
+    decision = record.get("decision")
+    if (
+        not isinstance(decision, dict)
+        or decision.get("result") != "pass"
+        or decision.get("reason_code") is not None
+        or decision.get("observed_decision") != "first_usable_committed"
+    ):
+        raise ValueError("observed_decision_invalid")
+    return expected_scenario, exact_test_id, replica
+
+
+def aggregate_records(
+    records: list[tuple[Path, dict[str, Any]]],
+    source_head_sha: str,
+    workflow_sha: str,
+) -> dict[str, Any]:
+    expected = {
+        f"{topology}:replica-{replica}:round-1"
+        for topology, replicas in EXPECTED_TOPOLOGIES.items()
+        for replica in replicas
+    }
+    seen: dict[str, tuple[Path, str]] = {}
+    validated: list[dict[str, Any]] = []
+    for path, record in records:
+        scenario, exact_test_id, _ = validate_record(record, source_head_sha, workflow_sha)
+        if scenario in seen:
+            previous_path, previous_test_id = seen[scenario]
+            raise ValueError(
+                f"duplicate_conflicting_record:{scenario}:{previous_path}:{path}:{previous_test_id}:{exact_test_id}"
+            )
+        seen[scenario] = (path, exact_test_id)
+        validated.append(record)
+
+    missing = sorted(expected - set(seen))
+    if missing:
+        raise ValueError("missing_scenario:" + ",".join(missing))
+    extra = sorted(set(seen) - expected)
+    if extra:
+        raise ValueError("unknown_scenario:" + ",".join(extra))
+    validated.sort(key=lambda record: (record["topology"], record["replica"], record["round"]))
+    aggregate: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "repository": REPOSITORY,
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
+        "result": "pass",
+        "executed_record_count": len(validated),
+        "relay_replica_count": sum(record["topology"] == "relay-blackhole" for record in validated),
+        "records": [
+            {
+                "scenario_id": record["scenario_id"],
+                "exact_test_id": record["exact_test_id"],
+                "topology": record["topology"],
+                "replica": record["replica"],
+                "round": record["round"],
+                "result": record["result"],
+            }
+            for record in validated
+        ],
+    }
+    canonical = json.dumps(aggregate, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    aggregate["aggregate_digest"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return aggregate
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-root", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    result = aggregate_records(_read_records(Path(args.input_root)), args.source_head_sha, args.workflow_sha)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/scripts/nat-sim/collect_evidence.py
+++ b/scripts/nat-sim/collect_evidence.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Build one machine-verifiable NAT topology replica evidence record.
+
+The record is deliberately assembled from the two daemon status snapshots and
+the local replica logs.  A static scenario manifest never supplies a result:
+the exact test id, process identity, status revision fence, first-usable
+summary/event, and invariants all have to be present in this invocation's
+artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+REPOSITORY = "yhan-sun/p2wlan"
+SUMMARY_SCHEMA_VERSION = 1
+SUMMARY_SOURCE = "authoritative_business_ingress_commit"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or not value:
+        raise ValueError(f"invalid_status:{path}")
+    return value
+
+
+def _int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _peer(status: dict[str, Any]) -> dict[str, Any] | None:
+    peers = status.get("peers")
+    if not isinstance(peers, list):
+        return None
+    candidates = [item for item in peers if isinstance(item, dict)]
+    return candidates[0] if candidates else None
+
+
+def _events(status: dict[str, Any]) -> list[dict[str, Any]]:
+    timeline = status.get("connection_timeline")
+    if not isinstance(timeline, dict):
+        return []
+    events = timeline.get("events")
+    return [event for event in events if isinstance(event, dict)] if isinstance(events, list) else []
+
+
+def _summaries(status: dict[str, Any]) -> list[dict[str, Any]]:
+    timeline = status.get("connection_timeline")
+    if not isinstance(timeline, dict):
+        return []
+    summaries = timeline.get("first_usable_summaries")
+    return [summary for summary in summaries if isinstance(summary, dict)] \
+        if isinstance(summaries, list) else []
+
+
+def _event_time(events: list[dict[str, Any]], name: str, peer_id: str, generation: int) -> int | None:
+    values = []
+    for event in events:
+        if event.get("event") != name or event.get("peer_id") not in {None, peer_id}:
+            continue
+        event_generation = event.get("connection_generation")
+        if event_generation is not None and event_generation != generation:
+            continue
+        at_ms = _int(event.get("at_ms"))
+        if at_ms is not None:
+            values.append(at_ms)
+    return min(values) if values else None
+
+
+def _status_identity(status: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "process_id": _int(status.get("process_id")),
+        "revision": _int(status.get("revision")),
+        "captured_revision": _int(status.get("captured_revision")),
+        "captured_at_ms": _int(status.get("captured_at_ms")),
+        "uptime_ms": _int(status.get("uptime_ms")),
+        "network_generation": _int(status.get("network_generation")),
+        "peer_snapshot_stale": status.get("peer_snapshot_stale"),
+    }
+
+
+def _valid_summary(
+    summary: dict[str, Any],
+    peer_id: str,
+    generation: int,
+    final_revision: int | None,
+) -> bool:
+    """Validate the producer contract before accepting a durable summary.
+
+    A summary is evidence only when it came from the authoritative business
+    ingress commit.  Treating a malformed/additive-looking object as a usable
+    summary would turn parser loss or hand-edited JSON into a false pass.
+    """
+    if summary.get("schema_version") != SUMMARY_SCHEMA_VERSION:
+        return False
+    if summary.get("source") != SUMMARY_SOURCE:
+        return False
+    if summary.get("peer_id") != peer_id or summary.get("network_generation") != generation:
+        return False
+    if summary.get("path") not in {"direct", "relay"}:
+        return False
+    first_at_ms = _int(summary.get("first_usable_at_ms"))
+    transition_revision = _int(summary.get("transition_revision"))
+    if first_at_ms is None or first_at_ms < 0 or transition_revision is None or transition_revision < 0:
+        return False
+    if final_revision is None or transition_revision > final_revision:
+        return False
+    if not isinstance(summary.get("business_sent"), bool):
+        return False
+    if summary.get("business_received") is not True:
+        return False
+    if not isinstance(summary.get("business_exchange"), bool):
+        return False
+    ready_at_ms = summary.get("relay_ready_at_ms")
+    delta_ms = summary.get("first_usable_delta_ms")
+    if ready_at_ms is not None:
+        ready_at_ms = _int(ready_at_ms)
+        if ready_at_ms is None or ready_at_ms < 0 or ready_at_ms > first_at_ms:
+            return False
+    if delta_ms is not None:
+        delta_ms = _int(delta_ms)
+        if delta_ms is None or ready_at_ms is None or delta_ms != first_at_ms - ready_at_ms:
+            return False
+    if summary.get("relay_id") is not None and not isinstance(summary.get("relay_id"), str):
+        return False
+    if summary.get("relay_connection_id") is not None and _int(summary.get("relay_connection_id")) is None:
+        return False
+    if summary.get("reason_code") is not None and not isinstance(summary.get("reason_code"), str):
+        return False
+    return True
+
+
+def _side_evidence(
+    label: str,
+    baseline: dict[str, Any],
+    final: dict[str, Any],
+    log_path: Path,
+    expected_path: str,
+    overlay_burst: int,
+) -> tuple[dict[str, Any], str | None]:
+    baseline_identity = _status_identity(baseline)
+    final_identity = _status_identity(final)
+    peer = _peer(final)
+    peer_id = str(peer.get("node_id")) if peer else ""
+    generation = final_identity["network_generation"]
+    if generation is None:
+        generation = 0
+
+    process_stable = (
+        baseline_identity["process_id"] is not None
+        and final_identity["process_id"] is not None
+        and baseline_identity["process_id"] == final_identity["process_id"]
+    )
+    final_converged = (
+        final_identity["revision"] is not None
+        and final_identity["captured_revision"] == final_identity["revision"]
+        and final_identity["peer_snapshot_stale"] is False
+    )
+    baseline_revision = baseline_identity["revision"]
+    final_revision = final_identity["revision"]
+    events = _events(final)
+    summaries = _summaries(final)
+
+    summary_candidates = [
+        summary
+        for summary in summaries
+        if _valid_summary(summary, peer_id, generation, final_revision)
+    ]
+    invalid_summary_present = any(
+        summary.get("peer_id") == peer_id
+        and summary.get("network_generation") == generation
+        and not _valid_summary(summary, peer_id, generation, final_revision)
+        for summary in summaries
+    )
+    # The authoritative transition is once per peer + network generation. Two
+    # otherwise well-shaped summaries with the same identity are conflicting
+    # producer output, not historical evidence that may be silently reduced to
+    # the earliest timestamp.
+    if len(summary_candidates) > 1:
+        invalid_summary_present = True
+    summary = min(
+        summary_candidates,
+        key=lambda item: int(item["transition_revision"]),
+        default=None,
+    )
+    first_event_candidates = [
+        event
+        for event in events
+        if event.get("event") == "first_usable_path"
+        and (event.get("peer_id") in {None, peer_id})
+        and (event.get("connection_generation") in {None, generation})
+    ]
+    first_event = min(
+        first_event_candidates,
+        key=lambda item: _int(item.get("at_ms")) if _int(item.get("at_ms")) is not None else 2**63,
+        default=None,
+    )
+
+    ready_at_ms = None
+    first_usable_at_ms = None
+    transition_revision = None
+    source = None
+    first_path = None
+    business_sent = False
+    business_received = False
+    business_exchange = False
+    relay_id = None
+    relay_connection_id = None
+    delta_ms = None
+    baseline_after_transition = False
+
+    if summary is not None:
+        source = "persistent_summary"
+        first_usable_at_ms = _int(summary.get("first_usable_at_ms"))
+        transition_revision = _int(summary.get("transition_revision"))
+        first_path = summary.get("path")
+        business_sent = summary.get("business_sent") is True
+        business_received = summary.get("business_received") is True
+        business_exchange = summary.get("business_exchange") is True
+        relay_id = summary.get("relay_id")
+        relay_connection_id = _int(summary.get("relay_connection_id"))
+        ready_at_ms = _int(summary.get("relay_ready_at_ms"))
+        delta_ms = _int(summary.get("first_usable_delta_ms"))
+        baseline_after_transition = (
+            baseline_revision is not None
+            and transition_revision is not None
+            and transition_revision <= baseline_revision
+        )
+    elif first_event is not None:
+        # The ring event is a valid fallback only when the transition is in the
+        # same process and can be placed after the baseline on that daemon's
+        # monotonic clock. If it was evicted, the durable summary above is the
+        # only acceptable source.
+        event_at_ms = _int(first_event.get("at_ms"))
+        baseline_at_ms = baseline_identity["captured_at_ms"]
+        event_revision = _int(first_event.get("transition_revision"))
+        if event_at_ms is not None and event_revision is not None and event_revision > 0:
+            source = "event"
+            first_usable_at_ms = event_at_ms
+            transition_revision = event_revision
+            first_path = first_event.get("path")
+            ready_at_ms = _event_time(events, "relay_transport_ready_peer", peer_id, generation)
+            if ready_at_ms is not None and event_at_ms >= ready_at_ms:
+                delta_ms = event_at_ms - ready_at_ms
+            baseline_after_transition = baseline_at_ms is not None and event_at_ms <= baseline_at_ms
+            # An event before the baseline is still usable evidence only if it
+            # was not lost from the status snapshot; it is marked explicitly so
+            # the report distinguishes it from a missed collector edge.
+            business_received = True
+            business_sent = False
+            business_exchange = False
+
+    peer_generation = peer.get("relay_confirmed_generation") if peer else None
+    relay_confirmed = (
+        peer is not None
+        and peer.get("relay_confirmed_endpoint")
+        and peer_generation == generation
+        and peer.get("relay_confirmed_connection_id") is not None
+    )
+    # Legacy/unit profiles may not expose a transport incarnation id. The
+    # production NAT profile does; keep the endpoint+generation proof strict.
+    if peer is not None and peer.get("relay_confirmed_endpoint") and peer_generation == generation:
+        relay_confirmed = True
+    relay_connected = final.get("relay_connected") is True
+    peer_received_generation = peer.get("relay_first_business_received_generation") if peer else None
+    peer_sent_generation = peer.get("relay_first_business_sent_generation") if peer else None
+    peer_exchange_generation = peer.get("relay_first_business_exchange_generation") if peer else None
+    # The durable summary records the dimensions at the first commit. A later
+    # final snapshot may contain the other relay-business direction, so merge
+    # only the exact same-generation peer markers into the observed final
+    # state; this never fabricates the first-usable transition itself.
+    business_received = peer_received_generation == generation or business_received
+    business_sent = peer_sent_generation == generation or business_sent
+    business_exchange = peer_exchange_generation == generation or business_exchange
+
+    log_text = log_path.read_text(encoding="utf-8", errors="replace") if log_path.is_file() else ""
+    overlay_verified = len(re.findall(r"overlay_payload_verified", log_text))
+    direct_promoted = len(re.findall(r"direct_promoted", log_text))
+    replay_rejected = len(re.findall(r"replay detected", log_text))
+    overlay_invalid = len(re.findall(r"overlay_payload_invalid", log_text))
+    burst_complete = len(re.findall(r"overlay_burst_complete", log_text))
+    burst_incomplete = len(re.findall(r"overlay_burst_incomplete", log_text))
+
+    stats = final.get("stats")
+    if not isinstance(stats, dict):
+        drops_packets = None
+    else:
+        drops = stats.get("outbound_drops")
+        drops_packets = (
+            sum(_int(counter.get("packets")) or 0 for counter in drops.values() if isinstance(counter, dict))
+            if isinstance(drops, dict)
+            else None
+        )
+    health = final.get("health")
+    critical_tasks = health.get("critical_tasks") if isinstance(health, dict) else None
+    tasks_ok = isinstance(critical_tasks, list) and bool(critical_tasks) and all(
+        isinstance(task, dict)
+        and task.get("critical") is True
+        and task.get("running") is True
+        and task.get("finished") is False
+        and task.get("error") is None
+        for task in critical_tasks
+        if isinstance(task, dict) and task.get("critical") is True
+    )
+    critical_count = sum(
+        1 for task in critical_tasks or [] if isinstance(task, dict) and task.get("critical") is True
+    )
+    tasks_ok = tasks_ok and critical_count > 0
+
+    source_ok = source in {"persistent_summary", "event"}
+    first_path_ok = first_path == expected_path
+    delta_ok = isinstance(delta_ms, int) and 0 <= delta_ms <= 3000
+    business_ok = business_received and (expected_path != "relay" or business_sent or business_exchange)
+    # Direct cold-start exits the smoke loop as soon as both sides prove the
+    # first authenticated Direct business ingress.  Its overlay generator is
+    # intentionally not awaited for a full burst; Relay-only waits for the
+    # configured burst because that profile is the availability gate.
+    burst_required = expected_path == "relay" and overlay_burst > 0
+    invariants = {
+        "process_incarnation_stable": process_stable,
+        "diagnostics_revision_converged": final_converged,
+        "first_usable_committed": source_ok and first_usable_at_ms is not None,
+        "first_usable_path_matches_topology": first_path_ok,
+        "relay_connected": relay_connected if expected_path == "relay" else True,
+        "relay_peer_confirmed": relay_confirmed if expected_path == "relay" else True,
+        "first_business_received": business_received,
+        "first_business_direction_complete": business_ok,
+        "first_usable_delta_fenced": delta_ok,
+        "critical_tasks_healthy": tasks_ok,
+        "overlay_verified": overlay_verified > 0,
+        "direct_not_used": direct_promoted == 0 if expected_path == "relay" else True,
+        "no_replay_or_invalid": replay_rejected == 0 and overlay_invalid == 0,
+        "burst_complete": not burst_required or (burst_complete > 0 and burst_incomplete == 0),
+        "outbound_drops_zero": drops_packets == 0,
+    }
+    reason = None
+    if not process_stable:
+        reason = "stale_process_identity"
+    elif not final_converged:
+        reason = "diagnostics_revision_not_converged"
+    elif source is None:
+        if relay_connected and not relay_confirmed and expected_path == "relay":
+            reason = "relay_confirmation_missing"
+        elif relay_confirmed and not business_received:
+            reason = "first_business_not_passed"
+        elif invalid_summary_present or (first_event is not None and transition_revision is None):
+            reason = "evidence_parser_loss"
+        else:
+            reason = "first_usable_never_observed"
+    elif invalid_summary_present:
+        reason = "evidence_parser_loss"
+    elif source == "event" and baseline_after_transition:
+        reason = "baseline_after_transition_event_retained"
+    elif not first_path_ok:
+        reason = "first_usable_path_mismatch"
+    elif not business_received:
+        reason = "first_business_not_passed"
+    elif expected_path == "relay" and not relay_confirmed:
+        reason = "relay_confirmation_missing"
+    elif not delta_ok:
+        reason = "first_usable_delta_missing"
+    elif not all(invariants.values()):
+        reason = next(name for name, value in invariants.items() if not value)
+
+    side = {
+        "label": label,
+        "baseline": baseline_identity,
+        "final": final_identity,
+        "observed": {
+            "peer_id": peer_id,
+            "process_identity": {
+                "baseline": baseline_identity,
+                "final": final_identity,
+            },
+            "relay_connected": relay_connected,
+            "relay_peer_confirmed": relay_confirmed,
+            "relay_confirmed_generation": peer_generation,
+            "relay_id": relay_id or (peer.get("relay_confirmed_endpoint") if peer else None),
+            "relay_connection_id": relay_connection_id
+            if relay_connection_id is not None
+            else (peer.get("relay_confirmed_connection_id") if peer else None),
+            "first_business_sent": business_sent,
+            "first_business_received": business_received,
+            "first_business_exchange": business_exchange,
+            "first_usable": {
+                "path": first_path,
+                "network_generation": generation,
+                "first_usable_at_ms": first_usable_at_ms,
+                "transition_revision": transition_revision,
+                "relay_ready_at_ms": ready_at_ms,
+                "delta_ms": delta_ms,
+                "source": source,
+                "baseline_after_transition": baseline_after_transition,
+            },
+            "overlay_verified": overlay_verified,
+            "direct_promoted": direct_promoted,
+            "burst_complete": burst_complete,
+            "burst_incomplete": burst_incomplete,
+            "replay_rejected": replay_rejected,
+            "overlay_invalid": overlay_invalid,
+            "outbound_drop_packets": drops_packets,
+        },
+        "collector": {
+            "source": source,
+            "revision_converged": final_converged,
+            "persistent_summary_present": summary is not None,
+            "timeline_event_present": first_event is not None,
+            "timeline_evicted": summary is not None and first_event is None,
+            "baseline_after_transition": baseline_after_transition,
+            "invalid_summary_present": invalid_summary_present,
+        },
+        "invariants": invariants,
+    }
+    return side, reason
+
+
+def build_record(args: argparse.Namespace) -> dict[str, Any]:
+    topology = args.topology
+    replica = int(args.replica)
+    round_number = int(args.round)
+    scenario_id = f"{topology}:replica-{replica}:round-{round_number}"
+    exact_test_id = f"nat-sim-smoke.sh::{topology}::replica-{replica}::round-{round_number}"
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "repository": REPOSITORY,
+        "source_head_sha": args.source_head_sha,
+        "workflow_sha": args.workflow_sha,
+        "topology": topology,
+        "replica": replica,
+        "round": round_number,
+        "scenario_id": scenario_id,
+        "exact_test_id": exact_test_id,
+        "executed": True,
+        "skipped": False,
+        "result": "fail",
+        "baseline": {},
+        "final": {},
+        "observed": {},
+        "decision": {"result": "fail", "reason_code": "collector_not_run"},
+        "invariants": {},
+        "collector": {"source": None, "revision_converged": False},
+    }
+    try:
+        baseline_a = _load(Path(args.baseline_a))
+        baseline_b = _load(Path(args.baseline_b))
+        final_a = _load(Path(args.final_a))
+        final_b = _load(Path(args.final_b))
+        side_a, reason_a = _side_evidence(
+            "a", baseline_a, final_a, Path(args.log_a), args.expected_path, int(args.overlay_burst)
+        )
+        side_b, reason_b = _side_evidence(
+            "b", baseline_b, final_b, Path(args.log_b), args.expected_path, int(args.overlay_burst)
+        )
+        record["baseline"] = {"a": side_a["baseline"], "b": side_b["baseline"]}
+        record["final"] = {"a": side_a["final"], "b": side_b["final"]}
+        record["observed"] = {"a": side_a["observed"], "b": side_b["observed"]}
+        record["collector"] = {
+            "a": side_a["collector"],
+            "b": side_b["collector"],
+            "source": "persistent_summary"
+            if side_a["collector"]["source"] == side_b["collector"]["source"] == "persistent_summary"
+            else "event"
+            if side_a["collector"]["source"] in {"event", "persistent_summary"}
+            and side_b["collector"]["source"] in {"event", "persistent_summary"}
+            else None,
+            "revision_converged": side_a["collector"]["revision_converged"]
+            and side_b["collector"]["revision_converged"],
+        }
+        record["invariants"] = {
+            "a": side_a["invariants"],
+            "b": side_b["invariants"],
+            "same_source_head": bool(args.source_head_sha),
+            "same_workflow_sha": bool(args.workflow_sha),
+        }
+        failed_reasons = [reason for reason in (reason_a, reason_b) if reason]
+        all_invariants = all(side_a["invariants"].values()) and all(side_b["invariants"].values())
+        result = not failed_reasons and all_invariants
+        reason = None if result else (failed_reasons[0] if failed_reasons else "invariant_failed")
+        record["result"] = "pass" if result else "fail"
+        record["decision"] = {
+            "result": record["result"],
+            "reason_code": reason,
+            "observed_decision": "first_usable_committed" if result else "first_usable_not_accepted",
+        }
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        reason = str(exc).split(":", 1)[0] or "evidence_parse_failed"
+        record["decision"] = {
+            "result": "fail",
+            "reason_code": reason,
+            "observed_decision": "evidence_not_converged",
+        }
+    return record
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--topology", required=True, choices=["relay-blackhole", "direct-cold-start"])
+    parser.add_argument("--replica", required=True, type=int)
+    parser.add_argument("--round", required=True, type=int)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--baseline-a", required=True)
+    parser.add_argument("--baseline-b", required=True)
+    parser.add_argument("--final-a", required=True)
+    parser.add_argument("--final-b", required=True)
+    parser.add_argument("--log-a", required=True)
+    parser.add_argument("--log-b", required=True)
+    parser.add_argument("--expected-path", required=True, choices=["relay", "direct"])
+    parser.add_argument("--overlay-burst", type=int, default=0)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    record = build_record(args)
+    output = Path(args.output)
+    output.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(record["decision"], sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nat-sim/nat-sim-smoke.sh
+++ b/scripts/nat-sim/nat-sim-smoke.sh
@@ -51,6 +51,8 @@ BASE_B=${BASE_B:-46000}
 DIRECT_TIMEOUT_S=${DIRECT_TIMEOUT_S:-60}
 OVERLAY_TIMEOUT_S=${OVERLAY_TIMEOUT_S:-30}
 NAT_SIM_ARTIFACT_DIR=${NAT_SIM_ARTIFACT_DIR:-}
+NAT_TOPOLOGY_HEAD_SHA=${NAT_TOPOLOGY_HEAD_SHA:-$(git -C "$ROOT_DIR" rev-parse HEAD)}
+NAT_TOPOLOGY_WORKFLOW_SHA=${NAT_TOPOLOGY_WORKFLOW_SHA:-$(git -C "$ROOT_DIR" rev-parse "$NAT_TOPOLOGY_HEAD_SHA:.github/workflows/nat-topology-gate.yml")}
 # Give every local daemon timeline an explicit, bounded correlation namespace.
 # The dual-end harness already supplies P2WLAN_TEST_RUN_ID; NAT-sim used to
 # leave it unset, which made the logs harder to join even though each daemon
@@ -281,6 +283,9 @@ if kind == "status":
         raise SystemExit("status_schema_missing_correlation_id")
     if not isinstance(timeline.get("events"), list):
         raise SystemExit("status_schema_missing_timeline_events")
+    summaries = timeline.get("first_usable_summaries", [])
+    if not isinstance(summaries, list):
+        raise SystemExit("status_schema_invalid_first_usable_summaries")
 elif kind == "metrics":
     required = (
         "active_connections",
@@ -300,6 +305,22 @@ PY
     echo "[nat-sim] FAIL reason_code=${kind}_schema_invalid file=$output" >&2
     return 1
   fi
+}
+
+# Establish the per-daemon baseline before the topology wait begins. The
+# baseline is a daemon-local (process id, revision, monotonic uptime) fence;
+# it is not a wall-clock sample and is never reconstructed after the fact.
+capture_baseline_status() {
+  local url="$1" output="$2" token_file="$3" side="$4"
+  for _ in {1..120}; do
+    if fetch_required_json "$url" "$output" status "$token_file"; then
+      echo "[nat-sim] baseline captured side=$side file=$output" >&2
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "[nat-sim] FAIL reason_code=baseline_status_not_available side=$side file=$output" >&2
+  return 1
 }
 
 # Sample the authenticated status endpoint without writing credentials or a
@@ -596,6 +617,15 @@ for round in $(seq 1 "$ROUNDS"); do
   NODE_B_PID=$!
   PIDS+=($NODE_B_PID)
 
+  capture_baseline_status \
+    "http://127.0.0.1:$DIAG_A_PORT/status" \
+    "$ROUND_DIR/node-a.baseline.status.json" \
+    "$NODE_A_RUNTIME/p2wlan-daemon.diag-auth" a
+  capture_baseline_status \
+    "http://127.0.0.1:$DIAG_B_PORT/status" \
+    "$ROUND_DIR/node-b.baseline.status.json" \
+    "$NODE_B_RUNTIME/p2wlan-daemon.diag-auth" b
+
   if [[ "$MODE" == "relay-only" ]]; then
     # Availability pass condition: BOTH sides complete a bidirectional
     # encrypted overlay loopback (overlay_payload_verified), which here rides
@@ -712,23 +742,64 @@ for round in $(seq 1 "$ROUNDS"); do
     grep -h 'overlay_payload_verified\|overlay_payload_sent\|overlay_payload_echo\|first_usable_confirmed' "$ROUND_DIR"/node-*.log 2>/dev/null | head -6
   } >"$ROUND_DIR/evidence.log" 2>&1 || true
 
+  TOPOLOGY="direct-cold-start"
+  EXPECTED_PATH="direct"
+  if [[ "$MODE" == "relay-only" ]]; then
+    TOPOLOGY="relay-blackhole"
+    EXPECTED_PATH="relay"
+  fi
+  python3 "$ROOT_DIR/scripts/nat-sim/collect_evidence.py" \
+    --topology "$TOPOLOGY" \
+    --replica "${NAT_TOPOLOGY_REPLICA:-1}" \
+    --round "$round" \
+    --source-head-sha "$NAT_TOPOLOGY_HEAD_SHA" \
+    --workflow-sha "$NAT_TOPOLOGY_WORKFLOW_SHA" \
+    --baseline-a "$ROUND_DIR/node-a.baseline.status.json" \
+    --baseline-b "$ROUND_DIR/node-b.baseline.status.json" \
+    --final-a "$ROUND_DIR/node-a.status.json" \
+    --final-b "$ROUND_DIR/node-b.status.json" \
+    --log-a "$ROUND_DIR/node-a.log" \
+    --log-b "$ROUND_DIR/node-b.log" \
+    --expected-path "$EXPECTED_PATH" \
+    --overlay-burst "$OVERLAY_BURST" \
+    --output "$ROUND_DIR/nat-evidence.json"
+  read -r EVIDENCE_PASS EVIDENCE_REASON EVIDENCE_A_DELTA EVIDENCE_B_DELTA < <(
+    python3 - "$ROUND_DIR/nat-evidence.json" <<'PY'
+import json
+import sys
+
+try:
+    record = json.load(open(sys.argv[1], encoding="utf-8"))
+    observed = record["observed"]
+    result = record["result"] == "pass"
+    reason = record.get("decision", {}).get("reason_code") or "none"
+    a_delta = observed["a"]["first_usable"].get("delta_ms")
+    b_delta = observed["b"]["first_usable"].get("delta_ms")
+    a_delta = a_delta if isinstance(a_delta, int) else -1
+    b_delta = b_delta if isinstance(b_delta, int) else -1
+    print(int(result), reason, a_delta, b_delta)
+except Exception:
+    print("0 collector_record_invalid -1 -1")
+PY
+  )
+
   # Per-daemon monotonic relay-ready -> first production business delta: the
-  # harness computes each delta from that daemon's own t_ms values and only
+  # collector reads each daemon's own persistent summary/event fence and only
   # reports their sum as a convenience; it never subtracts wall clocks across
-  # machines.
-  A_DELTA=$(node_first_usable_delta_ms "$ROUND_DIR/node-a.log")
-  B_DELTA=$(node_first_usable_delta_ms "$ROUND_DIR/node-b.log")
+  # machines or promotes a log-only timestamp to acceptance evidence.
+  A_DELTA="$EVIDENCE_A_DELTA"
+  B_DELTA="$EVIDENCE_B_DELTA"
   DELTA_OK=1
   if [[ -z "$A_DELTA" || -z "$B_DELTA" ]]; then
     if [[ "$MODE" == "relay-only" ]]; then
-      echo "[nat-sim] ROUND $round: FAIL reason_code=first_usable_delta_missing a_delta=${A_DELTA:-missing} b_delta=${B_DELTA:-missing}" >&2
+      echo "[nat-sim] ROUND $round: FAIL reason_code=${EVIDENCE_REASON:-first_usable_delta_missing} a_delta=${A_DELTA:-missing} b_delta=${B_DELTA:-missing}" >&2
       DELTA_OK=0
       overall=1
       A_DELTA=-1
       B_DELTA=-1
       SUM_DELTA=-1
     else
-      echo "[nat-sim] ROUND $round: FAIL reason_code=first_usable_delta_missing a_delta=${A_DELTA:-missing} b_delta=${B_DELTA:-missing}" >&2
+      echo "[nat-sim] ROUND $round: FAIL reason_code=${EVIDENCE_REASON:-first_usable_delta_missing} a_delta=${A_DELTA:-missing} b_delta=${B_DELTA:-missing}" >&2
       DELTA_OK=0
       overall=1
       A_DELTA=-1
@@ -814,6 +885,7 @@ except Exception:
       [[ "$A_BURST" -ge 1 && "$B_BURST" -ge 1 && "$A_BURST_BAD" -eq 0 && "$B_BURST_BAD" -eq 0 ]] || BURST_OK=0
     fi
     if [[ "$STATUS_SCHEMA_OK" -eq 1 && "$METRICS_SCHEMA_OK" -eq 1 && "$DELTA_OK" -eq 1 \
+          && "$EVIDENCE_PASS" -eq 1 \
           && "$overlay_ok" -eq 1 && "$A_DIRECT" -eq 0 && "$B_DIRECT" -eq 0 \
           && "$A_RELAY_CONFIRMED" -ge 1 && "$B_RELAY_CONFIRMED" -ge 1 \
           && "$a_relay_first" -eq 1 && "$b_relay_first" -eq 1 \
@@ -887,7 +959,9 @@ except Exception:
           && "$A_INVALID" -eq 0 && "$B_INVALID" -eq 0 ]]; then
       echo "[nat-sim] ROUND $round: PASS both_direct relay_before_direct_business=1 a_relay_confirmed_t_ms=$A_RELAY_CONFIRMED_TMS b_relay_confirmed_t_ms=$B_RELAY_CONFIRMED_TMS a_direct_promoted_t_ms=$A_DIRECT_PROMOTED_TMS b_direct_promoted_t_ms=$B_DIRECT_PROMOTED_TMS a_direct_business_t_ms=$A_DIRECT_BUSINESS_TMS b_direct_business_t_ms=$B_DIRECT_BUSINESS_TMS a_delta_ms=$A_DELTA b_delta_ms=$B_DELTA sum_delta_ms=$SUM_DELTA a_ingress=${A_INGRESS:-none} b_ingress=${B_INGRESS:-none} elapsed_ms=$ELAPSED_MS failure_reason=${FAIL_CODE:-none} (a_direct=$A_DIRECT b_direct=$B_DIRECT) a_overlay=$A_OVERLAY b_overlay=$B_OVERLAY evidence=$ROUND_DIR/evidence.log"
     else
-      if [[ "$direct_ok" -ne 1 ]]; then
+      if [[ "$EVIDENCE_PASS" -ne 1 ]]; then
+        DIRECT_REASON="${EVIDENCE_REASON:-component_evidence_invalid}"
+      elif [[ "$direct_ok" -ne 1 ]]; then
         DIRECT_REASON="direct_overlay_unverified"
       elif [[ "$DELTA_OK" -ne 1 || "$A_DELTA" -lt 0 || "$B_DELTA" -lt 0 ]]; then
         DIRECT_REASON="first_usable_delta_missing"

--- a/scripts/nat-sim/run-ci-topology.sh
+++ b/scripts/nat-sim/run-ci-topology.sh
@@ -27,6 +27,7 @@ if [[ -n "$EXPECTED_HEAD_SHA" ]]; then
 else
   ACTUAL_HEAD_SHA=$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo unknown)
 fi
+WORKFLOW_SHA=$(git -C "$ROOT_DIR" rev-parse "$ACTUAL_HEAD_SHA:.github/workflows/nat-topology-gate.yml")
 
 mkdir -p "$ARTIFACT_PARENT"
 if [[ -e "$ARTIFACT_DIR" || -e "$LOG_FILE" ]]; then
@@ -47,6 +48,7 @@ run_smoke() {
       NAT_SEED_BASE=20260828 \
       NAT_SIM_RUN_ID="$RUN_NAME" \
       NAT_TOPOLOGY_HEAD_SHA="$ACTUAL_HEAD_SHA" \
+      NAT_TOPOLOGY_WORKFLOW_SHA="$WORKFLOW_SHA" \
       NAT_TOPOLOGY_REPLICA="$REPLICA" \
       NAT_SIM_ARTIFACT_DIR="$ARTIFACT_DIR" \
       "$@" \

--- a/scripts/nat-sim/test_nat_sim.py
+++ b/scripts/nat-sim/test_nat_sim.py
@@ -2,10 +2,14 @@
 """Regression tests for the deterministic dual-NAT simulator."""
 
 import asyncio
+import copy
 import importlib.util
+import json
 import socket
 import struct
+import tempfile
 import unittest
+from argparse import Namespace
 from pathlib import Path
 
 
@@ -22,6 +26,20 @@ assert OBS_SPEC is not None
 assert OBS_SPEC.loader is not None
 OBSERVABILITY = importlib.util.module_from_spec(OBS_SPEC)
 OBS_SPEC.loader.exec_module(OBSERVABILITY)
+
+COLLECT_PATH = Path(__file__).with_name("collect_evidence.py")
+COLLECT_SPEC = importlib.util.spec_from_file_location("p2wlan_nat_collect_evidence", COLLECT_PATH)
+assert COLLECT_SPEC is not None
+assert COLLECT_SPEC.loader is not None
+COLLECT_EVIDENCE = importlib.util.module_from_spec(COLLECT_SPEC)
+COLLECT_SPEC.loader.exec_module(COLLECT_EVIDENCE)
+
+AGGREGATE_PATH = Path(__file__).with_name("aggregate_evidence.py")
+AGGREGATE_SPEC = importlib.util.spec_from_file_location("p2wlan_nat_aggregate_evidence", AGGREGATE_PATH)
+assert AGGREGATE_SPEC is not None
+assert AGGREGATE_SPEC.loader is not None
+AGGREGATE_EVIDENCE = importlib.util.module_from_spec(AGGREGATE_SPEC)
+AGGREGATE_SPEC.loader.exec_module(AGGREGATE_EVIDENCE)
 
 
 class CaptureProtocol(asyncio.DatagramProtocol):
@@ -107,6 +125,479 @@ class ObservabilityFailClosedTests(unittest.TestCase):
         drops = validated["stats"]["outbound_drops"]
         self.assertEqual(sum(item["packets"] for item in drops.values()), 5)
         self.assertEqual(sum(item["bytes"] for item in drops.values()), 500)
+
+
+class NatEvidenceContractTests(unittest.TestCase):
+    SOURCE_SHA = "a" * 40
+    WORKFLOW_SHA = "b" * 40
+
+    @staticmethod
+    def _status(process_id: int, expected_path: str = "relay", revision: int = 4) -> dict:
+        peer = {
+            "node_id": "node-b",
+            "online": True,
+            "relay_confirmed_endpoint": "relay.test" if expected_path == "relay" else None,
+            "relay_confirmed_generation": 1 if expected_path == "relay" else None,
+            "relay_confirmed_connection_id": 12 if expected_path == "relay" else None,
+            "relay_first_business_sent_generation": 1 if expected_path == "relay" else None,
+            "relay_first_business_received_generation": 1 if expected_path == "relay" else None,
+            "relay_first_business_exchange_generation": 1 if expected_path == "relay" else None,
+        }
+        summary = {
+            "schema_version": 1,
+            "peer_id": "node-b",
+            "path": expected_path,
+            "network_generation": 1,
+            "first_usable_at_ms": 20,
+            "transition_revision": 3,
+            "relay_ready_at_ms": 10,
+            "first_usable_delta_ms": 10,
+            "business_sent": True,
+            "business_received": True,
+            "business_exchange": True,
+            "relay_id": "relay.test" if expected_path == "relay" else None,
+            "relay_connection_id": 12 if expected_path == "relay" else None,
+            "source": "authoritative_business_ingress_commit",
+        }
+        return {
+            "process_id": process_id,
+            "node_id": "node-a",
+            "network_generation": 1,
+            "uptime_ms": 30,
+            "revision": revision,
+            "captured_revision": revision,
+            "captured_at_ms": 30,
+            "peer_snapshot_stale": False,
+            "relay_connected": expected_path == "relay",
+            "connection_timeline": {
+                "correlation_id": "node-a-1",
+                "events": [
+                    {
+                        "event": "relay_transport_ready_peer",
+                        "at_ms": 10,
+                        "peer_id": "node-b",
+                        "connection_generation": 1,
+                    },
+                    {
+                        "event": "first_usable_path",
+                        "at_ms": 20,
+                        "path": expected_path,
+                        "peer_id": "node-b",
+                        "connection_generation": 1,
+                    },
+                ],
+                "first_usable_summaries": [summary],
+            },
+            "peers": [peer],
+            "stats": {"outbound_drops": {}, "outbound_loss_events": []},
+            "health": {
+                "critical_tasks": [
+                    {"critical": True, "running": True, "finished": False, "error": None}
+                ]
+            },
+        }
+
+    def _write_record(self, root: Path, topology: str, replica: int) -> dict:
+        expected_path = "relay" if topology == "relay-blackhole" else "direct"
+        baseline = self._status(1234, expected_path, revision=1)
+        baseline["captured_at_ms"] = 5
+        baseline["uptime_ms"] = 5
+        final = self._status(1234, expected_path)
+        record = self._build_record(
+            root,
+            topology,
+            replica,
+            baseline,
+            baseline,
+            final,
+            final,
+        )
+        output_dir = root / f"record-{topology}-{replica}"
+        output_dir.mkdir()
+        (output_dir / "nat-evidence.json").write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+        return record
+
+    def _build_record(
+        self,
+        root: Path,
+        topology: str,
+        replica: int,
+        baseline_a: dict,
+        baseline_b: dict,
+        final_a: dict,
+        final_b: dict,
+        log_text: str = "overlay_payload_verified\noverlay_burst_complete\n",
+    ) -> dict:
+        expected_path = "relay" if topology == "relay-blackhole" else "direct"
+        log = root / f"{topology}-{replica}.log"
+        if expected_path == "direct" and "direct_promoted" not in log_text:
+            log_text = "direct_promoted\n" + log_text
+        log.write_text(log_text, encoding="utf-8")
+        baseline_a_path = root / f"{topology}-{replica}.a.baseline.json"
+        baseline_b_path = root / f"{topology}-{replica}.b.baseline.json"
+        final_a_path = root / f"{topology}-{replica}.a.final.json"
+        final_b_path = root / f"{topology}-{replica}.b.final.json"
+        baseline_a_path.write_text(json.dumps(baseline_a), encoding="utf-8")
+        baseline_b_path.write_text(json.dumps(baseline_b), encoding="utf-8")
+        final_a_path.write_text(json.dumps(final_a), encoding="utf-8")
+        final_b_path.write_text(json.dumps(final_b), encoding="utf-8")
+        return COLLECT_EVIDENCE.build_record(
+            Namespace(
+                topology=topology,
+                replica=replica,
+                round=1,
+                source_head_sha=self.SOURCE_SHA,
+                workflow_sha=self.WORKFLOW_SHA,
+                baseline_a=str(baseline_a_path),
+                baseline_b=str(baseline_b_path),
+                final_a=str(final_a_path),
+                final_b=str(final_b_path),
+                log_a=str(log),
+                log_b=str(log),
+                expected_path=expected_path,
+                overlay_burst=64 if expected_path == "relay" else 0,
+            )
+        )
+
+    def _all_records(self, root: Path) -> list[tuple[Path, dict]]:
+        records = []
+        for path in sorted(root.rglob("nat-evidence.json")):
+            records.append((path, json.loads(path.read_text(encoding="utf-8"))))
+        return records
+
+    @staticmethod
+    def _remove_first_usable(status: dict, clear_relay_business: bool = False) -> dict:
+        value = copy.deepcopy(status)
+        timeline = value["connection_timeline"]
+        timeline["events"] = [
+            event for event in timeline["events"] if event.get("event") != "first_usable_path"
+        ]
+        timeline["first_usable_summaries"] = []
+        if clear_relay_business:
+            peer = value["peers"][0]
+            peer["relay_first_business_sent_generation"] = None
+            peer["relay_first_business_received_generation"] = None
+            peer["relay_first_business_exchange_generation"] = None
+        return value
+
+    def test_transition_after_baseline_computes_delta_from_summary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                self._status(1234, "relay"),
+                self._status(1235, "relay"),
+            )
+            self.assertEqual(record["result"], "pass")
+            self.assertEqual(record["observed"]["a"]["first_usable"]["delta_ms"], 10)
+            self.assertFalse(record["observed"]["a"]["first_usable"]["baseline_after_transition"])
+
+    def test_transition_before_baseline_requires_persistent_summary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            baseline_a = self._status(1234, "relay", revision=4)
+            baseline_b = self._status(1235, "relay", revision=4)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                baseline_a,
+                baseline_b,
+                self._status(1234, "relay"),
+                self._status(1235, "relay"),
+            )
+            self.assertEqual(record["result"], "pass")
+            self.assertTrue(record["observed"]["a"]["first_usable"]["baseline_after_transition"])
+            self.assertEqual(record["observed"]["a"]["first_usable"]["source"], "persistent_summary")
+
+    def test_event_fallback_is_revision_fenced_and_computes_delta(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._status(1234, "relay")
+            final_b = self._status(1235, "relay")
+            for final in (final_a, final_b):
+                timeline = final["connection_timeline"]
+                timeline["first_usable_summaries"] = []
+                for event in timeline["events"]:
+                    if event["event"] == "first_usable_path":
+                        event["transition_revision"] = 3
+            baseline_a = self._status(1234, "relay", revision=1)
+            baseline_b = self._status(1235, "relay", revision=1)
+            for baseline in (baseline_a, baseline_b):
+                baseline["captured_at_ms"] = 5
+                baseline["uptime_ms"] = 5
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                baseline_a,
+                baseline_b,
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "pass")
+            self.assertEqual(record["observed"]["a"]["first_usable"]["source"], "event")
+            self.assertEqual(record["observed"]["a"]["first_usable"]["transition_revision"], 3)
+            self.assertEqual(record["observed"]["a"]["first_usable"]["delta_ms"], 10)
+
+    def test_event_only_baseline_after_transition_fails_setup_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._status(1234, "relay")
+            final_b = self._status(1235, "relay")
+            for final in (final_a, final_b):
+                timeline = final["connection_timeline"]
+                timeline["first_usable_summaries"] = []
+                for event in timeline["events"]:
+                    if event["event"] == "first_usable_path":
+                        event["transition_revision"] = 3
+            baseline_a = self._status(1234, "relay", revision=4)
+            baseline_b = self._status(1235, "relay", revision=4)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                baseline_a,
+                baseline_b,
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(
+                record["decision"]["reason_code"], "baseline_after_transition_event_retained"
+            )
+
+    def test_event_ring_eviction_uses_durable_summary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._status(1234, "relay")
+            final_b = self._status(1235, "relay")
+            for final in (final_a, final_b):
+                final["connection_timeline"]["events"] = [
+                    event
+                    for event in final["connection_timeline"]["events"]
+                    if event.get("event") != "first_usable_path"
+                ]
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "pass")
+            self.assertTrue(record["collector"]["a"]["timeline_evicted"])
+
+    def test_path_never_usable_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._remove_first_usable(self._status(1234, "direct"))
+            final_b = self._remove_first_usable(self._status(1235, "direct"))
+            record = self._build_record(
+                root,
+                "direct-cold-start",
+                1,
+                self._status(1234, "direct", revision=1),
+                self._status(1235, "direct", revision=1),
+                final_a,
+                final_b,
+                log_text="direct_promoted\n",
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["decision"]["reason_code"], "first_usable_never_observed")
+
+    def test_relay_connected_without_business_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._remove_first_usable(self._status(1234, "relay"), True)
+            final_b = self._remove_first_usable(self._status(1235, "relay"), True)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["decision"]["reason_code"], "first_business_not_passed")
+
+    def test_diagnostics_revision_lag_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._status(1234, "relay")
+            final_b = self._status(1235, "relay")
+            for final in (final_a, final_b):
+                final["captured_revision"] = final["revision"] - 1
+                final["peer_snapshot_stale"] = True
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["decision"]["reason_code"], "diagnostics_revision_not_converged")
+
+    def test_changed_process_identity_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                self._status(4321, "relay"),
+                self._status(1235, "relay"),
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["decision"]["reason_code"], "stale_process_identity")
+
+    def test_one_missing_side_is_reported_without_fanout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_b = self._remove_first_usable(self._status(1235, "direct"))
+            record = self._build_record(
+                root,
+                "direct-cold-start",
+                1,
+                self._status(1234, "direct", revision=1),
+                self._status(1235, "direct", revision=1),
+                self._status(1234, "direct"),
+                final_b,
+                log_text="direct_promoted\noverlay_payload_verified\n",
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["observed"]["a"]["first_usable"]["path"], "direct")
+            self.assertIsNone(record["observed"]["b"]["first_usable"]["path"])
+
+    def test_duplicate_same_generation_summary_is_parser_loss(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            final_a = self._status(1234, "relay")
+            final_b = self._status(1235, "relay")
+            for final in (final_a, final_b):
+                duplicate = copy.deepcopy(final["connection_timeline"]["first_usable_summaries"][0])
+                duplicate["first_usable_at_ms"] = 30
+                duplicate["first_usable_delta_ms"] = 20
+                duplicate["transition_revision"] = 4
+                final["connection_timeline"]["first_usable_summaries"].append(duplicate)
+            record = self._build_record(
+                root,
+                "relay-blackhole",
+                1,
+                self._status(1234, "relay", revision=1),
+                self._status(1235, "relay", revision=1),
+                final_a,
+                final_b,
+            )
+            self.assertEqual(record["result"], "fail")
+            self.assertEqual(record["decision"]["reason_code"], "evidence_parser_loss")
+
+    def test_valid_actual_execution_records_aggregate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 6):
+                self._write_record(root, "relay-blackhole", replica)
+            aggregate = AGGREGATE_EVIDENCE.aggregate_records(
+                self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+            )
+            self.assertEqual(aggregate["result"], "pass")
+            self.assertEqual(aggregate["relay_replica_count"], 5)
+            self.assertTrue(aggregate["aggregate_digest"].startswith("sha256:"))
+
+    def test_missing_replica_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 5):
+                self._write_record(root, "relay-blackhole", replica)
+            with self.assertRaisesRegex(ValueError, "missing_scenario:.*relay-blackhole:replica-5"):
+                AGGREGATE_EVIDENCE.aggregate_records(
+                    self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+                )
+
+    def test_mutated_test_name_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 6):
+                self._write_record(root, "relay-blackhole", replica)
+            path = root / "record-relay-blackhole-3" / "nat-evidence.json"
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["exact_test_id"] = value["exact_test_id"].replace("replica-3", "replica-2")
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "exact_test_id_scenario_mismatch"):
+                AGGREGATE_EVIDENCE.aggregate_records(
+                    self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+                )
+
+    def test_skipped_test_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 6):
+                self._write_record(root, "relay-blackhole", replica)
+            path = root / "record-relay-blackhole-4" / "nat-evidence.json"
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["skipped"] = True
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "test_skipped"):
+                AGGREGATE_EVIDENCE.aggregate_records(
+                    self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+                )
+
+    def test_static_manifest_scenario_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 6):
+                self._write_record(root, "relay-blackhole", replica)
+            value = json.loads(
+                (root / "record-relay-blackhole-1" / "nat-evidence.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            value["topology"] = "relay-blackhole-fictional"
+            value["scenario_id"] = "relay-blackhole-fictional:replica-1:round-1"
+            extra = root / "record-fictional"
+            extra.mkdir()
+            (extra / "nat-evidence.json").write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "scenario_identity_invalid"):
+                AGGREGATE_EVIDENCE.aggregate_records(
+                    self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+                )
+
+    def test_duplicate_conflicting_records_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_record(root, "direct-cold-start", 1)
+            for replica in range(1, 6):
+                self._write_record(root, "relay-blackhole", replica)
+            original = root / "record-relay-blackhole-2" / "nat-evidence.json"
+            duplicate_dir = root / "duplicate"
+            duplicate_dir.mkdir()
+            (duplicate_dir / "nat-evidence.json").write_text(
+                original.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate_conflicting_record"):
+                AGGREGATE_EVIDENCE.aggregate_records(
+                    self._all_records(root), self.SOURCE_SHA, self.WORKFLOW_SHA
+                )
 
 
 class NatIntegrationTests(unittest.IsolatedAsyncioTestCase):

--- a/scripts/nat-sim/validate_observability.py
+++ b/scripts/nat-sim/validate_observability.py
@@ -34,6 +34,10 @@ def validate_status(value: Any) -> dict[str, Any]:
         raise ValueError("status_schema_missing_correlation_id")
     if not isinstance(timeline.get("events"), list):
         raise ValueError("status_schema_missing_timeline_events")
+    if "first_usable_summaries" in timeline and not isinstance(
+        timeline.get("first_usable_summaries"), list
+    ):
+        raise ValueError("status_schema_invalid_first_usable_summaries")
     return value
 
 


### PR DESCRIPTION
Refs #56

Fixes the intermittent relay-blackhole first-usable evidence failure without relaxing the gate.

- Keeps retry publication in a bounded, latency-prioritized control-loop lane.
- Adds durable, revision-fenced first-usable summaries and per-replica evidence records.
- Aggregates only exact executed direct/relay scenarios (1 + 5 replicas).
- Preserves fail-closed handling for missing, stale, skipped, conflicting, and parser-loss evidence.

Local verification: Rust workspace tests, server Go tests, Python NAT contract tests, shell/YAML checks, direct pass, relay 5/5 pass.

This PR intentionally remains Draft.