### PR TITLE
feat:同步0.1.149发布版本与契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "if-addrs",
  "libc",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-android-native"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "hex",
  "jni 0.21.1",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "clap",
  "libc",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "blake2",
  "bytes",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "dirs",
  "reqwest",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.148"
+version = "0.1.149"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.148+148
+version: 0.1.149+149
 
 environment:
   sdk: ^3.13.0

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.148",
+  "version": "0.1.149",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",


### PR DESCRIPTION
## Summary
- Base main SHA: `713a61851966b22987fe485806d5935222995378`
- Version target: `0.1.149` (Flutter: `0.1.149+149`)
- Modified identity files:
  - `Cargo.toml`
  - `Cargo.lock`
  - `apps/flutter_client/pubspec.yaml`
  - `contracts/fixtures/status.json`

## Local Validation
- `cargo fmt --check`: passed
- `git diff --check`: passed
- `cargo check --workspace --all-features`: passed
- `test_release_identity.py`: passed (9 tests)
- `test_flutter_client_build_identity.py`: passed (19 tests)
- `scripts/security/tests`: passed (55 tests)
- `cargo audit --file Cargo.lock`: clean (0 vulnerabilities)
- `cargo deny check advisories bans licenses sources`: passed (clean)

## Security
- `RUSTSEC-2024-0429`: absent
- `security/advisory-exceptions.json`: `exceptions = []` (count = 0)

## Release State
- No tag created
- No release published