### PR TITLE
ci: make server artifact checksums portable

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -41,7 +41,10 @@ jobs:
             go version -m dist/p2wlan-control
             go version -m dist/p2wlan-relay
           } > dist/BUILD-METADATA.txt
-          sha256sum dist/p2wlan-control dist/p2wlan-relay > dist/SHA256SUMS
+          (
+            cd dist
+            sha256sum p2wlan-control p2wlan-relay > SHA256SUMS
+          )
           tar -C dist -czf p2wlan-server-linux-amd64.tar.gz \
             p2wlan-control p2wlan-relay BUILD-METADATA.txt SHA256SUMS
 


### PR DESCRIPTION
Fixes the server artifact checksum manifest so it matches the archive root layout and can be verified directly after download.

The deployed binaries were already verified manually; this keeps future deployments reproducible.