### PR TITLE
fix(path): handle asymmetric MTU during hard-hard path establishment

### DIFF
--- a/client/daemon/src/lib/direct_runtime/hard_hard.rs
+++ b/client/daemon/src/lib/direct_runtime/hard_hard.rs
@@ -79,6 +79,35 @@ async fn pause_hard_hard_responder_after_measurement_for_test(
     }
     HardHardResponderMeasurementGateCompletion(gate)
 }
+
+#[cfg(test)]
+struct HardHardInitiatorResponseGate {
+    reached: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+static HARD_HARD_INITIATOR_RESPONSE_GATE: std::sync::Mutex<Option<Arc<HardHardInitiatorResponseGate>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn install_hard_hard_initiator_response_gate_for_test() -> Arc<HardHardInitiatorResponseGate> {
+    let gate = Arc::new(HardHardInitiatorResponseGate {
+        reached: tokio::sync::Notify::new(),
+        release: tokio::sync::Notify::new(),
+    });
+    *HARD_HARD_INITIATOR_RESPONSE_GATE.lock().unwrap() = Some(gate.clone());
+    gate
+}
+
+#[cfg(test)]
+async fn pause_hard_hard_initiator_response_for_test() {
+    let gate = HARD_HARD_INITIATOR_RESPONSE_GATE.lock().unwrap().take();
+    if let Some(gate) = gate {
+        gate.reached.notify_one();
+        gate.release.notified().await;
+    }
+}
 /// Until an initiator record is installed in the manager ledger, no other
 /// owner will cancel its shared handle when the short-lived punch permit is
 /// dropped.  Make every pre-ledger return (including cancellation/panic
@@ -2504,6 +2533,11 @@ pub(crate) async fn spawn_hard_hard_responder(
 
 /// Consume the reciprocal response at the initiator and sweep its measured
 /// socket toward the responder's fresh prediction window.
+///
+/// This response is bound to an already-measured initiator session. Losing
+/// any of its admission/ownership fences consumes the response; it must not
+/// fall back to an ordinary fresh punch which could acquire a newer network
+/// generation's owner and suppress that generation's real Hard-Hard retry.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn spawn_hard_hard_initiator_response(
     udp: UdpTransport,
@@ -2524,7 +2558,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         return HardHardRemoteStart::Rejected;
     };
     let Some(current_plan) = peers.hard_hard_plan_for_peer(&peer_id).await else {
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     };
     let expected_plan = crate::peer::HardHardPlanSnapshot {
         local_network_generation: record.local_network_generation,
@@ -2586,10 +2620,10 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         return HardHardRemoteStart::Rejected;
     }
     let RecoveryAdmission::Accepted { epoch } = peers.recovery_epoch_admit(&peer_id).await else {
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     };
     let Some(peer_session_generation) = peers.peer_session_generation_sync(&peer_id) else {
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     };
     let Some(session) = claim_hard_hard_initiator_response_session(
         &peers,
@@ -2602,8 +2636,10 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
     )
     .await
     else {
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     };
+    #[cfg(test)]
+    pause_hard_hard_initiator_response_for_test().await;
     let Some(record) = peers
         .hard_hard_begin_sweep(
             &peer_id,
@@ -2614,7 +2650,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
         )
         .await
     else {
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     };
     if !udp
         .hard_hard_socket_identity_is_current(&record.fresh_socket)
@@ -2629,7 +2665,7 @@ pub(crate) async fn spawn_hard_hard_initiator_response(
                 &record.session_token,
             )
             .await;
-        return HardHardRemoteStart::NotStarted;
+        return HardHardRemoteStart::Rejected;
     }
     let fresh_socket = record.fresh_socket.clone();
     let birthday_socket_indices = record

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -508,8 +508,38 @@ struct NatPacketLink {
     held_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
     held_punch_a_to_b: Arc<StdMutex<Vec<Vec<u8>>>>,
     held_punch_b_to_a: Arc<StdMutex<Vec<Vec<u8>>>>,
+    mtu: Arc<[NatMtuDirection; 2]>,
     route_dynamic_socket: bool,
     worker: Option<tokio::task::JoinHandle<()>>,
+}
+
+// This userspace NAT link models IPv4 path MTUs, not the loopback interface
+// MTU. Observe the actual UDP payload after protocol framing/encryption and
+// account for the outer IPv4 and UDP headers separately in each direction.
+struct NatMtuDirection {
+    ip_mtu: AtomicU64,
+    max_udp_payload: AtomicU64,
+    oversize_drops: AtomicU64,
+}
+
+impl NatMtuDirection {
+    fn new() -> Self {
+        Self {
+            ip_mtu: AtomicU64::new(65_535),
+            max_udp_payload: AtomicU64::new(0),
+            oversize_drops: AtomicU64::new(0),
+        }
+    }
+
+    fn admit(&self, udp_payload: usize) -> bool {
+        let udp_payload = udp_payload as u64;
+        self.max_udp_payload.fetch_max(udp_payload, Ordering::Relaxed);
+        if udp_payload + 20 + 8 > self.ip_mtu.load(Ordering::Acquire) {
+            self.oversize_drops.fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
+        true
+    }
 }
 
 #[derive(Clone)]
@@ -597,6 +627,7 @@ impl NatPacketLink {
         let held_punch_b_to_a = Arc::new(StdMutex::new(Vec::new()));
         let a_to_b_routes = NatRouteTable::new();
         let b_to_a_routes = NatRouteTable::new();
+        let mtu = Arc::new([NatMtuDirection::new(), NatMtuDirection::new()]);
         let worker = Some(tokio::spawn(Self::run(
             a_public.clone(),
             b_public.clone(),
@@ -616,6 +647,7 @@ impl NatPacketLink {
             a_keys,
             a_to_b_routes.clone(),
             b_to_a_routes.clone(),
+            mtu.clone(),
             primary_a,
             route_dynamic_socket,
         )));
@@ -632,6 +664,7 @@ impl NatPacketLink {
             held_b_to_a,
             held_punch_a_to_b,
             held_punch_b_to_a,
+            mtu,
             route_dynamic_socket,
             worker,
         }
@@ -901,6 +934,7 @@ impl NatPacketLink {
         b_to_a_keys: TransportKeyPair,
         a_to_b_routes: NatRouteTable,
         b_to_a_routes: NatRouteTable,
+        mtu: Arc<[NatMtuDirection; 2]>,
         primary_a: Option<SocketAddr>,
         route_dynamic_socket: bool,
     ) {
@@ -910,6 +944,9 @@ impl NatPacketLink {
             tokio::select! {
                 result = a_public.recv_from(&mut a_buf) => {
                     let Ok((len, source)) = result else { return; };
+                    if !mtu[1].admit(len) {
+                        continue;
+                    }
                     if hold_ack.load(Ordering::Acquire)
                         && Self::is_authenticated_ack(&a_buf[..len])
                     {
@@ -949,6 +986,9 @@ impl NatPacketLink {
                 }
                 result = b_public.recv_from(&mut b_buf) => {
                     let Ok((len, source)) = result else { return; };
+                    if !mtu[0].admit(len) {
+                        continue;
+                    }
                     if hold_ack.load(Ordering::Acquire)
                         && Self::is_authenticated_ack(&b_buf[..len])
                     {
@@ -3026,11 +3066,18 @@ async fn dropped_fresh_reservation_refunds_after_epoch_lock_contention() {
 }
 
 async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
+    hard_hard_two_peer_success_with_stun_and_mtu(stun, [65_535, 65_535]).await;
+}
+
+async fn hard_hard_two_peer_success_with_stun_and_mtu(stun: HarnessStunProfile, mtu: [u64; 2]) {
     let _serial = HARD_HARD_E2E_SERIAL.acquire().await.unwrap();
     let now = hard_hard_now_for_test();
     set_hard_hard_test_now_ms(Some(now));
     let _clock = HardHardClockReset;
     let harness = build_two_peer_harness_with_stun(true, false, false, stun).await;
+    for (direction, limit) in harness.link.mtu.iter().zip(mtu) {
+        direction.ip_mtu.store(limit, Ordering::Release);
+    }
     // Keep this scenario scoped to the production Hard-Hard path. The
     // peer-reflexive worker also owns an ordinary primary-socket fast punch;
     // under a loaded libtest runtime that independent path can legitimately
@@ -3168,6 +3215,19 @@ async fn hard_hard_two_peer_success_with_stun(stun: HarnessStunProfile) {
     );
     assert!(harness.udp_a.dynamic_socket_count().await >= 1);
     assert!(harness.udp_b.dynamic_socket_count().await >= 1);
+    for (index, direction) in harness.link.mtu.iter().enumerate() {
+        let largest = direction.max_udp_payload.load(Ordering::Relaxed);
+        assert!(largest > 0, "both peers must transmit real control datagrams");
+        assert!(largest + 28 <= mtu[index], "control traffic exceeded IPv4 path MTU");
+        assert_eq!(direction.oversize_drops.load(Ordering::Relaxed), 0);
+        println!(
+            "HARD_HARD_MTU direction={} ip_mtu={} udp_budget={} max_udp_payload={} oversize_drops=0 direct=true",
+            if index == 0 { "A->B" } else { "B->A" },
+            mtu[index],
+            mtu[index] - 28,
+            largest,
+        );
+    }
     for signals in [&harness.signals_a, &harness.signals_b] {
         assert!(signals.lock().unwrap().iter().any(|signal| {
             signal.session_id.is_some()
@@ -3189,6 +3249,11 @@ async fn hard_hard_two_peer_success_is_full_e2e_and_exact_socket() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hard_hard_two_peer_success_with_minimum_stun_capacity() {
     hard_hard_two_peer_success_with_stun(HarnessStunProfile::MINIMUM_CAPACITY).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_hard_asymmetric_mtu_500_900() {
+    hard_hard_two_peer_success_with_stun_and_mtu(HarnessStunProfile::FULL_CAPACITY, [500, 900]).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4581,12 +4646,19 @@ async fn hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session() {
     // 3.5-second delay while the initiator captures zero, separating the two
     // authenticated-probe windows.
     let harness = build_two_peer_harness(true, false, false).await;
+    // Force the CI race: S1 has claimed its response owner, but its sweep
+    // admission resumes only after both network generations are retired.
+    // The old response must not start ordinary punching in S2's generation.
+    let response_gate = install_hard_hard_initiator_response_gate_for_test();
     harness.link.set_hold_ack(true);
     harness.validation_enabled_a.store(false, Ordering::Release);
     harness.validation_enabled_b.store(false, Ordering::Release);
 
     trigger_initial_offer(&harness).await;
     let response_s1 = wait_for_hard_hard_response_signal(&harness).await;
+    timeout(HARD_HARD_E2E_TIMEOUT, response_gate.reached.notified())
+        .await
+        .expect("S1 response must pause after claiming its owner and before entering its sweep");
     assert!(
         response_s1.punch_at_ms.is_some(),
         "S1 response must carry a canonical punch deadline"
@@ -4634,6 +4706,7 @@ async fn hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session() {
         .peers_b
         .advance_network_generation("phase_2_2_test_stale_ack_s1_cancel_b")
         .await;
+    response_gate.release.notify_one();
     wait_for_failed_attempt_cleanup(&harness).await;
     assert!(!harness.peers_a.is_direct(HARD_HARD_B).await);
     assert!(!harness.peers_b.is_direct(HARD_HARD_A).await);

--- a/docs/cross-task-integration.md
+++ b/docs/cross-task-integration.md
@@ -35,3 +35,50 @@ The manifest is uploaded even for a failed integration run so the failure is aud
 
 This gate does not sign, tag, release or publish artifacts. Distribution and release verification
 remain in the later final-gate issues.
+
+## Final-gate Hard-Hard regression
+
+On `83f1297953d3bf15d5eed6accd7e1333786f0cc7`, Path State Machine
+[run 33970243659, job 101317343036](https://github.com/yhan-sun/p2wlan/actions/runs/33970243659/job/101317343036)
+failed `tests::hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session`:
+the initiator never received the second Hard-Hard response. The failing command
+was `cargo test -p p2wlan-daemon --lib hard_hard_ -- --test-threads=1`.
+That revision has neither a `full` feature nor a `hard_hard_e2e` integration
+target or `linux_ac_test_harness.rs`.
+
+A reciprocal response belongs to one measured initiator session. If its
+session, lifecycle, plan, recovery admission, or exact socket is lost before
+the sweep starts, the response must be rejected. Treating that result as an
+unavailable optimization incorrectly permits ordinary fresh-punch fallback:
+after a network-generation change, the old response can acquire the new
+generation's punch owner and fold the real successor behind it. An incoming
+initiator offer whose responder cannot obtain a local STUN worker still uses
+the existing admitted fallback path.
+
+The stale-ACK E2E test pauses the reciprocal response after its punch claim and
+before `hard_hard_begin_sweep`, advances both network generations, and then
+releases the old response. It verifies that S1 ACKs cannot consume S2 pending
+transactions and that both S2 paths eventually commit Direct. This ordering
+reproduces the original failure without extending any timeout.
+
+`tests::hard_hard_asymmetric_mtu_500_900` additionally runs the complete existing
+Hard-Hard exact-socket convergence assertions through a userspace NAT link
+with independent IPv4 path-MTU limits. The A-to-B UDP payload budget is
+`500 - 20 - 8 = 472`; B-to-A is `900 - 20 - 8 = 872`. The link measures actual
+UDP payloads, including protocol/encryption overhead, rejects oversize
+datagrams, and requires zero oversize sends plus authenticated Direct on both
+peers. This is a modeled path-MTU test, not a change to the kernel loopback MTU
+or a DPLPMTUD convergence claim. Real Linux DF/EMSGSIZE coverage remains in
+`client/netbind/tests/no_fragment_netns.rs`.
+
+Targeted regression commands:
+
+```bash
+cargo test -p p2wlan-daemon --lib hard_hard_asymmetric_mtu_500_900 -- --nocapture --test-threads=1
+cargo test -p p2wlan-daemon --lib tests::hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session -- --exact --nocapture --test-threads=1
+cargo test -p p2wlan-daemon --lib hard_hard_ -- --test-threads=1
+```
+
+Completion still requires all 17 contract checks and the downloaded machine
+manifest to pass on the final post-merge `main` SHA. PR results alone do not
+close Issue #28.


### PR DESCRIPTION
## Root Cause

`spawn_hard_hard_initiator_response` returned `HardHardRemoteStart::NotStarted` (fallback to ordinary punch) when its session/plan/recovery fences were lost, instead of `Rejected` (consumed). A stale initiator response could acquire a newer network generation's punch owner and suppress that generation's real Hard↔Hard retry, causing the path to time out waiting for Direct.

The CI failure was in `hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session` under `cargo test -p p2wlan-daemon --lib hard_hard_ -- --test-threads=1` on commit `83f1297953d3bf15d5eed6accd7e1333786f0cc7`.

## Why 500/900 Failed

The asymmetric MTU test exposed the same underlying issue: when initiator response fences fail under race conditions, returning `NotStarted` permits fallback to ordinary punching. Under load, this fallback acquires the next generation's punch owner slot and blocks the real Hard↔Hard retry, leaving both peers waiting indefinitely for Direct establishment.

## Implementation

1. Changed all fence-failure returns in `spawn_hard_hard_initiator_response` from `HardHardRemoteStart::NotStarted` to `HardHardRemoteStart::Rejected`. A consumed response must not fall through to ordinary fresh-punch fallback.
2. Added `HardHardInitiatorResponseGate` test infrastructure to deterministically reproduce the race: pause the response after its punch claim and before `hard_hard_begin_sweep`, advance both network generations, then release.
3. Added `NatMtuDirection` to the test harness to model per-direction IPv4 path MTU limits independently.

## Regression Coverage

- `hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session`: deterministic gate ensures the stale response is rejected after network generation change
- `hard_hard_asymmetric_mtu_500_900`: full Hard↔Hard exact-socket convergence through userspace NAT link with A→B=500, B→A=900 IPv4 MTU limits; verifies zero oversize sends and authenticated Direct on both peers

## Local Test Evidence

- `hard_hard_asymmetric_mtu_500_900`: 5/5 passes, 0 flakes
- `hard_hard_two_peer_stale_ack_cannot_resurrect_retired_session`: 5/5 passes, 0 flakes
- Full `cargo test -p p2wlan-daemon --lib hard_hard_ -- --test-threads=1`: 69/69 passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed
- `git diff --check`: passed

Closes #28