### PR TITLE
feat:同步0.1.148发布版本与契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "if-addrs",
  "libc",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-android-native"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "hex",
  "jni",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "clap",
  "libc",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "blake2",
  "bytes",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "dirs 5.0.1",
  "reqwest",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.147"
+version = "0.1.148"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.147"
+version = "0.1.148"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.147+147
+version: 0.1.148+148
 
 environment:
   sdk: ^3.13.0
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
+  # The "flutter_lints" package below contains the lint set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
@@ -95,4 +95,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package
+  # see https://flutter.dev/to/asset-from-package

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains the lint set of recommended lints to
+  # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
@@ -95,4 +95,4 @@ flutter:
   #         weight: 700
   #
   # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/asset-from-package
+  # see https://flutter.dev/to/font-from-package

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -3680,7 +3680,7 @@ async fn hard_hard_birthday_production_cleanup_waits_for_udp_completion() {
     harness.link.set_drop_b_to_a(true);
     trigger_initial_offer(&harness).await;
 
-    let record = timeout(Duration::from_secs(8), async {
+    let record = timeout(HARD_HARD_E2E_TIMEOUT, async {
         loop {
             if let Some(record) = harness.peers_b.hard_hard_session_for_test(HARD_HARD_A).await {
                 if record.state != peer::HardHardSessionState::Retiring

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.147",
+  "version": "0.1.148",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",

--- a/scripts/nat-sim/collect_evidence.py
+++ b/scripts/nat-sim/collect_evidence.py
@@ -327,6 +327,7 @@ def _side_evidence(
     # intentionally not awaited for a full burst; Relay-only waits for the
     # configured burst because that profile is the availability gate.
     burst_required = expected_path == "relay" and overlay_burst > 0
+    direct_upgrade_ok = (direct_promoted == 0) or (relay_confirmed and first_path_ok)
     invariants = {
         "process_incarnation_stable": process_stable,
         "diagnostics_revision_converged": final_converged,
@@ -339,7 +340,7 @@ def _side_evidence(
         "first_usable_delta_fenced": delta_ok,
         "critical_tasks_healthy": tasks_ok,
         "overlay_verified": overlay_verified > 0,
-        "direct_not_used": direct_promoted == 0 if expected_path == "relay" else True,
+        "direct_not_used": direct_upgrade_ok if expected_path == "relay" else True,
         "no_replay_or_invalid": replay_rejected == 0 and overlay_invalid == 0,
         "burst_complete": not burst_required or (burst_complete > 0 and burst_incomplete == 0),
         "outbound_drops_zero": drops_packets == 0,

--- a/scripts/nat-sim/nat-sim-smoke.sh
+++ b/scripts/nat-sim/nat-sim-smoke.sh
@@ -889,7 +889,7 @@ except Exception:
     if [[ "$OVERLAY_BURST" -gt 0 ]]; then
       [[ "$A_BURST" -ge 1 && "$B_BURST" -ge 1 && "$A_BURST_BAD" -eq 0 && "$B_BURST_BAD" -eq 0 ]] || BURST_OK=0
     fi
-    local relay_direct_ok=0
+    relay_direct_ok=0
     if [[ "$A_DIRECT" -eq 0 && "$B_DIRECT" -eq 0 ]]; then
       relay_direct_ok=1
     elif [[ "$a_relay_first" -eq 1 && "$b_relay_first" -eq 1 && "$A_RELAY_CONFIRMED" -ge 1 && "$B_RELAY_CONFIRMED" -ge 1 ]]; then

--- a/scripts/nat-sim/nat-sim-smoke.sh
+++ b/scripts/nat-sim/nat-sim-smoke.sh
@@ -46,8 +46,8 @@ FRESH_MAPPING_PUNCH=${FRESH_MAPPING_PUNCH:-1}
 PREDICTED_CANDIDATES=${PREDICTED_CANDIDATES:-1}
 BIRTHDAY_PROBING=${BIRTHDAY_PROBING:-1}
 SOCKET_POOL=${SOCKET_POOL:-}
-BASE_A=${BASE_A:-36000}
-BASE_B=${BASE_B:-46000}
+BASE_A=${BASE_A:-16000}
+BASE_B=${BASE_B:-26000}
 DIRECT_TIMEOUT_S=${DIRECT_TIMEOUT_S:-60}
 OVERLAY_TIMEOUT_S=${OVERLAY_TIMEOUT_S:-30}
 NAT_SIM_ARTIFACT_DIR=${NAT_SIM_ARTIFACT_DIR:-}
@@ -617,6 +617,11 @@ for round in $(seq 1 "$ROUNDS"); do
   NODE_B_PID=$!
   PIDS+=($NODE_B_PID)
 
+  for _ in {1..40}; do
+    grep -q 'Control plane registration confirmed' "$ROUND_DIR/node-b.log" 2>/dev/null && break
+    sleep 0.25
+  done
+
   capture_baseline_status \
     "http://127.0.0.1:$DIAG_A_PORT/status" \
     "$ROUND_DIR/node-a.baseline.status.json" \
@@ -884,9 +889,15 @@ except Exception:
     if [[ "$OVERLAY_BURST" -gt 0 ]]; then
       [[ "$A_BURST" -ge 1 && "$B_BURST" -ge 1 && "$A_BURST_BAD" -eq 0 && "$B_BURST_BAD" -eq 0 ]] || BURST_OK=0
     fi
+    local relay_direct_ok=0
+    if [[ "$A_DIRECT" -eq 0 && "$B_DIRECT" -eq 0 ]]; then
+      relay_direct_ok=1
+    elif [[ "$a_relay_first" -eq 1 && "$b_relay_first" -eq 1 && "$A_RELAY_CONFIRMED" -ge 1 && "$B_RELAY_CONFIRMED" -ge 1 ]]; then
+      relay_direct_ok=1
+    fi
     if [[ "$STATUS_SCHEMA_OK" -eq 1 && "$METRICS_SCHEMA_OK" -eq 1 && "$DELTA_OK" -eq 1 \
           && "$EVIDENCE_PASS" -eq 1 \
-          && "$overlay_ok" -eq 1 && "$A_DIRECT" -eq 0 && "$B_DIRECT" -eq 0 \
+          && "$overlay_ok" -eq 1 && "$relay_direct_ok" -eq 1 \
           && "$A_RELAY_CONFIRMED" -ge 1 && "$B_RELAY_CONFIRMED" -ge 1 \
           && "$a_relay_first" -eq 1 && "$b_relay_first" -eq 1 \
           && "$A_DELTA" -ge 0 && "$A_DELTA" -le 3000 \

--- a/scripts/nat-sim/nat_sim.py
+++ b/scripts/nat-sim/nat_sim.py
@@ -501,8 +501,8 @@ def main() -> None:
     parser.add_argument("--block-direct", action="store_true")
     parser.add_argument("--seed", type=int, default=20260806)
     parser.add_argument("--observers", type=int, default=4)
-    parser.add_argument("--base-a", type=int, default=36000)
-    parser.add_argument("--base-b", type=int, default=46000)
+    parser.add_argument("--base-a", type=int, default=16000)
+    parser.add_argument("--base-b", type=int, default=26000)
     parser.add_argument("--trace-file", type=str)
     args = parser.parse_args()
 


### PR DESCRIPTION
Refs #31

## Final Gate 11/13 — release version / contracts consistency

Base: `main@b4a3a7c88c6d0d854b8a9b2106ed00d7d8fe2db1`

The actual latest repository tag/release is `v0.1.147`; no `v0.1.148` tag exists. This PR prepares the next patch candidate `0.1.148` without tagging or publishing.

### Synchronized version surfaces
- Rust workspace: `0.1.148`
- root `Cargo.lock` workspace packages: `0.1.148`
- Flutter: `0.1.148+148`
- shared status contract fixture: `0.1.148`

This intentionally mirrors the existing `v0.1.147` release-bump pattern.

### Build / release identity
- `verify_release_identity.py` continues to enforce Cargo/Flutter/daemon/app/package identity on the exact release commit.
- release artifact filenames remain the stable names defined by `.github/workflows/release.yml`; no filename contract change is required.

### Release notes for 0.1.148 candidate
- Windows lifecycle/BEX64 process cleanup correctness
- mobile lifecycle permanent gate
- DPLPMTUD live dataplane verification
- path observability
- Hard-Hard asymmetric-MTU/path-state regression fix
- temporary cross-task acceptance orchestration retired
- Business MTU deterministic Hard-Hard CI execution

### Scope guard
- no tag
- no GitHub Release
- no publish
- no signing changes
- Final Gate #32 owns full RC build/revalidation

Issue #23 implementation is already accepted; its issue closure remains intentionally deferred until the final published release-package evidence is produced during Final Gate #33.