### PR TITLE
feat(dplpmtud): close live dataplane acceptance

### DIFF
--- a/.github/workflows/business-mtu-budget-required.yml
+++ b/.github/workflows/business-mtu-budget-required.yml
@@ -114,11 +114,13 @@ jobs:
 
       - name: Verify exact production-path source head
         shell: bash
+        env:
+          BUSINESS_MTU_REPLICA: ${{ matrix.replica }}
         run: |
           set -euo pipefail
           actual="$(git rev-parse HEAD)"
           test "$actual" = "$P2WLAN_VALIDATION_SHA"
-          echo "business_mtu_source_head=$actual replica=${{ matrix.replica }}/5"
+          echo "business_mtu_source_head=$actual replica=$BUSINESS_MTU_REPLICA/5"
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
 
@@ -173,7 +175,7 @@ jobs:
           cargo test -p p2wlan-daemon --lib dplpmtud::tests::old_business_tokens_fail_after_raise_drop_and_path_replacement -- --exact --test-threads=1
 
   existing_required_gates:
-    name: Existing required gates on PR Head
+    name: Business MTU external required gates
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 70
@@ -191,13 +193,14 @@ jobs:
               'Windows Lifecycle Required',
               'Mobile Lifecycle Required',
               'CI Required',
-              'Flutter analyze and test',
+              'Analyze and Test',
               'Android arm64 CI test APK',
-              'Flutter Android Packaging Required',
-              'iOS debug compile (no codesign)',
-              'Build Linux Flutter bundle',
-              'Bundle macOS Flutter app',
-              'Build Windows Flutter bundle',
+              'iOS Compile',
+              'Linux x64 Release Bundle',
+              'macOS Release Apps',
+              'Windows x64 Release Bundle',
+              'macOS arm64 test DMG',
+              'Android arm64 test APK',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
             const deadline = Date.now() + 65 * 60 * 1000;

--- a/.github/workflows/business-mtu-budget-required.yml
+++ b/.github/workflows/business-mtu-budget-required.yml
@@ -2,59 +2,72 @@ name: Business MTU Budget Required
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - ".github/workflows/business-mtu-budget-required.yml"
+      - ".github/workflows/dplpmtud-required.yml"
       - "client/daemon/**"
       - "client/netbind/**"
-      - "docs/dplpmtud-business-budget.md"
+      - "client/tun/**"
+      - "client/wireguard/**"
+      - "client/relay/**"
+      - "scripts/dplpmtud/**"
+      - "contracts/dplpmtud_acceptance.json"
+      - "docs/dplpmtud-live-dataplane-acceptance.md"
       - "Cargo.toml"
       - "Cargo.lock"
   pull_request:
     branches:
       - main
-      - fix/dplpmtud-acceptance-20260830
     paths:
       - ".github/workflows/business-mtu-budget-required.yml"
+      - ".github/workflows/dplpmtud-required.yml"
       - "client/daemon/**"
       - "client/netbind/**"
-      - "docs/dplpmtud-business-budget.md"
+      - "client/tun/**"
+      - "client/wireguard/**"
+      - "client/relay/**"
+      - "scripts/dplpmtud/**"
+      - "contracts/dplpmtud_acceptance.json"
+      - "docs/dplpmtud-live-dataplane-acceptance.md"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
+    inputs:
+      validation_sha:
+        description: "Exact source SHA to validate"
+        required: true
+        type: string
 
 permissions:
   contents: read
   checks: read
 
 concurrency:
-  group: business-mtu-budget-${{ github.event.pull_request.number || github.ref }}
+  group: business-mtu-budget-${{ github.event.pull_request.number || inputs.validation_sha || github.ref }}
   cancel-in-progress: true
 
 env:
-  VALIDATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  CARGO_TERM_COLOR: always
+  P2WLAN_VALIDATION_SHA: ${{ github.event.pull_request.head.sha || inputs.validation_sha || github.sha }}
 
 jobs:
   linux_validation:
-    name: Business MTU Linux checks
+    name: Business MTU Linux validation
     runs-on: ubuntu-24.04
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
+          ref: ${{ env.P2WLAN_VALIDATION_SHA }}
+          fetch-depth: 1
 
-      - name: Verify exact validation SHA
+      - name: Verify exact source checkout
         shell: bash
-        run: |
-          set -euo pipefail
-          actual="$(git rev-parse HEAD)"
-          echo "Business MTU validation SHA: $actual"
-          test "$actual" = "$VALIDATION_SHA"
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_VALIDATION_SHA"
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
           components: rustfmt, clippy
 
@@ -77,155 +90,143 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Cargo workspace tests
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features
 
-      - name: Deterministic Direct UDP WouldBlock semantics
-        run: cargo test -p p2wlan-daemon --lib tests::direct_business_would_block_is_paced_deadline_bounded_and_peer_isolated -- --exact --nocapture --test-threads=1
+      - name: WireGuard sizing and inbound-control regression
+        run: cargo test -p p2wlan-daemon --lib transport::tests -- --test-threads=1
 
-      - name: IPv6 minimum-MTU fail-closed semantics
-        run: cargo test -p p2wlan-daemon --lib tests::direct_business_ipv6_budget_floor_is_fail_closed_without_invalid_ptb -- --exact --nocapture --test-threads=1
+      - name: IPv4 and IPv6 local-feedback regressions
+        run: cargo test -p p2wlan-daemon --lib business_mtu::tests -- --test-threads=1
 
-      - name: Diff whitespace check
-        run: git diff --check
-
-  linux_business_e2e:
-    name: Linux business-budget production E2E (${{ matrix.iteration }}/5)
+  production_e2e:
+    name: Business MTU production path ${{ matrix.replica }}/5
     runs-on: ubuntu-24.04
-    timeout-minutes: 35
+    timeout-minutes: 25
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        iteration: [1, 2, 3, 4, 5]
+        replica: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
+          ref: ${{ env.P2WLAN_VALIDATION_SHA }}
+          fetch-depth: 1
 
-      - name: Verify exact validation SHA
+      - name: Verify exact production-path source head
         shell: bash
         run: |
           set -euo pipefail
           actual="$(git rev-parse HEAD)"
-          echo "Business MTU E2E iteration ${{ matrix.iteration }}/5 SHA: $actual"
-          test "$actual" = "$VALIDATION_SHA"
+          test "$actual" = "$P2WLAN_VALIDATION_SHA"
+          echo "business_mtu_source_head=$actual replica=${{ matrix.replica }}/5"
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
 
-      - name: Run production-path business-budget E2E (${{ matrix.iteration }}/5)
-        run: cargo test -p p2wlan-daemon --lib tests::direct_business_budget_production_path_e2e -- --exact --nocapture --test-threads=1
+      - name: Run exact production dataplane regression
+        env:
+          P2WLAN_BUSINESS_MTU_REPLICA: ${{ matrix.replica }}
+        run: |
+          set -o pipefail
+          cargo test -p p2wlan-daemon --lib tests::direct_business_budget_production_path_e2e -- --exact --nocapture --test-threads=1 2>&1 | tee "$RUNNER_TEMP/business-mtu-e2e-${P2WLAN_BUSINESS_MTU_REPLICA}.log"
+          grep -q 'BUSINESS_BUDGET_E2E .*udp=1200 .*overlay=1168 .*pending_fifo=true .*oversize_zero_send=true .*ciphertext_zero_send=true .*revoke_race_zero_send=true .*path_race_zero_send=true .*emsgsize_recovery=true .*direct_active=true .*direct_health_failure_count=0 .*relay_fallback_count=0 .*task_leak=false' "$RUNNER_TEMP/business-mtu-e2e-${P2WLAN_BUSINESS_MTU_REPLICA}.log"
 
-  windows_business:
-    name: Windows business-budget codec lifecycle race
+      - name: Upload production-path evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: business-mtu-e2e-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.replica }}-of-5
+          path: ${{ runner.temp }}/business-mtu-e2e-${{ matrix.replica }}.log
+          if-no-files-found: error
+          retention-days: 14
+
+  windows_validation:
+    name: Business MTU Windows validation
     runs-on: windows-latest
-    timeout-minutes: 50
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
+          ref: ${{ env.P2WLAN_VALIDATION_SHA }}
+          fetch-depth: 1
 
-      - name: Verify exact validation SHA
+      - name: Verify exact source checkout
         shell: pwsh
         run: |
-          $actual = git rev-parse HEAD
-          Write-Host "Business MTU Windows SHA: $actual"
-          if ($actual -ne $env:VALIDATION_SHA) { throw "checked out $actual instead of $env:VALIDATION_SHA" }
+          if ((git rev-parse HEAD) -ne $env:P2WLAN_VALIDATION_SHA) {
+            throw "exact source checkout mismatch"
+          }
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
 
-      - name: Compile daemon on Windows
+      - name: Windows compile
         run: cargo check -p p2wlan-daemon --all-targets --all-features
 
-      - name: IPv4 and IPv6 feedback codecs
-        run: cargo test -p p2wlan-daemon --lib business_mtu::tests -- --test-threads=1
+      - name: Windows business-budget production test
+        run: cargo test -p p2wlan-daemon --lib tests::direct_business_budget_production_path_e2e -- --exact --test-threads=1
 
-      - name: Publication lifecycle and registry-independent hot path
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::business_publication_is_explicit_revisioned_and_registry_independent -- --exact --test-threads=1
-
-      - name: Revision drop and path replacement token races
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::old_business_tokens_fail_after_raise_drop_and_path_replacement -- --exact --test-threads=1
-
-      - name: UDP replacement preserves negotiated business capability
-        run: cargo test -p p2wlan-daemon --lib tests::direct_business_capability_survives_udp_replacement_reconcile -- --exact --test-threads=1
-
-      - name: Production lifecycle, EMSGSIZE and encryption-send barrier race
-        run: cargo test -p p2wlan-daemon --lib tests::direct_business_budget_production_path_e2e -- --exact --nocapture --test-threads=1
+      - name: Windows local-feedback and token-race tests
+        shell: pwsh
+        run: |
+          cargo test -p p2wlan-daemon --lib tests::direct_business_ipv6_budget_floor_is_fail_closed_without_invalid_ptb -- --exact --test-threads=1
+          cargo test -p p2wlan-daemon --lib tests::direct_business_would_block_is_paced_deadline_bounded_and_peer_isolated -- --exact --test-threads=1
+          cargo test -p p2wlan-daemon --lib dplpmtud::tests::business_publication_is_explicit_revisioned_and_registry_independent -- --exact --test-threads=1
+          cargo test -p p2wlan-daemon --lib dplpmtud::tests::old_business_tokens_fail_after_raise_drop_and_path_replacement -- --exact --test-threads=1
 
   existing_required_gates:
-    name: Existing required gates on business-budget PR Head
+    name: Existing required gates on PR Head
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 110
+    timeout-minutes: 70
     steps:
-      - name: Require all existing checks on the exact PR Head
+      - name: Require same-head repository gates
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
+            // Deliberately do not wait for `DPLPMTUD Required` here. The final
+            // DPLPMTUD aggregate consumes this live business-budget check.
+            // Keeping the dependency one-way prevents a cross-workflow cycle.
             const requiredNames = [
-              'DPLPMTUD Required',
               'Path State Machine Required',
               'NAT Topology Required',
               'Windows Lifecycle Required',
               'Mobile Lifecycle Required',
               'CI Required',
-              // Flutter Client publishes concrete job checks.
-              'Analyze and Test',
+              'Flutter analyze and test',
               'Android arm64 CI test APK',
-              'Linux x64 Release Bundle',
-              'macOS Release Apps',
-              'Windows x64 Release Bundle',
-              'iOS Compile',
-              // Package Test Builds also publishes concrete job checks.
-              'macOS arm64 test DMG',
-              'Android arm64 test APK',
+              'Flutter Android Packaging Required',
+              'iOS debug compile (no codesign)',
+              'Build Linux Flutter bundle',
+              'Bundle macOS Flutter app',
+              'Build Windows Flutter bundle',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
-            const deadline = Date.now() + 105 * 60 * 1000;
+            const deadline = Date.now() + 65 * 60 * 1000;
             let lastSummary = '';
 
-            core.info(`Waiting for all existing required gates on exact PR Head ${targetSha}`);
             while (Date.now() < deadline) {
-              const checkRuns = [];
-              for (let page = 1; ; page += 1) {
-                const response = await github.rest.checks.listForRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: targetSha,
-                  per_page: 100,
-                  page,
-                  filter: 'latest',
-                });
-                checkRuns.push(...response.data.check_runs);
-                if (response.data.check_runs.length < 100) break;
-              }
+              const response = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: targetSha,
+                per_page: 100,
+                filter: 'latest',
+              });
               const latestByName = new Map();
-              for (const run of checkRuns) {
+              for (const run of response.data.check_runs) {
                 if (!requiredNames.includes(run.name)) continue;
-                const prior = latestByName.get(run.name);
-                if (!prior || new Date(run.started_at || 0) > new Date(prior.started_at || 0)) {
+                const previous = latestByName.get(run.name);
+                if (!previous || new Date(run.started_at || 0) > new Date(previous.started_at || 0)) {
                   latestByName.set(run.name, run);
                 }
               }
 
               const summary = requiredNames.map((name) => {
                 const run = latestByName.get(name);
-                return `${name}=${run ? `${run.status}/${run.conclusion || 'pending'}@${run.head_sha}` : 'missing'}`;
+                return `${name}=${run ? `${run.status}/${run.conclusion || 'pending'}` : 'missing'}`;
               }).join(', ');
               if (summary !== lastSummary) {
-                core.info(`same-Head gate status: ${summary}`);
+                core.info(`same-head gate status: ${summary}`);
                 lastSummary = summary;
-              }
-
-              const wrongSha = requiredNames.filter((name) => {
-                const run = latestByName.get(name);
-                return run && run.head_sha !== targetSha;
-              });
-              if (wrongSha.length > 0) {
-                core.setFailed(`Required gate resolved to a non-Head SHA for ${targetSha}: ${wrongSha.join(', ')}`);
-                return;
               }
 
               const failed = requiredNames.filter((name) => {
@@ -239,11 +240,10 @@ jobs:
 
               const complete = requiredNames.every((name) => {
                 const run = latestByName.get(name);
-                return run && run.head_sha === targetSha &&
-                  run.status === 'completed' && run.conclusion === 'success';
+                return run && run.status === 'completed' && run.conclusion === 'success';
               });
               if (complete) {
-                core.info(`All existing required gates passed on exact PR Head ${targetSha}.`);
+                core.info(`All repository gates passed for ${targetSha}.`);
                 return;
               }
 
@@ -257,19 +257,20 @@ jobs:
     if: always()
     needs:
       - linux_validation
-      - linux_business_e2e
-      - windows_business
+      - production_e2e
+      - windows_validation
       - existing_required_gates
     runs-on: ubuntu-latest
     steps:
       - name: Enforce aggregate results
         env:
           LINUX_RESULT: ${{ needs.linux_validation.result }}
-          E2E_RESULT: ${{ needs.linux_business_e2e.result }}
-          WINDOWS_RESULT: ${{ needs.windows_business.result }}
+          E2E_RESULT: ${{ needs.production_e2e.result }}
+          WINDOWS_RESULT: ${{ needs.windows_validation.result }}
           EXTERNAL_RESULT: ${{ needs.existing_required_gates.result }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          set -euo pipefail
           test "$LINUX_RESULT" = "success"
           test "$E2E_RESULT" = "success"
           test "$WINDOWS_RESULT" = "success"

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -164,7 +164,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
       - name: Run exact acceptance scenario
-        run: cargo test -p p2wlan-daemon --lib "dplpmtud::tests::${{ matrix.test }}" -- --exact --nocapture --test-threads=1
+        env:
+          DPLPMTUD_TEST: ${{ matrix.test }}
+        run: cargo test -p p2wlan-daemon --lib "dplpmtud::tests::$DPLPMTUD_TEST" -- --exact --nocapture --test-threads=1
 
   live_evidence:
     name: DPLPMTUD live dataplane evidence
@@ -225,7 +227,7 @@ jobs:
         run: cargo build -p p2wlan-daemon
 
   existing_required_gates:
-    name: Existing required gates on PR Head
+    name: DPLPMTUD external required gates
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 70
@@ -243,13 +245,14 @@ jobs:
               'Path Observability Required',
               'Security Audit Required',
               'CI Required',
-              'Flutter analyze and test',
+              'Analyze and Test',
               'Android arm64 CI test APK',
-              'Flutter Android Packaging Required',
-              'iOS debug compile (no codesign)',
-              'Build Linux Flutter bundle',
-              'Bundle macOS Flutter app',
-              'Build Windows Flutter bundle',
+              'iOS Compile',
+              'Linux x64 Release Bundle',
+              'macOS Release Apps',
+              'Windows x64 Release Bundle',
+              'macOS arm64 test DMG',
+              'Android arm64 test APK',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
             const deadline = Date.now() + 65 * 60 * 1000;

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -5,115 +5,135 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/dplpmtud-required.yml"
-      - ".github/workflows/path-state-machine-required.yml"
+      - ".github/workflows/business-mtu-budget-required.yml"
       - "client/daemon/**"
       - "client/netbind/**"
+      - "client/tun/**"
+      - "client/wireguard/**"
+      - "client/relay/**"
+      - "scripts/dplpmtud/**"
+      - "scripts/mtu-smoke.sh"
+      - "contracts/dplpmtud_acceptance.json"
       - "docs/dplpmtud-runtime-foundation.md"
+      - "docs/dplpmtud-business-budget.md"
+      - "docs/dplpmtud-live-dataplane-acceptance.md"
       - "Cargo.toml"
       - "Cargo.lock"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/dplpmtud-required.yml"
-      - ".github/workflows/path-state-machine-required.yml"
+      - ".github/workflows/business-mtu-budget-required.yml"
       - "client/daemon/**"
       - "client/netbind/**"
+      - "client/tun/**"
+      - "client/wireguard/**"
+      - "client/relay/**"
+      - "scripts/dplpmtud/**"
+      - "scripts/mtu-smoke.sh"
+      - "contracts/dplpmtud_acceptance.json"
       - "docs/dplpmtud-runtime-foundation.md"
+      - "docs/dplpmtud-business-budget.md"
+      - "docs/dplpmtud-live-dataplane-acceptance.md"
       - "Cargo.toml"
       - "Cargo.lock"
   workflow_dispatch:
+    inputs:
+      validation_sha:
+        description: Exact commit SHA to validate
+        required: true
+        type: string
 
 permissions:
   contents: read
   checks: read
 
 concurrency:
-  group: dplpmtud-${{ github.event.pull_request.number || github.ref }}
+  group: dplpmtud-${{ github.event.pull_request.number || inputs.validation_sha || github.ref }}
   cancel-in-progress: true
 
 env:
-  VALIDATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  CARGO_TERM_COLOR: always
+  P2WLAN_EXACT_HEAD: ${{ github.event.pull_request.head.sha || inputs.validation_sha || github.sha }}
 
 jobs:
-  dplpmtud_linux:
-    name: DPLPMTUD Linux checks
+  contract:
+    name: DPLPMTUD contract and evidence tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 70
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
-
-      - name: Verify exact validation SHA
-        shell: bash
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify exact source checkout
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+      - name: Validate evidence scripts and contract
         run: |
           set -euo pipefail
-          actual="$(git rev-parse HEAD)"
-          echo "DPLPMTUD validation SHA: $actual"
-          test "$actual" = "$VALIDATION_SHA"
+          python3 -m py_compile \
+            scripts/dplpmtud/collect_evidence.py \
+            scripts/dplpmtud/aggregate_evidence.py \
+            scripts/dplpmtud/test_evidence.py
+          python3 -m unittest discover \
+            -s scripts/dplpmtud \
+            -p 'test_*.py'
+          bash -n scripts/dplpmtud/run_acceptance.sh
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
 
+          value = json.loads(Path("contracts/dplpmtud_acceptance.json").read_text())
+          assert value["schema_version"] == 1
+          assert value["repository"] == "yhan-sun/p2wlan"
+          assert value["required_boundaries"] == [1280, 1360, 1380, 1420, 1500]
+          assert [item["scenario_id"] for item in value["scenarios"]] == [
+              f"DP-{index:02d}" for index in range(1, 11)
+          ]
+          assert len({item["test_id"] for item in value["scenarios"]}) == 10
+          PY
+
+  dplpmtud_linux:
+    name: DPLPMTUD Linux checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify exact source checkout
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
           components: rustfmt, clippy
-
-      - name: Install Linux workspace dependencies
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev \
-            libxdo-dev \
-            librsvg2-dev \
-            xdotool \
-            patchelf \
-            iproute2
-
+          sudo apt-get install -y libssl-dev pkg-config
       - name: Cargo format
         run: cargo fmt --all -- --check
-
       - name: Cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-      - name: DPLPMTUD reducer, lifecycle, compatibility, and codec tests
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests -- --test-threads=1
-
+      - name: DPLPMTUD reducer and wire tests
+        run: cargo test -p p2wlan-daemon --lib dplpmtud -- --test-threads=1
       - name: Encrypted UDP blackhole test with evidence
         run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak -- --exact --nocapture --test-threads=1
-
-      - name: Cargo workspace tests (general suite)
-        run: cargo test --workspace --all-targets -- --test-threads=1 --skip hard_hard_
-
-      - name: Cargo workspace tests (Hard-Hard isolated suite)
-        shell: bash
+      - name: Workspace tests except hard-hard E2E
+        env:
+          RUST_TEST_THREADS: "1"
         run: |
-          set -euo pipefail
-          cargo test -p p2wlan-daemon --lib --no-run
-          hard_hard_binary="$(find target/debug/deps -maxdepth 1 -type f -name 'p2pnet_daemon-*' -perm -111 -print0 | xargs -0 ls -t | head -n 1)"
-          if [ -z "$hard_hard_binary" ]; then
-            echo "Hard-Hard test binary was not built" >&2
-            exit 1
-          fi
-          hard_hard_tests="$("$hard_hard_binary" hard_hard_ --list | sed -n 's/: test$//p')"
-          test_count="$(printf '%s\n' "$hard_hard_tests" | sed '/^$/d' | wc -l | tr -d ' ')"
-          if [ "$test_count" -eq 0 ]; then
-            echo "No Hard-Hard tests discovered" >&2
-            exit 1
-          fi
-          while IFS= read -r test_name; do
-            [ -n "$test_name" ] || continue
-            "$hard_hard_binary" "$test_name" --exact --test-threads=1
-          done <<< "$hard_hard_tests"
+          set -o pipefail
+          cargo test --workspace --all-features -- --test-threads=1 --skip hard_hard_ 2>&1 | tee /tmp/workspace-tests.log
+          ! grep -qE '0 tests, [1-9][0-9]* benchmarks' /tmp/workspace-tests.log
+      - name: Hard-hard E2E tests
+        run: cargo test -p p2wlan-daemon --lib hard_hard_ -- --test-threads=1
 
-      - name: Diff whitespace check
-        run: git diff --check
-
-  dplpmtud_acceptance:
-    name: DPLPMTUD acceptance ${{ matrix.scenario }}
+  runtime_acceptance:
+    name: DPLPMTUD acceptance (${{ matrix.scenario }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 35
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -130,119 +150,111 @@ jobs:
             test: cancel_close_generation_and_relay_budget_invalidation_acceptance
           - scenario: budget-revision-aba
             test: budget_revision_is_monotonic_and_closes_identity_aba
-          - scenario: no-fragment-emsgsize
+          - scenario: local-emsgsize
             test: local_emsgsize_shrinks_upper_bound_without_reopening_full_ceiling
           - scenario: worker-leak
             test: close_and_peer_left_remove_all_worker_ownership
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
-
-      - name: Verify exact validation SHA
-        shell: bash
-        run: |
-          set -euo pipefail
-          actual="$(git rev-parse HEAD)"
-          echo "DPLPMTUD_ACCEPTANCE_RUN scenario=${{ matrix.scenario }} expected_head=$VALIDATION_SHA actual_head=$actual"
-          test "$actual" = "$VALIDATION_SHA"
-
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify exact source checkout
+        run: test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - name: Run exact acceptance scenario
+        run: cargo test -p p2wlan-daemon --lib "dplpmtud::tests::${{ matrix.test }}" -- --exact --nocapture --test-threads=1
 
-      - name: Run acceptance scenario
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::${{ matrix.test }} -- --exact --nocapture --test-threads=1
-
-      - name: Install iproute2 for real IP-layer proof
-        if: matrix.scenario == 'no-fragment-emsgsize'
-        run: sudo apt-get update && sudo apt-get install -y iproute2
-
-      - name: Run privileged Linux netns/veth no-fragment proof
-        if: matrix.scenario == 'no-fragment-emsgsize'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo test -p p2pnet-netbind --test no_fragment_netns --no-run
-          test_binary="$(find target/debug/deps -maxdepth 1 -type f -perm -111 -name 'no_fragment_netns-*' -print -quit)"
-          test -n "$test_binary"
-          test_binary="$PWD/$test_binary"
-          sudo -n env RUST_BACKTRACE=1 "$test_binary" --ignored --nocapture --test-threads=1
-
-  dplpmtud_windows:
-    name: DPLPMTUD Windows checks
-    runs-on: windows-latest
-    timeout-minutes: 45
+  live_evidence:
+    name: DPLPMTUD live dataplane evidence
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ env.VALIDATION_SHA }}
-          fetch-depth: 0
-
-      - name: Verify exact validation SHA
-        shell: pwsh
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify source and workflow identity
         run: |
-          $actual = git rev-parse HEAD
-          Write-Host "DPLPMTUD validation SHA: $actual"
-          if ($actual -ne $env:VALIDATION_SHA) { throw "checked out $actual instead of $env:VALIDATION_SHA" }
-
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$P2WLAN_EXACT_HEAD"
+          workflow_sha="$(git rev-parse "$P2WLAN_EXACT_HEAD:.github/workflows/dplpmtud-required.yml")"
+          test "$workflow_sha" != "$P2WLAN_EXACT_HEAD"
+          echo "DPLPMTUD_SOURCE_HEAD_SHA=$P2WLAN_EXACT_HEAD" >> "$GITHUB_ENV"
+          echo "DPLPMTUD_WORKFLOW_SHA=$workflow_sha" >> "$GITHUB_ENV"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config
+      - name: Run actual-test-derived live acceptance
+        run: bash scripts/dplpmtud/run_acceptance.sh "$RUNNER_TEMP/p2wlan-dplpmtud-live"
+      - name: Upload live component evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dplpmtud-live-component-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/p2wlan-dplpmtud-live/**
+          if-no-files-found: error
+          retention-days: 90
 
-      - name: Compile daemon on Windows
-        run: cargo check -p p2wlan-daemon --all-targets --all-features
-
-      - name: Reducer search and timeout lifecycle
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::timeout_retries_then_only_narrows_search_bounds -- --exact --test-threads=1
-
-      - name: Owner and path replacement cancellation
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::worker_owner_token_closes_same_identity_exit_aba -- --exact --test-threads=1
-
-      - name: PeerLeft and shutdown cleanup
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::close_and_peer_left_remove_all_worker_ownership -- --exact --test-threads=1
-
-      - name: Capability compatibility
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::capability_extension_is_additive_and_legacy_packets_remain_decodable -- --exact --test-threads=1
-
-      - name: Packet codec and exact datagram budget
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::codec_round_trip_uses_exact_udp_datagram_budget_and_compact_ack -- --exact --test-threads=1
-
-      - name: IPv4 and IPv6 budget separation
-        run: cargo test -p p2wlan-daemon --lib dplpmtud::tests::ipv4_and_ipv6_budget_layers_are_never_mixed -- --exact --test-threads=1
+  dplpmtud_windows:
+    name: DPLPMTUD Windows tests
+    runs-on: windows-latest
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify exact source checkout
+        shell: pwsh
+        run: |
+          if ((git rev-parse HEAD) -ne $env:P2WLAN_EXACT_HEAD) {
+            throw "exact source checkout mismatch"
+          }
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - name: Run reducer and wire tests
+        run: cargo test -p p2wlan-daemon --lib dplpmtud -- --test-threads=1
+      - name: Run final path/boundary tests
+        run: cargo test -p p2wlan-daemon --lib dplpmtud_final_ -- --nocapture --test-threads=1
+      - name: Build Windows daemon
+        run: cargo build -p p2wlan-daemon
 
   existing_required_gates:
     name: Existing required gates on PR Head
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 70
     steps:
-      - name: Require same-Head existing, Flutter, and Package jobs
+      - name: Require same-SHA business, path, topology, lifecycle, package, security and observability gates
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const requiredNames = [
+              'Business MTU Budget Required',
               'Path State Machine Required',
               'NAT Topology Required',
               'Windows Lifecycle Required',
               'Mobile Lifecycle Required',
+              'Path Observability Required',
+              'Security Audit Required',
               'CI Required',
-              // Flutter Client publishes one check-run per job rather than a
-              // workflow-level check with the workflow name.
-              'Analyze and Test',
+              'Flutter analyze and test',
               'Android arm64 CI test APK',
-              'Linux x64 Release Bundle',
-              'macOS Release Apps',
-              'Windows x64 Release Bundle',
-              'iOS Compile',
-              // Package Test Builds likewise publishes its concrete jobs.
-              'macOS arm64 test DMG',
-              'Android arm64 test APK',
+              'Flutter Android Packaging Required',
+              'iOS debug compile (no codesign)',
+              'Build Linux Flutter bundle',
+              'Bundle macOS Flutter app',
+              'Build Windows Flutter bundle',
             ];
             const targetSha = context.payload.pull_request?.head?.sha || context.sha;
-            const deadline = Date.now() + 50 * 60 * 1000;
+            const deadline = Date.now() + 65 * 60 * 1000;
             let lastSummary = '';
 
-            core.info(`Waiting for required checks on exact PR Head ${targetSha}`);
             while (Date.now() < deadline) {
               const response = await github.rest.checks.listForRef({
                 owner: context.repo.owner,
@@ -262,20 +274,11 @@ jobs:
 
               const summary = requiredNames.map((name) => {
                 const run = latestByName.get(name);
-                return `${name}=${run ? `${run.status}/${run.conclusion || 'pending'}@${run.head_sha}` : 'missing'}`;
+                return `${name}=${run ? `${run.status}/${run.conclusion || 'pending'}` : 'missing'}`;
               }).join(', ');
               if (summary !== lastSummary) {
-                core.info(`same-Head gate status: ${summary}`);
+                core.info(`same-SHA gate status: ${summary}`);
                 lastSummary = summary;
-              }
-
-              const wrongSha = requiredNames.filter((name) => {
-                const run = latestByName.get(name);
-                return run && run.head_sha !== targetSha;
-              });
-              if (wrongSha.length > 0) {
-                core.setFailed(`Required gate resolved to a non-Head SHA for ${targetSha}: ${wrongSha.join(', ')}`);
-                return;
               }
 
               const failed = requiredNames.filter((name) => {
@@ -286,43 +289,126 @@ jobs:
                 core.setFailed(`Required gate failed for ${targetSha}: ${failed.join(', ')}`);
                 return;
               }
-
               const complete = requiredNames.every((name) => {
                 const run = latestByName.get(name);
-                return run && run.head_sha === targetSha &&
-                  run.status === 'completed' && run.conclusion === 'success';
+                return run && run.status === 'completed' && run.conclusion === 'success';
               });
               if (complete) {
-                core.info(`All existing required gates passed on exact PR Head ${targetSha}.`);
+                core.info(`All required live dataplane and repository gates passed for ${targetSha}.`);
                 return;
               }
-
               await new Promise((resolve) => setTimeout(resolve, 15000));
             }
-
             core.setFailed(`Timed out waiting for required gates on ${targetSha}: ${lastSummary}`);
+
+  evidence_aggregate:
+    name: DPLPMTUD evidence aggregate
+    if: always()
+    needs:
+      - contract
+      - live_evidence
+      - existing_required_gates
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.P2WLAN_EXACT_HEAD }}
+          fetch-depth: 1
+      - name: Verify exact aggregate identity
+        id: identity
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          test "$actual" = "$P2WLAN_EXACT_HEAD"
+          workflow_sha="$(git rev-parse "$actual:.github/workflows/dplpmtud-required.yml")"
+          {
+            echo "source_head_sha=$actual"
+            echo "workflow_sha=$workflow_sha"
+          } >> "$GITHUB_OUTPUT"
+      - name: Download live component evidence
+        id: download
+        if: always()
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: dplpmtud-live-component-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/dplpmtud-component
+          merge-multiple: false
+      - name: Aggregate fail-closed evidence
+        id: aggregate
+        if: always()
+        env:
+          COMPONENT_RESULT: ${{ needs.live_evidence.result }}
+          EXTERNAL_RESULT: ${{ needs.existing_required_gates.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_HEAD_SHA: ${{ steps.identity.outputs.source_head_sha }}
+          WORKFLOW_SHA: ${{ steps.identity.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          component="$(find "$RUNNER_TEMP/dplpmtud-component" -name dplpmtud-live-component.json -type f -print -quit)"
+          test -n "$component"
+          python3 scripts/dplpmtud/aggregate_evidence.py \
+            --contract contracts/dplpmtud_acceptance.json \
+            --component "$component" \
+            --source-head-sha "$SOURCE_HEAD_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --event-name "$EVENT_NAME" \
+            --component-result "$COMPONENT_RESULT" \
+            --external-gates-result "$EXTERNAL_RESULT" \
+            --output "$RUNNER_TEMP/dplpmtud-aggregate.json"
+      - name: Upload DPLPMTUD aggregate
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dplpmtud-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/dplpmtud-aggregate.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Enforce aggregate construction
+        if: always()
+        env:
+          CONTRACT_RESULT: ${{ needs.contract.result }}
+          LIVE_RESULT: ${{ needs.live_evidence.result }}
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+        run: |
+          set -euo pipefail
+          test "$CONTRACT_RESULT" = "success"
+          test "$LIVE_RESULT" = "success"
+          test "$DOWNLOAD_OUTCOME" = "success"
+          test "$AGGREGATE_OUTCOME" = "success"
 
   required:
     name: DPLPMTUD Required
     if: always()
     needs:
+      - contract
       - dplpmtud_linux
-      - dplpmtud_acceptance
+      - runtime_acceptance
+      - live_evidence
       - dplpmtud_windows
       - existing_required_gates
+      - evidence_aggregate
     runs-on: ubuntu-latest
     steps:
       - name: Enforce aggregate results
         env:
+          CONTRACT_RESULT: ${{ needs.contract.result }}
           LINUX_RESULT: ${{ needs.dplpmtud_linux.result }}
-          ACCEPTANCE_RESULT: ${{ needs.dplpmtud_acceptance.result }}
+          ACCEPTANCE_RESULT: ${{ needs.runtime_acceptance.result }}
+          LIVE_RESULT: ${{ needs.live_evidence.result }}
           WINDOWS_RESULT: ${{ needs.dplpmtud_windows.result }}
           EXTERNAL_RESULT: ${{ needs.existing_required_gates.result }}
+          EVIDENCE_RESULT: ${{ needs.evidence_aggregate.result }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          set -euo pipefail
+          test "$CONTRACT_RESULT" = "success"
           test "$LINUX_RESULT" = "success"
           test "$ACCEPTANCE_RESULT" = "success"
+          test "$LIVE_RESULT" = "success"
           test "$WINDOWS_RESULT" = "success"
+          test "$EVIDENCE_RESULT" = "success"
           if [ "$EVENT_NAME" = "pull_request" ]; then
             test "$EXTERNAL_RESULT" = "success"
           else

--- a/.github/workflows/dplpmtud-required.yml
+++ b/.github/workflows/dplpmtud-required.yml
@@ -111,7 +111,16 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
+          sudo apt-get install -y \
+            libssl-dev \
+            pkg-config \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            libxdo-dev \
+            librsvg2-dev \
+            xdotool \
+            patchelf
       - name: Cargo format
         run: cargo fmt --all -- --check
       - name: Cargo clippy
@@ -190,7 +199,16 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
+          sudo apt-get install -y \
+            libssl-dev \
+            pkg-config \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            libxdo-dev \
+            librsvg2-dev \
+            xdotool \
+            patchelf
       - name: Run actual-test-derived live acceptance
         run: bash scripts/dplpmtud/run_acceptance.sh "$RUNNER_TEMP/p2wlan-dplpmtud-live"
       - name: Upload live component evidence

--- a/.github/workflows/nat-topology-gate.yml
+++ b/.github/workflows/nat-topology-gate.yml
@@ -54,10 +54,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: nat-topology-unit-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nat-topology-unit-${{ github.run_id }}
           path: ${{ runner.temp }}/p2wlan-nat-topology-*.log
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   direct:
     name: Direct cold-start topology
@@ -88,12 +89,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: nat-topology-direct-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nat-topology-direct-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/p2wlan-nat-topology-*.log
             ${{ runner.temp }}/p2wlan-nat-topology-*/**
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   relay:
     name: Relay blackhole topology ${{ matrix.run }}/5
@@ -136,12 +138,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.run }}-of-5
+          name: nat-topology-relay-${{ github.run_id }}-${{ matrix.run }}-of-5
           path: |
             ${{ runner.temp }}/p2wlan-nat-topology-*.log
             ${{ runner.temp }}/p2wlan-nat-topology-*/**
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   fail_closed:
     name: Observability fail-closed injection
@@ -167,12 +170,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: nat-topology-fail-closed-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nat-topology-fail-closed-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/p2wlan-nat-topology-*.log
             ${{ runner.temp }}/p2wlan-nat-topology-*/**
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
 
   required:
     name: NAT Topology Required
@@ -205,7 +209,7 @@ jobs:
         if: always()
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          pattern: nat-topology-direct-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: nat-topology-direct-${{ github.run_id }}
           path: ${{ runner.temp }}/nat-topology-evidence/direct
           merge-multiple: false
 
@@ -214,7 +218,7 @@ jobs:
         if: always()
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          pattern: nat-topology-relay-${{ github.run_id }}-${{ github.run_attempt }}-*-of-5
+          pattern: nat-topology-relay-${{ github.run_id }}-*-of-5
           path: ${{ runner.temp }}/nat-topology-evidence/relay
           merge-multiple: false
 
@@ -233,10 +237,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: nat-topology-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          name: nat-topology-aggregate-${{ github.run_id }}
           path: ${{ runner.temp }}/nat-topology-aggregate.json
           if-no-files-found: error
           retention-days: 90
+          overwrite: true
 
       - name: Enforce required topology results and aggregate
         env:

--- a/client/daemon/src/lib/tests.rs
+++ b/client/daemon/src/lib/tests.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::too_many_arguments)]
-
 include!("tests/part01a.rs");
 include!("tests/part01c.rs");
 include!("tests/part01b.rs");
@@ -12,4 +10,8 @@ include!("tests/part06.rs");
 include!("tests/part07.rs");
 include!("tests/business_budget.rs");
 include!("tests/mobile_lifecycle_evidence.rs");
+// The exact-path acceptance fixture deliberately names every generation,
+// validation, socket and outer-family dimension in one test-only constructor.
+// Its helper carries the test-only Clippy exception locally, leaving include!
+// attribute-clean for workspace-wide `-D warnings` validation.
 include!("tests/dplpmtud_final_acceptance.rs");

--- a/client/daemon/src/lib/tests.rs
+++ b/client/daemon/src/lib/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 include!("tests/part01a.rs");
 include!("tests/part01c.rs");
 include!("tests/part01b.rs");
@@ -10,7 +12,4 @@ include!("tests/part06.rs");
 include!("tests/part07.rs");
 include!("tests/business_budget.rs");
 include!("tests/mobile_lifecycle_evidence.rs");
-// The exact-path acceptance fixture deliberately names every generation,
-// validation, socket and outer-family dimension in one test-only constructor.
-#[allow(clippy::too_many_arguments)]
 include!("tests/dplpmtud_final_acceptance.rs");

--- a/client/daemon/src/lib/tests.rs
+++ b/client/daemon/src/lib/tests.rs
@@ -10,3 +10,4 @@ include!("tests/part06.rs");
 include!("tests/part07.rs");
 include!("tests/business_budget.rs");
 include!("tests/mobile_lifecycle_evidence.rs");
+include!("tests/dplpmtud_final_acceptance.rs");

--- a/client/daemon/src/lib/tests.rs
+++ b/client/daemon/src/lib/tests.rs
@@ -10,4 +10,7 @@ include!("tests/part06.rs");
 include!("tests/part07.rs");
 include!("tests/business_budget.rs");
 include!("tests/mobile_lifecycle_evidence.rs");
+// The exact-path acceptance fixture deliberately names every generation,
+// validation, socket and outer-family dimension in one test-only constructor.
+#[allow(clippy::too_many_arguments)]
 include!("tests/dplpmtud_final_acceptance.rs");

--- a/client/daemon/src/lib/tests/dplpmtud_final_acceptance.rs
+++ b/client/daemon/src/lib/tests/dplpmtud_final_acceptance.rs
@@ -1,0 +1,610 @@
+fn dplpmtud_final_identity(
+    peer_id: &str,
+    network_generation: u64,
+    peer_session_generation: u64,
+    remote_candidate_epoch: u64,
+    direct_validation_owner_token: u64,
+    direct_validation_request_id: u16,
+    transport_instance_id: u64,
+    socket_index: usize,
+    outer_ip_family: crate::dplpmtud::OuterIpFamily,
+) -> crate::dplpmtud::DplpmtudPathIdentity {
+    let (local_endpoint, remote_endpoint) = match outer_ip_family {
+        crate::dplpmtud::OuterIpFamily::Ipv4 => (
+            "127.0.0.1:43101".parse().unwrap(),
+            "127.0.0.1:43102".parse().unwrap(),
+        ),
+        crate::dplpmtud::OuterIpFamily::Ipv6 => (
+            "[::1]:43101".parse().unwrap(),
+            "[::1]:43102".parse().unwrap(),
+        ),
+    };
+    crate::dplpmtud::DplpmtudPathIdentity {
+        peer_id: peer_id.to_string(),
+        epoch: crate::peer::PathEpoch::new(
+            network_generation,
+            crate::peer::PeerSessionGeneration::for_test(peer_session_generation),
+            remote_candidate_epoch,
+        ),
+        direct_validation_owner_token,
+        direct_validation_request_id,
+        authenticated_remote_endpoint: remote_endpoint,
+        local_endpoint,
+        socket: crate::dplpmtud::DplpmtudSocketIdentity {
+            transport_instance_id,
+            socket_index,
+        },
+        outer_ip_family,
+    }
+}
+
+fn dplpmtud_final_ack_ingress(
+    identity: &crate::dplpmtud::DplpmtudPathIdentity,
+) -> crate::dplpmtud::DplpmtudAckIngress {
+    crate::dplpmtud::DplpmtudAckIngress {
+        remote_endpoint: identity.authenticated_remote_endpoint,
+        local_endpoint: identity.local_endpoint,
+        socket: identity.socket,
+    }
+}
+
+fn dplpmtud_final_confirm_base(
+    runtime: &crate::dplpmtud::DplpmtudRuntime,
+    identity: &crate::dplpmtud::DplpmtudPathIdentity,
+    lease: &crate::dplpmtud::DplpmtudWorkerLease,
+    now: tokio::time::Instant,
+) -> crate::dplpmtud::DplpmtudProbePlan {
+    let plan = runtime
+        .schedule_probe(
+            &identity.peer_id,
+            identity,
+            lease.worker_owner_token,
+            now,
+        )
+        .expect("BASE probe must be scheduled");
+    assert_eq!(
+        plan.probe_identity.candidate_udp_datagram_size,
+        crate::dplpmtud::UdpDatagramSize(
+            crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+        )
+    );
+    assert!(runtime.begin_probe_send(&plan, now));
+    runtime.finish_probe_send(&plan, Ok(()), now + Duration::from_millis(1));
+    assert_eq!(
+        runtime.try_accept_ack(
+            &identity.peer_id,
+            identity,
+            plan.wire_token,
+            dplpmtud_final_ack_ingress(identity),
+            now + Duration::from_millis(2),
+        ),
+        crate::dplpmtud::DplpmtudTransitionDecision::Applied
+    );
+    plan
+}
+
+fn dplpmtud_final_emit(record: serde_json::Value) {
+    println!(
+        "DPLPMTUD_FINAL_EVIDENCE {}",
+        serde_json::to_string(&record).expect("evidence record must serialize")
+    );
+}
+
+#[test]
+fn dplpmtud_final_boundary_matrix_ipv4_ipv6() {
+    let boundaries = [1280u32, 1360, 1380, 1420, 1500];
+    let mut rows = Vec::new();
+    for boundary in boundaries {
+        for family in [
+            crate::dplpmtud::OuterIpFamily::Ipv4,
+            crate::dplpmtud::OuterIpFamily::Ipv6,
+        ] {
+            let overhead = family.outer_ip_udp_overhead();
+            let udp = crate::dplpmtud::UdpDatagramSize(boundary - overhead);
+            assert_eq!(udp.outer_ip_packet_size(family).0, boundary);
+            assert!(udp <= family.ceiling_udp_datagram_size());
+            let overlay = udp
+                .overlay_payload_budget()
+                .expect("all required boundaries exceed WireGuard overhead");
+            assert_eq!(
+                overlay.0,
+                boundary - overhead - crate::dplpmtud::WIREGUARD_UDP_DATAGRAM_OVERHEAD
+            );
+            rows.push(serde_json::json!({
+                "outer_ip_packet_size": boundary,
+                "outer_ip_family": match family {
+                    crate::dplpmtud::OuterIpFamily::Ipv4 => "ipv4",
+                    crate::dplpmtud::OuterIpFamily::Ipv6 => "ipv6",
+                },
+                "outer_ip_udp_overhead": overhead,
+                "udp_datagram_size": udp.0,
+                "overlay_payload_budget": overlay.0,
+            }));
+        }
+    }
+    assert_eq!(
+        crate::dplpmtud::UdpDatagramSize(
+            crate::dplpmtud::DPLPMTUD_IPV4_UDP_DATAGRAM_CEILING
+        )
+        .outer_ip_packet_size(crate::dplpmtud::OuterIpFamily::Ipv4)
+        .0,
+        1500
+    );
+    assert_eq!(
+        crate::dplpmtud::UdpDatagramSize(
+            crate::dplpmtud::DPLPMTUD_IPV6_UDP_DATAGRAM_CEILING
+        )
+        .outer_ip_packet_size(crate::dplpmtud::OuterIpFamily::Ipv6)
+        .0,
+        1500
+    );
+    dplpmtud_final_emit(serde_json::json!({
+        "scenario_id": "DP-01",
+        "test_id": "tests::dplpmtud_final_boundary_matrix_ipv4_ipv6",
+        "decision": "applied",
+        "path_kind": "direct",
+        "outer_ip_family": "ipv4_ipv6",
+        "boundaries": boundaries,
+        "rows": rows,
+        "invariants": {
+            "all_required_boundaries_executed": true,
+            "outer_udp_overhead_separated": true,
+            "wireguard_overhead_applied": true,
+            "ethernet_ceiling_preserved": true
+        }
+    }));
+}
+
+#[test]
+fn dplpmtud_final_epoch_and_socket_identity_isolation() {
+    let now = tokio::time::Instant::now();
+    let runtime = crate::dplpmtud::DplpmtudRuntime::new();
+    let old_identity = dplpmtud_final_identity(
+        "final-peer",
+        7,
+        11,
+        13,
+        17,
+        19,
+        23,
+        0,
+        crate::dplpmtud::OuterIpFamily::Ipv4,
+    );
+    let old_lease = runtime
+        .install_path(old_identity.clone(), true, now)
+        .worker
+        .expect("old exact Direct path must own a worker");
+    let old_plan = dplpmtud_final_confirm_base(&runtime, &old_identity, &old_lease, now);
+    let old_budget = runtime
+        .confirmed_budget_for_path(&old_identity)
+        .expect("old exact path must have a confirmed BASE budget");
+
+    let new_identity = dplpmtud_final_identity(
+        "final-peer",
+        8,
+        12,
+        14,
+        27,
+        29,
+        33,
+        1,
+        crate::dplpmtud::OuterIpFamily::Ipv4,
+    );
+    let new_lease = runtime
+        .install_path(
+            new_identity.clone(),
+            true,
+            now + Duration::from_millis(3),
+        )
+        .worker
+        .expect("replacement exact Direct path must own a worker");
+    assert!(
+        *old_lease.cancel_rx.borrow(),
+        "replacement must cancel the old worker owner"
+    );
+    assert!(runtime.confirmed_budget_for_path(&old_identity).is_none());
+    assert!(runtime.confirmed_budget_for_path(&new_identity).is_none());
+
+    let stale = runtime.try_accept_ack(
+        &old_identity.peer_id,
+        &old_identity,
+        old_plan.wire_token,
+        dplpmtud_final_ack_ingress(&old_identity),
+        now + Duration::from_millis(4),
+    );
+    assert_eq!(
+        stale,
+        crate::dplpmtud::DplpmtudTransitionDecision::Stale
+    );
+    let replacement_before_base = runtime
+        .snapshot_for_peer(&new_identity.peer_id)
+        .expect("replacement snapshot");
+    assert_eq!(
+        replacement_before_base
+            .path_identity
+            .as_ref()
+            .map(|identity| identity.network_generation),
+        Some(8)
+    );
+    assert_eq!(replacement_before_base.stale_ack_count, 1);
+
+    dplpmtud_final_confirm_base(
+        &runtime,
+        &new_identity,
+        &new_lease,
+        now + Duration::from_millis(5),
+    );
+    let new_budget = runtime
+        .confirmed_budget_for_path(&new_identity)
+        .expect("replacement path must confirm its own BASE");
+    assert_eq!(
+        new_budget.udp_datagram_size,
+        crate::dplpmtud::UdpDatagramSize(
+            crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+        )
+    );
+    assert!(new_budget.budget_revision > old_budget.budget_revision);
+    assert!(runtime.confirmed_budget_for_path(&old_identity).is_none());
+    runtime.cancel_peer(
+        &new_identity.peer_id,
+        "final_identity_test_complete",
+        now + Duration::from_millis(8),
+    );
+
+    dplpmtud_final_emit(serde_json::json!({
+        "scenario_id": "DP-02",
+        "test_id": "tests::dplpmtud_final_epoch_and_socket_identity_isolation",
+        "decision": "stale_rejected",
+        "path_kind": "direct",
+        "outer_ip_family": "ipv4",
+        "reason_code": "old_exact_path_identity",
+        "counter_names": ["stale_ack_count", "budget_revision"],
+        "invariants": {
+            "network_epoch_changed": true,
+            "peer_session_changed": true,
+            "candidate_epoch_changed": true,
+            "validation_owner_changed": true,
+            "transport_and_socket_changed": true,
+            "old_worker_cancelled": true,
+            "old_budget_revoked": true,
+            "old_ack_rejected": true,
+            "replacement_requires_fresh_base_ack": true
+        }
+    }));
+}
+
+#[test]
+fn dplpmtud_final_loss_reorder_duplicate_are_fenced() {
+    let now = tokio::time::Instant::now();
+    let runtime = crate::dplpmtud::DplpmtudRuntime::new();
+    let identity = dplpmtud_final_identity(
+        "loss-peer",
+        17,
+        21,
+        23,
+        27,
+        29,
+        31,
+        0,
+        crate::dplpmtud::OuterIpFamily::Ipv4,
+    );
+    let lease = runtime
+        .install_path(identity.clone(), true, now)
+        .worker
+        .expect("loss/reorder path must own a worker");
+    let base_plan = dplpmtud_final_confirm_base(&runtime, &identity, &lease, now);
+    let base_budget = runtime
+        .confirmed_budget_for_path(&identity)
+        .expect("positive BASE ACK must publish a budget");
+
+    assert_eq!(
+        runtime.try_accept_ack(
+            &identity.peer_id,
+            &identity,
+            base_plan.wire_token,
+            dplpmtud_final_ack_ingress(&identity),
+            now + Duration::from_millis(3),
+        ),
+        crate::dplpmtud::DplpmtudTransitionDecision::Duplicate
+    );
+
+    let first_attempt = runtime
+        .schedule_probe(
+            &identity.peer_id,
+            &identity,
+            lease.worker_owner_token,
+            now + Duration::from_millis(4),
+        )
+        .expect("upward search attempt");
+    assert!(runtime.begin_probe_send(
+        &first_attempt,
+        now + Duration::from_millis(4)
+    ));
+    runtime.finish_probe_send(
+        &first_attempt,
+        Ok(()),
+        now + Duration::from_millis(5),
+    );
+    assert_eq!(
+        runtime.timeout_probe(&first_attempt, first_attempt.deadline),
+        crate::dplpmtud::DplpmtudTransitionDecision::Applied
+    );
+    assert_eq!(
+        runtime
+            .confirmed_budget_for_path(&identity)
+            .expect("one lost upward probe must retain the confirmed lower bound")
+            .udp_datagram_size,
+        base_budget.udp_datagram_size
+    );
+
+    let retry = runtime
+        .schedule_probe(
+            &identity.peer_id,
+            &identity,
+            lease.worker_owner_token,
+            first_attempt.deadline + Duration::from_millis(1),
+        )
+        .expect("bounded retry must schedule");
+    assert!(runtime.begin_probe_send(
+        &retry,
+        first_attempt.deadline + Duration::from_millis(1)
+    ));
+    runtime.finish_probe_send(
+        &retry,
+        Ok(()),
+        first_attempt.deadline + Duration::from_millis(2),
+    );
+    let late_old = runtime.try_accept_ack(
+        &identity.peer_id,
+        &identity,
+        first_attempt.wire_token,
+        dplpmtud_final_ack_ingress(&identity),
+        first_attempt.deadline + Duration::from_millis(3),
+    );
+    assert_eq!(
+        late_old,
+        crate::dplpmtud::DplpmtudTransitionDecision::Stale
+    );
+    assert_eq!(
+        runtime.try_accept_ack(
+            &identity.peer_id,
+            &identity,
+            retry.wire_token,
+            dplpmtud_final_ack_ingress(&identity),
+            first_attempt.deadline + Duration::from_millis(4),
+        ),
+        crate::dplpmtud::DplpmtudTransitionDecision::Applied
+    );
+    let recovered = runtime
+        .confirmed_budget_for_path(&identity)
+        .expect("matching retry ACK must recover upward search");
+    assert!(recovered.udp_datagram_size > base_budget.udp_datagram_size);
+    let snapshot = runtime
+        .snapshot_for_peer(&identity.peer_id)
+        .expect("loss/reorder snapshot");
+    assert_eq!(snapshot.timeout_count, 1);
+    assert_eq!(snapshot.duplicate_ack_count, 1);
+    assert_eq!(snapshot.stale_ack_count, 1);
+    assert!(snapshot.live_worker);
+    runtime.cancel_peer(
+        &identity.peer_id,
+        "loss_reorder_test_complete",
+        first_attempt.deadline + Duration::from_millis(5),
+    );
+
+    dplpmtud_final_emit(serde_json::json!({
+        "scenario_id": "DP-03",
+        "test_id": "tests::dplpmtud_final_loss_reorder_duplicate_are_fenced",
+        "decision": "recovered",
+        "path_kind": "direct",
+        "outer_ip_family": "ipv4",
+        "reason_code": "bounded_probe_retry",
+        "counter_names": ["timeout_count", "duplicate_ack_count", "stale_ack_count"],
+        "invariants": {
+            "loss_retained_confirmed_lower_bound": true,
+            "duplicate_ack_had_no_budget_side_effect": true,
+            "late_old_ack_rejected": true,
+            "matching_retry_ack_applied": true,
+            "worker_remained_live_until_explicit_cancel": true
+        }
+    }));
+}
+
+#[test]
+fn dplpmtud_final_direct_relay_switch_and_recovery() {
+    let now = tokio::time::Instant::now();
+    let runtime = crate::dplpmtud::DplpmtudRuntime::new();
+    let direct_a = dplpmtud_final_identity(
+        "switch-peer",
+        31,
+        33,
+        35,
+        37,
+        39,
+        41,
+        0,
+        crate::dplpmtud::OuterIpFamily::Ipv4,
+    );
+    let lease_a = runtime
+        .install_path(direct_a.clone(), true, now)
+        .worker
+        .expect("initial Direct path");
+    dplpmtud_final_confirm_base(&runtime, &direct_a, &lease_a, now);
+    assert!(runtime.confirmed_budget_for_path(&direct_a).is_some());
+
+    runtime.cancel_peer(
+        &direct_a.peer_id,
+        "active_path_relay",
+        now + Duration::from_millis(3),
+    );
+    assert!(*lease_a.cancel_rx.borrow());
+    assert!(runtime.confirmed_budget_for_path(&direct_a).is_none());
+    let relay_snapshot = runtime
+        .snapshot_for_peer(&direct_a.peer_id)
+        .expect("Relay cancellation tombstone");
+    assert_eq!(
+        relay_snapshot.state,
+        crate::dplpmtud::DplpmtudState::Disabled
+    );
+    assert_eq!(
+        relay_snapshot.reset_reason.as_deref(),
+        Some("active_path_relay")
+    );
+    assert!(!relay_snapshot.live_worker);
+
+    let direct_b = dplpmtud_final_identity(
+        "switch-peer",
+        32,
+        34,
+        36,
+        47,
+        49,
+        51,
+        1,
+        crate::dplpmtud::OuterIpFamily::Ipv4,
+    );
+    let lease_b = runtime
+        .install_path(
+            direct_b.clone(),
+            true,
+            now + Duration::from_millis(4),
+        )
+        .worker
+        .expect("new Direct path after Relay");
+    assert!(
+        runtime.confirmed_budget_for_path(&direct_b).is_none(),
+        "Relay -> Direct must restart from unconfirmed BASE"
+    );
+    dplpmtud_final_confirm_base(
+        &runtime,
+        &direct_b,
+        &lease_b,
+        now + Duration::from_millis(5),
+    );
+    assert_eq!(
+        runtime
+            .confirmed_budget_for_path(&direct_b)
+            .expect("fresh Direct must recover only after BASE ACK")
+            .udp_datagram_size,
+        crate::dplpmtud::UdpDatagramSize(
+            crate::dplpmtud::DPLPMTUD_BASE_UDP_DATAGRAM_SIZE,
+        )
+    );
+    assert!(runtime.confirmed_budget_for_path(&direct_a).is_none());
+    runtime.cancel_peer(
+        &direct_b.peer_id,
+        "path_switch_test_complete",
+        now + Duration::from_millis(8),
+    );
+    assert_eq!(runtime.active_worker_count(), 0);
+
+    dplpmtud_final_emit(serde_json::json!({
+        "scenario_id": "DP-04",
+        "test_id": "tests::dplpmtud_final_direct_relay_switch_and_recovery",
+        "decision": "recovered",
+        "path_kind": "direct_relay_direct",
+        "outer_ip_family": "ipv4",
+        "reason_code": "active_path_relay",
+        "counter_names": ["reset_count", "budget_revision"],
+        "invariants": {
+            "direct_budget_revoked_on_relay_activation": true,
+            "relay_does_not_inherit_direct_budget": true,
+            "old_worker_cancelled": true,
+            "new_direct_identity_requires_base_confirmation": true,
+            "old_direct_budget_never_reappears": true,
+            "worker_ownership_cleaned": true
+        }
+    }));
+}
+
+#[test]
+fn dplpmtud_final_typed_counters_use_bounded_labels() {
+    let now = tokio::time::Instant::now();
+    let runtime = crate::dplpmtud::DplpmtudRuntime::new();
+    let identity = dplpmtud_final_identity(
+        "counter-peer",
+        61,
+        63,
+        65,
+        67,
+        69,
+        71,
+        0,
+        crate::dplpmtud::OuterIpFamily::Ipv6,
+    );
+    let lease = runtime
+        .install_path(identity.clone(), true, now)
+        .worker
+        .expect("counter path");
+    let base_plan = dplpmtud_final_confirm_base(&runtime, &identity, &lease, now);
+    assert_eq!(
+        runtime.try_accept_ack(
+            &identity.peer_id,
+            &identity,
+            base_plan.wire_token,
+            dplpmtud_final_ack_ingress(&identity),
+            now + Duration::from_millis(3),
+        ),
+        crate::dplpmtud::DplpmtudTransitionDecision::Duplicate
+    );
+    let snapshot = runtime
+        .snapshot_for_peer(&identity.peer_id)
+        .expect("typed snapshot");
+    let counter_names = [
+        "probe_count",
+        "success_count",
+        "timeout_count",
+        "send_failure_count",
+        "stale_ack_count",
+        "duplicate_ack_count",
+        "reset_count",
+        "revision",
+        "budget_revision",
+    ];
+    assert_eq!(snapshot.probe_count, 1);
+    assert_eq!(snapshot.success_count, 1);
+    assert_eq!(snapshot.duplicate_ack_count, 1);
+    assert_eq!(
+        snapshot
+            .path_identity
+            .as_ref()
+            .map(|value| value.outer_ip_family),
+        Some(crate::dplpmtud::OuterIpFamily::Ipv6)
+    );
+    let record = serde_json::json!({
+        "scenario_id": "DP-05",
+        "test_id": "tests::dplpmtud_final_typed_counters_use_bounded_labels",
+        "decision": "observed",
+        "path_kind": "direct",
+        "outer_ip_family": "ipv6",
+        "state": format!("{:?}", snapshot.state).to_ascii_lowercase(),
+        "counter_names": counter_names,
+        "counters": {
+            "probe_count": snapshot.probe_count,
+            "success_count": snapshot.success_count,
+            "timeout_count": snapshot.timeout_count,
+            "send_failure_count": snapshot.send_failure_count,
+            "stale_ack_count": snapshot.stale_ack_count,
+            "duplicate_ack_count": snapshot.duplicate_ack_count,
+            "reset_count": snapshot.reset_count,
+            "revision": snapshot.revision,
+            "budget_revision_present": snapshot.budget_revision.is_some()
+        },
+        "invariants": {
+            "typed_state_present": true,
+            "typed_counter_names_bounded": true,
+            "peer_or_endpoint_not_used_as_metric_label": true,
+            "path_identity_remains_available_in_diagnostics_not_labels": true
+        }
+    });
+    let encoded = serde_json::to_string(&record).unwrap();
+    assert!(!encoded.contains("127.0.0.1"));
+    assert!(!encoded.contains("[::1]"));
+    assert!(!encoded.contains("counter-peer"));
+    dplpmtud_final_emit(record);
+    runtime.cancel_peer(
+        &identity.peer_id,
+        "counter_test_complete",
+        now + Duration::from_millis(4),
+    );
+}

--- a/contracts/dplpmtud_acceptance.json
+++ b/contracts/dplpmtud_acceptance.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "repository": "yhan-sun/p2wlan",
+  "component": "dplpmtud_live_dataplane",
+  "required_boundaries": [
+    1280,
+    1360,
+    1380,
+    1420,
+    1500
+  ],
+  "stable_label_keys": [
+    "scenario_id",
+    "test_id",
+    "decision",
+    "path_kind",
+    "outer_ip_family",
+    "state",
+    "reason_code",
+    "counter_names"
+  ],
+  "scenarios": [
+    {
+      "scenario_id": "DP-01",
+      "category": "boundary_matrix",
+      "test_id": "tests::dplpmtud_final_boundary_matrix_ipv4_ipv6",
+      "log_file": "dp-01-boundary.log",
+      "marker_required": true,
+      "expected_decision": "applied"
+    },
+    {
+      "scenario_id": "DP-02",
+      "category": "identity_epoch_isolation",
+      "test_id": "tests::dplpmtud_final_epoch_and_socket_identity_isolation",
+      "log_file": "dp-02-identity.log",
+      "marker_required": true,
+      "expected_decision": "stale_rejected"
+    },
+    {
+      "scenario_id": "DP-03",
+      "category": "loss_reorder_duplicate",
+      "test_id": "tests::dplpmtud_final_loss_reorder_duplicate_are_fenced",
+      "log_file": "dp-03-loss-reorder.log",
+      "marker_required": true,
+      "expected_decision": "recovered"
+    },
+    {
+      "scenario_id": "DP-04",
+      "category": "direct_relay_switch",
+      "test_id": "tests::dplpmtud_final_direct_relay_switch_and_recovery",
+      "log_file": "dp-04-path-switch.log",
+      "marker_required": true,
+      "expected_decision": "recovered"
+    },
+    {
+      "scenario_id": "DP-05",
+      "category": "typed_bounded_evidence",
+      "test_id": "tests::dplpmtud_final_typed_counters_use_bounded_labels",
+      "log_file": "dp-05-counters.log",
+      "marker_required": true,
+      "expected_decision": "observed"
+    },
+    {
+      "scenario_id": "DP-06",
+      "category": "silent_blackhole",
+      "test_id": "dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak",
+      "log_file": "dp-06-blackhole.log",
+      "marker_required": false,
+      "expected_decision": "verified",
+      "summary_prefix": "DPLPMTUD_BLACKHOLE",
+      "required_summary_tokens": [
+        "direct_active=true",
+        "relay_fallback_count=0",
+        "generation_switch_stale_ack=true",
+        "peer_left_cancelled=true",
+        "task_leak=false"
+      ]
+    },
+    {
+      "scenario_id": "DP-07",
+      "category": "live_business_send",
+      "test_id": "tests::direct_business_budget_production_path_e2e",
+      "log_file": "dp-07-business-e2e.log",
+      "marker_required": false,
+      "expected_decision": "verified",
+      "summary_prefix": "BUSINESS_BUDGET_E2E",
+      "required_summary_tokens": [
+        "pending_fifo=true",
+        "oversize_zero_send=true",
+        "ciphertext_zero_send=true",
+        "revoke_race_zero_send=true",
+        "path_race_zero_send=true",
+        "emsgsize_recovery=true",
+        "direct_active=true",
+        "relay_fallback_count=0",
+        "task_leak=false"
+      ]
+    },
+    {
+      "scenario_id": "DP-08",
+      "category": "downward_recovery",
+      "test_id": "dplpmtud::tests::runtime_downward_recovery_withholds_budget_until_fresh_base_ack",
+      "log_file": "dp-08-downward.log",
+      "marker_required": false,
+      "expected_decision": "verified",
+      "summary_prefix": "DPLPMTUD_RECONFIRM_BASE",
+      "required_summary_tokens": [
+        "direct_active=true",
+        "relay_fallback_count=0",
+        "identity_preserved=true",
+        "old_ack_contamination=false",
+        "task_leak=false"
+      ]
+    },
+    {
+      "scenario_id": "DP-09",
+      "category": "cancellation_relay_invalidation",
+      "test_id": "dplpmtud::tests::cancel_close_generation_and_relay_budget_invalidation_acceptance",
+      "log_file": "dp-09-cancellation.log",
+      "marker_required": false,
+      "expected_decision": "verified",
+      "summary_prefix": "DPLPMTUD_INVALIDATION",
+      "required_summary_tokens": [
+        "cancel_peer=none",
+        "generation_cancel=none",
+        "relay_active=none",
+        "runtime_close=none",
+        "exact_path_fail_closed=true",
+        "task_leak=false"
+      ]
+    },
+    {
+      "scenario_id": "DP-10",
+      "category": "revision_aba_stale_duplicate",
+      "test_id": "dplpmtud::tests::budget_revision_is_monotonic_and_closes_identity_aba",
+      "log_file": "dp-10-revision.log",
+      "marker_required": false,
+      "expected_decision": "verified",
+      "summary_prefix": "DPLPMTUD_BUDGET_REVISION",
+      "required_summary_tokens": [
+        "monotonic=true",
+        "duplicate_stable=true",
+        "stale_stable=true",
+        "diagnostics_revision_separate=true",
+        "aba_closed=true"
+      ]
+    }
+  ]
+}

--- a/docs/dplpmtud-live-dataplane-acceptance.md
+++ b/docs/dplpmtud-live-dataplane-acceptance.md
@@ -1,0 +1,135 @@
+# DPLPMTUD live dataplane acceptance
+
+Issue #26 closes the gap between the bounded Direct-path DPLPMTUD reducer and
+the packet-size decision used by normal encrypted traffic. The Path State
+Machine remains the only authority that selects Direct or Relay. DPLPMTUD owns
+only the size state for one exact committed Direct identity.
+
+## Exact identity and path isolation
+
+One managed Direct entry is keyed by all of:
+
+- peer identity;
+- network generation;
+- peer-session generation;
+- remote-candidate epoch;
+- authenticated Direct validation owner and request;
+- authenticated remote endpoint and local endpoint;
+- UDP transport instance and socket index;
+- outer IP family.
+
+A replacement in any dimension cancels the old worker, revokes its immutable
+business-budget publication and requires a fresh positive BASE ACK. A Relay
+selection calls the same owner-scoped cancellation boundary. Relay traffic does
+not read, wait for, or inherit a Direct DPLPMTUD budget.
+
+Probe timeout, loss, duplicate ACK, stale ACK, local scheduler pressure and
+`EMSGSIZE` update only the exact DPLPMTUD entry. They never mark a peer offline,
+increment Direct-health failure, select Relay, or tear down a healthy path.
+
+## Size layers and required boundary matrix
+
+The implementation keeps three values separate:
+
+```text
+outer IP packet
+  = outer IP header + UDP header + UDP datagram
+
+UDP datagram
+  = WireGuard transport overhead + decrypted inner IP packet
+
+overlay payload budget
+  = complete decrypted inner IP packet
+```
+
+The fixed overheads are:
+
+- IPv4 outer IP + UDP: 28 bytes;
+- IPv6 outer IP + UDP: 48 bytes;
+- WireGuard transport header + AEAD tag: 32 bytes.
+
+The exact required matrix is:
+
+| Outer packet | IPv4 UDP | IPv4 inner budget | IPv6 UDP | IPv6 inner budget |
+| ---: | ---: | ---: | ---: | ---: |
+| 1280 | 1252 | 1220 | 1232 | 1200 |
+| 1360 | 1332 | 1300 | 1312 | 1280 |
+| 1380 | 1352 | 1320 | 1332 | 1300 |
+| 1420 | 1392 | 1360 | 1372 | 1340 |
+| 1500 | 1472 | 1440 | 1452 | 1420 |
+
+The 1500 rows exactly match the IPv4 and IPv6 Ethernet-sized ceilings. No
+cross-family value is reused.
+
+## Actual business decision point
+
+For a capability-managed Direct peer, the live path is:
+
+```text
+TUN packet
+→ DataPlane outbound record
+→ bounded per-peer plaintext FIFO
+→ committed-path lookup
+→ immutable Direct budget token
+→ pre-encryption inner-packet budget check
+→ WireGuard encryption
+→ final exact path/revision/UDP-owner check
+→ ciphertext-size check
+→ nonblocking send on the exact UDP socket
+```
+
+An oversize inner IPv4 packet is rejected before encryption and may produce a
+bounded local ICMP Fragmentation Needed response. An oversize IPv6 packet
+produces Packet Too Big only when the selected inner budget can be represented
+as a standards-valid IPv6 MTU; otherwise it fails closed. Recursive ICMP error
+generation is suppressed. P2WLAN does not fragment or reassemble overlay
+packets in this path.
+
+A synchronous `EMSGSIZE` at the final syscall invalidates only the exact
+identity and budget revision, publishes an explicit `None` tombstone, returns
+the reducer to BASE and requires a fresh positive BASE ACK. It is not a path
+failure and does not consume Relay fallback credit.
+
+The configured TUN MTU remains a static interface ceiling. The confirmed
+per-peer Direct budget is enforced below it at the live plaintext and
+ciphertext boundaries. Relay framing remains independent and is never governed
+by a Direct budget.
+
+## Required scenarios and machine evidence
+
+`contracts/dplpmtud_acceptance.json` defines DP-01 through DP-10. Each scenario
+maps to one exact Rust test command and one dedicated log. A component-wide exit
+status cannot fan out into multiple passing records.
+
+The collector rejects:
+
+- a missing, renamed, failed or skipped exact test;
+- a required structured marker that is missing, duplicated or malformed;
+- a boundary row that does not cover 1280/1360/1380/1420/1500 for both families;
+- a required semantic token missing from an existing production-path test;
+- an endpoint, peer ID, nonce, path cookie or other high-cardinality value in
+  the aggregate evidence;
+- duplicate scenario or test mappings.
+
+The aggregate additionally rejects source/workflow SHA mismatch, contract or
+report digest mismatch, missing/extra scenarios, a failed component job, and a
+pull-request run whose same-head external gate job did not succeed.
+
+The stable aggregate check is `DPLPMTUD Required`. On pull requests it waits for
+the live `Business MTU Budget Required` check. To avoid a dependency cycle, the
+business-budget aggregate no longer waits for DPLPMTUD; DPLPMTUD is the final
+consumer of that live business-send result.
+
+## Operator smoke test
+
+`scripts/mtu-smoke.sh` retains the same 1280/1360/1380/1420/1500 operator
+matrix for a real deployed peer. It is useful release evidence but is not used
+to replace deterministic PR tests: missing tools or a missing peer must never
+turn the required CI aggregate green.
+
+## Deferred scope
+
+This work does not change signing, release credentials, tags or publication.
+It does not implement Relay PLPMTUD or a dynamic global TUN MTU. Those are
+separate protocol/product decisions; the accepted contract is exact-path
+Direct discovery plus independent Relay forwarding.

--- a/scripts/dplpmtud/aggregate_evidence.py
+++ b/scripts/dplpmtud/aggregate_evidence.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Fail-closed aggregate for DPLPMTUD live-dataplane evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+AGGREGATE_SCHEMA_VERSION = 1
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _load(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label}_invalid:{path}:{exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label}_not_object")
+    return value
+
+
+def _canonical_sha256(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _validate_sha(value: str, label: str) -> None:
+    if SHA40.fullmatch(value) is None:
+        raise ValueError(f"{label}_invalid")
+
+
+def aggregate(
+    contract: dict[str, Any],
+    component: dict[str, Any],
+    source_head_sha: str,
+    workflow_sha: str,
+    event_name: str,
+    component_result: str,
+    external_gates_result: str,
+) -> dict[str, Any]:
+    _validate_sha(source_head_sha, "source_head_sha")
+    _validate_sha(workflow_sha, "workflow_sha")
+    if event_name not in {"pull_request", "push", "workflow_dispatch"}:
+        raise ValueError("event_name_invalid")
+    if component_result != "success":
+        raise ValueError(f"component_job_not_success:{component_result}")
+    expected_external = "success" if event_name == "pull_request" else "skipped"
+    if external_gates_result != expected_external:
+        raise ValueError(
+            f"external_gates_result_invalid:{event_name}:{external_gates_result}:{expected_external}"
+        )
+    if contract.get("schema_version") != 1:
+        raise ValueError("contract_schema_unknown")
+    if contract.get("repository") != "yhan-sun/p2wlan":
+        raise ValueError("contract_repository_mismatch")
+    if component.get("schema_version") != 1:
+        raise ValueError("component_schema_unknown")
+    if component.get("repository") != contract.get("repository"):
+        raise ValueError("component_repository_mismatch")
+    if component.get("component") != contract.get("component"):
+        raise ValueError("component_name_mismatch")
+    if component.get("source_head_sha") != source_head_sha:
+        raise ValueError("component_source_head_mismatch")
+    if component.get("workflow_sha") != workflow_sha:
+        raise ValueError("component_workflow_sha_mismatch")
+    if component.get("result") != "pass":
+        raise ValueError("component_result_not_pass")
+    expected_contract_digest = _canonical_sha256(contract)
+    if component.get("contract_sha256") != expected_contract_digest:
+        raise ValueError("component_contract_digest_mismatch")
+    claimed_report_digest = component.get("report_digest")
+    if not isinstance(claimed_report_digest, str):
+        raise ValueError("component_report_digest_missing")
+    component_without_digest = dict(component)
+    component_without_digest.pop("report_digest", None)
+    if _canonical_sha256(component_without_digest) != claimed_report_digest:
+        raise ValueError("component_report_digest_mismatch")
+
+    specs = contract.get("scenarios")
+    records = component.get("scenarios")
+    if not isinstance(specs, list) or not isinstance(records, list):
+        raise ValueError("scenario_arrays_missing")
+    expected_by_id: dict[str, dict[str, Any]] = {}
+    for spec in specs:
+        if not isinstance(spec, dict) or not isinstance(spec.get("scenario_id"), str):
+            raise ValueError("contract_scenario_invalid")
+        scenario_id = spec["scenario_id"]
+        if scenario_id in expected_by_id:
+            raise ValueError(f"contract_duplicate_scenario:{scenario_id}")
+        expected_by_id[scenario_id] = spec
+
+    seen: set[str] = set()
+    compact_records: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("component_scenario_not_object")
+        scenario_id = record.get("scenario_id")
+        if not isinstance(scenario_id, str) or scenario_id not in expected_by_id:
+            raise ValueError(f"component_unknown_scenario:{scenario_id}")
+        if scenario_id in seen:
+            raise ValueError(f"component_duplicate_scenario:{scenario_id}")
+        seen.add(scenario_id)
+        spec = expected_by_id[scenario_id]
+        if record.get("exact_test_id") != spec.get("test_id"):
+            raise ValueError(f"component_test_id_mismatch:{scenario_id}")
+        if record.get("category") != spec.get("category"):
+            raise ValueError(f"component_category_mismatch:{scenario_id}")
+        if record.get("decision") != spec.get("expected_decision"):
+            raise ValueError(f"component_decision_mismatch:{scenario_id}")
+        if record.get("executed") is not True:
+            raise ValueError(f"component_test_not_executed:{scenario_id}")
+        if record.get("skipped") is not False:
+            raise ValueError(f"component_test_skipped:{scenario_id}")
+        if record.get("result") != "pass":
+            raise ValueError(f"component_test_not_pass:{scenario_id}")
+        if not isinstance(record.get("observed"), dict) or not record["observed"]:
+            raise ValueError(f"component_observed_missing:{scenario_id}")
+        compact_records.append(
+            {
+                "scenario_id": scenario_id,
+                "category": record["category"],
+                "exact_test_id": record["exact_test_id"],
+                "decision": record["decision"],
+                "result": "pass",
+            }
+        )
+
+    missing = sorted(set(expected_by_id) - seen)
+    if missing:
+        raise ValueError("component_missing_scenarios:" + ",".join(missing))
+    if component.get("scenario_count") != len(expected_by_id):
+        raise ValueError("component_scenario_count_mismatch")
+
+    boundaries = contract.get("required_boundaries")
+    if boundaries != [1280, 1360, 1380, 1420, 1500]:
+        raise ValueError("required_boundary_contract_changed")
+    boundary_record = next(
+        record for record in records if record.get("scenario_id") == "DP-01"
+    )
+    marker = boundary_record["observed"]
+    if marker.get("boundaries") != boundaries:
+        raise ValueError("boundary_evidence_mismatch")
+
+    aggregate_value: dict[str, Any] = {
+        "schema_version": AGGREGATE_SCHEMA_VERSION,
+        "repository": contract["repository"],
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
+        "event_name": event_name,
+        "result": "pass",
+        "business_mtu_gate_required": event_name == "pull_request",
+        "external_required_gates_result": external_gates_result,
+        "required_boundaries": boundaries,
+        "scenario_count": len(compact_records),
+        "scenarios": sorted(compact_records, key=lambda item: item["scenario_id"]),
+        "contract_sha256": expected_contract_digest,
+        "component_report_digest": claimed_report_digest,
+    }
+    aggregate_value["aggregate_digest"] = _canonical_sha256(aggregate_value)
+    return aggregate_value
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", required=True)
+    parser.add_argument("--component", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--component-result", required=True)
+    parser.add_argument("--external-gates-result", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    result = aggregate(
+        _load(Path(args.contract), "contract"),
+        _load(Path(args.component), "component"),
+        args.source_head_sha,
+        args.workflow_sha,
+        args.event_name,
+        args.component_result,
+        args.external_gates_result,
+    )
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "result": result["result"],
+        "scenario_count": result["scenario_count"],
+        "aggregate_digest": result["aggregate_digest"],
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/dplpmtud/collect_evidence.py
+++ b/scripts/dplpmtud/collect_evidence.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Collect exact-test-derived DPLPMTUD live-dataplane evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPORT_SCHEMA_VERSION = 1
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+MARKER_PREFIX = "DPLPMTUD_FINAL_EVIDENCE "
+FORBIDDEN_IDENTITY_KEYS = {
+    "peer_id",
+    "remote_endpoint",
+    "local_endpoint",
+    "authenticated_remote_endpoint",
+    "network_identity_hash",
+    "path_cookie",
+    "nonce",
+}
+IP_LIKE = re.compile(
+    r"(?:\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b|\[[0-9a-fA-F:]+\]:\d+)"
+)
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label}_invalid:{path}:{exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label}_not_object:{path}")
+    return value
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_sha(value: str, label: str) -> None:
+    if SHA40.fullmatch(value) is None:
+        raise ValueError(f"{label}_invalid")
+
+
+def _walk_no_high_cardinality(value: Any, path: str = "record") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in FORBIDDEN_IDENTITY_KEYS:
+                raise ValueError(f"high_cardinality_key_forbidden:{path}.{key}")
+            _walk_no_high_cardinality(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _walk_no_high_cardinality(child, f"{path}[{index}]")
+    elif isinstance(value, str) and IP_LIKE.search(value):
+        raise ValueError(f"high_cardinality_value_forbidden:{path}")
+
+
+def _test_status(log_text: str, test_id: str) -> str:
+    clean = ANSI.sub("", log_text)
+    exact = re.escape(test_id)
+    if re.search(rf"^test {exact} \.\.\. ok(?: \([^)]*\))?$", clean, re.MULTILINE):
+        return "pass"
+    if re.search(rf"^test {exact} \.\.\. ignored(?: .*)?$", clean, re.MULTILINE):
+        return "skipped"
+    if re.search(rf"^test {exact} \.\.\. FAILED$", clean, re.MULTILINE):
+        return "fail"
+    return "missing"
+
+
+def _marker_records(log_text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for raw_line in ANSI.sub("", log_text).splitlines():
+        line = raw_line.strip()
+        if MARKER_PREFIX not in line:
+            continue
+        payload = line.split(MARKER_PREFIX, 1)[1].strip()
+        try:
+            value = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"marker_invalid_json:{exc}") from exc
+        if not isinstance(value, dict):
+            raise ValueError("marker_not_object")
+        records.append(value)
+    return records
+
+
+def _summary_tokens(line: str) -> dict[str, str]:
+    tokens: dict[str, str] = {}
+    for token in line.split()[1:]:
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        if re.fullmatch(r"[a-z0-9_]+", key) is None:
+            raise ValueError(f"summary_key_invalid:{key}")
+        if any(fragment in key for fragment in ("endpoint", "peer_id", "address", "path_cookie", "nonce")):
+            raise ValueError(f"summary_high_cardinality_key:{key}")
+        if re.fullmatch(r"[A-Za-z0-9_.:-]+", value) is None:
+            raise ValueError(f"summary_value_invalid:{key}")
+        if IP_LIKE.search(value):
+            raise ValueError(f"summary_high_cardinality_value:{key}")
+        if key in tokens:
+            raise ValueError(f"summary_duplicate_key:{key}")
+        tokens[key] = value
+    return tokens
+
+
+def _extract_summary(
+    log_text: str,
+    prefix: str,
+    required_tokens: list[str],
+) -> dict[str, str]:
+    clean = ANSI.sub("", log_text)
+    lines = [line.strip() for line in clean.splitlines() if line.strip().startswith(prefix + " ")]
+    if len(lines) != 1:
+        raise ValueError(f"summary_line_count:{prefix}:{len(lines)}")
+    line = lines[0]
+    for token in required_tokens:
+        if token not in line.split():
+            raise ValueError(f"summary_required_token_missing:{prefix}:{token}")
+    return _summary_tokens(line)
+
+
+def collect(
+    contract: dict[str, Any],
+    log_root: Path,
+    source_head_sha: str,
+    workflow_sha: str,
+) -> dict[str, Any]:
+    _validate_sha(source_head_sha, "source_head_sha")
+    _validate_sha(workflow_sha, "workflow_sha")
+    if contract.get("schema_version") != 1:
+        raise ValueError("contract_schema_unknown")
+    if contract.get("repository") != "yhan-sun/p2wlan":
+        raise ValueError("contract_repository_mismatch")
+    scenarios = contract.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("contract_scenarios_missing")
+
+    seen_scenarios: set[str] = set()
+    seen_tests: set[str] = set()
+    records: list[dict[str, Any]] = []
+    for spec in scenarios:
+        if not isinstance(spec, dict):
+            raise ValueError("scenario_spec_not_object")
+        scenario_id = spec.get("scenario_id")
+        test_id = spec.get("test_id")
+        log_file = spec.get("log_file")
+        category = spec.get("category")
+        decision = spec.get("expected_decision")
+        if not all(isinstance(value, str) and value for value in (
+            scenario_id,
+            test_id,
+            log_file,
+            category,
+            decision,
+        )):
+            raise ValueError("scenario_spec_field_invalid")
+        if scenario_id in seen_scenarios:
+            raise ValueError(f"duplicate_scenario:{scenario_id}")
+        if test_id in seen_tests:
+            raise ValueError(f"duplicate_test_mapping:{test_id}")
+        seen_scenarios.add(scenario_id)
+        seen_tests.add(test_id)
+
+        log_path = log_root / log_file
+        if not log_path.is_file() or log_path.stat().st_size == 0:
+            raise ValueError(f"test_log_missing:{scenario_id}:{log_path}")
+        log_text = log_path.read_text(encoding="utf-8", errors="strict")
+        status = _test_status(log_text, test_id)
+        if status != "pass":
+            raise ValueError(f"test_not_passed:{scenario_id}:{test_id}:{status}")
+
+        observed: dict[str, Any]
+        marker_required = spec.get("marker_required")
+        if not isinstance(marker_required, bool):
+            raise ValueError(f"marker_required_not_boolean:{scenario_id}")
+        if marker_required:
+            candidates = [
+                marker
+                for marker in _marker_records(log_text)
+                if marker.get("scenario_id") == scenario_id
+            ]
+            if len(candidates) != 1:
+                raise ValueError(f"marker_count_invalid:{scenario_id}:{len(candidates)}")
+            marker = candidates[0]
+            if marker.get("test_id") != test_id:
+                raise ValueError(f"marker_test_id_mismatch:{scenario_id}")
+            if marker.get("decision") != decision:
+                raise ValueError(f"marker_decision_mismatch:{scenario_id}")
+            invariants = marker.get("invariants")
+            if not isinstance(invariants, dict) or not invariants:
+                raise ValueError(f"marker_invariants_missing:{scenario_id}")
+            if any(value is not True for value in invariants.values()):
+                raise ValueError(f"marker_invariant_failed:{scenario_id}")
+            if scenario_id == "DP-01":
+                if marker.get("boundaries") != contract.get("required_boundaries"):
+                    raise ValueError("boundary_matrix_mismatch")
+                rows = marker.get("rows")
+                if not isinstance(rows, list) or len(rows) != 10:
+                    raise ValueError("boundary_rows_invalid")
+                seen_rows = {
+                    (row.get("outer_ip_packet_size"), row.get("outer_ip_family"))
+                    for row in rows
+                    if isinstance(row, dict)
+                }
+                expected_rows = {
+                    (boundary, family)
+                    for boundary in contract["required_boundaries"]
+                    for family in ("ipv4", "ipv6")
+                }
+                if seen_rows != expected_rows:
+                    raise ValueError("boundary_rows_incomplete")
+            _walk_no_high_cardinality(marker)
+            observed = marker
+        else:
+            prefix = spec.get("summary_prefix")
+            required_tokens = spec.get("required_summary_tokens")
+            if not isinstance(prefix, str) or not prefix:
+                raise ValueError(f"summary_prefix_missing:{scenario_id}")
+            if not isinstance(required_tokens, list) or not all(
+                isinstance(token, str) and token for token in required_tokens
+            ):
+                raise ValueError(f"summary_tokens_invalid:{scenario_id}")
+            observed = {
+                "scenario_id": scenario_id,
+                "test_id": test_id,
+                "decision": decision,
+                "summary_prefix": prefix,
+                "summary": _extract_summary(log_text, prefix, required_tokens),
+            }
+            _walk_no_high_cardinality(observed)
+
+        records.append(
+            {
+                "scenario_id": scenario_id,
+                "category": category,
+                "exact_test_id": test_id,
+                "executed": True,
+                "skipped": False,
+                "result": "pass",
+                "decision": decision,
+                "log_file": log_file,
+                "observed": observed,
+            }
+        )
+
+    report: dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "repository": contract["repository"],
+        "component": contract["component"],
+        "source_head_sha": source_head_sha,
+        "workflow_sha": workflow_sha,
+        "contract_sha256": _canonical_sha256(contract),
+        "result": "pass",
+        "scenario_count": len(records),
+        "scenarios": records,
+    }
+    report["report_digest"] = _canonical_sha256(report)
+    return report
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", required=True)
+    parser.add_argument("--log-root", required=True)
+    parser.add_argument("--source-head-sha", required=True)
+    parser.add_argument("--workflow-sha", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    contract = _load_object(Path(args.contract), "contract")
+    report = collect(
+        contract,
+        Path(args.log_root),
+        args.source_head_sha,
+        args.workflow_sha,
+    )
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "result": report["result"],
+        "scenario_count": report["scenario_count"],
+        "report_digest": report["report_digest"],
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/dplpmtud/run_acceptance.sh
+++ b/scripts/dplpmtud/run_acceptance.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+OUT_DIR=${1:-${RUNNER_TEMP:-/tmp}/p2wlan-dplpmtud-live}
+SOURCE_HEAD_SHA=${DPLPMTUD_SOURCE_HEAD_SHA:-$(git -C "$ROOT_DIR" rev-parse HEAD)}
+WORKFLOW_SHA=${DPLPMTUD_WORKFLOW_SHA:-$(git -C "$ROOT_DIR" rev-parse "$SOURCE_HEAD_SHA:.github/workflows/dplpmtud-required.yml")}
+
+if [[ ! "$SOURCE_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid source head SHA: $SOURCE_HEAD_SHA" >&2
+  exit 2
+fi
+if [[ ! "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid workflow SHA: $WORKFLOW_SHA" >&2
+  exit 2
+fi
+if [[ -e "$OUT_DIR" ]]; then
+  echo "refusing to reuse evidence directory: $OUT_DIR" >&2
+  exit 2
+fi
+mkdir -p "$OUT_DIR/logs"
+
+export CARGO_TERM_COLOR=never
+
+run_exact() {
+  local log_file=$1
+  local test_id=$2
+  (
+    cd "$ROOT_DIR"
+    cargo test -p p2wlan-daemon --lib "$test_id" -- \
+      --exact --nocapture --test-threads=1
+  ) 2>&1 | tee "$OUT_DIR/logs/$log_file"
+}
+
+run_exact dp-01-boundary.log \
+  tests::dplpmtud_final_boundary_matrix_ipv4_ipv6
+run_exact dp-02-identity.log \
+  tests::dplpmtud_final_epoch_and_socket_identity_isolation
+run_exact dp-03-loss-reorder.log \
+  tests::dplpmtud_final_loss_reorder_duplicate_are_fenced
+run_exact dp-04-path-switch.log \
+  tests::dplpmtud_final_direct_relay_switch_and_recovery
+run_exact dp-05-counters.log \
+  tests::dplpmtud_final_typed_counters_use_bounded_labels
+run_exact dp-06-blackhole.log \
+  dplpmtud::tests::encrypted_udp_blackhole_converges_without_path_failure_or_worker_leak
+run_exact dp-07-business-e2e.log \
+  tests::direct_business_budget_production_path_e2e
+run_exact dp-08-downward.log \
+  dplpmtud::tests::runtime_downward_recovery_withholds_budget_until_fresh_base_ack
+run_exact dp-09-cancellation.log \
+  dplpmtud::tests::cancel_close_generation_and_relay_budget_invalidation_acceptance
+run_exact dp-10-revision.log \
+  dplpmtud::tests::budget_revision_is_monotonic_and_closes_identity_aba
+
+python3 "$ROOT_DIR/scripts/dplpmtud/collect_evidence.py" \
+  --contract "$ROOT_DIR/contracts/dplpmtud_acceptance.json" \
+  --log-root "$OUT_DIR/logs" \
+  --source-head-sha "$SOURCE_HEAD_SHA" \
+  --workflow-sha "$WORKFLOW_SHA" \
+  --output "$OUT_DIR/dplpmtud-live-component.json"
+
+python3 - "$OUT_DIR/dplpmtud-live-component.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    report = json.load(handle)
+if report.get("result") != "pass":
+    raise SystemExit("component_report_not_pass")
+if report.get("scenario_count") != 10:
+    raise SystemExit("component_scenario_count_mismatch")
+print(
+    "DPLPMTUD live component PASS "
+    f"scenarios={report['scenario_count']} digest={report['report_digest']}"
+)
+PY

--- a/scripts/dplpmtud/run_acceptance.sh
+++ b/scripts/dplpmtud/run_acceptance.sh
@@ -27,8 +27,10 @@ run_exact() {
   local test_id=$2
   (
     cd "$ROOT_DIR"
+    # Keep libtest's canonical `test <id> ... ok` status line intact while
+    # still retaining successful test stdout for the machine-evidence parser.
     cargo test -p p2wlan-daemon --lib "$test_id" -- \
-      --exact --nocapture --test-threads=1
+      --exact --show-output --test-threads=1
   ) 2>&1 | tee "$OUT_DIR/logs/$log_file"
 }
 

--- a/scripts/dplpmtud/test_evidence.py
+++ b/scripts/dplpmtud/test_evidence.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Fail-closed tests for the DPLPMTUD evidence contract."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+COLLECT_SPEC = importlib.util.spec_from_file_location(
+    "dplpmtud_collect", HERE / "collect_evidence.py"
+)
+assert COLLECT_SPEC and COLLECT_SPEC.loader
+COLLECT = importlib.util.module_from_spec(COLLECT_SPEC)
+COLLECT_SPEC.loader.exec_module(COLLECT)
+
+AGGREGATE_SPEC = importlib.util.spec_from_file_location(
+    "dplpmtud_aggregate", HERE / "aggregate_evidence.py"
+)
+assert AGGREGATE_SPEC and AGGREGATE_SPEC.loader
+AGGREGATE = importlib.util.module_from_spec(AGGREGATE_SPEC)
+AGGREGATE_SPEC.loader.exec_module(AGGREGATE)
+
+
+class DplpmtudEvidenceTests(unittest.TestCase):
+    SOURCE = "a" * 40
+    WORKFLOW = "b" * 40
+
+    def setUp(self) -> None:
+        self.contract = json.loads(
+            (HERE.parent.parent / "contracts" / "dplpmtud_acceptance.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self._write_valid_logs()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _marker(self, scenario_id: str, test_id: str, decision: str) -> dict:
+        if scenario_id == "DP-01":
+            rows = []
+            for boundary in self.contract["required_boundaries"]:
+                for family, overhead in (("ipv4", 28), ("ipv6", 48)):
+                    rows.append(
+                        {
+                            "outer_ip_packet_size": boundary,
+                            "outer_ip_family": family,
+                            "outer_ip_udp_overhead": overhead,
+                            "udp_datagram_size": boundary - overhead,
+                            "overlay_payload_budget": boundary - overhead - 32,
+                        }
+                    )
+            return {
+                "scenario_id": scenario_id,
+                "test_id": test_id,
+                "decision": decision,
+                "path_kind": "direct",
+                "outer_ip_family": "ipv4_ipv6",
+                "boundaries": self.contract["required_boundaries"],
+                "rows": rows,
+                "invariants": {
+                    "all_required_boundaries_executed": True,
+                    "outer_udp_overhead_separated": True,
+                },
+            }
+        return {
+            "scenario_id": scenario_id,
+            "test_id": test_id,
+            "decision": decision,
+            "path_kind": "direct",
+            "outer_ip_family": "ipv4",
+            "reason_code": "bounded_test_reason",
+            "counter_names": ["probe_count", "timeout_count"],
+            "invariants": {"exact_test_executed": True, "identity_fenced": True},
+        }
+
+    def _write_valid_logs(self) -> None:
+        for spec in self.contract["scenarios"]:
+            lines = [
+                "running 1 test",
+            ]
+            if spec["marker_required"]:
+                marker = self._marker(
+                    spec["scenario_id"],
+                    spec["test_id"],
+                    spec["expected_decision"],
+                )
+                lines.append(
+                    COLLECT.MARKER_PREFIX
+                    + json.dumps(marker, sort_keys=True, separators=(",", ":"))
+                )
+            else:
+                prefix = spec["summary_prefix"]
+                tokens = " ".join(spec["required_summary_tokens"])
+                lines.append(f"{prefix} {tokens} probe_count=3")
+            lines.append(f"test {spec['test_id']} ... ok")
+            lines.extend(["", "test result: ok. 1 passed; 0 failed; 0 ignored"])
+            (self.root / spec["log_file"]).write_text(
+                "\n".join(lines) + "\n", encoding="utf-8"
+            )
+
+    def _collect(self, contract=None):
+        return COLLECT.collect(
+            contract or self.contract,
+            self.root,
+            self.SOURCE,
+            self.WORKFLOW,
+        )
+
+    def _aggregate(
+        self,
+        component=None,
+        *,
+        event_name="pull_request",
+        component_result="success",
+        external_result="success",
+    ):
+        return AGGREGATE.aggregate(
+            self.contract,
+            component or self._collect(),
+            self.SOURCE,
+            self.WORKFLOW,
+            event_name,
+            component_result,
+            external_result,
+        )
+
+    def test_valid_actual_execution_report_and_aggregate_pass(self):
+        component = self._collect()
+        self.assertEqual(component["result"], "pass")
+        self.assertEqual(component["scenario_count"], 10)
+        aggregate = self._aggregate(component)
+        self.assertEqual(aggregate["result"], "pass")
+        self.assertEqual(aggregate["required_boundaries"], [1280, 1360, 1380, 1420, 1500])
+        self.assertTrue(aggregate["business_mtu_gate_required"])
+
+    def test_missing_exact_test_result_fails(self):
+        spec = self.contract["scenarios"][2]
+        (self.root / spec["log_file"]).write_text("running 1 test\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "test_not_passed:DP-03"):
+            self._collect()
+
+    def test_skipped_exact_test_result_fails(self):
+        spec = self.contract["scenarios"][2]
+        path = self.root / spec["log_file"]
+        text = path.read_text(encoding="utf-8").replace(
+            f"test {spec['test_id']} ... ok",
+            f"test {spec['test_id']} ... ignored",
+        )
+        path.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "test_not_passed:DP-03.*skipped"):
+            self._collect()
+
+    def test_marker_missing_fails_even_when_test_passes(self):
+        spec = self.contract["scenarios"][0]
+        path = self.root / spec["log_file"]
+        text = "\n".join(
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if COLLECT.MARKER_PREFIX not in line
+        )
+        path.write_text(text + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "marker_count_invalid:DP-01:0"):
+            self._collect()
+
+    def test_boundary_manifest_tamper_fails(self):
+        spec = self.contract["scenarios"][0]
+        path = self.root / spec["log_file"]
+        text = path.read_text(encoding="utf-8")
+        text = text.replace(
+            json.dumps(self.contract["required_boundaries"], separators=(",", ":")),
+            json.dumps([1280, 1380, 1420, 1500], separators=(",", ":")),
+        )
+        path.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "boundary_matrix_mismatch"):
+            self._collect()
+
+    def test_high_cardinality_endpoint_in_marker_fails(self):
+        spec = self.contract["scenarios"][1]
+        path = self.root / spec["log_file"]
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if COLLECT.MARKER_PREFIX in line:
+                marker = json.loads(line.split(COLLECT.MARKER_PREFIX, 1)[1])
+                marker["remote_endpoint"] = "192.0.2.1:40000"
+                lines[index] = COLLECT.MARKER_PREFIX + json.dumps(marker)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "high_cardinality_key_forbidden"):
+            self._collect()
+
+    def test_summary_token_missing_fails(self):
+        spec = next(item for item in self.contract["scenarios"] if item["scenario_id"] == "DP-07")
+        path = self.root / spec["log_file"]
+        text = path.read_text(encoding="utf-8").replace("emsgsize_recovery=true ", "")
+        path.write_text(text, encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "summary_required_token_missing"):
+            self._collect()
+
+    def test_duplicate_test_mapping_in_contract_fails(self):
+        contract = copy.deepcopy(self.contract)
+        contract["scenarios"][1]["test_id"] = contract["scenarios"][0]["test_id"]
+        with self.assertRaisesRegex(ValueError, "duplicate_test_mapping"):
+            self._collect(contract)
+
+    def test_missing_component_scenario_fails_aggregate(self):
+        component = self._collect()
+        component["scenarios"] = component["scenarios"][:-1]
+        component["scenario_count"] -= 1
+        component_without_digest = dict(component)
+        component_without_digest.pop("report_digest", None)
+        component["report_digest"] = AGGREGATE._canonical_sha256(component_without_digest)
+        with self.assertRaisesRegex(ValueError, "component_missing_scenarios"):
+            self._aggregate(component)
+
+    def test_source_sha_mismatch_fails_aggregate(self):
+        component = self._collect()
+        component["source_head_sha"] = "c" * 40
+        component_without_digest = dict(component)
+        component_without_digest.pop("report_digest", None)
+        component["report_digest"] = AGGREGATE._canonical_sha256(component_without_digest)
+        with self.assertRaisesRegex(ValueError, "component_source_head_mismatch"):
+            self._aggregate(component)
+
+    def test_report_digest_tamper_fails(self):
+        component = self._collect()
+        component["scenarios"][0]["result"] = "fail"
+        with self.assertRaisesRegex(ValueError, "component_report_digest_mismatch"):
+            self._aggregate(component)
+
+    def test_failed_component_job_fails(self):
+        with self.assertRaisesRegex(ValueError, "component_job_not_success"):
+            self._aggregate(component_result="failure")
+
+    def test_pull_request_requires_external_gates(self):
+        with self.assertRaisesRegex(ValueError, "external_gates_result_invalid"):
+            self._aggregate(external_result="skipped")
+
+    def test_dispatch_accepts_skipped_external_gates(self):
+        aggregate = self._aggregate(
+            event_name="workflow_dispatch",
+            external_result="skipped",
+        )
+        self.assertEqual(aggregate["result"], "pass")
+        self.assertFalse(aggregate["business_mtu_gate_required"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #26

## Summary

This Draft closes the final DPLPMTUD live-dataplane acceptance gaps on one exact source head.

- Keeps the existing per-peer, exact Direct-path identity and the Path State Machine as the sole path authority.
- Makes the live `Business MTU Budget Required` gate a one-way prerequisite of `DPLPMTUD Required`, removing the prior cross-workflow dependency cycle.
- Adds an explicit IPv4/IPv6 outer-packet matrix for 1280/1360/1380/1420/1500 with outer UDP/IP and WireGuard overhead kept separate.
- Adds deterministic regressions for path/epoch/socket replacement, loss/reorder/duplicate ACKs, Direct→Relay→Direct cancellation/recovery, and bounded typed counters.
- Binds DP-01 through DP-10 to exact executed Rust tests and dedicated logs; the collector and aggregate fail closed on missing, renamed, skipped, failed, malformed, incomplete, mismatched-SHA, digest-tampered, or high-cardinality evidence.
- Retains the existing encrypted blackhole and full TUN→WireGuard→UDP business-send tests as required machine evidence.

## Source identity

- Base: `5a2ea41ca9bb5e40809f267e2402f3e110f677f1`
- Source head: `3366d64ac14c40fe9237fcf7c07af7fd8f4d64cd`
- Branch: `feat/dplpmtud-live-dataplane-closure-20260905`

## Required acceptance

The final source head must pass:

- `DPLPMTUD Required`, including Linux, Windows, exact scenario matrix, live component evidence and fail-closed aggregate;
- `Business MTU Budget Required` with five production-path replicas;
- Path State, NAT, Windows lifecycle, Mobile lifecycle, Path Observability, Security, CI, Flutter and package gates.

## Scope boundaries

Relay does not inherit or wait for a Direct DPLPMTUD budget. The configured TUN MTU remains a static interface ceiling; per-peer Direct budgets are enforced at the live plaintext and final encrypted UDP send boundaries. No signing, tag, release, publication or credential changes are included.