### PR TITLE
fix: harden friend-room direct connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-crypto"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-nat"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "if-addrs",
  "p2pnet-crypto",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-netbind"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "if-addrs",
  "libc",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-relay"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-tun"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "p2pnet-wireguard"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "hex",
  "p2pnet-crypto",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-android-native"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "hex",
  "jni 0.21.1",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-cli"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "clap",
  "libc",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-daemon"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "blake2",
  "bytes",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-desktop-host"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "dirs",
  "reqwest",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "p2wlan-tray"
-version = "0.1.152"
+version = "0.1.153"
 dependencies = [
  "arboard",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.152"
+version = "0.1.153"
 edition = "2021"
 authors = ["P2PNet Team"]
 license = "MIT"

--- a/apps/flutter_client/lib/core/api/control_api.dart
+++ b/apps/flutter_client/lib/core/api/control_api.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import '../build_info.dart';
 import '../diagnostics/session_log_bundle.dart';
+import '../diagnostics/support_log_protocol.dart';
 import '../security/redactor.dart';
 import '../state/settings_store.dart';
 
@@ -31,10 +32,15 @@ class DeviceUpdateResult {
 }
 
 class SupportLogUploadResult {
-  const SupportLogUploadResult({required this.uploadId, this.receivedAt});
+  const SupportLogUploadResult({
+    required this.uploadId,
+    this.receivedAt,
+    this.instances = 1,
+  });
 
   final String uploadId;
   final String? receivedAt;
+  final int instances;
 }
 
 class ControlApi {
@@ -44,7 +50,7 @@ class ControlApi {
 
   static const _requestTimeout = Duration(seconds: 8);
   static const _supportLogUploadTimeout = Duration(seconds: 60);
-  static const _maxSupportLogCompressedBytes = 8 * 1024 * 1024;
+  static const _maxSupportLogCompressedBytes = maxSupportLogCompressedBytes;
 
   final HttpClient _client;
 
@@ -222,6 +228,7 @@ class ControlApi {
     required ClientBuildInfo clientBuild,
     required DaemonBuildInfo? daemonBuild,
     required Iterable<SessionLogFile> files,
+    Iterable<String> omittedRoomProfileIds = const [],
   }) async {
     final token = authToken.trim();
     if (token.isEmpty) {
@@ -234,36 +241,46 @@ class ControlApi {
     if (logFiles.isEmpty) {
       throw const ControlApiException('没有找到本次启动的日志');
     }
+    final omittedProfiles = _normalizeOmittedRoomProfiles(
+      omittedRoomProfileIds,
+    );
+    _validateSupportLogFiles(logFiles);
 
     // Redaction, JSON expansion, UTF-8 encoding and gzip are deliberately
     // performed off the Flutter UI isolate. `async` alone does not move CPU
     // work off the main isolate and was causing Android to freeze on large
     // daemon logs.
-    final compressed = await _prepareSupportLogPayload(
-      uploadedAt: DateTime.now().toUtc().toIso8601String(),
-      deviceName: deviceName.trim(),
-      platform: Platform.operatingSystem,
-      clientBuild: {
-        'app_version': clientBuild.appVersion,
-        'git_commit': clientBuild.gitCommit,
-        'build_id': clientBuild.buildId,
-        'dirty': clientBuild.dirtyLabel,
-        'diff_hash': clientBuild.diffHash,
-        'profile': clientBuild.profile,
-      },
-      daemonBuild: daemonBuild == null
-          ? null
-          : {
-              'app_version': daemonBuild.appVersion,
-              'daemon_version': daemonBuild.daemonVersion,
-              'git_commit': daemonBuild.gitCommit,
-              'build_id': daemonBuild.buildId,
-              'dirty': daemonBuild.dirtyLabel,
-              'diff_hash': daemonBuild.diffHash,
-              'profile': daemonBuild.profile,
-            },
-      files: logFiles,
-    );
+    late final Uint8List compressed;
+    try {
+      compressed = await _prepareSupportLogPayload(
+        uploadedAt: DateTime.now().toUtc().toIso8601String(),
+        deviceName: deviceName.trim(),
+        platform: Platform.operatingSystem,
+        clientBuild: {
+          'app_version': clientBuild.appVersion,
+          'git_commit': clientBuild.gitCommit,
+          'build_id': clientBuild.buildId,
+          'dirty': clientBuild.dirtyLabel,
+          'diff_hash': clientBuild.diffHash,
+          'profile': clientBuild.profile,
+        },
+        daemonBuild: daemonBuild == null
+            ? null
+            : {
+                'app_version': daemonBuild.appVersion,
+                'daemon_version': daemonBuild.daemonVersion,
+                'git_commit': daemonBuild.gitCommit,
+                'build_id': daemonBuild.buildId,
+                'dirty': daemonBuild.dirtyLabel,
+                'diff_hash': daemonBuild.diffHash,
+                'profile': daemonBuild.profile,
+              },
+        files: logFiles,
+        omittedRoomProfileIds: omittedProfiles,
+      );
+    } on _SupportLogPayloadTooLarge {
+      throw const ControlApiException('日志展开后过大，请缩短本次启动时间后再试');
+    }
     if (compressed.length > _maxSupportLogCompressedBytes) {
       throw const ControlApiException('日志压缩后仍然过大，请缩短本次启动时间后再试');
     }
@@ -304,9 +321,15 @@ class ControlApi {
       if (uploadId.isEmpty || body['success'] == false) {
         throw const ControlApiException('控制服务器没有返回日志上传编号');
       }
+      final instances = body['instances'] is num
+          ? (body['instances'] as num).toInt()
+          : (body['instances'] is String
+                ? int.tryParse(body['instances'] as String) ?? 1
+                : 1);
       return SupportLogUploadResult(
         uploadId: uploadId,
         receivedAt: body['received_at']?.toString(),
+        instances: instances,
       );
     } on ControlApiException {
       rethrow;
@@ -402,8 +425,9 @@ Future<Uint8List> _prepareSupportLogPayload({
   required Map<String, String> clientBuild,
   required Map<String, String>? daemonBuild,
   required List<Map<String, String>> files,
+  required List<String> omittedRoomProfileIds,
 }) async {
-  final transferable = await Isolate.run(() {
+  final encoded = await Isolate.run<Map<String, Object?>>(() {
     final logFiles = files
         .map(
           (file) => <String, String>{
@@ -414,8 +438,25 @@ Future<Uint8List> _prepareSupportLogPayload({
           },
         )
         .toList(growable: false);
+    final roomProfiles = <String>{};
+    for (final f in logFiles) {
+      final name = f['name'] ?? '';
+      if (name.startsWith('rooms/')) {
+        final parts = name.split('/');
+        if (parts.length >= 2 && parts[1].isNotEmpty) {
+          roomProfiles.add(parts[1]);
+        }
+      } else if (name == 'p2wlan-room.log') {
+        roomProfiles.add('legacy');
+      }
+    }
+    final omittedProfiles = omittedRoomProfileIds
+        .where((profileId) => !roomProfiles.contains(profileId))
+        .toSet();
+    final hasRoomLogs = roomProfiles.isNotEmpty;
+    final schemaVersion = hasRoomLogs || omittedProfiles.isNotEmpty ? 2 : 1;
     final payload = <String, dynamic>{
-      'schema_version': 1,
+      'schema_version': schemaVersion,
       'uploaded_at': uploadedAt,
       'device_name': deviceName,
       'platform': platform,
@@ -423,13 +464,93 @@ Future<Uint8List> _prepareSupportLogPayload({
       ...?daemonBuild == null
           ? null
           : <String, dynamic>{'daemon_build': daemonBuild},
+      if (schemaVersion == 2)
+        'manifest': <String, dynamic>{
+          'total_instances': 1 + roomProfiles.length,
+          'has_room_logs': hasRoomLogs,
+          'retained_room_instances': roomProfiles.length,
+          if (omittedProfiles.isNotEmpty) ...<String, dynamic>{
+            'omitted_room_instances': omittedProfiles.length,
+            'omitted_reason': 'room_instance_budget',
+          },
+        },
       'files': logFiles,
     };
     final jsonBytes = utf8.encode(jsonEncode(payload));
+    if (jsonBytes.length > maxSupportLogExpandedBytes) {
+      return <String, Object?>{'expanded_too_large': true};
+    }
     final compressed = GZipCodec().encode(jsonBytes);
-    return TransferableTypedData.fromList([Uint8List.fromList(compressed)]);
+    return <String, Object?>{
+      'compressed': TransferableTypedData.fromList([
+        Uint8List.fromList(compressed),
+      ]),
+    };
   });
+  if (encoded['expanded_too_large'] == true) {
+    throw const _SupportLogPayloadTooLarge();
+  }
+  final transferable = encoded['compressed'];
+  if (transferable is! TransferableTypedData) {
+    throw StateError('support log encoder did not return compressed data');
+  }
   return transferable.materialize().asUint8List();
+}
+
+class _SupportLogPayloadTooLarge implements Exception {
+  const _SupportLogPayloadTooLarge();
+}
+
+void _validateSupportLogFiles(List<Map<String, String>> files) {
+  final names = <String>{};
+  final roomProfiles = <String>{};
+  final roomLogProfiles = <String>{};
+  for (final file in files) {
+    final name = (file['name'] ?? '').trim();
+    if (name.isEmpty || !names.add(name)) {
+      throw const ControlApiException('日志文件名为空或重复，请重试上传');
+    }
+    if (name.startsWith('rooms/')) {
+      final parts = name.split('/');
+      final validRoomFile =
+          parts.length == 3 &&
+          RegExp(r'^[a-f0-9]{64}$').hasMatch(parts[1]) &&
+          (parts[2] == 'p2wlan-daemon.log' ||
+              parts[2] == 'p2wlan-room.log' ||
+              parts[2] == 'status-summary.json');
+      if (!validRoomFile) {
+        throw const ControlApiException('房间日志文件名无效，请重试上传');
+      }
+      roomProfiles.add(parts[1]);
+      if (parts[2] != 'status-summary.json' && !roomLogProfiles.add(parts[1])) {
+        throw const ControlApiException('同一房间只能上传一个守护进程日志');
+      }
+    }
+  }
+  if (roomProfiles.length > maxSupportLogRoomInstances) {
+    throw ControlApiException('本次最多可上传 $maxSupportLogRoomInstances 个房间实例的日志');
+  }
+  final maxFiles = roomProfiles.isEmpty ? 3 : maxSupportLogFilesV2;
+  if (files.length > maxFiles) {
+    throw ControlApiException('本次日志文件超过协议上限 $maxFiles 个');
+  }
+}
+
+List<String> _normalizeOmittedRoomProfiles(Iterable<String> profileIds) {
+  final normalized = <String>[];
+  final seen = <String>{};
+  final profileIdPattern = RegExp(r'^[a-f0-9]{64}$');
+  for (final rawProfileId in profileIds) {
+    final profileId = rawProfileId.trim();
+    if (!profileIdPattern.hasMatch(profileId)) {
+      throw const ControlApiException('被省略房间的日志身份无效，请重试上传');
+    }
+    if (seen.add(profileId)) normalized.add(profileId);
+  }
+  if (normalized.length > maxTrackedSupportLogRoomInstances) {
+    throw const ControlApiException('本次省略的房间实例超过支持日志的记录上限');
+  }
+  return List.unmodifiable(normalized);
 }
 
 String _normalizeAuthControlServer(String value) {
@@ -466,6 +587,14 @@ String _zhAuthError(
   if (normalized.contains('invalid password')) return '密码不符合要求，至少需要 6 个字符';
   if (normalized.contains('registration failed')) return '注册失败，邮箱可能已存在';
   if (normalized.contains('rate limit')) return '请求过于频繁，请稍后再试';
+  if (normalized.contains('schema_version') ||
+      normalized.contains('schema version')) {
+    return '控制服务器不支持多房间日志格式(schema v2)，请升级服务端后再试';
+  }
+  if (normalized.contains('manifest') &&
+      normalized.contains('total_instances')) {
+    return '日志包实例清单与实际文件不一致，请重试上传';
+  }
   return raw.isEmpty ? '控制服务器请求失败' : raw;
 }
 

--- a/apps/flutter_client/lib/core/diagnostics/session_log_bundle.dart
+++ b/apps/flutter_client/lib/core/diagnostics/session_log_bundle.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 
 import '../daemon/diagnostics_auth.dart';
 import '../security/redactor.dart';
+import 'support_log_protocol.dart';
 
 // Mobile log uploads must not make the Flutter UI hold several copies of a
 // multi-megabyte, high-volume daemon log while it is being redacted and
@@ -19,18 +20,31 @@ class SessionLogFile {
 }
 
 class CurrentSessionLogBundle {
-  const CurrentSessionLogBundle({required this.files});
+  const CurrentSessionLogBundle({
+    required this.files,
+    this.omittedRoomProfileIds = const [],
+  });
 
   final List<SessionLogFile> files;
+  final List<String> omittedRoomProfileIds;
 
   /// Collect the files from the platform-specific directory used by the
   /// running daemon. Android resolves this through the native Context because
   /// its private files directory is not exposed as a stable HOME path.
   static Future<CurrentSessionLogBundle> collectCurrentStartup({
     int maxBytesPerFile = maxCurrentSessionLogBytesPerFile,
+    List<String> activeRoomProfileIds = const [],
+    Map<String, String> dynamicSummaries = const {},
   }) async {
     final directory = await resolveP2WlanLogDir();
     final separator = Platform.pathSeparator;
+    final roomSelection = selectSupportLogRoomProfiles(activeRoomProfileIds);
+    final roomProfileIds = roomSelection.retainedProfileIds;
+    final summaries = <String, String>{
+      for (final profileId in roomProfileIds)
+        if ((dynamicSummaries[profileId] ?? '').trim().isNotEmpty)
+          profileId: dynamicSummaries[profileId]!,
+    };
     // File reads and redaction are CPU/memory work from the UI's point of
     // view. Keep the platform channel lookup above on the main isolate, then
     // do the actual collection in a worker isolate.
@@ -38,6 +52,9 @@ class CurrentSessionLogBundle {
       () => _collectCurrentStartupFiles(
         daemonLogPath: '${directory.path}${separator}p2wlan-daemon.log',
         clientLogPath: '${directory.path}${separator}p2wlan-client.log',
+        logDirPath: directory.path,
+        activeRoomProfileIds: roomProfileIds,
+        dynamicSummaries: summaries,
         maxBytesPerFile: maxBytesPerFile,
       ),
     );
@@ -48,23 +65,28 @@ class CurrentSessionLogBundle {
               SessionLogFile(name: file['name']!, content: file['content']!),
         ),
       ),
+      omittedRoomProfileIds: roomSelection.omittedProfileIds,
     );
   }
 
-  /// Read only the two files that represent the current daemon startup.
+  /// Read only the files that represent the current daemon startup.
   /// Rotated `.1` files are deliberately never consulted.
   static Future<CurrentSessionLogBundle> collect({
     required String daemonLogPath,
     required String clientLogPath,
+    List<({String name, String path})> extraFiles = const [],
+    List<SessionLogFile> inlineFiles = const [],
     int maxBytesPerFile = maxCurrentSessionLogBytesPerFile,
     bool redactFiles = true,
   }) async {
     final candidates = <({String name, String path})>[
       (name: 'p2wlan-daemon.log', path: daemonLogPath),
       (name: 'p2wlan-client.log', path: clientLogPath),
+      ...extraFiles,
     ];
     final files = <SessionLogFile>[];
     final seenPaths = <String>{};
+    final seenNames = <String>{};
     for (final candidate in candidates) {
       final normalizedPath = candidate.path.trim();
       if (normalizedPath.isEmpty || !seenPaths.add(normalizedPath)) continue;
@@ -72,8 +94,16 @@ class CurrentSessionLogBundle {
       if (!await file.exists()) continue;
       final rawContent = await _readCurrentFile(file, maxBytesPerFile);
       final content = redactFiles ? redactSensitive(rawContent) : rawContent;
-      if (content.trim().isEmpty) continue;
+      if (content.trim().isEmpty || !seenNames.add(candidate.name)) continue;
       files.add(SessionLogFile(name: candidate.name, content: content));
+    }
+    for (final file in inlineFiles) {
+      final name = file.name.trim();
+      if (name.isEmpty || !seenNames.add(name)) continue;
+      final rawContent = _truncateInlineContent(file.content, maxBytesPerFile);
+      final content = redactFiles ? redactSensitive(rawContent) : rawContent;
+      if (content.trim().isEmpty) continue;
+      files.add(SessionLogFile(name: name, content: content));
     }
     if (files.isEmpty) {
       throw const FileSystemException(
@@ -87,11 +117,51 @@ class CurrentSessionLogBundle {
 Future<List<Map<String, String>>> _collectCurrentStartupFiles({
   required String daemonLogPath,
   required String clientLogPath,
+  required String logDirPath,
+  required List<String> activeRoomProfileIds,
+  required Map<String, String> dynamicSummaries,
   required int maxBytesPerFile,
 }) async {
+  final separator = Platform.pathSeparator;
+  final extraFiles = <({String name, String path})>[];
+  final inlineFiles = <SessionLogFile>[];
+  for (final profileId in activeRoomProfileIds) {
+    final daemonPath =
+        '$logDirPath${separator}rooms${separator}$profileId${separator}p2wlan-daemon.log';
+    if (await File(daemonPath).exists()) {
+      extraFiles.add((
+        name: 'rooms/$profileId/p2wlan-daemon.log',
+        path: daemonPath,
+      ));
+    }
+    final dynamicSummary = dynamicSummaries[profileId];
+    if (dynamicSummary != null && dynamicSummary.trim().isNotEmpty) {
+      // The summary is assembled from the current in-memory room lifecycle,
+      // including failures before the daemon ever exposes /status.  Keeping it
+      // inline avoids synchronously writing a support artifact on the UI
+      // isolate and avoids relying on a file that a failed process never made.
+      inlineFiles.add(
+        SessionLogFile(
+          name: 'rooms/$profileId/status-summary.json',
+          content: dynamicSummary,
+        ),
+      );
+    } else {
+      final summaryPath =
+          '$logDirPath${separator}rooms${separator}$profileId${separator}status-summary.json';
+      if (await File(summaryPath).exists()) {
+        extraFiles.add((
+          name: 'rooms/$profileId/status-summary.json',
+          path: summaryPath,
+        ));
+      }
+    }
+  }
   final bundle = await CurrentSessionLogBundle.collect(
     daemonLogPath: daemonLogPath,
     clientLogPath: clientLogPath,
+    extraFiles: extraFiles,
+    inlineFiles: inlineFiles,
     maxBytesPerFile: maxBytesPerFile,
     // The upload encoder is the final redaction boundary. Keeping the file
     // raw here avoids doing the same expensive pass twice in worker isolates.
@@ -102,6 +172,20 @@ Future<List<Map<String, String>>> _collectCurrentStartupFiles({
         (file) => <String, String>{'name': file.name, 'content': file.content},
       )
       .toList(growable: false);
+}
+
+String _truncateInlineContent(String content, int maxBytes) {
+  if (maxBytes <= 0) {
+    throw ArgumentError('maxBytes must be positive');
+  }
+  final bytes = utf8.encode(content);
+  if (bytes.length <= maxBytes) return content;
+  final tail = utf8.decode(
+    bytes.sublist(bytes.length - maxBytes),
+    allowMalformed: true,
+  );
+  return '[p2wlan] generated status summary exceeded $maxBytes bytes; '
+      'showing its tail only.\n$tail';
 }
 
 Future<String> _readCurrentFile(File file, int maxBytes) async {

--- a/apps/flutter_client/lib/core/diagnostics/session_log_bundle.dart
+++ b/apps/flutter_client/lib/core/diagnostics/session_log_bundle.dart
@@ -127,7 +127,10 @@ Future<List<Map<String, String>>> _collectCurrentStartupFiles({
   final inlineFiles = <SessionLogFile>[];
   for (final profileId in activeRoomProfileIds) {
     final daemonPath =
-        '$logDirPath${separator}rooms${separator}$profileId${separator}p2wlan-daemon.log';
+        '$logDirPath$separator'
+        'rooms$separator'
+        '$profileId$separator'
+        'p2wlan-daemon.log';
     if (await File(daemonPath).exists()) {
       extraFiles.add((
         name: 'rooms/$profileId/p2wlan-daemon.log',
@@ -148,7 +151,10 @@ Future<List<Map<String, String>>> _collectCurrentStartupFiles({
       );
     } else {
       final summaryPath =
-          '$logDirPath${separator}rooms${separator}$profileId${separator}status-summary.json';
+          '$logDirPath$separator'
+          'rooms$separator'
+          '$profileId$separator'
+          'status-summary.json';
       if (await File(summaryPath).exists()) {
         extraFiles.add((
           name: 'rooms/$profileId/status-summary.json',

--- a/apps/flutter_client/lib/core/diagnostics/support_log_protocol.dart
+++ b/apps/flutter_client/lib/core/diagnostics/support_log_protocol.dart
@@ -1,0 +1,52 @@
+/// Limits shared by the support-log collector and its wire encoder.
+///
+/// A default desktop client can run eight friend rooms at once.  Each room
+/// contributes at most its daemon log and one generated status summary, in
+/// addition to the main daemon and Flutter client logs.  Keeping these values
+/// explicit prevents the collector from producing a normal payload that the
+/// server rejects solely because the two sides disagreed on file counts.
+const maxSupportLogRoomInstances = 8;
+const maxSupportLogInstancesV2 = 1 + maxSupportLogRoomInstances;
+const maxSupportLogFilesV2 = 2 + (maxSupportLogRoomInstances * 2);
+const maxTrackedSupportLogRoomInstances = maxSupportLogRoomInstances * 2;
+
+const maxSupportLogExpandedBytes = 32 * 1024 * 1024;
+const maxSupportLogCompressedBytes = 8 * 1024 * 1024;
+
+class SupportLogRoomSelection {
+  const SupportLogRoomSelection({
+    required this.retainedProfileIds,
+    required this.omittedProfileIds,
+  });
+
+  final List<String> retainedProfileIds;
+  final List<String> omittedProfileIds;
+}
+
+/// Keeps the supplied priority order, deduplicates valid local profile ids,
+/// and makes any overflow explicit for the v2 manifest.  The collector uses
+/// the retained ids while the omitted count explains why an older room is not
+/// in this particular support bundle.
+SupportLogRoomSelection selectSupportLogRoomProfiles(
+  Iterable<String> profileIds,
+) {
+  final retained = <String>[];
+  final omitted = <String>[];
+  final seen = <String>{};
+  final profileIdPattern = RegExp(r'^[a-f0-9]{64}$');
+  for (final rawProfileId in profileIds) {
+    final profileId = rawProfileId.trim();
+    if (!profileIdPattern.hasMatch(profileId) || !seen.add(profileId)) {
+      continue;
+    }
+    if (retained.length < maxSupportLogRoomInstances) {
+      retained.add(profileId);
+    } else {
+      omitted.add(profileId);
+    }
+  }
+  return SupportLogRoomSelection(
+    retainedProfileIds: List.unmodifiable(retained),
+    omittedProfileIds: List.unmodifiable(omitted),
+  );
+}

--- a/apps/flutter_client/lib/core/rooms/parallel_rooms.dart
+++ b/apps/flutter_client/lib/core/rooms/parallel_rooms.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
 import '../daemon/daemon_controller.dart';
+import '../diagnostics/support_log_protocol.dart';
 import '../models/diagnostics_models.dart';
 import 'room_api.dart';
 import 'room_profiles.dart';
@@ -75,7 +77,12 @@ class ParallelRooms extends ChangeNotifier {
   final _sessions = <String, ParallelRoomSession>{};
   final _operations = <String, Future<DaemonCommandResult>>{};
   final _recovering = <String>{};
+  final _recentRoomSnapshots = <String, DiagnosticsSnapshot?>{};
+  final _recentRoomPlans = <String, ParallelRoomPlan>{};
+  final _recentRoomPhases = <String, RoomConnectionPhase>{};
+  final _recentRoomMessages = <String, String>{};
   Timer? _timer;
+  Duration? _scheduledInterval;
   var _credentials = '';
   var _epoch = 0;
   var _admissionPauses = 0;
@@ -84,6 +91,97 @@ class ParallelRooms extends ChangeNotifier {
   String? lastError;
 
   Map<String, ParallelRoomSession> get sessions => Map.unmodifiable(_sessions);
+  Map<String, DiagnosticsSnapshot?> get recentRoomSnapshots =>
+      Map.unmodifiable(_recentRoomSnapshots);
+  List<String> get supportLogProfileCandidates {
+    final ids = <String>[];
+    void add(String id) {
+      if (!ids.contains(id)) {
+        ids.add(id);
+      }
+    }
+
+    for (final s in _sessions.values) {
+      if (!_isCurrentAccountPlan(s.plan)) continue;
+      add(s.plan.profileId);
+    }
+    // The map is an LRU-style bounded history.  Prefer the most recently
+    // stopped/failed rooms after all live rooms, so a support bundle stays
+    // within the v2 eight-room contract without losing the latest failure.
+    for (final id in _recentRoomPlans.keys.toList().reversed) {
+      final plan = _recentRoomPlans[id];
+      if (plan == null || !_isCurrentAccountPlan(plan)) continue;
+      add(id);
+    }
+    return List.unmodifiable(ids);
+  }
+
+  SupportLogRoomSelection get supportLogSelection =>
+      selectSupportLogRoomProfiles(supportLogProfileCandidates);
+
+  List<String> get allRecentRoomProfileIds =>
+      supportLogSelection.retainedProfileIds;
+
+  Map<String, String> exportStatusSummaries() {
+    final summaries = <String, String>{};
+    for (final id in allRecentRoomProfileIds) {
+      ParallelRoomSession? active;
+      for (final s in _sessions.values) {
+        if (s.plan.profileId == id) {
+          active = s;
+          break;
+        }
+      }
+      final snapshot = active?.snapshot ?? _recentRoomSnapshots[id];
+      final plan = active?.plan ?? _recentRoomPlans[id];
+      if (plan != null) {
+        final phase =
+            active?.phase ??
+            _recentRoomPhases[id] ??
+            RoomConnectionPhase.unavailable;
+        final message = active?.message ?? _recentRoomMessages[id];
+        summaries[id] = jsonEncode({
+          'network_id': plan.room.id,
+          'room_name': plan.room.name,
+          'profile_id': id,
+          'phase': phase.name,
+          if (message != null && message.isNotEmpty) 'message': message,
+          if (snapshot != null) 'last_status': snapshot.raw,
+        });
+      }
+    }
+    return summaries;
+  }
+
+  void _rememberRoom(
+    ParallelRoomPlan plan, {
+    DiagnosticsSnapshot? snapshot,
+    bool replaceSnapshot = false,
+    RoomConnectionPhase? phase,
+    String? message,
+  }) {
+    // A late status/start failure from the previous account must never make
+    // its room path eligible for the next account's support upload.
+    if (!_isCurrentAccountPlan(plan)) return;
+    final id = plan.profileId;
+    _recentRoomPlans.remove(id);
+    _recentRoomPlans[id] = plan;
+    if (replaceSnapshot) _recentRoomSnapshots[id] = snapshot;
+    if (phase != null) _recentRoomPhases[id] = phase;
+    if (message == null || message.isEmpty) {
+      _recentRoomMessages.remove(id);
+    } else {
+      _recentRoomMessages[id] = message;
+    }
+    while (_recentRoomPlans.length > maxTrackedSupportLogRoomInstances) {
+      final oldest = _recentRoomPlans.keys.first;
+      _recentRoomPlans.remove(oldest);
+      _recentRoomSnapshots.remove(oldest);
+      _recentRoomPhases.remove(oldest);
+      _recentRoomMessages.remove(oldest);
+    }
+  }
+
   bool get hasSessions =>
       _sessions.isNotEmpty || _operations.isNotEmpty || _recovering.isNotEmpty;
   int get activeConnections => _sessions.length;
@@ -96,11 +194,21 @@ class ParallelRooms extends ChangeNotifier {
   String _credentialKey(AppSettings value) =>
       '${value.controlServer}\n${value.authToken}';
 
+  bool _isCurrentAccountPlan(ParallelRoomPlan plan) {
+    final planCredentials = _credentialKey(plan.settings);
+    return planCredentials == _credentials &&
+        planCredentials == _credentialKey(readSettings());
+  }
+
   Future<DaemonCommandResult> credentialsChanged() {
     final next = _credentialKey(readSettings());
     if (next == _credentials) return Future.value(_ok());
     _credentials = next;
     _epoch++;
+    _recentRoomPlans.clear();
+    _recentRoomSnapshots.clear();
+    _recentRoomPhases.clear();
+    _recentRoomMessages.clear();
     return stopAll();
   }
 
@@ -194,6 +302,12 @@ class ParallelRooms extends ChangeNotifier {
     if (conflict != null) return _fail(conflict);
     final entry = ParallelRoomSession(plan, runtimeFactory(plan));
     _sessions[room.id] = entry;
+    _rememberRoom(
+      plan,
+      snapshot: null,
+      replaceSnapshot: true,
+      phase: RoomConnectionPhase.starting,
+    );
     _notify();
     DaemonCommandResult started;
     try {
@@ -202,13 +316,24 @@ class ParallelRooms extends ChangeNotifier {
       started = _fail('房间启动失败，需要清理本地运行时');
     }
     if (!started.ok || !_accepts(epoch, credentials)) {
+      entry.phase = RoomConnectionPhase.failed;
+      entry.message = started.ok
+          ? '登录状态已变化，连接已取消'
+          : (started.message.isEmpty ? '房间启动失败' : started.message);
+      _rememberRoom(
+        entry.plan,
+        snapshot: entry.snapshot,
+        replaceSnapshot: true,
+        phase: entry.phase,
+        message: entry.message,
+      );
       final cleanup = await _disconnect(room.id);
       return cleanup.ok
           ? (started.ok ? _fail('登录状态已变化，连接已取消') : started)
           : cleanup;
     }
     await _refresh(entry);
-    _ensureTimer();
+    _schedulePoll();
     if (entry.phase != RoomConnectionPhase.running) {
       return _fail('房间进程已启动，但地址或路由尚未就绪；可重试状态检查或断开');
     }
@@ -235,6 +360,9 @@ class ParallelRooms extends ChangeNotifier {
   Future<DaemonCommandResult> _disconnect(String id) async {
     final entry = _sessions[id];
     if (entry == null) return _ok();
+    final previousSnapshot = entry.snapshot;
+    final previousPhase = entry.phase;
+    final previousMessage = entry.message;
     entry.revision++;
     entry.phase = RoomConnectionPhase.stopping;
     entry.snapshot = null;
@@ -247,15 +375,39 @@ class ParallelRooms extends ChangeNotifier {
     }
     if (result.ok) {
       _sessions.remove(id);
+      final retainedFailure =
+          previousPhase == RoomConnectionPhase.failed ||
+          previousPhase == RoomConnectionPhase.unavailable;
+      _rememberRoom(
+        entry.plan,
+        snapshot: previousSnapshot,
+        replaceSnapshot: true,
+        phase: retainedFailure
+            ? previousPhase
+            : RoomConnectionPhase.unavailable,
+        message: retainedFailure ? previousMessage : '房间运行时已停止；保留本次实例日志供支持分析',
+      );
       entry.runtime.close();
     } else {
       entry.phase = RoomConnectionPhase.failed;
-      entry.message = '停止失败，运行时仍被保留，请重试断开';
+      entry.message = previousMessage == null || previousMessage.isEmpty
+          ? '停止失败，运行时仍被保留，请重试断开'
+          : '$previousMessage；停止失败，运行时仍被保留，请重试断开';
+      _rememberRoom(
+        entry.plan,
+        snapshot: previousSnapshot,
+        replaceSnapshot: true,
+        phase: entry.phase,
+        message: entry.message,
+      );
       lastError = entry.message;
     }
     if (_sessions.isEmpty) {
       _timer?.cancel();
       _timer = null;
+      _scheduledInterval = null;
+    } else {
+      _schedulePoll();
     }
     _notify();
     return result;
@@ -343,15 +495,35 @@ class ParallelRooms extends ChangeNotifier {
         final runtime = runtimeFactory(plan);
         final entry = ParallelRoomSession(plan, runtime);
         _sessions[room.id] = entry;
+        _rememberRoom(
+          plan,
+          snapshot: null,
+          replaceSnapshot: true,
+          phase: RoomConnectionPhase.starting,
+        );
         try {
           if (!await runtime.exists()) {
             _sessions.remove(room.id);
+            _rememberRoom(
+              plan,
+              snapshot: null,
+              replaceSnapshot: true,
+              phase: RoomConnectionPhase.unavailable,
+              message: '未发现房间运行时；保留本次实例日志供支持分析',
+            );
             runtime.close();
             return _ok();
           }
         } catch (_) {
           entry.phase = RoomConnectionPhase.failed;
           entry.message = '无法确认房间进程状态，请重试断开';
+          _rememberRoom(
+            plan,
+            snapshot: null,
+            replaceSnapshot: true,
+            phase: entry.phase,
+            message: entry.message,
+          );
           return _fail(entry.message!);
         }
         if (_credentialKey(account) != _credentialKey(readSettings()) ||
@@ -359,7 +531,7 @@ class ParallelRooms extends ChangeNotifier {
           return _disconnect(room.id);
         }
         await _refresh(entry);
-        _ensureTimer();
+        _schedulePoll();
         return _ok();
       });
     } finally {
@@ -386,6 +558,12 @@ class ParallelRooms extends ChangeNotifier {
       entry.snapshot = snapshot;
       entry.phase = RoomConnectionPhase.running;
       entry.message = null;
+      _rememberRoom(
+        entry.plan,
+        snapshot: snapshot,
+        replaceSnapshot: true,
+        phase: entry.phase,
+      );
     } catch (_) {
       if (!_disposed &&
           revision == entry.revision &&
@@ -393,24 +571,109 @@ class ParallelRooms extends ChangeNotifier {
         entry.snapshot = null;
         entry.phase = RoomConnectionPhase.unavailable;
         entry.message = '运行时或路由不可用；未显示过期的在线状态';
+        _rememberRoom(
+          entry.plan,
+          snapshot: null,
+          replaceSnapshot: true,
+          phase: entry.phase,
+          message: entry.message,
+        );
       }
     } finally {
       entry.refreshing = false;
       _notify();
+      _schedulePoll();
     }
   }
 
-  void _ensureTimer() {
-    if (_disposed || refreshInterval <= Duration.zero || _timer != null) return;
-    _timer = Timer.periodic(refreshInterval, (_) {
-      for (final entry in _sessions.values.toList()) {
-        if (entry.phase != RoomConnectionPhase.starting &&
-            entry.phase != RoomConnectionPhase.stopping &&
-            entry.phase != RoomConnectionPhase.failed) {
-          unawaited(_refresh(entry));
-        }
+  bool _isPeerTransitional(PeerSnapshot p) {
+    if (!p.online) return false;
+    final state = p.state.toLowerCase();
+    if (state.contains('connect') ||
+        state.contains('handshake') ||
+        state.contains('prob') ||
+        state.contains('punch')) {
+      return true;
+    }
+    if (p.path == 'probing' || p.path == 'direct_trial') return true;
+    if (p.path == 'relay' && !p.isRelayVerified) return true;
+    if (p.path == 'direct' && !p.isDirectVerified) return true;
+    return false;
+  }
+
+  bool _isSessionTransitional(ParallelRoomSession entry) {
+    if (entry.phase == RoomConnectionPhase.starting) return true;
+    if (entry.phase == RoomConnectionPhase.running) {
+      final snap = entry.snapshot;
+      if (snap == null || snap.peerSnapshotStale) return true;
+      final onlinePeers = snap.peers.where((p) => p.online);
+      if (onlinePeers.any(_isPeerTransitional)) {
+        return true;
       }
-    });
+    }
+    return false;
+  }
+
+  bool _hasTransitionalSession() {
+    return _sessions.values.any(_isSessionTransitional);
+  }
+
+  Duration get _currentPollingInterval {
+    if (refreshInterval <= Duration.zero) return Duration.zero;
+    if (_hasTransitionalSession()) {
+      return refreshInterval < const Duration(milliseconds: 500)
+          ? refreshInterval
+          : const Duration(milliseconds: 500);
+    }
+    return refreshInterval;
+  }
+
+  void _schedulePoll() {
+    if (_disposed ||
+        refreshInterval <= Duration.zero ||
+        _sessions.isEmpty ||
+        !hasListeners) {
+      _timer?.cancel();
+      _timer = null;
+      _scheduledInterval = null;
+      return;
+    }
+    final interval = _currentPollingInterval;
+    if (_timer != null && _scheduledInterval == interval) {
+      return;
+    }
+    _timer?.cancel();
+    _scheduledInterval = interval;
+    _timer = Timer(interval, _onPollTimer);
+  }
+
+  void _onPollTimer() {
+    _timer = null;
+    _scheduledInterval = null;
+    if (_disposed || _sessions.isEmpty || !hasListeners) return;
+    for (final entry in _sessions.values.toList()) {
+      if (entry.phase != RoomConnectionPhase.stopping &&
+          entry.phase != RoomConnectionPhase.failed) {
+        unawaited(_refresh(entry));
+      }
+    }
+    _schedulePoll();
+  }
+
+  @override
+  void addListener(VoidCallback listener) {
+    super.addListener(listener);
+    _schedulePoll();
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!hasListeners) {
+      _timer?.cancel();
+      _timer = null;
+      _scheduledInterval = null;
+    }
   }
 
   void _notify() {
@@ -422,6 +685,8 @@ class ParallelRooms extends ChangeNotifier {
     if (_disposed) return;
     _disposed = true;
     _timer?.cancel();
+    _timer = null;
+    _scheduledInterval = null;
     unawaited(stopAll());
     super.dispose();
   }

--- a/apps/flutter_client/lib/features/rooms/rooms_page.dart
+++ b/apps/flutter_client/lib/features/rooms/rooms_page.dart
@@ -369,9 +369,8 @@ class _RoomsPageState extends State<RoomsPage> {
   }
 
   void _notify(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<bool> _confirm(String title, String message) async {
@@ -1743,9 +1742,9 @@ class _RoomsPageState extends State<RoomsPage> {
                           child: Semantics(
                             liveRegion: true,
                             child: Card(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.errorContainer,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .errorContainer,
                               child: Padding(
                                 padding: const EdgeInsets.all(16),
                                 child: Row(

--- a/apps/flutter_client/lib/features/rooms/rooms_page.dart
+++ b/apps/flutter_client/lib/features/rooms/rooms_page.dart
@@ -65,7 +65,66 @@ class _RoomsPageState extends State<RoomsPage> {
     if (mounted) {
       setState(() {});
       _roomViewRevision.value++;
+      _scheduleTimer();
     }
+  }
+
+  bool _isPeerTransitional(PeerSnapshot p) {
+    if (!p.online) return false;
+    final state = p.state.toLowerCase();
+    if (state.contains('connect') ||
+        state.contains('handshake') ||
+        state.contains('prob') ||
+        state.contains('punch')) {
+      return true;
+    }
+    if (p.path == 'probing' || p.path == 'direct_trial') return true;
+    if (p.path == 'relay' && !p.isRelayVerified) return true;
+    if (p.path == 'direct' && !p.isDirectVerified) return true;
+    return false;
+  }
+
+  bool _hasTransitionalConnection() {
+    for (final session in _parallel.sessions.values) {
+      if (session.phase == RoomConnectionPhase.starting) return true;
+      if (session.phase == RoomConnectionPhase.running) {
+        final snap = session.snapshot;
+        if (snap == null) return true;
+        final onlinePeers = snap.peers.where((p) => p.online);
+        if (onlinePeers.any(_isPeerTransitional)) {
+          return true;
+        }
+      }
+    }
+    final primaryRoomId = widget.settingsStore.settings.networkId;
+    if (isRoomNetwork(primaryRoomId)) {
+      if (widget.statusStore.daemonStarting) return true;
+      final snap = widget.statusStore.snapshot;
+      if (snap != null && snap.networkId == primaryRoomId) {
+        final onlinePeers = snap.peers.where((p) => p.online);
+        if (onlinePeers.any(_isPeerTransitional)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void _scheduleTimer() {
+    _timer?.cancel();
+    if (!mounted) return;
+    final hasTransitional = _hasTransitionalConnection();
+    final interval = hasTransitional
+        ? const Duration(milliseconds: 500)
+        : const Duration(seconds: 5);
+    _timer = Timer(interval, () {
+      if (!mounted) return;
+      if (!_busy && !_refreshing) {
+        unawaited(_refresh(silent: true).whenComplete(_scheduleTimer));
+      } else {
+        _scheduleTimer();
+      }
+    });
   }
 
   bool get _canConnect =>
@@ -104,9 +163,7 @@ class _RoomsPageState extends State<RoomsPage> {
         widget.initialRoomId ??
         (isRoomNetwork(settings.networkId) ? settings.networkId : null);
     unawaited(_refresh());
-    _timer = Timer.periodic(const Duration(seconds: 5), (_) {
-      if (!_busy && !_refreshing) unawaited(_refresh(silent: true));
-    });
+    _scheduleTimer();
     _handleInvitation();
   }
 
@@ -210,15 +267,72 @@ class _RoomsPageState extends State<RoomsPage> {
     return '未设置用户名';
   }
 
-  String _connectionLabel(ParallelRoomSession? session) =>
-      switch (session?.phase) {
-        RoomConnectionPhase.starting => '连接中',
-        RoomConnectionPhase.running => '已连接',
-        RoomConnectionPhase.stopping => '断开中',
-        RoomConnectionPhase.unavailable => '连接不可用',
-        RoomConnectionPhase.failed => '需处理',
-        null => '未连接',
-      };
+  String _connectionLabel(
+    ParallelRoomSession? session, [
+    DiagnosticsSnapshot? snapshot,
+  ]) {
+    if (session != null) {
+      switch (session.phase) {
+        case RoomConnectionPhase.stopping:
+          return '断开中';
+        case RoomConnectionPhase.unavailable:
+          return '连接不可用';
+        case RoomConnectionPhase.failed:
+          return '需处理';
+        case RoomConnectionPhase.starting:
+          if (snapshot == null && session.snapshot == null) return '本机启动';
+        case RoomConnectionPhase.running:
+          break;
+      }
+    }
+
+    final currentSnapshot = snapshot ?? session?.snapshot;
+    if (currentSnapshot == null) {
+      return session?.phase == RoomConnectionPhase.starting
+          ? '本机启动'
+          : (session == null ? '未连接' : '连接中');
+    }
+
+    final onlinePeers = currentSnapshot.peers.where((p) => p.online).toList();
+    if (onlinePeers.isEmpty) {
+      return '等待好友';
+    }
+
+    if (onlinePeers.any((p) => p.isDirectVerified)) {
+      return '已直连';
+    }
+
+    final hasRelay = onlinePeers.any((p) => p.isRelayVerified);
+    final isProbing = onlinePeers.any(
+      (p) =>
+          p.path == 'probing' ||
+          p.path == 'direct_trial' ||
+          p.probeLatencyMs != null ||
+          p.state.toLowerCase().contains('punch') ||
+          p.state.toLowerCase().contains('prob'),
+    );
+
+    if (hasRelay && isProbing) {
+      return '中继可用 · 直连探测';
+    }
+    if (hasRelay) {
+      return '中继可用';
+    }
+
+    final isHandshaking = onlinePeers.any(
+      (p) =>
+          p.state.toLowerCase().contains('handshake') ||
+          p.state.toLowerCase().contains('connect'),
+    );
+    if (isHandshaking) {
+      return '建立加密会话';
+    }
+    if (isProbing) {
+      return '直连探测';
+    }
+
+    return '已连接';
+  }
 
   String _message(Object error) =>
       error is RoomException ? error.message : '操作未完成，请检查连接后重试';
@@ -255,8 +369,9 @@ class _RoomsPageState extends State<RoomsPage> {
   }
 
   void _notify(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<bool> _confirm(String title, String message) async {
@@ -791,7 +906,7 @@ class _RoomsPageState extends State<RoomsPage> {
                         child: Icon(Icons.lock_outline, size: 16),
                       ),
                     Text(
-                      connected ? '已连接' : _connectionLabel(session),
+                      _connectionLabel(session, _roomSnapshot(room)),
                       style: Theme.of(context).textTheme.labelMedium,
                     ),
                   ],
@@ -1277,7 +1392,7 @@ class _RoomsPageState extends State<RoomsPage> {
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: Text(
-                        primaryConnected ? '已连接' : _connectionLabel(connection),
+                        _connectionLabel(connection, _roomSnapshot(room)),
                         style: Theme.of(context).textTheme.labelMedium,
                       ),
                     ),
@@ -1628,9 +1743,9 @@ class _RoomsPageState extends State<RoomsPage> {
                           child: Semantics(
                             liveRegion: true,
                             child: Card(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .errorContainer,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.errorContainer,
                               child: Padding(
                                 padding: const EdgeInsets.all(16),
                                 child: Row(

--- a/apps/flutter_client/lib/features/rooms/rooms_page.dart
+++ b/apps/flutter_client/lib/features/rooms/rooms_page.dart
@@ -818,7 +818,6 @@ class _RoomsPageState extends State<RoomsPage> {
     }
     if (room.isOwner) owner = owner.isEmpty ? '我' : '$owner（我）';
     final session = _parallel.session(room.id);
-    final connected = _roomSnapshot(room) != null;
     return Material(
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(14),

--- a/apps/flutter_client/lib/features/settings/settings_page/actions.dart
+++ b/apps/flutter_client/lib/features/settings/settings_page/actions.dart
@@ -282,7 +282,13 @@ extension _SettingsPageActions on _SettingsPageState {
       _logUploadError = null;
     });
     try {
-      final bundle = await CurrentSessionLogBundle.collectCurrentStartup();
+      final parallel = widget.statusStore.parallelRooms;
+      final activeRoomProfileIds = parallel.supportLogProfileCandidates;
+      final dynamicSummaries = parallel.exportStatusSummaries();
+      final bundle = await CurrentSessionLogBundle.collectCurrentStartup(
+        activeRoomProfileIds: activeRoomProfileIds,
+        dynamicSummaries: dynamicSummaries,
+      );
       final result = await _controlApi.uploadSupportLogs(
         controlServer: settings.controlServer,
         authToken: authToken,
@@ -290,9 +296,13 @@ extension _SettingsPageActions on _SettingsPageState {
         clientBuild: ClientBuildInfo.current,
         daemonBuild: widget.statusStore.daemonController.lastDaemonBuildInfo,
         files: bundle.files,
+        omittedRoomProfileIds: bundle.omittedRoomProfileIds,
       );
       if (mounted) {
-        _showSnackBar(strings.logsUploaded(result.uploadId));
+        final message = result.instances > 1
+            ? '${strings.logsUploaded(result.uploadId)} (${result.instances} 个实例)'
+            : strings.logsUploaded(result.uploadId);
+        _showSnackBar(message);
       }
     } catch (error) {
       if (mounted) {
@@ -329,7 +339,8 @@ extension _SettingsPageActions on _SettingsPageState {
 
   void _showSnackBar(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 }

--- a/apps/flutter_client/lib/features/settings/settings_page/actions.dart
+++ b/apps/flutter_client/lib/features/settings/settings_page/actions.dart
@@ -339,8 +339,7 @@ extension _SettingsPageActions on _SettingsPageState {
 
   void _showSnackBar(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 }

--- a/apps/flutter_client/pubspec.yaml
+++ b/apps/flutter_client/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.152+152
+version: 0.1.153+153
 
 environment:
   sdk: ^3.13.0

--- a/apps/flutter_client/test/control_api_test.dart
+++ b/apps/flutter_client/test/control_api_test.dart
@@ -72,26 +72,20 @@ void main() {
     expect(defaultControlServer, 'http://47.109.40.237:18080');
   });
 
-  test(
-    'JWT expiry guard identifies expired tokens without rejecting opaque tokens',
-    () {
-      final now = DateTime.utc(2026, 8, 21, 16);
-      String tokenFor(int exp) {
-        final payload = base64Url
-            .encode(utf8.encode(jsonEncode({'exp': exp})))
-            .replaceAll('=', '');
-        return 'header.$payload.signature';
-      }
+  test('JWT expiry guard identifies expired tokens without rejecting opaque tokens', () {
+    final now = DateTime.utc(2026, 8, 21, 16);
+    String tokenFor(int exp) {
+      final payload = base64Url
+          .encode(utf8.encode(jsonEncode({'exp': exp})))
+          .replaceAll('=', '');
+      return 'header.$payload.signature';
+    }
 
-      final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
-      expect(
-        isAuthTokenExpired(tokenFor(nowSeconds + 3600), now: now),
-        isFalse,
-      );
-      expect(isAuthTokenExpired(tokenFor(nowSeconds - 3600), now: now), isTrue);
-      expect(isAuthTokenExpired('custom-deployment-token', now: now), isFalse);
-    },
-  );
+    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+    expect(isAuthTokenExpired(tokenFor(nowSeconds + 3600), now: now), isFalse);
+    expect(isAuthTokenExpired(tokenFor(nowSeconds - 3600), now: now), isTrue);
+    expect(isAuthTokenExpired('custom-deployment-token', now: now), isFalse);
+  });
 
   test('settings load migrates the old placeholder control host', () async {
     final tempDir = await Directory.systemTemp.createTemp(
@@ -332,9 +326,9 @@ void main() {
         buffer.addAll(chunk);
         return buffer;
       });
-      final payload =
-          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
-              as Map<String, dynamic>;
+      final payload = jsonDecode(
+        utf8.decode(GZipCodec().decode(compressed)),
+      ) as Map<String, dynamic>;
       final files = payload['files'] as List<dynamic>;
       expect(
         (files.single as Map<String, dynamic>)['content'],
@@ -375,8 +369,7 @@ void main() {
         files: const [
           SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
           SessionLogFile(
-            name:
-                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+            name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
             content: 'room daemon ok\n',
           ),
         ],
@@ -391,9 +384,9 @@ void main() {
         buffer.addAll(chunk);
         return buffer;
       });
-      final payload =
-          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
-              as Map<String, dynamic>;
+      final payload = jsonDecode(
+        utf8.decode(GZipCodec().decode(compressed)),
+      ) as Map<String, dynamic>;
       expect(payload['schema_version'], 2);
       final manifest = payload['manifest'] as Map<String, dynamic>;
       expect(manifest['has_room_logs'], true);
@@ -412,68 +405,60 @@ void main() {
     },
   );
 
-  test(
-    'uploadSupportLogs v2 does not inflate total_instances when multiple files exist per room',
-    () async {
-      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      addTearDown(() => server.close(force: true));
-      final api = ControlApi();
-      addTearDown(api.close);
+  test('uploadSupportLogs v2 does not inflate total_instances when multiple files exist per room', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final api = ControlApi();
+    addTearDown(api.close);
 
-      final uploadFuture = api.uploadSupportLogs(
-        controlServer: 'http://127.0.0.1:${server.port}',
-        authToken: 'token-123',
-        deviceName: 'Mini',
-        clientBuild: const ClientBuildInfo(
-          appVersion: '0.1.135',
-          gitCommit: 'abc',
-          buildId: 'build',
-          dirtyValue: 'false',
-          diffHash: 'none',
-          profile: 'release',
+    final uploadFuture = api.uploadSupportLogs(
+      controlServer: 'http://127.0.0.1:${server.port}',
+      authToken: 'token-123',
+      deviceName: 'Mini',
+      clientBuild: const ClientBuildInfo(
+        appVersion: '0.1.135',
+        gitCommit: 'abc',
+        buildId: 'build',
+        dirtyValue: 'false',
+        diffHash: 'none',
+        profile: 'release',
+      ),
+      daemonBuild: null,
+      files: const [
+        SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
+        SessionLogFile(
+          name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+          content: 'room daemon ok\n',
         ),
-        daemonBuild: null,
-        files: const [
-          SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
-          SessionLogFile(
-            name:
-                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
-            content: 'room daemon ok\n',
-          ),
-          SessionLogFile(
-            name:
-                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
-            content: '{"network_id":"r1"}\n',
-          ),
-        ],
-      );
-      final request = await server.first.timeout(const Duration(seconds: 3));
-      final compressed = await request.fold<List<int>>(<int>[], (
-        buffer,
-        chunk,
-      ) {
-        buffer.addAll(chunk);
-        return buffer;
-      });
-      final payload =
-          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
-              as Map<String, dynamic>;
-      expect(payload['schema_version'], 2);
-      final manifest = payload['manifest'] as Map<String, dynamic>;
-      expect(manifest['has_room_logs'], true);
-      // Main daemon (1) + room profile (1) = 2 instances, despite 3 files!
-      expect(manifest['total_instances'], 2);
+        SessionLogFile(
+          name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
+          content: '{"network_id":"r1"}\n',
+        ),
+      ],
+    );
+    final request = await server.first.timeout(const Duration(seconds: 3));
+    final compressed = await request.fold<List<int>>(<int>[], (buffer, chunk) {
+      buffer.addAll(chunk);
+      return buffer;
+    });
+    final payload = jsonDecode(
+      utf8.decode(GZipCodec().decode(compressed)),
+    ) as Map<String, dynamic>;
+    expect(payload['schema_version'], 2);
+    final manifest = payload['manifest'] as Map<String, dynamic>;
+    expect(manifest['has_room_logs'], true);
+    // Main daemon (1) + room profile (1) = 2 instances, despite 3 files!
+    expect(manifest['total_instances'], 2);
 
-      request.response
-        ..headers.contentType = ContentType.json
-        ..write('{"success":true,"upload_id":"upload-v2-dedup","instances":2}');
-      await request.response.close();
+    request.response
+      ..headers.contentType = ContentType.json
+      ..write('{"success":true,"upload_id":"upload-v2-dedup","instances":2}');
+    await request.response.close();
 
-      final result = await uploadFuture;
-      expect(result.uploadId, 'upload-v2-dedup');
-      expect(result.instances, 2);
-    },
-  );
+    final result = await uploadFuture;
+    expect(result.uploadId, 'upload-v2-dedup');
+    expect(result.instances, 2);
+  });
 
   for (final roomCount in [5, 8]) {
     test(
@@ -530,9 +515,9 @@ void main() {
           buffer.addAll(chunk);
           return buffer;
         });
-        final payload =
-            jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
-                as Map<String, dynamic>;
+        final payload = jsonDecode(
+          utf8.decode(GZipCodec().decode(compressed)),
+        ) as Map<String, dynamic>;
         expect(payload['schema_version'], 2);
         expect(
           (payload['files'] as List<dynamic>),
@@ -559,72 +544,66 @@ void main() {
     );
   }
 
-  test(
-    'uploadSupportLogs records the room instances omitted by the bounded collector',
-    () async {
-      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      addTearDown(() => server.close(force: true));
-      final api = ControlApi();
-      addTearDown(api.close);
-      final files = <SessionLogFile>[
-        const SessionLogFile(name: 'p2wlan-daemon.log', content: 'main\n'),
-        const SessionLogFile(name: 'p2wlan-client.log', content: 'client\n'),
-      ];
-      for (var room = 1; room <= 8; room++) {
-        final profileId = room.toRadixString(16).padLeft(64, '0');
-        files.addAll([
-          SessionLogFile(
-            name: 'rooms/$profileId/p2wlan-daemon.log',
-            content: 'room $room\n',
-          ),
-          SessionLogFile(
-            name: 'rooms/$profileId/status-summary.json',
-            content: '{"phase":"failed"}',
-          ),
-        ]);
-      }
-      final omittedProfileId = (9).toRadixString(16).padLeft(64, '0');
-
-      final uploadFuture = api.uploadSupportLogs(
-        controlServer: 'http://127.0.0.1:${server.port}',
-        authToken: 'token-123',
-        deviceName: 'Mini',
-        clientBuild: const ClientBuildInfo(
-          appVersion: '0.1.135',
-          gitCommit: 'abc',
-          buildId: 'build',
-          dirtyValue: 'false',
-          diffHash: 'none',
-          profile: 'release',
+  test('uploadSupportLogs records the room instances omitted by the bounded collector', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final api = ControlApi();
+    addTearDown(api.close);
+    final files = <SessionLogFile>[
+      const SessionLogFile(name: 'p2wlan-daemon.log', content: 'main\n'),
+      const SessionLogFile(name: 'p2wlan-client.log', content: 'client\n'),
+    ];
+    for (var room = 1; room <= 8; room++) {
+      final profileId = room.toRadixString(16).padLeft(64, '0');
+      files.addAll([
+        SessionLogFile(
+          name: 'rooms/$profileId/p2wlan-daemon.log',
+          content: 'room $room\n',
         ),
-        daemonBuild: null,
-        files: files,
-        omittedRoomProfileIds: [omittedProfileId],
-      );
-      final request = await server.first.timeout(const Duration(seconds: 3));
-      final compressed = await request.fold<List<int>>(<int>[], (
-        buffer,
-        chunk,
-      ) {
-        buffer.addAll(chunk);
-        return buffer;
-      });
-      final payload =
-          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
-              as Map<String, dynamic>;
-      final manifest = payload['manifest'] as Map<String, dynamic>;
-      expect(manifest['total_instances'], 9);
-      expect(manifest['retained_room_instances'], 8);
-      expect(manifest['omitted_room_instances'], 1);
-      expect(manifest['omitted_reason'], 'room_instance_budget');
-      request.response
-        ..headers.contentType = ContentType.json
-        ..write('{"success":true,"upload_id":"upload-omitted","instances":9}');
-      await request.response.close();
+        SessionLogFile(
+          name: 'rooms/$profileId/status-summary.json',
+          content: '{"phase":"failed"}',
+        ),
+      ]);
+    }
+    final omittedProfileId = (9).toRadixString(16).padLeft(64, '0');
 
-      expect((await uploadFuture).instances, 9);
-    },
-  );
+    final uploadFuture = api.uploadSupportLogs(
+      controlServer: 'http://127.0.0.1:${server.port}',
+      authToken: 'token-123',
+      deviceName: 'Mini',
+      clientBuild: const ClientBuildInfo(
+        appVersion: '0.1.135',
+        gitCommit: 'abc',
+        buildId: 'build',
+        dirtyValue: 'false',
+        diffHash: 'none',
+        profile: 'release',
+      ),
+      daemonBuild: null,
+      files: files,
+      omittedRoomProfileIds: [omittedProfileId],
+    );
+    final request = await server.first.timeout(const Duration(seconds: 3));
+    final compressed = await request.fold<List<int>>(<int>[], (buffer, chunk) {
+      buffer.addAll(chunk);
+      return buffer;
+    });
+    final payload = jsonDecode(
+      utf8.decode(GZipCodec().decode(compressed)),
+    ) as Map<String, dynamic>;
+    final manifest = payload['manifest'] as Map<String, dynamic>;
+    expect(manifest['total_instances'], 9);
+    expect(manifest['retained_room_instances'], 8);
+    expect(manifest['omitted_room_instances'], 1);
+    expect(manifest['omitted_reason'], 'room_instance_budget');
+    request.response
+      ..headers.contentType = ContentType.json
+      ..write('{"success":true,"upload_id":"upload-omitted","instances":9}');
+    await request.response.close();
+
+    expect((await uploadFuture).instances, 9);
+  });
 
   test(
     'uploadSupportLogs translates schema v2 and manifest mismatch errors',
@@ -650,8 +629,7 @@ void main() {
         files: const [
           SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
           SessionLogFile(
-            name:
-                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+            name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
             content: 'room daemon ok\n',
           ),
         ],
@@ -696,9 +674,9 @@ void main() {
       request.headers.value(HttpHeaders.authorizationHeader),
       'Bearer token-123',
     );
-    final payload =
-        jsonDecode(await utf8.decoder.bind(request).join())
-            as Map<String, dynamic>;
+    final payload = jsonDecode(
+      await utf8.decoder.bind(request).join(),
+    ) as Map<String, dynamic>;
     expect(payload['device_name'], 'Studio Mac');
     expect(payload['virtual_ip'], '10.20.0.88');
     request.response.headers.contentType = ContentType.json;

--- a/apps/flutter_client/test/control_api_test.dart
+++ b/apps/flutter_client/test/control_api_test.dart
@@ -72,20 +72,26 @@ void main() {
     expect(defaultControlServer, 'http://47.109.40.237:18080');
   });
 
-  test('JWT expiry guard identifies expired tokens without rejecting opaque tokens', () {
-    final now = DateTime.utc(2026, 8, 21, 16);
-    String tokenFor(int exp) {
-      final payload = base64Url
-          .encode(utf8.encode(jsonEncode({'exp': exp})))
-          .replaceAll('=', '');
-      return 'header.$payload.signature';
-    }
+  test(
+    'JWT expiry guard identifies expired tokens without rejecting opaque tokens',
+    () {
+      final now = DateTime.utc(2026, 8, 21, 16);
+      String tokenFor(int exp) {
+        final payload = base64Url
+            .encode(utf8.encode(jsonEncode({'exp': exp})))
+            .replaceAll('=', '');
+        return 'header.$payload.signature';
+      }
 
-    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
-    expect(isAuthTokenExpired(tokenFor(nowSeconds + 3600), now: now), isFalse);
-    expect(isAuthTokenExpired(tokenFor(nowSeconds - 3600), now: now), isTrue);
-    expect(isAuthTokenExpired('custom-deployment-token', now: now), isFalse);
-  });
+      final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+      expect(
+        isAuthTokenExpired(tokenFor(nowSeconds + 3600), now: now),
+        isFalse,
+      );
+      expect(isAuthTokenExpired(tokenFor(nowSeconds - 3600), now: now), isTrue);
+      expect(isAuthTokenExpired('custom-deployment-token', now: now), isFalse);
+    },
+  );
 
   test('settings load migrates the old placeholder control host', () async {
     final tempDir = await Directory.systemTemp.createTemp(
@@ -326,9 +332,9 @@ void main() {
         buffer.addAll(chunk);
         return buffer;
       });
-      final payload = jsonDecode(
-        utf8.decode(GZipCodec().decode(compressed)),
-      ) as Map<String, dynamic>;
+      final payload =
+          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
+              as Map<String, dynamic>;
       final files = payload['files'] as List<dynamic>;
       expect(
         (files.single as Map<String, dynamic>)['content'],
@@ -341,6 +347,332 @@ void main() {
 
       final result = await uploadFuture;
       expect(result.uploadId, 'upload-1');
+      expect(result.instances, 1);
+    },
+  );
+
+  test(
+    'uploadSupportLogs v2 sends manifest and includes room instances',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final api = ControlApi();
+      addTearDown(api.close);
+
+      final uploadFuture = api.uploadSupportLogs(
+        controlServer: 'http://127.0.0.1:${server.port}',
+        authToken: 'token-123',
+        deviceName: 'Mini',
+        clientBuild: const ClientBuildInfo(
+          appVersion: '0.1.135',
+          gitCommit: 'abc',
+          buildId: 'build',
+          dirtyValue: 'false',
+          diffHash: 'none',
+          profile: 'release',
+        ),
+        daemonBuild: null,
+        files: const [
+          SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
+          SessionLogFile(
+            name:
+                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+            content: 'room daemon ok\n',
+          ),
+        ],
+      );
+      final request = await server.first.timeout(const Duration(seconds: 3));
+      expect(request.method, 'POST');
+      expect(request.uri.path, '/api/v1/support/logs');
+      final compressed = await request.fold<List<int>>(<int>[], (
+        buffer,
+        chunk,
+      ) {
+        buffer.addAll(chunk);
+        return buffer;
+      });
+      final payload =
+          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
+              as Map<String, dynamic>;
+      expect(payload['schema_version'], 2);
+      final manifest = payload['manifest'] as Map<String, dynamic>;
+      expect(manifest['has_room_logs'], true);
+      expect(manifest['total_instances'], 2);
+      final files = payload['files'] as List<dynamic>;
+      expect(files.length, 2);
+
+      request.response
+        ..headers.contentType = ContentType.json
+        ..write('{"success":true,"upload_id":"upload-v2","instances":2}');
+      await request.response.close();
+
+      final result = await uploadFuture;
+      expect(result.uploadId, 'upload-v2');
+      expect(result.instances, 2);
+    },
+  );
+
+  test(
+    'uploadSupportLogs v2 does not inflate total_instances when multiple files exist per room',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final api = ControlApi();
+      addTearDown(api.close);
+
+      final uploadFuture = api.uploadSupportLogs(
+        controlServer: 'http://127.0.0.1:${server.port}',
+        authToken: 'token-123',
+        deviceName: 'Mini',
+        clientBuild: const ClientBuildInfo(
+          appVersion: '0.1.135',
+          gitCommit: 'abc',
+          buildId: 'build',
+          dirtyValue: 'false',
+          diffHash: 'none',
+          profile: 'release',
+        ),
+        daemonBuild: null,
+        files: const [
+          SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
+          SessionLogFile(
+            name:
+                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+            content: 'room daemon ok\n',
+          ),
+          SessionLogFile(
+            name:
+                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
+            content: '{"network_id":"r1"}\n',
+          ),
+        ],
+      );
+      final request = await server.first.timeout(const Duration(seconds: 3));
+      final compressed = await request.fold<List<int>>(<int>[], (
+        buffer,
+        chunk,
+      ) {
+        buffer.addAll(chunk);
+        return buffer;
+      });
+      final payload =
+          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
+              as Map<String, dynamic>;
+      expect(payload['schema_version'], 2);
+      final manifest = payload['manifest'] as Map<String, dynamic>;
+      expect(manifest['has_room_logs'], true);
+      // Main daemon (1) + room profile (1) = 2 instances, despite 3 files!
+      expect(manifest['total_instances'], 2);
+
+      request.response
+        ..headers.contentType = ContentType.json
+        ..write('{"success":true,"upload_id":"upload-v2-dedup","instances":2}');
+      await request.response.close();
+
+      final result = await uploadFuture;
+      expect(result.uploadId, 'upload-v2-dedup');
+      expect(result.instances, 2);
+    },
+  );
+
+  for (final roomCount in [5, 8]) {
+    test(
+      'uploadSupportLogs v2 sends all files for $roomCount room instances',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        final api = ControlApi();
+        addTearDown(api.close);
+        final files = <SessionLogFile>[
+          const SessionLogFile(
+            name: 'p2wlan-daemon.log',
+            content: 'main daemon ok\n',
+          ),
+          const SessionLogFile(
+            name: 'p2wlan-client.log',
+            content: 'client ok\n',
+          ),
+        ];
+        for (var room = 1; room <= roomCount; room++) {
+          final profileId = room.toRadixString(16).padLeft(64, '0');
+          files.addAll([
+            SessionLogFile(
+              name: 'rooms/$profileId/p2wlan-daemon.log',
+              content: 'room $room daemon ok\n',
+            ),
+            SessionLogFile(
+              name: 'rooms/$profileId/status-summary.json',
+              content: '{"phase":"unavailable","room":$room}',
+            ),
+          ]);
+        }
+
+        final uploadFuture = api.uploadSupportLogs(
+          controlServer: 'http://127.0.0.1:${server.port}',
+          authToken: 'token-123',
+          deviceName: 'Mini',
+          clientBuild: const ClientBuildInfo(
+            appVersion: '0.1.135',
+            gitCommit: 'abc',
+            buildId: 'build',
+            dirtyValue: 'false',
+            diffHash: 'none',
+            profile: 'release',
+          ),
+          daemonBuild: null,
+          files: files,
+        );
+        final request = await server.first.timeout(const Duration(seconds: 3));
+        final compressed = await request.fold<List<int>>(<int>[], (
+          buffer,
+          chunk,
+        ) {
+          buffer.addAll(chunk);
+          return buffer;
+        });
+        final payload =
+            jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
+                as Map<String, dynamic>;
+        expect(payload['schema_version'], 2);
+        expect(
+          (payload['files'] as List<dynamic>),
+          hasLength(2 + roomCount * 2),
+        );
+        expect(
+          (payload['manifest'] as Map<String, dynamic>)['total_instances'],
+          roomCount + 1,
+        );
+        request.response
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode({
+              'success': true,
+              'upload_id': 'upload-$roomCount-rooms',
+              'instances': roomCount + 1,
+            }),
+          );
+        await request.response.close();
+
+        final result = await uploadFuture;
+        expect(result.instances, roomCount + 1);
+      },
+    );
+  }
+
+  test(
+    'uploadSupportLogs records the room instances omitted by the bounded collector',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final api = ControlApi();
+      addTearDown(api.close);
+      final files = <SessionLogFile>[
+        const SessionLogFile(name: 'p2wlan-daemon.log', content: 'main\n'),
+        const SessionLogFile(name: 'p2wlan-client.log', content: 'client\n'),
+      ];
+      for (var room = 1; room <= 8; room++) {
+        final profileId = room.toRadixString(16).padLeft(64, '0');
+        files.addAll([
+          SessionLogFile(
+            name: 'rooms/$profileId/p2wlan-daemon.log',
+            content: 'room $room\n',
+          ),
+          SessionLogFile(
+            name: 'rooms/$profileId/status-summary.json',
+            content: '{"phase":"failed"}',
+          ),
+        ]);
+      }
+      final omittedProfileId = (9).toRadixString(16).padLeft(64, '0');
+
+      final uploadFuture = api.uploadSupportLogs(
+        controlServer: 'http://127.0.0.1:${server.port}',
+        authToken: 'token-123',
+        deviceName: 'Mini',
+        clientBuild: const ClientBuildInfo(
+          appVersion: '0.1.135',
+          gitCommit: 'abc',
+          buildId: 'build',
+          dirtyValue: 'false',
+          diffHash: 'none',
+          profile: 'release',
+        ),
+        daemonBuild: null,
+        files: files,
+        omittedRoomProfileIds: [omittedProfileId],
+      );
+      final request = await server.first.timeout(const Duration(seconds: 3));
+      final compressed = await request.fold<List<int>>(<int>[], (
+        buffer,
+        chunk,
+      ) {
+        buffer.addAll(chunk);
+        return buffer;
+      });
+      final payload =
+          jsonDecode(utf8.decode(GZipCodec().decode(compressed)))
+              as Map<String, dynamic>;
+      final manifest = payload['manifest'] as Map<String, dynamic>;
+      expect(manifest['total_instances'], 9);
+      expect(manifest['retained_room_instances'], 8);
+      expect(manifest['omitted_room_instances'], 1);
+      expect(manifest['omitted_reason'], 'room_instance_budget');
+      request.response
+        ..headers.contentType = ContentType.json
+        ..write('{"success":true,"upload_id":"upload-omitted","instances":9}');
+      await request.response.close();
+
+      expect((await uploadFuture).instances, 9);
+    },
+  );
+
+  test(
+    'uploadSupportLogs translates schema v2 and manifest mismatch errors',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final api = ControlApi();
+      addTearDown(api.close);
+
+      final uploadFuture = api.uploadSupportLogs(
+        controlServer: 'http://127.0.0.1:${server.port}',
+        authToken: 'token-123',
+        deviceName: 'Mini',
+        clientBuild: const ClientBuildInfo(
+          appVersion: '0.1.135',
+          gitCommit: 'abc',
+          buildId: 'build',
+          dirtyValue: 'false',
+          diffHash: 'none',
+          profile: 'release',
+        ),
+        daemonBuild: null,
+        files: const [
+          SessionLogFile(name: 'p2wlan-daemon.log', content: 'daemon ok\n'),
+          SessionLogFile(
+            name:
+                'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+            content: 'room daemon ok\n',
+          ),
+        ],
+      );
+      final request = await server.first.timeout(const Duration(seconds: 3));
+      request.response
+        ..statusCode = HttpStatus.badRequest
+        ..headers.contentType = ContentType.json
+        ..write('{"error":"unsupported schema_version: 2"}');
+      await request.response.close();
+
+      await expectLater(
+        uploadFuture,
+        throwsA(
+          isA<ControlApiException>().having(
+            (error) => error.message,
+            'message',
+            contains('不支持多房间日志格式'),
+          ),
+        ),
+      );
     },
   );
 
@@ -364,9 +696,9 @@ void main() {
       request.headers.value(HttpHeaders.authorizationHeader),
       'Bearer token-123',
     );
-    final payload = jsonDecode(
-      await utf8.decoder.bind(request).join(),
-    ) as Map<String, dynamic>;
+    final payload =
+        jsonDecode(await utf8.decoder.bind(request).join())
+            as Map<String, dynamic>;
     expect(payload['device_name'], 'Studio Mac');
     expect(payload['virtual_ip'], '10.20.0.88');
     request.response.headers.contentType = ContentType.json;

--- a/apps/flutter_client/test/parallel_rooms_test.dart
+++ b/apps/flutter_client/test/parallel_rooms_test.dart
@@ -205,7 +205,11 @@ void main() {
       final connecting = manager.connect(room(1));
       await Future<void>.delayed(Duration.zero);
       settings = settings.copyWith(authToken: token('other'));
+      expect(manager.allRecentRoomProfileIds, isEmpty);
+      expect(manager.exportStatusSummaries(), isEmpty);
       final stopped = manager.credentialsChanged();
+      expect(manager.allRecentRoomProfileIds, isEmpty);
+      expect(manager.exportStatusSummaries(), isEmpty);
       gate.complete();
       expect((await connecting).ok, isFalse);
       expect((await stopped).ok, isTrue);
@@ -313,6 +317,59 @@ void main() {
       expect(runtimes[room(1).id]!.closed, isFalse);
     },
   );
+
+  for (final failure in ['start', 'first status']) {
+    test(
+      'retains a current-account support summary after $failure failure and cleanup',
+      () async {
+        configure = (runtime) {
+          runtime.failStart = failure == 'start';
+          runtime.failStatus = failure == 'first status';
+        };
+
+        final result = await manager.connect(room(1));
+        expect(result.ok, isFalse);
+        final profileId = runtimes[room(1).id]!.plan.profileId;
+        if (manager.session(room(1).id) != null) {
+          expect((await manager.disconnect(room(1).id)).ok, isTrue);
+        }
+
+        expect(manager.session(room(1).id), isNull);
+        expect(manager.allRecentRoomProfileIds, contains(profileId));
+        final summary =
+            jsonDecode(manager.exportStatusSummaries()[profileId]!)
+                as Map<String, dynamic>;
+        expect(summary['network_id'], room(1).id);
+        expect(summary['profile_id'], profileId);
+        expect(summary['phase'], failure == 'start' ? 'failed' : 'unavailable');
+        expect(summary['message'], isNotEmpty);
+
+        // Histories belong only to the credential scope that created them.
+        settings = settings.copyWith(authToken: token('another-account'));
+        expect((await manager.credentialsChanged()).ok, isTrue);
+        expect(manager.allRecentRoomProfileIds, isEmpty);
+        expect(manager.exportStatusSummaries(), isEmpty);
+      },
+    );
+  }
+
+  test('support log history retains the newest eight room instances', () async {
+    for (var number = 1; number <= 9; number++) {
+      configure = (runtime) => runtime.failStart = true;
+      expect((await manager.connect(room(number))).ok, isFalse);
+    }
+
+    final retained = manager.allRecentRoomProfileIds;
+    expect(retained, hasLength(8));
+    expect(
+      retained,
+      isNot(contains(ParallelRoomPlan(settings, room(1)).profileId)),
+    );
+    expect(retained, contains(ParallelRoomPlan(settings, room(9)).profileId));
+    expect(manager.supportLogSelection.omittedProfileIds, [
+      ParallelRoomPlan(settings, room(1)).profileId,
+    ]);
+  });
 
   test('CIDR overlap checks ranges not strings and rejects malformed data', () {
     expect(cidrsOverlap('10.0.0.0/8', '10.21.9.0/24'), isTrue);

--- a/apps/flutter_client/test/parallel_rooms_test.dart
+++ b/apps/flutter_client/test/parallel_rooms_test.dart
@@ -336,9 +336,9 @@ void main() {
 
         expect(manager.session(room(1).id), isNull);
         expect(manager.allRecentRoomProfileIds, contains(profileId));
-        final summary =
-            jsonDecode(manager.exportStatusSummaries()[profileId]!)
-                as Map<String, dynamic>;
+        final summary = jsonDecode(
+          manager.exportStatusSummaries()[profileId]!,
+        ) as Map<String, dynamic>;
         expect(summary['network_id'], room(1).id);
         expect(summary['profile_id'], profileId);
         expect(summary['phase'], failure == 'start' ? 'failed' : 'unavailable');

--- a/apps/flutter_client/test/rooms_page_test.dart
+++ b/apps/flutter_client/test/rooms_page_test.dart
@@ -94,8 +94,12 @@ class _FakeRoomApi extends RoomApi {
 }
 
 class _RoomRuntime implements RoomRuntime {
-  _RoomRuntime(this.snapshot);
-  final DiagnosticsSnapshot snapshot;
+  _RoomRuntime(this.snapshot) {
+    instances.add(this);
+  }
+  static final instances = <_RoomRuntime>[];
+  DiagnosticsSnapshot snapshot;
+  int statusCalls = 0;
   @override
   Future<bool> exists() async => false;
   @override
@@ -105,7 +109,11 @@ class _RoomRuntime implements RoomRuntime {
   Future<DaemonCommandResult> stop() async =>
       const DaemonCommandResult(ok: true, message: '');
   @override
-  Future<DiagnosticsSnapshot> status() async => snapshot;
+  Future<DiagnosticsSnapshot> status() async {
+    statusCalls++;
+    return snapshot;
+  }
+
   @override
   void close() {}
 }
@@ -145,6 +153,7 @@ void main() {
     DiagnosticsSnapshot? snapshot,
     bool shell = false,
     bool enterRoom = true,
+    bool enableDaemonPolling = false,
   }) async {
     final dir = await tester.runAsync(
       () => Directory.systemTemp.createTemp('p2wlan-rooms-ui-'),
@@ -166,7 +175,9 @@ void main() {
     final parallel = ParallelRooms(
       readSettings: () => settings.settings,
       supported: snapshot != null,
-      refreshInterval: Duration.zero,
+      refreshInterval: enableDaemonPolling
+          ? const Duration(seconds: 5)
+          : Duration.zero,
       runtimeFactory: (_) => _RoomRuntime(snapshot!),
     );
     if (snapshot != null) {
@@ -521,5 +532,122 @@ void main() {
     expect(find.text(api.joinError!), findsNothing);
     expect(tester.takeException(), isNull);
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('connection phase displays fine-grained status labels', (
+    tester,
+  ) async {
+    // 1. Direct confirmed
+    final directSnap = _snapshot(verified: true);
+    await pump(tester, snapshot: directSnap, enterRoom: false);
+    await tester.pumpAndSettle();
+    expect(find.text('已直连'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    // 2. Waiting for peer
+    final waitingSnap = DiagnosticsSnapshot.fromJson({
+      'network_id': _roomId,
+      'virtual_ip': '10.21.1.2',
+      'node_id': 'local',
+      'peers': <dynamic>[],
+    });
+    await pump(tester, snapshot: waitingSnap, enterRoom: false);
+    await tester.pumpAndSettle();
+    expect(find.text('等待好友'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    // 3. Handshaking
+    final handshakingSnap = DiagnosticsSnapshot.fromJson({
+      'network_id': _roomId,
+      'virtual_ip': '10.21.1.2',
+      'node_id': 'local',
+      'peers': [
+        {
+          'node_id': 'remote',
+          'device_name': '好友电脑',
+          'virtual_ip': '10.21.1.3',
+          'online': true,
+          'state': 'handshake',
+        },
+      ],
+    });
+    await pump(tester, snapshot: handshakingSnap, enterRoom: false);
+    await tester.pumpAndSettle();
+    expect(find.text('建立加密会话'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    // 4. Relay confirmed
+    final relaySnap = DiagnosticsSnapshot.fromJson({
+      'network_id': _roomId,
+      'virtual_ip': '10.21.1.2',
+      'node_id': 'local',
+      'peers': [
+        {
+          'node_id': 'remote',
+          'device_name': '好友电脑',
+          'virtual_ip': '10.21.1.3',
+          'online': true,
+          'active_path': 'relay',
+          'state': 'relay',
+          'relay_confirmed_endpoint': '1.2.3.4:443',
+          'relay_confirmed_generation': 1,
+        },
+      ],
+    });
+    await pump(tester, snapshot: relaySnap, enterRoom: false);
+    await tester.pumpAndSettle();
+    expect(find.text('中继可用'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('review: unconfirmed relay is not shown as available', (
+    tester,
+  ) async {
+    final snap = DiagnosticsSnapshot.fromJson({
+      'network_id': _roomId,
+      'virtual_ip': '10.21.1.2',
+      'node_id': 'local',
+      'peers': [
+        {
+          'node_id': 'remote',
+          'online': true,
+          'active_path': 'relay',
+          'state': 'connecting',
+        },
+      ],
+    });
+    expect(snap.peers.single.isRelayVerified, isFalse);
+    await pump(tester, snapshot: snap, enterRoom: false);
+    final readyLabels = find.textContaining('中继可用').evaluate().length;
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(
+      readyLabels,
+      0,
+      reason: 'An unconfirmed transport path is not an encrypted usable relay',
+    );
+  });
+
+  testWidgets('review: transition polling reads daemon status within 600ms', (
+    tester,
+  ) async {
+    _RoomRuntime.instances.clear();
+    await pump(
+      tester,
+      snapshot: _snapshot(verified: false),
+      enterRoom: false,
+      enableDaemonPolling: true,
+    );
+    final runtime = _RoomRuntime.instances.last;
+    final before = runtime.statusCalls;
+    runtime.snapshot = _snapshot(verified: true);
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+    final after = runtime.statusCalls;
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(
+      after,
+      greaterThan(before),
+      reason: '500ms adaptive polling must fetch a fresh daemon snapshot',
+    );
   });
 }

--- a/apps/flutter_client/test/session_log_bundle_test.dart
+++ b/apps/flutter_client/test/session_log_bundle_test.dart
@@ -117,13 +117,11 @@ void main() {
       clientLogPath: client.path,
       extraFiles: [
         (
-          name:
-              'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+          name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
           path: roomLog.path,
         ),
         (
-          name:
-              'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
+          name: 'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
           path: roomSummary.path,
         ),
       ],

--- a/apps/flutter_client/test/session_log_bundle_test.dart
+++ b/apps/flutter_client/test/session_log_bundle_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:p2wlan_flutter_client/core/diagnostics/session_log_bundle.dart';
+import 'package:p2wlan_flutter_client/core/diagnostics/support_log_protocol.dart';
 
 void main() {
   test('collects current files and never reads rotated logs', () async {
@@ -89,4 +90,127 @@ void main() {
     }
     expect(content, contains('<redacted>'));
   });
+
+  test('collects room instance logs and redacts sensitive data', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'p2wlan_session_logs_room_',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final daemon = File('${directory.path}/p2wlan-daemon.log');
+    final client = File('${directory.path}/p2wlan-client.log');
+    await daemon.writeAsString('daemon ok\n');
+    await client.writeAsString('client ok\n');
+
+    final roomDir = Directory(
+      '${directory.path}/rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    );
+    await roomDir.create(recursive: true);
+    final roomLog = File('${roomDir.path}/p2wlan-daemon.log');
+    final roomSummary = File('${roomDir.path}/status-summary.json');
+    await roomLog.writeAsString('room daemon token=super-secret-key\n');
+    await roomSummary.writeAsString(
+      '{"network_id":"room-1","token":"auth-secret"}\n',
+    );
+
+    final bundle = await CurrentSessionLogBundle.collect(
+      daemonLogPath: daemon.path,
+      clientLogPath: client.path,
+      extraFiles: [
+        (
+          name:
+              'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+          path: roomLog.path,
+        ),
+        (
+          name:
+              'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
+          path: roomSummary.path,
+        ),
+      ],
+    );
+
+    expect(bundle.files.length, 4);
+    expect(bundle.files.map((f) => f.name), [
+      'p2wlan-daemon.log',
+      'p2wlan-client.log',
+      'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p2wlan-daemon.log',
+      'rooms/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/status-summary.json',
+    ]);
+
+    final collectedRoomLog = bundle.files.firstWhere(
+      (f) => f.name.contains('rooms/') && f.name.endsWith('.log'),
+    );
+    expect(collectedRoomLog.content, contains('token=<redacted>'));
+    expect(collectedRoomLog.content, isNot(contains('super-secret-key')));
+
+    final collectedSummary = bundle.files.firstWhere(
+      (f) => f.name.endsWith('.json'),
+    );
+    expect(collectedSummary.content, contains('<redacted>'));
+    expect(collectedSummary.content, isNot(contains('auth-secret')));
+  });
+
+  test(
+    'collects logs and generated summaries for the default eight-room budget',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'p2wlan_session_logs_eight_rooms_',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final daemon = File('${directory.path}/p2wlan-daemon.log');
+      final client = File('${directory.path}/p2wlan-client.log');
+      await daemon.writeAsString('main daemon ok\n');
+      await client.writeAsString('client ok\n');
+      final extraFiles = <({String name, String path})>[];
+      final inlineFiles = <SessionLogFile>[];
+      for (var room = 1; room <= maxSupportLogRoomInstances; room++) {
+        final profileId = room.toRadixString(16).padLeft(64, '0');
+        final roomDir = Directory('${directory.path}/rooms/$profileId');
+        await roomDir.create(recursive: true);
+        final roomLog = File('${roomDir.path}/p2wlan-daemon.log');
+        await roomLog.writeAsString('room $room daemon ok\n');
+        extraFiles.add((
+          name: 'rooms/$profileId/p2wlan-daemon.log',
+          path: roomLog.path,
+        ));
+        inlineFiles.add(
+          SessionLogFile(
+            name: 'rooms/$profileId/status-summary.json',
+            content: '{"phase":"failed","message":"start failed"}',
+          ),
+        );
+      }
+
+      final bundle = await CurrentSessionLogBundle.collect(
+        daemonLogPath: daemon.path,
+        clientLogPath: client.path,
+        extraFiles: extraFiles,
+        inlineFiles: inlineFiles,
+      );
+
+      expect(bundle.files, hasLength(maxSupportLogFilesV2));
+      expect(
+        bundle.files.where((file) => file.name.endsWith('status-summary.json')),
+        hasLength(maxSupportLogRoomInstances),
+      );
+    },
+  );
+
+  test(
+    'records room instances omitted by the bounded support-log selection',
+    () {
+      final profileIds = [
+        for (var room = 1; room <= maxSupportLogRoomInstances + 1; room++)
+          room.toRadixString(16).padLeft(64, '0'),
+      ];
+
+      final selection = selectSupportLogRoomProfiles(profileIds);
+
+      expect(
+        selection.retainedProfileIds,
+        hasLength(maxSupportLogRoomInstances),
+      );
+      expect(selection.omittedProfileIds, [profileIds.last]);
+    },
+  );
 }

--- a/client/android-native/src/lib.rs
+++ b/client/android-native/src/lib.rs
@@ -411,6 +411,11 @@ mod android_bridge {
         {
             return Err("room profile belongs to a different network".into());
         }
+        // `Config::load_from_file` deliberately does not deserialize this
+        // transient path.  The pre-daemon registration below must reserve the
+        // same durable incarnation that `Daemon::new` will consume after the
+        // profile is persisted and the VPN fd is available.
+        config.config_path = Some(path.clone());
         config.control.auth_token = request.auth_token.clone();
         config.control.proxy_mode = ControlProxyMode::Direct;
         config.network.manual = false;
@@ -418,29 +423,50 @@ mod android_bridge {
         if !request.device_name.trim().is_empty() {
             config.node.device_name = request.device_name.trim().to_owned();
         }
-        let runtime = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|_| "room registration runtime unavailable")?;
-        runtime
+        // Room preparation performs a control-plane registration before the
+        // daemon is constructed. Reserve one durable boot incarnation now so
+        // the registration's `registration_incarnation` and the daemon's
+        // candidate/control labels share the same lifecycle fence. A missing
+        // durable state remains the existing fail-closed zero-incarnation
+        // behavior; the daemon will not invent a timestamp fallback.
+        let _ = p2pnet_daemon::incarnation::reserve_boot_incarnation(&config);
+        let runtime = match Builder::new_current_thread().enable_all().build() {
+            Ok(runtime) => runtime,
+            Err(_) => {
+                p2pnet_daemon::incarnation::discard_prepared_boot_incarnation(&config);
+                return Err("room registration runtime unavailable".into());
+            }
+        };
+        if runtime
             .block_on(p2pnet_daemon::control::ControlClient::register_room_profile(&mut config))
-            .map_err(|_| {
+            .is_err()
+        {
+            p2pnet_daemon::incarnation::discard_prepared_boot_incarnation(&config);
+            return Err(
                 "room registration failed; check membership, server version and connectivity"
-            })?;
+                    .into(),
+            );
+        }
         let reply = serde_json::json!({"virtual_ip": config.network.virtual_ip, "cidr": config.network.cidr}).to_string();
         config.control.auth_token.clear();
         config.diagnostics.auth_token = None;
         config.diagnostics.auth_token_path = None;
         config.diagnostics.log_path = None;
-        let _guard = start_lock()
-            .lock()
-            .map_err(|_| "room profile lock unavailable")?;
+        let _guard = match start_lock().lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                p2pnet_daemon::incarnation::discard_prepared_boot_incarnation(&config);
+                return Err("room profile lock unavailable".into());
+            }
+        };
         if runtime_running() {
+            p2pnet_daemon::incarnation::discard_prepared_boot_incarnation(&config);
             return Err("VPN state changed during room preparation".into());
         }
-        config
-            .save_to_file(&path)
-            .map_err(|_| "room identity could not be persisted")?;
+        if config.save_to_file(&path).is_err() {
+            p2pnet_daemon::incarnation::discard_prepared_boot_incarnation(&config);
+            return Err("room identity could not be persisted".into());
+        }
         Ok(reply)
     }
 

--- a/client/daemon/src/candidate_refresh.rs
+++ b/client/daemon/src/candidate_refresh.rs
@@ -359,4 +359,125 @@ mod tests {
             &sources,
         ));
     }
+
+    #[test]
+    fn test_port_mapping_local_addr_wildcard_resolution() {
+        let wildcard: SocketAddr = "0.0.0.0:61302".parse().unwrap();
+        let mut sources = HashMap::new();
+        let host_cand = "192.168.1.100:61302".to_string();
+        sources.insert(host_cand.clone(), "host".to_string());
+
+        // 1. When host candidate is in the list, resolves host candidate
+        let resolved =
+            port_mapping_local_addr(Some(wildcard), &[host_cand.clone()], &sources, None);
+        assert_eq!(resolved, Some("192.168.1.100:61302".parse().unwrap()));
+
+        // 1b. Stale host candidate port from previous socket is rebound to current socket port
+        let stale_host = "192.168.1.100:54321".to_string();
+        let mut stale_sources = HashMap::new();
+        stale_sources.insert(stale_host.clone(), "host".to_string());
+        let resolved_stale =
+            port_mapping_local_addr(Some(wildcard), &[stale_host], &stale_sources, None);
+        assert_eq!(
+            resolved_stale,
+            Some("192.168.1.100:61302".parse().unwrap()),
+            "Must bind to current UDP socket port, not stale candidate port"
+        );
+
+        // 2. Multi-NIC interface selection: selects the interface matching the default gateway subnet
+        let mock_addresses = vec![
+            IpAddr::V4("10.0.0.5".parse().unwrap()),
+            IpAddr::V4("192.168.1.100".parse().unwrap()),
+        ];
+        let gw_192 = Some("192.168.1.1".parse::<Ipv4Addr>().unwrap());
+        let gw_10 = Some("10.0.0.1".parse::<Ipv4Addr>().unwrap());
+
+        let resolved_gw_192 = port_mapping_local_addr_with_addresses(
+            Some(wildcard),
+            &[],
+            &HashMap::new(),
+            gw_192,
+            &mock_addresses,
+        );
+        assert_eq!(
+            resolved_gw_192,
+            Some("192.168.1.100:61302".parse().unwrap()),
+            "Must choose 192.168.1.100 matching gateway 192.168.1.1 subnet"
+        );
+
+        let resolved_gw_10 = port_mapping_local_addr_with_addresses(
+            Some(wildcard),
+            &[],
+            &HashMap::new(),
+            gw_10,
+            &mock_addresses,
+        );
+        assert_eq!(
+            resolved_gw_10,
+            Some("10.0.0.5:61302".parse().unwrap()),
+            "Must choose 10.0.0.5 matching gateway 10.0.0.1 subnet"
+        );
+
+        // A prior host snapshot can put the secondary interface first.  For a
+        // wildcard-bound socket, gateway mapping must still use the interface
+        // that reaches the selected default gateway.
+        let wrong_interface_host = "10.0.0.5:61302".to_string();
+        let gateway_interface_host = "192.168.1.100:61302".to_string();
+        let host_sources = HashMap::from([
+            (wrong_interface_host.clone(), "host".to_string()),
+            (gateway_interface_host.clone(), "host".to_string()),
+        ]);
+        let host_selected_gateway_192 = port_mapping_local_addr_with_addresses(
+            Some(wildcard),
+            &[wrong_interface_host, gateway_interface_host],
+            &host_sources,
+            gw_192,
+            &mock_addresses,
+        );
+        assert_eq!(
+            host_selected_gateway_192,
+            Some("192.168.1.100:61302".parse().unwrap()),
+            "Host-candidate order must not override the gateway interface"
+        );
+
+        // 3. Direct LAN IP on socket is preserved
+        let direct_lan: SocketAddr = "192.168.1.50:51820".parse().unwrap();
+        assert_eq!(
+            port_mapping_local_addr(Some(direct_lan), &[], &HashMap::new(), None),
+            Some(direct_lan)
+        );
+
+        // 4. Loopback or port 0 is rejected
+        let loopback: SocketAddr = "127.0.0.1:51820".parse().unwrap();
+        assert_ne!(
+            port_mapping_local_addr(Some(loopback), &[], &HashMap::new(), None),
+            Some(loopback)
+        );
+        let port_zero: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert_eq!(
+            port_mapping_local_addr(Some(port_zero), &[], &HashMap::new(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn test_stale_gateway_mapping_rejected_on_socket_or_generation_change() {
+        let initial_udp: Option<SocketAddr> = Some("0.0.0.0:40001".parse().unwrap());
+        let rebound_udp: Option<SocketAddr> = Some("0.0.0.0:40002".parse().unwrap());
+        let initial_gen = 1u64;
+        let advanced_gen = 2u64;
+
+        assert!(
+            !port_mapping_result_is_current(initial_udp, initial_gen, rebound_udp, initial_gen),
+            "Socket rebound must mark mapping stale"
+        );
+        assert!(
+            !port_mapping_result_is_current(initial_udp, initial_gen, initial_udp, advanced_gen),
+            "Generation advance must mark mapping stale"
+        );
+        assert!(
+            port_mapping_result_is_current(initial_udp, initial_gen, initial_udp, initial_gen),
+            "Matching socket and generation is valid"
+        );
+    }
 }

--- a/client/daemon/src/candidate_refresh.rs
+++ b/client/daemon/src/candidate_refresh.rs
@@ -368,8 +368,12 @@ mod tests {
         sources.insert(host_cand.clone(), "host".to_string());
 
         // 1. When host candidate is in the list, resolves host candidate
-        let resolved =
-            port_mapping_local_addr(Some(wildcard), &[host_cand.clone()], &sources, None);
+        let resolved = port_mapping_local_addr(
+            Some(wildcard),
+            std::slice::from_ref(&host_cand),
+            &sources,
+            None,
+        );
         assert_eq!(resolved, Some("192.168.1.100:61302".parse().unwrap()));
 
         // 1b. Stale host candidate port from previous socket is rebound to current socket port

--- a/client/daemon/src/candidate_refresh/port_mapping/apply.rs
+++ b/client/daemon/src/candidate_refresh/port_mapping/apply.rs
@@ -1,11 +1,15 @@
 pub(super) async fn maybe_add_port_mapping_udp_candidate(
     udp_local_addr: Option<SocketAddr>,
+    existing_candidates: &[String],
+    existing_candidate_sources: &HashMap<String, String>,
     candidates: &mut Vec<String>,
     candidate_sources: &mut HashMap<String, String>,
     runtime: Arc<RwLock<GatewayMappingRuntime>>,
     diagnostics: Arc<RwLock<GatewayMappingDiagnostics>>,
 ) {
-    let Some(local_addr) = port_mapping_local_addr(udp_local_addr, candidates, candidate_sources)
+    let gateway = default_ipv4_gateway().await;
+    let Some(local_addr) =
+        port_mapping_local_addr(udp_local_addr, existing_candidates, existing_candidate_sources, gateway)
     else {
         let mut diagnostics = diagnostics.write().await;
         diagnostics.local_endpoint = None;

--- a/client/daemon/src/candidate_refresh/port_mapping/gateway.rs
+++ b/client/daemon/src/candidate_refresh/port_mapping/gateway.rs
@@ -100,7 +100,7 @@ pub(super) fn resolve_physical_lan_ipv4_for_port_with_addresses(
                 let candidate = SocketAddr::new(IpAddr::V4(v4), port);
                 if is_port_mapping_local_addr(candidate) {
                     let score = subnet_prefix_score(v4, gw);
-                    if score > 0 && best_match.as_ref().map_or(true, |(_, s)| score > *s) {
+                    if score > 0 && best_match.as_ref().is_none_or(|(_, s)| score > *s) {
                         best_match = Some((v4, score));
                     }
                 }

--- a/client/daemon/src/candidate_refresh/port_mapping/gateway.rs
+++ b/client/daemon/src/candidate_refresh/port_mapping/gateway.rs
@@ -1,4 +1,4 @@
-async fn default_ipv4_gateway() -> Option<Ipv4Addr> {
+pub(super) async fn default_ipv4_gateway() -> Option<Ipv4Addr> {
     tokio::task::spawn_blocking(default_ipv4_gateway_blocking)
         .await
         .ok()
@@ -69,22 +69,176 @@ fn parse_ipv4_token(token: &str) -> Option<Ipv4Addr> {
         .ok()
 }
 
-fn port_mapping_local_addr(
+pub(super) fn subnet_prefix_score(a: Ipv4Addr, b: Ipv4Addr) -> u8 {
+    let ao = a.octets();
+    let bo = b.octets();
+    if ao[0] == bo[0] && ao[1] == bo[1] && ao[2] == bo[2] {
+        24
+    } else if ao[0] == bo[0] && ao[1] == bo[1] {
+        16
+    } else if ao[0] == 10 && bo[0] == 10 {
+        8
+    } else {
+        0
+    }
+}
+
+pub(super) fn resolve_physical_lan_ipv4_for_port_with_addresses(
+    port: u16,
+    gateway: Option<Ipv4Addr>,
+    addresses: &[IpAddr],
+) -> Option<SocketAddr> {
+    if port == 0 {
+        return None;
+    }
+
+    if let Some(gw) = gateway {
+        // 1. Subnet matching against known/provided interface addresses
+        let mut best_match: Option<(Ipv4Addr, u8)> = None;
+        for addr in addresses {
+            if let IpAddr::V4(v4) = *addr {
+                let candidate = SocketAddr::new(IpAddr::V4(v4), port);
+                if is_port_mapping_local_addr(candidate) {
+                    let score = subnet_prefix_score(v4, gw);
+                    if score > 0 && best_match.as_ref().map_or(true, |(_, s)| score > *s) {
+                        best_match = Some((v4, score));
+                    }
+                }
+            }
+        }
+        if let Some((v4, _)) = best_match {
+            return Some(SocketAddr::new(IpAddr::V4(v4), port));
+        }
+
+        // 2. Try an OS routing probe to the gateway if no provided address
+        // matched.  A wildcard-bound socket has no interface affinity of its
+        // own, so the route to the gateway is the only authoritative fallback.
+        let probe_target = SocketAddr::new(IpAddr::V4(gw), 80);
+        if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
+            if socket.connect(probe_target).is_ok() {
+                if let Ok(local) = socket.local_addr() {
+                    if let IpAddr::V4(v4) = local.ip() {
+                        let candidate = SocketAddr::new(IpAddr::V4(v4), port);
+                        if is_port_mapping_local_addr(candidate) {
+                            return Some(candidate);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Do not fall through to an arbitrary LAN address when we know which
+        // gateway will receive the mapping protocol packets.  On multi-NIC
+        // hosts that would send UPnP/PCP/NAT-PMP from one interface to the
+        // gateway on another, and leave a deceptively usable-looking but
+        // unreachable mapped candidate behind.
+        return None;
+    } else {
+        // Probe route to public IP to find outgoing default interface
+        let public_target = SocketAddr::from(([8, 8, 8, 8], 53));
+        if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0") {
+            if socket.connect(public_target).is_ok() {
+                if let Ok(local) = socket.local_addr() {
+                    if let IpAddr::V4(v4) = local.ip() {
+                        let candidate = SocketAddr::new(IpAddr::V4(v4), port);
+                        if is_port_mapping_local_addr(candidate) {
+                            return Some(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: any valid LAN address
+    for addr in addresses {
+        if let IpAddr::V4(v4) = *addr {
+            let candidate = SocketAddr::new(IpAddr::V4(v4), port);
+            if is_port_mapping_local_addr(candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[allow(dead_code)]
+pub(super) fn resolve_physical_lan_ipv4_for_port(
+    port: u16,
+    gateway: Option<Ipv4Addr>,
+) -> Option<SocketAddr> {
+    resolve_physical_lan_ipv4_for_port_with_addresses(
+        port,
+        gateway,
+        &p2pnet_nat::gather_local_addresses(),
+    )
+}
+
+pub(super) fn port_mapping_local_addr(
     udp_local_addr: Option<SocketAddr>,
     candidates: &[String],
     candidate_sources: &HashMap<String, String>,
+    gateway: Option<Ipv4Addr>,
 ) -> Option<SocketAddr> {
+    port_mapping_local_addr_with_addresses(
+        udp_local_addr,
+        candidates,
+        candidate_sources,
+        gateway,
+        &p2pnet_nat::gather_local_addresses(),
+    )
+}
+
+pub(super) fn port_mapping_local_addr_with_addresses(
+    udp_local_addr: Option<SocketAddr>,
+    candidates: &[String],
+    candidate_sources: &HashMap<String, String>,
+    gateway: Option<Ipv4Addr>,
+    addresses: &[IpAddr],
+) -> Option<SocketAddr> {
+    let target_port = udp_local_addr.map(|addr| addr.port()).filter(|&p| p > 0);
+
     if udp_local_addr.is_some_and(is_port_mapping_local_addr) {
         return udp_local_addr;
     }
 
-    candidates.iter().find_map(|candidate| {
-        if candidate_sources.get(candidate).map(String::as_str) != Some("host") {
-            return None;
-        }
-        let endpoint = candidate.parse::<SocketAddr>().ok()?;
-        is_port_mapping_local_addr(endpoint).then_some(endpoint)
-    })
+    let port = target_port?;
+
+    let host_candidate = |require_gateway_match: bool| {
+        candidates.iter().find_map(|candidate| {
+            if candidate_sources.get(candidate).map(String::as_str) != Some("host") {
+                return None;
+            }
+            let endpoint = candidate.parse::<SocketAddr>().ok()?;
+            if !is_port_mapping_local_addr(endpoint) {
+                return None;
+            }
+            if require_gateway_match
+                && !gateway.is_some_and(|gw| match endpoint.ip() {
+                    IpAddr::V4(ip) => subnet_prefix_score(ip, gw) > 0,
+                    IpAddr::V6(_) => false,
+                })
+            {
+                return None;
+            }
+            Some(SocketAddr::new(endpoint.ip(), port))
+        })
+    };
+
+    if gateway.is_some() {
+        // Both a host candidate and an interface-enumeration fallback may be
+        // present here.  Prefer the physical interface selected for the
+        // gateway, so candidate ordering cannot make a stale VPN/secondary
+        // interface drive gateway mapping traffic.
+        return resolve_physical_lan_ipv4_for_port_with_addresses(port, gateway, addresses)
+            .or_else(|| host_candidate(true));
+    }
+
+    // Without a discoverable gateway a current host candidate is still the
+    // best concrete binding hint.  It must use the active socket port, never
+    // the port captured by an older candidate snapshot.
+    host_candidate(false)
+        .or_else(|| resolve_physical_lan_ipv4_for_port_with_addresses(port, None, addresses))
 }
 
 fn is_port_mapping_local_addr(endpoint: SocketAddr) -> bool {

--- a/client/daemon/src/candidate_refresh/runtime.rs
+++ b/client/daemon/src/candidate_refresh/runtime.rs
@@ -21,6 +21,18 @@ pub(super) struct UdpCandidateRefreshContext {
     pub(super) boot_epoch_ms: u64,
 }
 
+/// Gateway discovery is allowed to run concurrently with STUN.  Its result is
+/// usable only while the UDP socket and the network generation it started on
+/// are still current; otherwise it can advertise a mapping for an old route.
+fn port_mapping_result_is_current(
+    mapping_start_udp_addr: Option<SocketAddr>,
+    mapping_start_generation: u64,
+    current_udp_addr: Option<SocketAddr>,
+    current_generation: u64,
+) -> bool {
+    current_udp_addr == mapping_start_udp_addr && current_generation == mapping_start_generation
+}
+
 /// The reason that woke the candidate-refresh scheduler.
 ///
 /// These reasons are intentionally kept separate: a volatile publication is
@@ -304,6 +316,8 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
         // operations. Run them concurrently without holding the shared
         // candidate lock. A peer signal must be able to reuse the last
         // committed snapshot while either discovery path is in flight.
+        let mapping_start_udp_addr = udp.local_addr().ok();
+        let mapping_start_generation = peers.current_network_generation_sync();
         let mapping_future = async {
             if !upnp_enabled {
                 return (Vec::new(), HashMap::new());
@@ -315,8 +329,12 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
             );
             let mut discovered = Vec::new();
             let mut discovered_sources = HashMap::new();
+            let existing_candidates = local_candidates.read().await.clone();
+            let existing_sources = local_candidate_sources.read().await.clone();
             maybe_add_port_mapping_udp_candidate(
-                udp.local_addr().ok(),
+                mapping_start_udp_addr,
+                &existing_candidates,
+                &existing_sources,
                 &mut discovered,
                 &mut discovered_sources,
                 gateway_mapping_runtime.clone(),
@@ -372,7 +390,10 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
             candidate_count = candidates.len(),
             "UDP candidate refresh gather completed"
         );
-        peers.update_nat_profile(report.nat_profile.clone()).await;
+        // A periodic gather is the only path that creates new `o=` NAT
+        // evidence. Its returned version must travel with this exact report;
+        // the endpoint heartbeat later reuses the committed label unchanged.
+        let nat_publication = peers.update_nat_profile(report.nat_profile.clone()).await;
         let profile_changed = {
             let mut current_profile = nat_profile.write().await;
             if current_profile.as_ref() == Some(&report.nat_profile) {
@@ -421,12 +442,32 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
                 });
         }
 
-        for endpoint in mapped_candidates {
-            if !candidates.contains(&endpoint) {
-                candidates.push(endpoint.clone());
-            }
-            if let Some(source) = mapped_sources.get(&endpoint) {
-                candidate_sources.insert(endpoint, source.clone());
+        let current_udp_addr = udp.local_addr().ok();
+        let current_generation = peers.current_network_generation_sync();
+        let is_stale_mapping = !port_mapping_result_is_current(
+            mapping_start_udp_addr,
+            mapping_start_generation,
+            current_udp_addr,
+            current_generation,
+        );
+
+        if is_stale_mapping {
+            debug!(
+                target: "p2wlan_daemon::candidate_refresh",
+                ?mapping_start_udp_addr,
+                ?current_udp_addr,
+                mapping_start_generation,
+                current_generation,
+                "Discarding gateway port mapping results because UDP socket instance or network generation changed during discovery"
+            );
+        } else {
+            for endpoint in mapped_candidates {
+                if !candidates.contains(&endpoint) {
+                    candidates.push(endpoint.clone());
+                }
+                if let Some(source) = mapped_sources.get(&endpoint) {
+                    candidate_sources.insert(endpoint, source.clone());
+                }
             }
         }
 
@@ -518,12 +559,27 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
         let new_candidate_count = candidates.len();
         let real_change = change_reason != "no_change" && change_reason != "order_only";
         if !candidate_refresh_requires_commit(real_change, should_advance_generation) {
-            if profile_changed {
+            if profile_changed || nat_publication.observation_advanced {
                 debug!(
-                    "UDP NAT profile changed without advertised candidate endpoint changes: mapping={:?} public={:?}",
+                    "Publishing refreshed UDP NAT evidence without advertised candidate endpoint changes: mapping={:?} public={:?} observation={:?}",
                     report.nat_profile.mapping_behavior,
-                    report.nat_profile.public_endpoint
+                    report.nat_profile.public_endpoint,
+                    nat_publication.observation,
                 );
+                let endpoint = control_udp_endpoint_from_candidates(&candidates, &candidate_sources)
+                    .or(advertised_endpoint)
+                    .unwrap_or_default();
+                let nat_type = report
+                    .nat_profile
+                    .control_label_with_generation_and_observation(
+                        nat_publication.generation,
+                        nat_publication.observation,
+                    );
+                if let Err(err) = control.update_endpoint(&endpoint, &nat_type).await {
+                    warn!("Failed to publish refreshed UDP NAT profile '{endpoint}': {err}");
+                } else if !endpoint.is_empty() {
+                    published_endpoint = Some(endpoint.clone());
+                }
             }
             debug!(
                 "UDP candidate refresh kept the existing {} candidates: changed_reason={change_reason} old_hash={old_hash} new_hash={new_hash} old_candidate_count={old_candidate_count} new_candidate_count={new_candidate_count}",
@@ -584,11 +640,18 @@ pub(super) async fn run_udp_candidate_refresh(context: UdpCandidateRefreshContex
                 published_endpoint.as_deref(),
                 &endpoint,
                 report.nat_profile.mapping_behavior,
-            );
+            )
+            // A same-capability live STUN result renews remote evidence using
+            // `o=`. Do not wait for endpoint churn: that would let a stable
+            // good mapping expire while cached heartbeats keep replaying o-1.
+            || nat_publication.observation_advanced;
         if should_update_endpoint {
             let nat_type = report
                 .nat_profile
-                .control_label_with_generation(peers.current_local_profile_generation_sync());
+                .control_label_with_generation_and_observation(
+                    nat_publication.generation,
+                    nat_publication.observation,
+                );
             if let Err(err) = control.update_endpoint(&endpoint, &nat_type).await {
                 warn!("Failed to publish refreshed UDP endpoint '{endpoint}': {err}");
             } else if !endpoint.is_empty() {

--- a/client/daemon/src/control.rs
+++ b/client/daemon/src/control.rs
@@ -48,19 +48,19 @@ pub use http::proxy_consults_environment;
 /// Short, non-sensitive HTTP proxy behavior label (diagnostics/structured
 /// events).  See [`control::proxy`](crate::control::proxy) for the policy.
 pub use http::proxy_http_behavior_label;
-#[cfg(test)]
-use http::register_device_payload;
 pub(crate) use http::{
     candidate_generation_incarnation, candidate_generation_is_malformed_encoded,
     candidate_generation_predecessor_floor,
 };
 use http::{
-    create_tunnel, fetch_relay_ticket_http, normalize_http_base_url, obtain_device_credential,
-    poll_peers, poll_signals, prepare_signal_payload, register_device, release_presence,
-    route_aware_control_http_clients, send_prepared_signal, send_signal, update_endpoint,
-    RouteAwareControlHttpClient, SignalDeliveryTracker, SignalSigningIdentity,
-    SIGNAL_REST_PROTOCOL_VERSION,
+    control_label_with_registration_seq, create_tunnel, fetch_relay_ticket_http,
+    normalize_http_base_url, obtain_device_credential, poll_peers, poll_signals,
+    prepare_signal_payload, register_device, release_presence, route_aware_control_http_clients,
+    send_prepared_signal, send_signal, update_endpoint, RouteAwareControlHttpClient,
+    SignalDeliveryTracker, SignalSigningIdentity, SIGNAL_REST_PROTOCOL_VERSION,
 };
+#[cfg(test)]
+use http::{register_device_payload, register_device_payload_with_incarnation};
 use websocket::spawn_signal_websocket;
 /// Stable WebSocket proxy policy label (`direct_only`).  Signaling never rides
 /// an ambient proxy.

--- a/client/daemon/src/control/client.rs
+++ b/client/daemon/src/control/client.rs
@@ -7,7 +7,7 @@ impl ControlClient {
             return Err(DaemonError::Config("room registration requires an authenticated managed profile".into()));
         }
         let http = control_http_client(config.control.proxy_mode)?;
-        let (node_id, virtual_ip, cidr, relays, _) = register_device(
+        let (node_id, virtual_ip, cidr, relays, _, _) = register_device(
             &http,
             &normalize_http_base_url(&config.control.server_url),
             &config.control.auth_token,
@@ -98,10 +98,11 @@ impl ControlClient {
                 completed: shutdown_done_rx,
             })
         });
+        let critical_lifecycle_tx = cmd_tx.clone();
         let client = Self {
             shutdown_lifecycle,
             event_tx: event_tx.clone(),
-            cmd_tx,
+            cmd_tx: cmd_tx.clone(),
             critical_offer_tx,
             critical_answer_tx,
             critical_ctrl_tx,
@@ -143,6 +144,10 @@ impl ControlClient {
                 health: health.clone(),
                 state: state.clone(),
             };
+            let advertised_snapshot = Arc::new(std::sync::Mutex::new(
+                AdvertisedEndpointSnapshot::default(),
+            ));
+            let critical_advertised_snapshot = advertised_snapshot.clone();
             let critical = async move {
                 run_critical_control_loop(
                     critical_http,
@@ -156,6 +161,8 @@ impl ControlClient {
                     critical_relay_selection,
                     critical_health,
                     shutdown_rx,
+                    critical_advertised_snapshot,
+                    critical_lifecycle_tx,
                 )
                 .await;
             };
@@ -171,6 +178,7 @@ impl ControlClient {
                     relay_selection,
                     critical_auth_tx,
                     health,
+                    advertised_snapshot,
                 )
                 .await;
             };
@@ -198,16 +206,39 @@ impl ControlClient {
     pub(crate) fn disabled_for_test() -> Self {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
         let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
-        let (critical_offer_tx, critical_offer_rx) = mpsc::channel(CRITICAL_OFFER_QUEUE_CAPACITY);
-        let (critical_answer_tx, critical_answer_rx) =
-            mpsc::channel(CRITICAL_ANSWER_QUEUE_CAPACITY);
-        let (critical_ctrl_tx, critical_ctrl_rx) = mpsc::channel(CRITICAL_CTRL_QUEUE_CAPACITY);
-        let (candidate_offer_tx, candidate_offer_rx) =
-            mpsc::channel(CANDIDATE_OFFER_QUEUE_CAPACITY);
-        drop(critical_offer_rx);
-        drop(critical_answer_rx);
-        drop(critical_ctrl_rx);
-        drop(candidate_offer_rx);
+        let (critical_offer_tx, mut critical_offer_rx) =
+            mpsc::channel::<CriticalOfferCommand>(CRITICAL_OFFER_QUEUE_CAPACITY);
+        let (critical_answer_tx, mut critical_answer_rx) =
+            mpsc::channel::<CriticalAnswerCommand>(CRITICAL_ANSWER_QUEUE_CAPACITY);
+        let (critical_ctrl_tx, mut critical_ctrl_rx) =
+            mpsc::channel::<CriticalControlCommand>(CRITICAL_CTRL_QUEUE_CAPACITY);
+        let (candidate_offer_tx, mut candidate_offer_rx) =
+            mpsc::channel::<CandidateOfferCommand>(CANDIDATE_OFFER_QUEUE_CAPACITY);
+        tokio::spawn(async move {
+            while let Some(cmd) = critical_offer_rx.recv().await {
+                let _ = cmd.response_tx.send(PeerOfferSendOutcome::Sent);
+            }
+        });
+        tokio::spawn(async move {
+            while let Some(cmd) = critical_answer_rx.recv().await {
+                let _ = cmd.response_tx.send(Ok(()));
+            }
+        });
+        tokio::spawn(async move {
+            while let Some(cmd) = candidate_offer_rx.recv().await {
+                let _ = cmd.response_tx.send(PeerOfferSendOutcome::Sent);
+            }
+        });
+        tokio::spawn(async move {
+            while let Some(cmd) = critical_ctrl_rx.recv().await {
+                match cmd {
+                    CriticalControlCommand::UpdateEndpoint { response_tx, .. } => {
+                        let _ = response_tx.send(Ok(()));
+                    }
+                    CriticalControlCommand::Shutdown => break,
+                }
+            }
+        });
         let state = Arc::new(RwLock::new(ClientState {
             room_authorization: Arc::new(crate::rooms::RoomAuthorization::new("default")),
             registered: false,
@@ -303,6 +334,11 @@ impl ControlClient {
     /// Get a snapshot of the known peers.
     pub async fn peers(&self) -> HashMap<String, PeerInfo> {
         self.state.read().await.peers.clone()
+    }
+
+    #[cfg(test)]
+    pub async fn set_peer_for_test(&self, peer: PeerInfo) {
+        self.state.write().await.peers.insert(peer.node_id.clone(), peer);
     }
 
     /// Get the assigned virtual IP.

--- a/client/daemon/src/control/http/auth.rs
+++ b/client/daemon/src/control/http/auth.rs
@@ -108,36 +108,37 @@ pub(super) async fn obtain_device_credential(
 struct RelayTicketResponse {
     ticket: Option<String>,
     expires_at: Option<i64>,
-    error: Option<String>,
 }
 
 pub(super) async fn fetch_relay_ticket_http(
     http: &reqwest::Client,
     base_url: &str,
     token: &str,
+    registration_seq: Option<u64>,
     audience: &str,
     region: &str,
 ) -> Result<FetchRelayTicketResponse> {
-    let resp = http
-        .post(format!("{base_url}/api/v1/relay/tickets"))
-        .timeout(CONTROL_REQUEST_TIMEOUT)
-        .bearer_auth(token)
-        .json(&serde_json::json!({
-            "audience": audience,
-            "region": region,
-        }))
+    let resp = with_registration_sequence(
+        http
+            .post(format!("{base_url}/api/v1/relay/tickets"))
+            .timeout(CONTROL_REQUEST_TIMEOUT)
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "audience": audience,
+                "region": region,
+            })),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("relay ticket request failed: {e}")))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body: RelayTicketResponse = resp.json().await.unwrap_or(RelayTicketResponse {
-            ticket: None,
-            expires_at: None,
-            error: Some(format!("HTTP {status}")),
-        });
-        let msg = body.error.unwrap_or_else(|| format!("HTTP {status}"));
+        let (msg, error_code, current_seq) = control_error_detail(resp).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &msg) {
+            return Err(error);
+        }
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             return Err(DaemonError::ControlPlane(format!("permanent auth: {msg}")));
         }

--- a/client/daemon/src/control/http/device.rs
+++ b/client/daemon/src/control/http/device.rs
@@ -9,12 +9,28 @@ pub(super) fn normalize_http_base_url(server_url: &str) -> String {
     }
 }
 
+/// Server-verified registration session header carried by a daemon after it
+/// has completed an incarnation-aware registration.  Unlike the peer-visible
+/// NAT `l=` label, this header is an authenticated control-plane fence and is
+/// therefore used for every device-credential control action.
+pub(super) const REGISTRATION_SEQUENCE_HEADER: &str = "X-P2WLAN-Registration-Seq";
+
+pub(super) fn with_registration_sequence(
+    request: reqwest::RequestBuilder,
+    registration_seq: Option<u64>,
+) -> reqwest::RequestBuilder {
+    match registration_seq.filter(|seq| *seq > 0) {
+        Some(seq) => request.header(REGISTRATION_SEQUENCE_HEADER, seq.to_string()),
+        None => request,
+    }
+}
+
 pub(super) async fn register_device(
     http: &reqwest::Client,
     base_url: &str,
     token: &str,
     config: &Config,
-) -> Result<(String, String, String, Vec<String>, Vec<RelayCatalogEntry>)> {
+) -> Result<(String, String, String, Vec<String>, Vec<RelayCatalogEntry>, Option<u64>)> {
     let res = http
         .post(format!("{base_url}/api/v1/devices"))
         .timeout(CONTROL_REQUEST_TIMEOUT)
@@ -26,7 +42,10 @@ pub(super) async fn register_device(
 
     if !res.status().is_success() {
         let status = res.status();
-        let detail = control_error_detail(res).await;
+        let (detail, error_code, registration_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, registration_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
             "register request returned HTTP {status}: {detail}"
         )));
@@ -51,6 +70,37 @@ pub(super) async fn register_device(
         .virtual_ip
         .ok_or_else(|| DaemonError::ControlPlane("register response missing virtual_ip".into()))?;
     let cidr = body.cidr.unwrap_or_else(|| "10.20.0.0/16".to_string());
+    let local_incarnation = crate::incarnation::local_incarnation();
+    // Old servers omit both fields.  Once either lifecycle field is present,
+    // accepting a partial response would make this daemon publish unauthenticated
+    // control actions without a server-issued session proof.
+    if body.registration_incarnation.is_some() || body.registration_seq.is_some() {
+        let server_incarnation = body.registration_incarnation.ok_or_else(|| {
+            DaemonError::ControlPlane(
+                "registration response included lifecycle data but omitted registration_incarnation"
+                    .into(),
+            )
+        })?;
+        let registration_seq = body.registration_seq.filter(|seq| *seq > 0).ok_or_else(|| {
+            DaemonError::ControlPlane(
+                "registration response included lifecycle data but omitted a valid registration_seq"
+                    .into(),
+            )
+        })?;
+        if local_incarnation == 0 || server_incarnation != local_incarnation {
+            return Err(DaemonError::ControlPlane(format!(
+                "registration conflict (registration_incarnation_mismatch) local={local_incarnation} server={server_incarnation}"
+            )));
+        }
+        return Ok((
+            node_id,
+            virtual_ip,
+            cidr,
+            body.relay_servers,
+            body.relay_catalog,
+            Some(registration_seq),
+        ));
+    }
 
     Ok((
         node_id,
@@ -58,10 +108,18 @@ pub(super) async fn register_device(
         cidr,
         body.relay_servers,
         body.relay_catalog,
+        body.registration_seq,
     ))
 }
 
 pub(super) fn register_device_payload(config: &Config) -> serde_json::Value {
+    register_device_payload_with_incarnation(config, crate::incarnation::local_incarnation())
+}
+
+pub(super) fn register_device_payload_with_incarnation(
+    config: &Config,
+    incarnation: u64,
+) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "public_key": config.node.public_key,
         "ed25519_public_key": config.node.ed25519_public_key,
@@ -70,6 +128,13 @@ pub(super) fn register_device_payload(config: &Config) -> serde_json::Value {
         "app_version": env!("CARGO_PKG_VERSION"),
         "network_id": config.network.network_id,
     });
+
+    // A zero value means the durable state file was unavailable. Do not invent
+    // a wall-clock fallback: doing so could make an old daemon appear newer.
+    // Older servers also accept the missing optional field during rollout.
+    if incarnation != 0 {
+        payload["registration_incarnation"] = serde_json::json!(incarnation);
+    }
 
     if config.network.network_id.starts_with("room-") {
         payload["room_protocol_version"] = serde_json::json!(1);
@@ -85,15 +150,122 @@ pub(super) fn register_device_payload(config: &Config) -> serde_json::Value {
     payload
 }
 
-async fn control_error_detail(res: reqwest::Response) -> String {
+pub(super) async fn control_error_detail(
+    res: reqwest::Response,
+) -> (String, Option<String>, Option<u64>) {
     let status = res.status();
     let text = res.text().await.unwrap_or_default();
     if text.trim().is_empty() {
-        return status.to_string();
+        return (status.to_string(), None, None);
     }
     match serde_json::from_str::<ControlErrorResponse>(&text) {
-        Ok(body) => body.error.unwrap_or(text),
-        Err(_) => text,
+        Ok(body) => (body.error.unwrap_or(text), body.error_code, body.registration_seq),
+        Err(_) => (text, None, None),
+    }
+}
+
+pub(super) fn registration_conflict_error(
+    status: reqwest::StatusCode,
+    error_code: Option<String>,
+    registration_seq: Option<u64>,
+    detail: &str,
+) -> Option<DaemonError> {
+    if status != reqwest::StatusCode::CONFLICT {
+        return None;
+    }
+    let code = error_code?;
+    if !matches!(
+        code.as_str(),
+        "registration_conflict"
+            | "registration_protocol_upgrade_required"
+            | "registration_incarnation_mismatch"
+            | "registration_lifecycle_conflict"
+    ) {
+        return None;
+    }
+    Some(DaemonError::ControlPlane(format!(
+        "registration conflict ({code}) current_registration_seq={}: {detail}",
+        registration_seq
+            .map(|sequence| sequence.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+    )))
+}
+
+/// Add the server-issued registration sequence to an endpoint NAT label.
+///
+/// The control server uses `l=` as a compare-and-swap fence for endpoint
+/// metadata. This final HTTP-boundary canonicalizer covers the ordinary,
+/// heartbeat, and critical lanes even when an older candidate source emitted
+/// a label without lifecycle metadata. An existing `l=` is replaced rather
+/// than trusted, since only the registration response is authoritative.
+pub(super) fn control_label_with_registration_seq(
+    nat_type: &str,
+    registration_seq: Option<u64>,
+) -> String {
+    let Some(registration_seq) = registration_seq else {
+        return nat_type.to_string();
+    };
+
+    let trimmed = nat_type.trim();
+    let seed = if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        "p2v2:"
+    } else {
+        trimmed
+    };
+    let mut fields: Vec<String> = seed
+        .split(';')
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+        .filter(|field| {
+            let field = field
+                .strip_prefix("p2v2:")
+                .or_else(|| field.strip_prefix("p2:"))
+                .unwrap_or(field);
+            !field.starts_with("l=")
+        })
+        .map(ToOwned::to_owned)
+        .collect();
+    if fields.is_empty() || fields.iter().all(|field| field == "p2v2:" || field == "p2:") {
+        fields.clear();
+        fields.push("p2v2:".to_string());
+    }
+
+    let append_lifecycle = |fields: &mut Vec<String>| {
+        if fields.last().is_some_and(|field| field.ends_with(':')) {
+            let last = fields.last_mut().expect("last checked above");
+            last.push_str(&format!("l={registration_seq}"));
+        } else {
+            fields.push(format!("l={registration_seq}"));
+        }
+    };
+    append_lifecycle(&mut fields);
+
+    // Device NAT metadata is capped at 128 bytes by the server. Keep the
+    // ordering fences and traversal-relevant fields, dropping optional
+    // diagnostics in the same order as NatProfile's producer does.
+    for optional_key in ["h=", "c=", "f=", "r="] {
+        let label = fields.join(";");
+        if label.len() <= 128 {
+            return label;
+        }
+        if let Some(position) = fields.iter().position(|field| {
+            field
+                .strip_prefix("p2v2:")
+                .or_else(|| field.strip_prefix("p2:"))
+                .unwrap_or(field)
+                .starts_with(optional_key)
+        }) {
+            fields.remove(position);
+        }
+    }
+    let label = fields.join(";");
+    if label.len() <= 128 {
+        label
+    } else {
+        // Preserve the registration CAS fence even for a malformed or
+        // unusually long legacy value. The peer will conservatively fall back
+        // from structured NAT inference until a normal candidate update wins.
+        format!("p2v2:l={registration_seq}")
     }
 }
 
@@ -105,8 +277,10 @@ pub(super) async fn update_endpoint(
     endpoint: &str,
     nat_type: &str,
     relay_rtt_ms: Option<u64>,
+    registration_seq: Option<u64>,
 ) -> Result<()> {
-    let res = http
+    let res = with_registration_sequence(
+        http
         .patch(format!("{base_url}/api/v1/devices/{device_id}/endpoint"))
         .timeout(CONTROL_REQUEST_TIMEOUT)
         .bearer_auth(token)
@@ -114,15 +288,21 @@ pub(super) async fn update_endpoint(
             "endpoint": endpoint,
             "nat_type": nat_type,
             "relay_rtt_ms": relay_rtt_ms,
-        }))
+        })),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("endpoint update request failed: {e}")))?;
 
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "endpoint update returned HTTP {}",
-            res.status()
+            "endpoint update returned HTTP {status}: {detail}",
         )));
     }
 
@@ -146,19 +326,30 @@ pub(super) async fn release_presence(
     base_url: &str,
     token: &str,
     device_id: &str,
+    registration_seq: Option<u64>,
 ) -> Result<()> {
-    let res = http
+    let res = with_registration_sequence(
+        http
         .post(format!("{base_url}/api/v1/devices/{device_id}/offline"))
         .timeout(PRESENCE_RELEASE_TIMEOUT)
         .bearer_auth(token)
+        .json(&serde_json::json!({
+            "registration_seq": registration_seq,
+        })),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("presence release request failed: {e}")))?;
 
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "presence release returned HTTP {}",
-            res.status()
+            "presence release returned HTTP {status}: {detail}",
         )));
     }
 

--- a/client/daemon/src/control/http/device.rs
+++ b/client/daemon/src/control/http/device.rs
@@ -269,6 +269,7 @@ pub(super) fn control_label_with_registration_seq(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn update_endpoint(
     http: &reqwest::Client,
     base_url: &str,

--- a/client/daemon/src/control/http/peers.rs
+++ b/client/daemon/src/control/http/peers.rs
@@ -4,28 +4,36 @@ pub(super) async fn poll_peers(
     token: &str,
     config: &Config,
     self_node_id: &str,
+    registration_seq: Option<u64>,
     state: &Arc<RwLock<ClientState>>,
     event_tx: &mpsc::UnboundedSender<ControlEvent>,
 ) -> Result<()> {
     let request_started = std::time::Instant::now();
-    let res = http
+    let res = with_registration_sequence(
+        http
         .get(format!(
             "{base_url}/api/v1/nodes?network_id={}",
             config.network.network_id
         ))
         .timeout(CONTROL_REQUEST_TIMEOUT)
-        .bearer_auth(token)
+        .bearer_auth(token),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("list nodes request failed: {e}")))?;
 
     if !res.status().is_success() {
-        if matches!(res.status().as_u16(), 401 | 403 | 404) {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if matches!(status.as_u16(), 401 | 403 | 404) {
             state.read().await.room_authorization.invalidate();
         }
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "list nodes request returned HTTP {}",
-            res.status()
+            "list nodes request returned HTTP {status}: {detail}",
         )));
     }
 
@@ -156,11 +164,13 @@ pub(super) async fn create_tunnel(
     base_url: &str,
     token: &str,
     device_id: &str,
+    registration_seq: Option<u64>,
     protocol: &str,
     local_port: u16,
     remote_port: u16,
 ) -> Result<(String, String)> {
-    let res = http
+    let res = with_registration_sequence(
+        http
         .post(format!("{base_url}/api/v1/tunnels"))
         .timeout(CONTROL_REQUEST_TIMEOUT)
         .bearer_auth(token)
@@ -170,15 +180,21 @@ pub(super) async fn create_tunnel(
             "local_port": local_port,
             "remote_port": remote_port,
             "local_address": "127.0.0.1",
-        }))
+        })),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("create tunnel request failed: {e}")))?;
 
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "create tunnel request returned HTTP {}",
-            res.status()
+            "create tunnel request returned HTTP {status}: {detail}",
         )));
     }
 

--- a/client/daemon/src/control/http/peers.rs
+++ b/client/daemon/src/control/http/peers.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn poll_peers(
     http: &reqwest::Client,
     base_url: &str,
@@ -159,6 +160,7 @@ pub(super) fn peer_metadata_changed(known: &PeerInfo, peer: &PeerInfo) -> bool {
         || known.relay_rtt_ms != peer.relay_rtt_ms
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn create_tunnel(
     http: &reqwest::Client,
     base_url: &str,

--- a/client/daemon/src/control/http/signal.rs
+++ b/client/daemon/src/control/http/signal.rs
@@ -177,6 +177,7 @@ pub(super) async fn send_prepared_signal(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn poll_signals(
     http: &reqwest::Client,
     base_url: &str,
@@ -569,6 +570,7 @@ struct LeasedSignalDelivery {
 /// time: if an ACK is ambiguous, later rows stay unacknowledged and the
 /// server's per-pair head-of-line lease will replay from the first uncertain
 /// commit instead of allowing a newer handshake to overtake it.
+#[allow(clippy::too_many_arguments)]
 fn spawn_signal_application_lane(
     http: reqwest::Client,
     base_url: String,

--- a/client/daemon/src/control/http/signal.rs
+++ b/client/daemon/src/control/http/signal.rs
@@ -3,6 +3,7 @@ pub(super) async fn send_signal(
     http: &reqwest::Client,
     base_url: &str,
     token: &str,
+    registration_seq: Option<u64>,
     from_node_id: &str,
     to_node_id: &str,
     signal_type: &str,
@@ -28,7 +29,7 @@ pub(super) async fn send_signal(
         probe_ephemeral_public_key,
         signing_identity,
     )?;
-    send_prepared_signal(http, base_url, token, &payload).await
+    send_prepared_signal(http, base_url, token, registration_seq, &payload).await
 }
 
 /// Build one immutable signal body.
@@ -104,21 +105,28 @@ pub(super) async fn send_prepared_signal(
     http: &reqwest::Client,
     base_url: &str,
     token: &str,
+    registration_seq: Option<u64>,
     payload: &serde_json::Value,
 ) -> Result<()> {
-    let res = http
-        .post(format!("{base_url}/api/v1/signals"))
-        .timeout(SIGNAL_SEND_TIMEOUT)
-        .bearer_auth(token)
-        .json(payload)
+    let res = with_registration_sequence(
+        http.post(format!("{base_url}/api/v1/signals"))
+            .timeout(SIGNAL_SEND_TIMEOUT)
+            .bearer_auth(token)
+            .json(payload),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("send signal request failed: {e}")))?;
 
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "send signal returned HTTP {}",
-            res.status()
+            "send signal returned HTTP {status}: {detail}",
         )));
     }
 
@@ -174,6 +182,7 @@ pub(super) async fn poll_signals(
     base_url: &str,
     token: &str,
     self_node_id: &str,
+    registration_seq: Option<u64>,
     event_tx: &mpsc::UnboundedSender<ControlEvent>,
     wait_ms: u64,
     delivery_tracker: &Arc<tokio::sync::Mutex<SignalDeliveryTracker>>,
@@ -184,20 +193,26 @@ pub(super) async fn poll_signals(
     // expires and the batch is redelivered.  An old server ignores the query
     // parameter and keeps its delete-on-GET contract, which is exactly what
     // an old client expects (no infinite redelivery either way).
-    let res = http
-        .get(format!(
+    let res = with_registration_sequence(
+        http.get(format!(
             "{base_url}/api/v1/signals?node_id={self_node_id}&wait_ms={wait_ms}&ack=1"
         ))
         .timeout(signal_poll_timeout(wait_ms))
-        .bearer_auth(token)
+        .bearer_auth(token),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("list signals request failed: {e}")))?;
 
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "list signals returned HTTP {}",
-            res.status()
+            "list signals returned HTTP {status}: {detail}",
         )));
     }
 
@@ -432,6 +447,7 @@ pub(super) async fn poll_signals(
             base_url.to_string(),
             token.to_string(),
             self_node_id.to_string(),
+            registration_seq,
             event_tx.clone(),
             delivery_tracker.clone(),
             deliveries,
@@ -558,6 +574,7 @@ fn spawn_signal_application_lane(
     base_url: String,
     token: String,
     self_node_id: String,
+    registration_seq: Option<u64>,
     event_tx: mpsc::UnboundedSender<ControlEvent>,
     delivery_tracker: Arc<tokio::sync::Mutex<SignalDeliveryTracker>>,
     deliveries: Vec<LeasedSignalDelivery>,
@@ -657,6 +674,7 @@ fn spawn_signal_application_lane(
                 &base_url,
                 &token,
                 &self_node_id,
+                registration_seq,
                 std::slice::from_ref(&delivery.ack),
             )
             .await
@@ -684,20 +702,27 @@ async fn ack_signals(
     base_url: &str,
     token: &str,
     self_node_id: &str,
+    registration_seq: Option<u64>,
     acks: &[SignalAckRequest],
 ) -> Result<()> {
-    let res = http
-        .post(format!("{base_url}/api/v1/signals/ack?node_id={self_node_id}"))
-        .timeout(SIGNAL_SEND_TIMEOUT)
-        .bearer_auth(token)
-        .json(&serde_json::json!({ "signals": acks }))
+    let res = with_registration_sequence(
+        http.post(format!("{base_url}/api/v1/signals/ack?node_id={self_node_id}"))
+            .timeout(SIGNAL_SEND_TIMEOUT)
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "signals": acks })),
+        registration_seq,
+    )
         .send()
         .await
         .map_err(|e| DaemonError::ControlPlane(format!("signal ack request failed: {e}")))?;
     if !res.status().is_success() {
+        let status = res.status();
+        let (detail, error_code, current_seq) = control_error_detail(res).await;
+        if let Some(error) = registration_conflict_error(status, error_code, current_seq, &detail) {
+            return Err(error);
+        }
         return Err(DaemonError::ControlPlane(format!(
-            "signal ack returned HTTP {}",
-            res.status()
+            "signal ack returned HTTP {status}: {detail}",
         )));
     }
     Ok(())

--- a/client/daemon/src/control/runtime/commands.rs
+++ b/client/daemon/src/control/runtime/commands.rs
@@ -8,7 +8,17 @@ match cmd {
                             peer_roster_tick.reset();
                             let poll_result = async {
                                 let current_http = http.current()?;
-                                poll_peers(&current_http, &base_url, &token, &config, &self_node_id, &state, event_tx).await
+                                poll_peers(
+                                    &current_http,
+                                    &base_url,
+                                    &token,
+                                    &config,
+                                    &self_node_id,
+                                    registration_seq,
+                                    &state,
+                                    event_tx,
+                                )
+                                .await
                             }
                             .await;
                             match &poll_result {
@@ -20,7 +30,12 @@ match cmd {
                                     let _ = event_tx.send(ControlEvent::ControlHealthy);
                                 }
                                 Err(err) => {
-                                    warn!("Immediate peer polling failed: {err}");
+                                    let err_str = err.to_string();
+                                    if is_registration_conflict_error(&err_str) {
+                                        emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                        return;
+                                    }
+                                    warn!("Immediate peer polling failed: {err_str}");
                                     poll_failures = poll_failures.saturating_add(1);
                                 }
                             }
@@ -36,7 +51,17 @@ match cmd {
                         ControlCommand::CreateTunnel { protocol, local_port, remote_port } => {
                             let res = async {
                                 let current_http = http.current()?;
-                                create_tunnel(&current_http, &base_url, &token, &self_node_id, &protocol, local_port, remote_port).await
+                                create_tunnel(
+                                    &current_http,
+                                    &base_url,
+                                    &token,
+                                    &self_node_id,
+                                    registration_seq,
+                                    &protocol,
+                                    local_port,
+                                    remote_port,
+                                )
+                                .await
                             }
                             .await;
                             match res {
@@ -45,6 +70,10 @@ match cmd {
                                 }
                                 Err(err) => {
                                     let err_str = err.to_string();
+                                    if is_registration_conflict_error(&err_str) {
+                                        emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                        return;
+                                    }
                                     let code = if is_permanent_auth_error(&err_str) { 401u16 } else { 3000u16 };
                                     let _ = event_tx.send(ControlEvent::ServerError { code, message: err_str });
                                     if code == 401 {
@@ -55,6 +84,10 @@ match cmd {
                         }
                         ControlCommand::UpdateEndpoint { endpoint, nat_type, response_tx } => {
                             let relay_rtt_ms = current_relay_rtt_ms(relay_selection.as_ref()).await;
+                            let published_nat_type = control_label_with_registration_seq(
+                                &nat_type,
+                                registration_seq,
+                            );
                             let res = async {
                                 let current_http = http.current()?;
                                 update_endpoint(
@@ -63,17 +96,20 @@ match cmd {
                                     &token,
                                     &self_node_id,
                                     &endpoint,
-                                    &nat_type,
+                                    &published_nat_type,
                                     relay_rtt_ms,
+                                    registration_seq,
                                 )
                                 .await
                             }
                             .await;
                             match &res {
                                 Ok(()) => {
-                                    advertised_endpoint = endpoint;
-                                    advertised_nat_type = nat_type;
-                                    debug!("Updated endpoint for {self_node_id}: {advertised_endpoint} ({advertised_nat_type})");
+                                    advertised_snapshot
+                                        .lock()
+                                        .unwrap()
+                                        .update(endpoint.clone(), published_nat_type.clone());
+                                    debug!("Updated endpoint for {self_node_id}: {endpoint} ({published_nat_type})");
                                     if let Some(health) = health.as_ref() {
                                         health.mark_device_lease_success().await;
                                     }
@@ -94,7 +130,20 @@ match cmd {
                                     }
                                 }
                             }
+                            let lifecycle_conflict = res
+                                .as_ref()
+                                .err()
+                                .is_some_and(|err| is_registration_conflict_error(&err.to_string()));
                             let _ = response_tx.send(res);
+                            if lifecycle_conflict {
+                                emit_registration_lifecycle_conflict(
+                                    health.as_ref(),
+                                    event_tx,
+                                    "endpoint update rejected by the current registration lifecycle".into(),
+                                )
+                                .await;
+                                return;
+                            }
                         }
                         ControlCommand::SendPeerReflexive { to_node_id, observed_endpoint, punch_at_ms, response_tx } => {
                             let candidates = vec![observed_endpoint.clone()];
@@ -103,7 +152,24 @@ match cmd {
                             ]);
                             let res = async {
                                 let current_http = http.current()?;
-                                send_signal(&current_http, &base_url, &token, &self_node_id, &to_node_id, "peer_reflexive", &candidates, &candidate_sources, &[], punch_at_ms, None, None, None, None).await
+                                send_signal(
+                                    &current_http,
+                                    &base_url,
+                                    &token,
+                                    registration_seq,
+                                    &self_node_id,
+                                    &to_node_id,
+                                    "peer_reflexive",
+                                    &candidates,
+                                    &candidate_sources,
+                                    &[],
+                                    punch_at_ms,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                )
+                                .await
                             }
                             .await;
                             match &res {
@@ -120,7 +186,20 @@ match cmd {
                                     }
                                 }
                             }
+                            let lifecycle_conflict = res
+                                .as_ref()
+                                .err()
+                                .is_some_and(|err| is_registration_conflict_error(&err.to_string()));
                             let _ = response_tx.send(res);
+                            if lifecycle_conflict {
+                                emit_registration_lifecycle_conflict(
+                                    health.as_ref(),
+                                    event_tx,
+                                    "peer-reflexive signal rejected by the current registration lifecycle".into(),
+                                )
+                                .await;
+                                return;
+                            }
                         }
                         ControlCommand::DeleteTunnel { tunnel_id } => {
                             debug!("Tunnel deletion queued locally for {tunnel_id}");
@@ -128,15 +207,42 @@ match cmd {
                         ControlCommand::FetchRelayTicket { audience, region, response_tx } => {
                             let result = async {
                                 let current_http = http.current()?;
-                                fetch_relay_ticket_http(&current_http, &base_url, &token, &audience, &region).await
+                                fetch_relay_ticket_http(
+                                    &current_http,
+                                    &base_url,
+                                    &token,
+                                    registration_seq,
+                                    &audience,
+                                    &region,
+                                )
+                                .await
                             }
                             .await;
+                            let lifecycle_conflict = result
+                                .as_ref()
+                                .err()
+                                .is_some_and(|err| is_registration_conflict_error(&err.to_string()));
                             let _ = response_tx.send(result);
+                            if lifecycle_conflict {
+                                emit_registration_lifecycle_conflict(
+                                    health.as_ref(),
+                                    event_tx,
+                                    "relay ticket request rejected by the current registration lifecycle".into(),
+                                )
+                                .await;
+                                return;
+                            }
                         }
                         ControlCommand::Shutdown { response_tx } => {
                             let release_result = async {
                                 let current_http = http.current()?;
-                                release_presence(&current_http, &base_url, &token, &self_node_id)
+                                release_presence(
+                                    &current_http,
+                                    &base_url,
+                                    &token,
+                                    &self_node_id,
+                                    registration_seq,
+                                )
                                     .await
                             }
                             .await;
@@ -148,6 +254,10 @@ match cmd {
                             }
                             let _ = response_tx.send(());
                             let _ = event_tx.send(ControlEvent::Disconnected);
+                            return;
+                        }
+                        ControlCommand::LifecycleConflict { message } => {
+                            emit_registration_lifecycle_conflict(health.as_ref(), event_tx, message).await;
                             return;
                         }
                     }

--- a/client/daemon/src/control/runtime/critical.rs
+++ b/client/daemon/src/control/runtime/critical.rs
@@ -30,6 +30,8 @@ async fn run_critical_control_loop(
     relay_selection: Option<Arc<RwLock<RelaySelectionDiagnostics>>>,
     health: Option<Arc<crate::tasks::HealthState>>,
     mut shutdown_rx: watch::Receiver<bool>,
+    advertised_snapshot: Arc<std::sync::Mutex<AdvertisedEndpointSnapshot>>,
+    lifecycle_tx: mpsc::UnboundedSender<ControlCommand>,
 ) {
     let answer_permits = Arc::new(Semaphore::new(CRITICAL_ANSWER_MAX_INFLIGHT));
     let offer_permits = Arc::new(Semaphore::new(CRITICAL_OFFER_MAX_INFLIGHT));
@@ -81,6 +83,8 @@ async fn run_critical_control_loop(
                             ctrl_permits.clone(),
                             relay_selection.clone(),
                             health.clone(),
+                            advertised_snapshot.clone(),
+                            lifecycle_tx.clone(),
                         ));
                     }
                     CriticalControlCommand::Shutdown => {
@@ -301,8 +305,13 @@ async fn run_candidate_offer_worker(
                 // not prove that the server did not accept its POST; starting
                 // a new future here can therefore duplicate a candidate
                 // publication that already reached the control plane.
-                let request =
-                    send_prepared_signal(&current_http, &auth.base_url, &auth.token, &payload);
+                let request = send_prepared_signal(
+                    &current_http,
+                    &auth.base_url,
+                    &auth.token,
+                    auth.registration_seq,
+                    &payload,
+                );
                 tokio::pin!(request);
                 loop {
                     let remaining = deadline.saturating_duration_since(Instant::now());
@@ -529,6 +538,8 @@ async fn run_critical_endpoint_command(
     permits: Arc<Semaphore>,
     relay_selection: Option<Arc<RwLock<RelaySelectionDiagnostics>>>,
     health: Option<Arc<crate::tasks::HealthState>>,
+    advertised_snapshot: Arc<std::sync::Mutex<AdvertisedEndpointSnapshot>>,
+    lifecycle_tx: mpsc::UnboundedSender<ControlCommand>,
 ) {
     let Some(_permit) = acquire_critical_permit_or_skip(&permits, &response_tx).await else {
         return;
@@ -539,9 +550,25 @@ async fn run_critical_endpoint_command(
     else {
         return;
     };
+    // The critical lane may have waited behind another endpoint publication.
+    // Do not issue a request if ordinary registration has already replaced
+    // this identity; the server header fence remains the final authority for
+    // the race after this local check.
+    if auth_rx
+        .borrow()
+        .as_ref()
+        .is_none_or(|current| !auth.same_identity_as(current))
+    {
+        let _ = response_tx.send(Err(DaemonError::ControlPlane(
+            "critical endpoint publish aborted: control identity was replaced by re-registration"
+                .into(),
+        )));
+        return;
+    }
     let relay_rtt_ms = current_relay_rtt_ms(relay_selection.as_ref()).await;
+    let published_nat_type = control_label_with_registration_seq(&nat_type, auth.registration_seq);
     let remaining = deadline.saturating_duration_since(Instant::now());
-    let result = if remaining.is_zero() {
+    let mut result = if remaining.is_zero() {
         Err(DaemonError::ControlPlane(
             "critical lane deadline exceeded before endpoint publish".into(),
         ))
@@ -556,8 +583,9 @@ async fn run_critical_endpoint_command(
                         &auth.token,
                         &auth.self_node_id,
                         &endpoint,
-                        &nat_type,
+                        &published_nat_type,
                         relay_rtt_ms,
+                        auth.registration_seq,
                     )) => {
                         match result {
                             Ok(result) => result,
@@ -571,18 +599,40 @@ async fn run_critical_endpoint_command(
             }
         }
     };
+    // A successful response must still belong to the registration that issued
+    // it.  This prevents an old critical task from updating its local
+    // snapshot or reporting a healthy lease after a concurrent re-register.
+    if result.is_ok()
+        && auth_rx
+            .borrow()
+            .as_ref()
+            .is_none_or(|current| !auth.same_identity_as(current))
+    {
+        result = Err(DaemonError::ControlPlane(
+            "critical endpoint publish completed after control identity was replaced".into(),
+        ));
+    }
     match &result {
         Ok(()) => {
             if let Some(health) = health.as_ref() {
                 health.mark_device_lease_success().await;
             }
+            advertised_snapshot
+                .lock()
+                .unwrap()
+                .update(endpoint.clone(), published_nat_type.clone());
             debug!(
                 "Updated endpoint for {} through handshake control lane: {} ({})",
-                auth.self_node_id, endpoint, nat_type
+                auth.self_node_id, endpoint, published_nat_type
             );
             let _ = event_tx.send(ControlEvent::ControlHealthy);
         }
         Err(error) => {
+            if is_registration_conflict_error(&error.to_string()) {
+                let _ = lifecycle_tx.send(ControlCommand::LifecycleConflict {
+                    message: error.to_string(),
+                });
+            }
             if let Some(health) = health.as_ref() {
                 // Endpoint PATCH is the online lease operation. Preserve API
                 // reachability independently: a later successful GET may
@@ -716,6 +766,7 @@ async fn send_critical_signal<T>(
                         &current_http,
                         &auth.base_url,
                         &auth.token,
+                        auth.registration_seq,
                         &payload,
                     )) => {
                         match result {
@@ -733,7 +784,12 @@ async fn send_critical_signal<T>(
             Ok(()) => return Some(Ok(())),
             Err(error)
                 if attempt + 1 < CRITICAL_SIGNAL_MAX_ATTEMPTS
-                    && !is_permanent_auth_error(&error.to_string()) =>
+                    && !is_permanent_auth_error(&error.to_string())
+                    // A 409 session fence is conclusive. Retrying the exact
+                    // same stale proof only burns the handshake window while
+                    // the ordinary lifecycle is already shutting this daemon
+                    // down on its next control poll.
+                    && !is_registration_conflict_error(&error.to_string()) =>
             {
                 warn!(
                     "Critical {signal_type} to {to_node_id} failed on attempt {}; retrying: {error}",

--- a/client/daemon/src/control/runtime/helpers.rs
+++ b/client/daemon/src/control/runtime/helpers.rs
@@ -85,6 +85,35 @@ fn is_permanent_auth_error(err: &str) -> bool {
         || err.contains("permanent auth")
 }
 
+/// Registration lifecycle conflicts are a fencing signal, not a transient
+/// transport failure. In particular, a stale process must never turn a 409
+/// into a fresh registration by manufacturing a larger incarnation.
+fn is_registration_conflict_error(err: &str) -> bool {
+    err.contains("registration conflict (registration_conflict)")
+        || err.contains("registration conflict (registration_protocol_upgrade_required)")
+        || err.contains("registration conflict (registration_incarnation_mismatch)")
+        || err.contains("registration conflict (registration_lifecycle_conflict)")
+}
+
+/// A lifecycle conflict means another daemon incarnation now owns this device
+/// credential.  It is not recoverable inside this process: re-registering a
+/// stale incarnation would either fail again or, on a partially upgraded
+/// server, risk taking ownership back from the newer daemon.
+async fn emit_registration_lifecycle_conflict(
+    health: Option<&Arc<crate::tasks::HealthState>>,
+    event_tx: &mpsc::UnboundedSender<ControlEvent>,
+    message: String,
+) {
+    error!("Control registration lifecycle conflict — restart required: {message}");
+    if let Some(health) = health {
+        health.set_control_connected(false);
+        health.set_device_lease_healthy(false);
+        health.set_reauth_required(true);
+    }
+    let _ = event_tx.send(ControlEvent::ReauthRequired { message });
+    let _ = event_tx.send(ControlEvent::Disconnected);
+}
+
 async fn current_relay_rtt_ms(
     relay_selection: Option<&Arc<RwLock<RelaySelectionDiagnostics>>>,
 ) -> Option<u64> {

--- a/client/daemon/src/control/runtime/loop.rs
+++ b/client/daemon/src/control/runtime/loop.rs
@@ -10,6 +10,7 @@ async fn run_control_loop(
     relay_selection: Option<Arc<RwLock<RelaySelectionDiagnostics>>>,
     critical_auth_tx: watch::Sender<Option<CriticalControlAuth>>,
     health: Option<Arc<crate::tasks::HealthState>>,
+    advertised_snapshot: Arc<std::sync::Mutex<AdvertisedEndpointSnapshot>>,
 ) {
     let base_url = normalize_http_base_url(&config.control.server_url);
 
@@ -38,7 +39,7 @@ async fn run_control_loop(
         // registration generation while this loop is reconnecting.
         let _ = critical_auth_tx.send(None);
         // ---- Registration with exponential backoff ----
-        let self_node_id = {
+        let (self_node_id, registration_seq) = {
             let mut attempt: u32 = 0;
             loop {
                 let registration = async {
@@ -47,11 +48,12 @@ async fn run_control_loop(
                 }
                 .await;
                 match registration {
-                    Ok((node_id, virtual_ip, cidr, server_relay_servers, relay_catalog)) => {
+                    Ok((node_id, virtual_ip, cidr, server_relay_servers, relay_catalog, registration_seq)) => {
                         let _ = critical_auth_tx.send(Some(CriticalControlAuth {
                             base_url: base_url.clone(),
                             token: token.clone(),
                             self_node_id: node_id.clone(),
+                            registration_seq,
                             signal_signing_identity: signal_signing_identity.clone(),
                         }));
                         if let Some(health) = health.as_ref() {
@@ -67,6 +69,14 @@ async fn run_control_loop(
                             let mut s = state.write().await;
                             s.registered = true;
                             s.virtual_ip = Some(virtual_ip.clone());
+                        }
+                        {
+                            let mut snap = advertised_snapshot.lock().unwrap();
+                            snap.endpoint.clear();
+                            snap.nat_type = "unknown".to_string();
+                            snap.generation = None;
+                            snap.lifecycle = None;
+                            snap.observation = None;
                         }
                         if !server_relay_servers.is_empty() {
                             config.relay.servers = server_relay_servers.clone();
@@ -115,6 +125,7 @@ async fn run_control_loop(
                             base_url: base_url.clone(),
                             token: token.clone(),
                             self_node_id: node_id.clone(),
+                            registration_seq,
                             signal_signing_identity: signal_signing_identity.clone(),
                         }));
 
@@ -167,13 +178,30 @@ async fn run_control_loop(
                             base_url: base_url.clone(),
                             token: token.clone(),
                             self_node_id: node_id.clone(),
+                            registration_seq,
                             signal_signing_identity: signal_signing_identity.clone(),
                         }));
 
-                        break node_id;
+                        break (node_id, registration_seq);
                     }
                     Err(err) => {
                         let err_str = err.to_string();
+                        if is_registration_conflict_error(&err_str) {
+                            // A persistent daemon incarnation is intentionally
+                            // not incremented in-process. Retrying this stale
+                            // request as if it were transient could let an old
+                            // process fence a newer one, so only a fresh daemon
+                            // boot may reserve a new incarnation.
+                            error!(
+                                "Control registration lifecycle conflict — restart required: {err_str}"
+                            );
+                            if let Some(health) = health.as_ref() {
+                                health.set_reauth_required(true);
+                            }
+                            let _ = event_tx.send(ControlEvent::ReauthRequired { message: err_str });
+                            let _ = event_tx.send(ControlEvent::Disconnected);
+                            return;
+                        }
                         if is_permanent_auth_error(&err_str) {
                             if token != user_token && !user_token.trim().is_empty() {
                                 warn!(
@@ -249,6 +277,7 @@ async fn run_control_loop(
                 &token,
                 &config,
                 &self_node_id,
+                registration_seq,
                 &state,
                 event_tx,
             )
@@ -256,7 +285,12 @@ async fn run_control_loop(
         }
         .await;
         if let Err(err) = initial_peer_poll {
-            warn!("Initial peer polling failed: {err}");
+            let err_str = err.to_string();
+            if is_registration_conflict_error(&err_str) {
+                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                return;
+            }
+            warn!("Initial peer polling failed: {err_str}");
             if let Some(health) = health.as_ref() {
                 health.set_control_connected(false);
             }
@@ -274,6 +308,7 @@ async fn run_control_loop(
                 &base_url,
                 &token,
                 &self_node_id,
+                registration_seq,
                 event_tx,
                 0,
                 &recent_signal_ids,
@@ -282,7 +317,12 @@ async fn run_control_loop(
         }
         .await;
         if let Err(err) = initial_signal_poll {
-            warn!("Initial signal polling failed: {err}");
+            let err_str = err.to_string();
+            if is_registration_conflict_error(&err_str) {
+                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                return;
+            }
+            warn!("Initial signal polling failed: {err_str}");
             if let Some(health) = health.as_ref() {
                 health.set_control_connected(false);
             }
@@ -302,6 +342,7 @@ async fn run_control_loop(
                 &token,
                 &self_node_id,
                 &config.network.network_id,
+                registration_seq,
                 signal_wake_tx.clone(),
                 signal_ws_connected.clone(),
             )
@@ -323,12 +364,18 @@ async fn run_control_loop(
         let mut poll_failures: u32 = 0;
         let mut signal_failures: u32 = 0;
         let mut heartbeat_failures: u32 = 0;
-        let mut advertised_endpoint = String::new();
-        let mut advertised_nat_type = "unknown".to_string();
         loop {
             tokio::select! {
                 _ = heartbeat_tick.tick() => {
+                    let (advertised_endpoint, advertised_nat_type) = {
+                        let snap = advertised_snapshot.lock().unwrap();
+                        (snap.endpoint.clone(), snap.nat_type.clone())
+                    };
                     let relay_rtt_ms = current_relay_rtt_ms(relay_selection.as_ref()).await;
+                    let advertised_nat_type = control_label_with_registration_seq(
+                        &advertised_nat_type,
+                        registration_seq,
+                    );
                     let heartbeat_result = async {
                         let current_http = http.current()?;
                         update_endpoint(
@@ -339,6 +386,7 @@ async fn run_control_loop(
                             &advertised_endpoint,
                             &advertised_nat_type,
                             relay_rtt_ms,
+                            registration_seq,
                         )
                         .await
                     }
@@ -360,6 +408,10 @@ async fn run_control_loop(
                         Err(err) => {
                             heartbeat_failures = heartbeat_failures.saturating_add(1);
                             let err_str = err.to_string();
+                            if is_registration_conflict_error(&err_str) {
+                                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                return;
+                            }
                             warn!(
                                 "Device lease refresh failed (attempt {heartbeat_failures}): {err_str}"
                             );
@@ -388,12 +440,26 @@ async fn run_control_loop(
                 _ = peer_roster_tick.tick() => {
                     let poll_result = async {
                         let current_http = http.current()?;
-                        poll_peers(&current_http, &base_url, &token, &config, &self_node_id, &state, event_tx).await
+                        poll_peers(
+                            &current_http,
+                            &base_url,
+                            &token,
+                            &config,
+                            &self_node_id,
+                            registration_seq,
+                            &state,
+                            event_tx,
+                        )
+                        .await
                     }
                     .await;
                     match &poll_result {
                         Err(e) => {
                             let err_str = e.to_string();
+                            if is_registration_conflict_error(&err_str) {
+                                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                return;
+                            }
                             if is_permanent_auth_error(&err_str) {
                                 error!("Permanent auth failure during polling: {err_str}");
                                 if let Some(health) = health.as_ref() {
@@ -454,7 +520,17 @@ async fn run_control_loop(
                 Some(()) = signal_wake_rx.recv() => {
                     let signal_result = async {
                         let current_http = http.current()?;
-                        poll_signals(&current_http, &base_url, &token, &self_node_id, event_tx, 0, &recent_signal_ids).await
+                        poll_signals(
+                            &current_http,
+                            &base_url,
+                            &token,
+                            &self_node_id,
+                            registration_seq,
+                            event_tx,
+                            0,
+                            &recent_signal_ids,
+                        )
+                        .await
                     }
                     .await;
                     match signal_result {
@@ -467,6 +543,10 @@ async fn run_control_loop(
                         }
                         Err(e) => {
                             let err_str = e.to_string();
+                            if is_registration_conflict_error(&err_str) {
+                                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                return;
+                            }
                             if is_permanent_auth_error(&err_str) {
                                 error!("Permanent auth failure after WebSocket signal wake: {err_str}");
                                 if let Some(health) = health.as_ref() {
@@ -496,7 +576,17 @@ async fn run_control_loop(
                     let wait_ms = signal_poll_wait_ms(ws_connected);
                     let signal_result = async {
                         let current_http = http.current()?;
-                        poll_signals(&current_http, &base_url, &token, &self_node_id, event_tx, wait_ms, &recent_signal_ids).await
+                        poll_signals(
+                            &current_http,
+                            &base_url,
+                            &token,
+                            &self_node_id,
+                            registration_seq,
+                            event_tx,
+                            wait_ms,
+                            &recent_signal_ids,
+                        )
+                        .await
                     }
                     .await;
                     match signal_result {
@@ -509,6 +599,10 @@ async fn run_control_loop(
                         }
                         Err(e) => {
                             let err_str = e.to_string();
+                            if is_registration_conflict_error(&err_str) {
+                                emit_registration_lifecycle_conflict(health.as_ref(), event_tx, err_str).await;
+                                return;
+                            }
                             if is_permanent_auth_error(&err_str) {
                                 error!("Permanent auth failure during signal polling: {err_str}");
                                 if let Some(health) = health.as_ref() {

--- a/client/daemon/src/control/shutdown.rs
+++ b/client/daemon/src/control/shutdown.rs
@@ -110,7 +110,14 @@ impl ControlSupervisor {
             if let Some(auth) = auth {
                 let release = async {
                     let http = self.http.current()?;
-                    release_presence(&http, &auth.base_url, &auth.token, &auth.self_node_id).await
+                    release_presence(
+                        &http,
+                        &auth.base_url,
+                        &auth.token,
+                        &auth.self_node_id,
+                        auth.registration_seq,
+                    )
+                    .await
                 };
                 match timeout(Duration::from_millis(1250), release).await {
                     Ok(Ok(())) => info!(reason_code = "presence_released", "Device presence released"),

--- a/client/daemon/src/control/tests.rs
+++ b/client/daemon/src/control/tests.rs
@@ -30,6 +30,143 @@ fn manual_register_payload_keeps_requested_virtual_ip() {
 }
 
 #[test]
+fn registration_payload_uses_persisted_incarnation_without_a_wall_clock_fallback() {
+    let config = test_config();
+
+    let fenced = register_device_payload_with_incarnation(&config, 42);
+    assert_eq!(fenced["registration_incarnation"], 42);
+
+    let unavailable = register_device_payload_with_incarnation(&config, 0);
+    assert!(unavailable.get("registration_incarnation").is_none());
+}
+
+#[tokio::test]
+async fn registration_rejects_partial_lifecycle_response() {
+    async fn registration_result(body: &'static str) -> Result<()> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let config = test_config();
+        let result = register_device(
+            &test_no_proxy_client(),
+            &format!("http://{address}"),
+            "test-token",
+            &config,
+        )
+        .await
+        .map(|_| ());
+        server.await.unwrap();
+        result
+    }
+
+    let missing_incarnation = registration_result(
+        r#"{"success":true,"node_id":"node-a","virtual_ip":"10.20.0.2","cidr":"10.20.0.0/16","registration_seq":7}"#,
+    )
+    .await
+    .expect_err("a sequence without its incarnation must not enable session fencing");
+    assert!(missing_incarnation
+        .to_string()
+        .contains("omitted registration_incarnation"));
+
+    let missing_sequence = registration_result(
+        r#"{"success":true,"node_id":"node-a","virtual_ip":"10.20.0.2","cidr":"10.20.0.0/16","registration_incarnation":7}"#,
+    )
+    .await
+    .expect_err("an incarnation without its sequence must not enable session fencing");
+    assert!(missing_sequence
+        .to_string()
+        .contains("omitted a valid registration_seq"));
+}
+
+#[test]
+fn endpoint_control_label_replaces_untrusted_lifecycle_and_stays_bounded() {
+    let base = "p2v2:m=endpoint_independent;a=stable;d=0;c=100;f=endpoint_independent;h=supported;g=18446744073709551615;o=18446744073709551615;l=1";
+    let label = control_label_with_registration_seq(base, Some(2));
+
+    assert!(
+        label.len() <= 128,
+        "label exceeds server field cap: {label}"
+    );
+    assert_eq!(extract_nat_lifecycle(&label), Some(2));
+    assert!(!label.contains("l=1"));
+    assert_eq!(
+        control_label_with_registration_seq("unknown", Some(9)),
+        "p2v2:l=9"
+    );
+    assert_eq!(
+        control_label_with_registration_seq("p2v2:m=endpoint_independent;l=1", None),
+        "p2v2:m=endpoint_independent;l=1"
+    );
+}
+
+#[test]
+fn registration_conflicts_are_never_treated_as_transient_auth_or_network_errors() {
+    assert!(is_registration_conflict_error(
+        "registration conflict (registration_conflict) current_registration_seq=3: registration sequence conflict"
+    ));
+    assert!(is_registration_conflict_error(
+        "registration conflict (registration_protocol_upgrade_required) current_registration_seq=3: registration requires a sequence-aware client"
+    ));
+    assert!(!is_registration_conflict_error(
+        "register request returned HTTP 503"
+    ));
+}
+
+#[test]
+fn advertised_endpoint_snapshot_keeps_newer_observation_and_registration_fences() {
+    let mut snapshot = AdvertisedEndpointSnapshot::default();
+    let base = "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown";
+    let endpoint = "203.0.113.7:41000".to_string();
+
+    snapshot.update(endpoint.clone(), format!("{base};g=7;o=2;l=5"));
+    assert_eq!(snapshot.endpoint, endpoint);
+    assert_eq!(snapshot.generation, Some(7));
+    assert_eq!(snapshot.observation, Some(2));
+    assert_eq!(snapshot.lifecycle, Some(5));
+
+    // A delayed ordinary lane request cannot replace a newer critical-lane
+    // observation, remove its o fence, or regress the registration lifecycle.
+    snapshot.update(
+        "203.0.113.99:41000".to_string(),
+        format!("{base};g=7;o=1;l=5"),
+    );
+    snapshot.update("203.0.113.98:41000".to_string(), format!("{base};g=7;l=5"));
+    snapshot.update(
+        "203.0.113.97:41000".to_string(),
+        format!("{base};g=99;o=99;l=4"),
+    );
+    assert_eq!(snapshot.endpoint, endpoint);
+    assert_eq!(snapshot.observation, Some(2));
+    assert_eq!(snapshot.lifecycle, Some(5));
+
+    // A real same-capability observation advances o. A newer server lifecycle
+    // may intentionally reset the daemon's local g/o counters.
+    snapshot.update(
+        "203.0.113.8:41000".to_string(),
+        format!("{base};g=7;o=3;l=5"),
+    );
+    assert_eq!(snapshot.observation, Some(3));
+    snapshot.update(
+        "203.0.113.9:41000".to_string(),
+        format!("{base};g=1;o=1;l=6"),
+    );
+    assert_eq!(snapshot.endpoint, "203.0.113.9:41000");
+    assert_eq!(snapshot.generation, Some(1));
+    assert_eq!(snapshot.observation, Some(1));
+    assert_eq!(snapshot.lifecycle, Some(6));
+}
+
+#[test]
 fn ordinary_endpoint_update_uses_the_device_lease_health_lane() {
     // `commands.rs` is include!-spliced inside the runtime select branch, so a
     // source-level contract assertion is the narrowest regression test for

--- a/client/daemon/src/control/tests/client.rs
+++ b/client/daemon/src/control/tests/client.rs
@@ -341,6 +341,7 @@ async fn poll_signals_skips_bad_handshake_without_dropping_healthy_signals() {
         &format!("http://{address}"),
         "test-token",
         "node-a",
+        None,
         &event_tx,
         0,
         &Arc::new(tokio::sync::Mutex::new(
@@ -384,8 +385,10 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let ack_posts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let missing_registration_sequence = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let server = {
         let ack_posts = ack_posts.clone();
+        let missing_registration_sequence = missing_registration_sequence.clone();
         tokio::spawn(async move {
             loop {
                 let (mut stream, _) = listener.accept().await.unwrap();
@@ -404,6 +407,11 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
                     }
                 }
                 let request = String::from_utf8_lossy(&buf);
+                if !request.lines().any(|line| {
+                    line.eq_ignore_ascii_case("x-p2wlan-registration-seq: 41")
+                }) {
+                    missing_registration_sequence.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
                 if request.starts_with("POST") {
                     // The ACK request: count it and reply success.
                     ack_posts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -457,6 +465,7 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
         &format!("http://{address}"),
         "test-token",
         "node-a",
+        Some(41),
         &event_tx,
         0,
         &dedup,
@@ -489,6 +498,7 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
         &format!("http://{address}"),
         "test-token",
         "node-a",
+        Some(41),
         &event_tx,
         0,
         &dedup,
@@ -525,6 +535,7 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
         &format!("http://{address}"),
         "test-token",
         "node-a",
+        Some(41),
         &event_tx,
         0,
         &dedup,
@@ -542,6 +553,11 @@ async fn poll_signals_ack_mode_applies_then_acks_and_dedupes_redelivery() {
     })
     .await
     .expect("the redelivered batch must still be ACKed");
+    assert_eq!(
+        missing_registration_sequence.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "every signal GET and ACK from an incarnation-aware daemon must carry its registration sequence"
+    );
     server.abort();
 }
 

--- a/client/daemon/src/control/tests/peers.rs
+++ b/client/daemon/src/control/tests/peers.rs
@@ -31,6 +31,7 @@ async fn poll_peers_preserves_offline_devices_from_control_plane() {
         "test-token",
         &config,
         "self-node",
+        None,
         &state,
         &event_tx,
     )
@@ -94,6 +95,7 @@ async fn poll_peers_admits_online_peer_before_historical_offline_rows() {
         "test-token",
         &config,
         "self-node",
+        None,
         &state,
         &event_tx,
     )

--- a/client/daemon/src/control/tests/websocket.rs
+++ b/client/daemon/src/control/tests/websocket.rs
@@ -37,6 +37,13 @@ async fn signal_websocket_authenticates_negotiates_and_wakes() {
                             .and_then(|value| value.to_str().ok()),
                         Some(SIGNAL_WS_PROTOCOL)
                     );
+                    assert_eq!(
+                        request
+                            .headers()
+                            .get("x-p2wlan-registration-seq")
+                            .and_then(|value| value.to_str().ok()),
+                        Some("37")
+                    );
                     response.headers_mut().insert(
                         SEC_WEBSOCKET_PROTOCOL,
                         HeaderValue::from_static(SIGNAL_WS_PROTOCOL),
@@ -87,6 +94,7 @@ async fn signal_websocket_authenticates_negotiates_and_wakes() {
             "dc-test-token",
             "node-a",
             "network-a",
+            Some(37),
             wake_tx,
             client_connected,
         )

--- a/client/daemon/src/control/types.rs
+++ b/client/daemon/src/control/types.rs
@@ -394,6 +394,15 @@ struct RegisterDeviceResponse {
     node_id: Option<String>,
     virtual_ip: Option<String>,
     cidr: Option<String>,
+    /// Server-issued lifecycle for endpoint publications. Older servers omit
+    /// it, so the client keeps the protocol additive during a rolling update.
+    #[serde(default)]
+    registration_seq: Option<u64>,
+    /// Echo of the daemon's persisted boot incarnation. It lets the client
+    /// reject a malformed success response rather than publishing endpoint
+    /// metadata for a different process.
+    #[serde(default)]
+    registration_incarnation: Option<u64>,
     #[serde(default)]
     relay_servers: Vec<String>,
     #[serde(default)]
@@ -404,6 +413,10 @@ struct RegisterDeviceResponse {
 #[derive(Debug, Deserialize)]
 struct ControlErrorResponse {
     error: Option<String>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    registration_seq: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -643,6 +656,9 @@ struct CriticalControlAuth {
     base_url: String,
     token: String,
     self_node_id: String,
+    /// Server-issued lifecycle used to fence endpoint publications from a
+    /// daemon process that was superseded while its request was in flight.
+    registration_seq: Option<u64>,
     signal_signing_identity: Option<SignalSigningIdentity>,
 }
 
@@ -654,6 +670,7 @@ impl CriticalControlAuth {
         self.base_url == other.base_url
             && self.token == other.token
             && self.self_node_id == other.self_node_id
+            && self.registration_seq == other.registration_seq
     }
 }
 
@@ -803,10 +820,144 @@ enum ControlCommand {
         region: String,
         response_tx: tokio::sync::oneshot::Sender<Result<FetchRelayTicketResponse>>,
     },
+    /// A server-verified registration sequence rejected an in-flight action.
+    /// The ordinary lifecycle owns the terminal transition so the critical
+    /// handshake lane cannot continue publishing with a fenced identity.
+    LifecycleConflict { message: String },
     /// Shutdown after best-effort release of the server-side presence lease.
     Shutdown {
         /// A bounded graceful-shutdown acknowledgement. The control loop
         /// sends this after the release request has completed or timed out.
         response_tx: tokio::sync::oneshot::Sender<()>,
     },
+}
+
+/// Unified, versioned snapshot of the advertised UDP endpoint and NAT profile.
+/// Shared across the critical handshake lane, ordinary command lane, and periodic heartbeat
+/// to prevent stale cached values from overwriting newer publications.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AdvertisedEndpointSnapshot {
+    pub endpoint: String,
+    pub nat_type: String,
+    pub generation: Option<u64>,
+    /// Server-issued registration lifecycle (`l=`) of the accepted
+    /// publication. A newer lifecycle may restart `g`/`o`; an older one may
+    /// not overwrite this process's latest endpoint.
+    pub lifecycle: Option<u64>,
+    /// Latest real NAT observation (`o=`) accepted for this generation and
+    /// lifecycle. Heartbeats replay this value unchanged.
+    pub observation: Option<u64>,
+}
+
+impl AdvertisedEndpointSnapshot {
+    pub fn update(&mut self, endpoint: String, nat_type: String) {
+        let incoming_gen = extract_nat_generation(&nat_type);
+        let incoming_lifecycle = extract_nat_lifecycle(&nat_type);
+        let incoming_observation = extract_nat_observation(&nat_type);
+        let lifecycle_advanced = match (self.lifecycle, incoming_lifecycle) {
+            (Some(current), Some(incoming)) if incoming < current => return,
+            // Once a registration lifecycle is known, an unlabeled request
+            // cannot replace it. This blocks an old command lane publication
+            // from clobbering a newly registered process's snapshot.
+            (Some(_), None) => return,
+            (Some(current), Some(incoming)) => incoming > current,
+            (None, _) => false,
+        };
+        let accepts = if lifecycle_advanced {
+            true
+        } else {
+            match (self.generation, incoming_gen) {
+            (Some(current), Some(incoming)) => {
+                if incoming < current {
+                    false
+                } else if incoming == current {
+                    let current_hint = p2pnet_nat::parse_nat_hint(&self.nat_type);
+                    let incoming_hint = p2pnet_nat::parse_nat_hint(&nat_type);
+                    if current_hint.parsed && incoming_hint.parsed {
+                        if current_hint.mapping != p2pnet_nat::MappingBehavior::Unknown
+                            && incoming_hint.mapping != p2pnet_nat::MappingBehavior::Unknown
+                            && current_hint.mapping != incoming_hint.mapping
+                        {
+                            return;
+                        }
+                        if current_hint.filtering != p2pnet_nat::FilteringBehavior::Unknown
+                            && incoming_hint.filtering != p2pnet_nat::FilteringBehavior::Unknown
+                            && current_hint.filtering != incoming_hint.filtering
+                        {
+                            return;
+                        }
+                        if current_hint.allocation != p2pnet_nat::NatAllocation::Unknown
+                            && incoming_hint.allocation != p2pnet_nat::NatAllocation::Unknown
+                            && current_hint.allocation != incoming_hint.allocation
+                        {
+                            return;
+                        }
+                    }
+                    match (self.observation, incoming_observation) {
+                        (Some(current), Some(incoming)) if incoming < current => return,
+                        // Do not let an older cached label lose its real
+                        // observation fence and turn later heartbeats into a
+                        // pseudo-freshness source.
+                        (Some(_), None) => return,
+                        _ => {}
+                    }
+                    if endpoint.trim().is_empty() && !self.endpoint.trim().is_empty() {
+                        return;
+                    }
+                    true
+                } else {
+                    true
+                }
+            }
+            (Some(_), None) => false,
+            (None, _) => true,
+            }
+        };
+        if accepts {
+            self.endpoint = endpoint;
+            self.nat_type = nat_type;
+            self.generation = incoming_gen;
+            self.lifecycle = incoming_lifecycle;
+            self.observation = incoming_observation;
+        }
+    }
+}
+
+pub fn extract_nat_generation(input: &str) -> Option<u64> {
+    if let Some(hint) = p2pnet_nat::parse_nat_hint(input).profile_generation {
+        return Some(hint);
+    }
+    for part in input.split(|c: char| c == ';' || c == ' ' || c == '(' || c == ')') {
+        if let Some(val) = part.strip_prefix("g=") {
+            if let Ok(gen) = val.parse::<u64>() {
+                return Some(gen);
+            }
+        }
+    }
+    None
+}
+
+pub fn extract_nat_observation(input: &str) -> Option<u64> {
+    if let Some(hint) = p2pnet_nat::parse_nat_hint(input).observation_sequence {
+        return Some(hint);
+    }
+    extract_nat_label_u64(input, "o")
+}
+
+pub fn extract_nat_lifecycle(input: &str) -> Option<u64> {
+    if let Some(hint) = p2pnet_nat::parse_nat_hint(input).registration_lifecycle {
+        return Some(hint);
+    }
+    extract_nat_label_u64(input, "l")
+}
+
+fn extract_nat_label_u64(input: &str, key: &str) -> Option<u64> {
+    for part in input.split(|c: char| c == ';' || c == ' ' || c == '(' || c == ')') {
+        if let Some(value) = part.strip_prefix(&format!("{key}=")) {
+            if let Ok(value) = value.parse::<u64>() {
+                return Some(value);
+            }
+        }
+    }
+    None
 }

--- a/client/daemon/src/control/types.rs
+++ b/client/daemon/src/control/types.rs
@@ -927,7 +927,7 @@ pub fn extract_nat_generation(input: &str) -> Option<u64> {
     if let Some(hint) = p2pnet_nat::parse_nat_hint(input).profile_generation {
         return Some(hint);
     }
-    for part in input.split(|c: char| c == ';' || c == ' ' || c == '(' || c == ')') {
+    for part in input.split([';', ' ', '(', ')']) {
         if let Some(val) = part.strip_prefix("g=") {
             if let Ok(gen) = val.parse::<u64>() {
                 return Some(gen);
@@ -952,7 +952,7 @@ pub fn extract_nat_lifecycle(input: &str) -> Option<u64> {
 }
 
 fn extract_nat_label_u64(input: &str, key: &str) -> Option<u64> {
-    for part in input.split(|c: char| c == ';' || c == ' ' || c == '(' || c == ')') {
+    for part in input.split([';', ' ', '(', ')']) {
         if let Some(value) = part.strip_prefix(&format!("{key}=")) {
             if let Ok(value) = value.parse::<u64>() {
                 return Some(value);

--- a/client/daemon/src/control/websocket.rs
+++ b/client/daemon/src/control/websocket.rs
@@ -18,7 +18,9 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tokio::time;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL};
+use tokio_tungstenite::tungstenite::http::header::{
+    HeaderName, AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL,
+};
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
 use tracing::{debug, info, warn};
@@ -139,6 +141,7 @@ pub(super) fn spawn_signal_websocket(
     token: &str,
     node_id: &str,
     network_id: &str,
+    registration_seq: Option<u64>,
     wake_tx: mpsc::Sender<()>,
     connected: Arc<AtomicBool>,
 ) -> SignalWebSocketTask {
@@ -154,6 +157,7 @@ pub(super) fn spawn_signal_websocket(
             &token,
             &node_id,
             &network_id,
+            registration_seq,
             wake_tx,
             task_lifecycle,
         )
@@ -168,6 +172,7 @@ pub(super) async fn run_signal_websocket(
     token: &str,
     expected_node_id: &str,
     expected_network_id: &str,
+    registration_seq: Option<u64>,
     wake_tx: mpsc::Sender<()>,
     connected: Arc<AtomicBool>,
 ) {
@@ -176,6 +181,7 @@ pub(super) async fn run_signal_websocket(
         token,
         expected_node_id,
         expected_network_id,
+        registration_seq,
         wake_tx,
         SignalConnectionLifecycle::new(connected),
     )
@@ -187,6 +193,7 @@ async fn run_signal_websocket_with_lifecycle(
     token: &str,
     expected_node_id: &str,
     expected_network_id: &str,
+    registration_seq: Option<u64>,
     wake_tx: mpsc::Sender<()>,
     lifecycle: SignalConnectionLifecycle,
 ) {
@@ -223,6 +230,19 @@ async fn run_signal_websocket_with_lifecycle(
             SEC_WEBSOCKET_PROTOCOL,
             HeaderValue::from_static(SIGNAL_WS_PROTOCOL),
         );
+        if let Some(registration_seq) = registration_seq.filter(|seq| *seq > 0) {
+            let registration_seq = match HeaderValue::from_str(&registration_seq.to_string()) {
+                Ok(value) => value,
+                Err(_) => {
+                    warn!("WebSocket signaling disabled: invalid registration sequence header");
+                    return;
+                }
+            };
+            request.headers_mut().insert(
+                HeaderName::from_static("x-p2wlan-registration-seq"),
+                registration_seq,
+            );
+        }
 
         // Proxy policy: WebSocket signaling is ALWAYS direct-only. The raw
         // TCP socket is created explicitly so direct-only also means bypassing

--- a/client/daemon/src/incarnation.rs
+++ b/client/daemon/src/incarnation.rs
@@ -16,10 +16,14 @@
 //! re-seed after a clock rollback would otherwise let an older incarnation
 //! look newer than the high-water a receiver already recorded.
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Mutex, OnceLock,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use fs2::FileExt;
@@ -56,6 +60,13 @@ pub struct IncarnationState {
 /// path (`next_candidate_generation`) without re-reading the state file.
 static LOCAL_INCARNATION: AtomicU64 = AtomicU64::new(0);
 
+/// A room profile is registered before Android creates its daemon.  Keep the
+/// durable incarnation reserved for that registration until the immediately
+/// following `Daemon::new` consumes it.  The key is the profile path, not the
+/// state-file directory: several room profiles can legitimately share an app
+/// directory and must never consume one another's reservation.
+static PREPARED_BOOT_INCARNATIONS: OnceLock<Mutex<HashMap<PathBuf, u64>>> = OnceLock::new();
+
 /// Record the incarnation of the current boot for this process.
 pub fn set_local_incarnation(incarnation: u64) {
     LOCAL_INCARNATION.store(incarnation, Ordering::Relaxed);
@@ -64,6 +75,85 @@ pub fn set_local_incarnation(incarnation: u64) {
 /// The current boot's incarnation, or 0 when no daemon was constructed yet.
 pub fn local_incarnation() -> u64 {
     LOCAL_INCARNATION.load(Ordering::Relaxed)
+}
+
+fn prepared_boot_incarnations() -> &'static Mutex<HashMap<PathBuf, u64>> {
+    PREPARED_BOOT_INCARNATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Reserve an incarnation for a pre-daemon authenticated registration.
+///
+/// Android prepares a room profile by registering it before it owns the VPN
+/// fd and creates the daemon.  That registration and the daemon it launches
+/// form one boot, so they must use the same incarnation. A caller that retries
+/// before discarding its failed preparation reuses the same reservation;
+/// Android discards failed preparations so a later user-initiated start is a
+/// separate boot.
+///
+/// Call [`take_prepared_or_next_boot_incarnation`] when constructing the
+/// daemon.  Other callers should continue to use [`next_boot_incarnation`].
+pub fn reserve_boot_incarnation(config: &Config) -> Option<u64> {
+    let Some(config_path) = config.config_path.clone() else {
+        return next_boot_incarnation(config);
+    };
+
+    let mut prepared = prepared_boot_incarnations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(&incarnation) = prepared.get(&config_path) {
+        set_local_incarnation(incarnation);
+        return Some(incarnation);
+    }
+
+    let incarnation = next_boot_incarnation(config)?;
+    prepared.insert(config_path, incarnation);
+    Some(incarnation)
+}
+
+/// Consume a room-preparation reservation, or reserve a normal new boot.
+///
+/// This is the daemon-construction counterpart of
+/// [`reserve_boot_incarnation`].  A reservation is intentionally single-use:
+/// the next daemon start after it has been consumed is a distinct boot and
+/// must advance the durable counter.
+pub fn take_prepared_or_next_boot_incarnation(config: &Config) -> Option<u64> {
+    if let Some(config_path) = config.config_path.as_ref() {
+        let prepared = prepared_boot_incarnations()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(config_path);
+        if let Some(incarnation) = prepared {
+            set_local_incarnation(incarnation);
+            return Some(incarnation);
+        }
+    }
+
+    next_boot_incarnation(config)
+}
+
+/// Discard a pre-daemon reservation that will not lead to a daemon boot.
+///
+/// Android calls this when room registration, the final start-state check, or
+/// profile persistence fails.  It only removes the matching profile's
+/// reservation; a successful room preparation must leave its reservation in
+/// place for [`take_prepared_or_next_boot_incarnation`].
+pub fn discard_prepared_boot_incarnation(config: &Config) {
+    let Some(config_path) = config.config_path.as_ref() else {
+        return;
+    };
+
+    let discarded = prepared_boot_incarnations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(config_path);
+    if discarded.is_some_and(|incarnation| local_incarnation() == incarnation) {
+        set_local_incarnation(0);
+    }
+}
+
+fn disable_local_incarnation() -> Option<u64> {
+    set_local_incarnation(0);
+    None
 }
 
 pub fn incarnation_path(config: &Config) -> Option<PathBuf> {
@@ -187,7 +277,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
             warn!(
                 "Fresh-mapping prediction disabled: no config path, so no durable incarnation state exists for this boot"
             );
-            return None;
+            return disable_local_incarnation();
         }
     };
     let lock_path = path
@@ -231,7 +321,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                     "Fresh-mapping prediction disabled: cannot open the incarnation lock at {}: {error}",
                     lock_path.display()
                 );
-                return None;
+                return disable_local_incarnation();
             }
         };
         if let Err(error) = lock_file.lock_exclusive() {
@@ -239,7 +329,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                 "Fresh-mapping prediction disabled: cannot lock the incarnation state at {}: {error}",
                 lock_path.display()
             );
-            return None;
+            return disable_local_incarnation();
         }
         let lock_guard = LockGuard(lock_file);
 
@@ -250,7 +340,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                     "Fresh-mapping prediction disabled for this boot: the persisted incarnation at {} is missing its trusted monotonic state (corrupt, unreadable, or an incompatible version); refusing to re-seed from the wall clock. Remove the file to re-seed deliberately.",
                     path.display()
                 );
-                return None;
+                return disable_local_incarnation();
             }
         };
         let loaded = match loaded {
@@ -267,7 +357,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                         path.display(),
                         lock_path.display()
                     );
-                    return None;
+                    return disable_local_incarnation();
                 }
                 state_loss_confirms -= 1;
                 std::thread::sleep(std::time::Duration::from_millis(10));
@@ -289,7 +379,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                         "Fresh-mapping prediction disabled: failed to persist the first-boot incarnation at {}: {error}",
                         path.display()
                     );
-                    return None;
+                    return disable_local_incarnation();
                 }
                 set_local_incarnation(seed.incarnation);
                 return Some(seed.incarnation);
@@ -300,7 +390,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                 "Fresh-mapping prediction disabled: the persisted incarnation {} reached the u64 limit; refusing to wrap back to a value receivers already recorded",
                 loaded.incarnation
             );
-            return None;
+            return disable_local_incarnation();
         };
         let state = IncarnationState {
             version: INCARNATION_VERSION,
@@ -312,7 +402,7 @@ pub fn next_boot_incarnation(config: &Config) -> Option<u64> {
                 "Fresh-mapping prediction disabled: failed to persist the incremented incarnation at {}: {error}",
                 path.display()
             );
-            return None;
+            return disable_local_incarnation();
         }
         break next;
     };
@@ -402,6 +492,68 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(state.incarnation, second);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pre_registration_reservation_is_reused_once_by_the_daemon_boot() {
+        let dir = isolate("pre-registration");
+        let config = temp_config(Some(dir.join("room-profile.json")));
+
+        let prepared = reserve_boot_incarnation(&config)
+            .expect("room preparation must reserve a durable incarnation");
+        assert_eq!(
+            reserve_boot_incarnation(&config),
+            Some(prepared),
+            "a retried room registration must keep the same server-side fence"
+        );
+        assert_eq!(
+            take_prepared_or_next_boot_incarnation(&config),
+            Some(prepared),
+            "the following daemon must consume the pre-registration value"
+        );
+
+        let following_boot = take_prepared_or_next_boot_incarnation(&config)
+            .expect("a later daemon start reserves a new value");
+        assert!(
+            following_boot > prepared,
+            "the reservation is single-use and must not mask a real restart"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pre_registration_reservations_are_scoped_to_each_profile_path() {
+        let dir = isolate("profile-scoped-pre-registration");
+        let first = temp_config(Some(dir.join("room-a.json")));
+        let second = temp_config(Some(dir.join("room-b.json")));
+
+        let first_reserved = reserve_boot_incarnation(&first).unwrap();
+        let second_reserved = reserve_boot_incarnation(&second).unwrap();
+        assert_ne!(first_reserved, second_reserved);
+        assert_eq!(
+            take_prepared_or_next_boot_incarnation(&first),
+            Some(first_reserved)
+        );
+        assert_eq!(
+            take_prepared_or_next_boot_incarnation(&second),
+            Some(second_reserved)
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discarded_pre_registration_reservation_cannot_be_consumed_by_a_later_boot() {
+        let dir = isolate("discarded-pre-registration");
+        let config = temp_config(Some(dir.join("room-profile.json")));
+
+        let discarded = reserve_boot_incarnation(&config).unwrap();
+        discard_prepared_boot_incarnation(&config);
+        let later_boot = take_prepared_or_next_boot_incarnation(&config).unwrap();
+        assert!(
+            later_boot > discarded,
+            "a failed room preparation must not leak its lifecycle into a later start"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -781,31 +781,71 @@ impl Daemon {
     async fn wait_for_peer_offer_identity(
         &self,
         peer_id: &str,
+        expected_sender_public_key: Option<&str>,
         cancellation: &mut watch::Receiver<bool>,
     ) -> bool {
         let deadline = Instant::now() + UNKNOWN_PEER_OFFER_WAIT;
         loop {
             if self
                 .peers
-                .peer_identity_public_key_sync(peer_id)
-                .is_some()
+                .signal_sender_identity_matches_peer_sync(peer_id, expected_sender_public_key)
+                && self.peers.peer_session_generation_sync(peer_id).is_some()
             {
                 return true;
             }
             if self
                 .restore_peer_offer_identity_from_control_roster(peer_id)
                 .await
+                && self
+                    .peers
+                    .signal_sender_identity_matches_peer_sync(peer_id, expected_sender_public_key)
+                && self.peers.peer_session_generation_sync(peer_id).is_some()
             {
                 return true;
             }
             if *cancellation.borrow() {
                 return false;
             }
+            let recorded_key = self.peers.peer_identity_recorded_public_key_sync(peer_id);
+            if let (Some(recorded), Some(expected)) = (recorded_key.as_deref(), expected_sender_public_key) {
+                if !expected.trim().is_empty() && !recorded.trim().is_empty() && expected.trim() != recorded.trim() {
+                    debug!(
+                        "Rejecting peer offer from {peer_id}: sender key {expected} does not match recorded key {recorded}"
+                    );
+                    self.timeline.emit(
+                        "peer_offer_rejected",
+                        None,
+                        Some("sender_key_mismatch"),
+                        Some(format!("peer={peer_id}")),
+                    );
+                    return false;
+                }
+            }
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
+                let peers_snapshot = self.control.peers().await;
+                let peer_entry = peers_snapshot.get(peer_id);
+                let reason = match peer_entry {
+                    None => "membership_revoked",
+                    Some(peer) if !peer.online => "peer_lifecycle_pending",
+                    Some(peer)
+                        if expected_sender_public_key.is_some_and(|k| {
+                            !k.trim().is_empty() && k.trim() != peer.public_key.trim()
+                        }) =>
+                    {
+                        "sender_key_mismatch"
+                    }
+                    _ => "peer_lifecycle_pending",
+                };
                 debug!(
-                    "Dropping deferred peer offer from {peer_id}: peer identity was not registered within {:?}",
+                    "Dropping deferred peer offer from {peer_id}: peer identity was not registered within {:?}, reason={reason}",
                     UNKNOWN_PEER_OFFER_WAIT
+                );
+                self.timeline.emit(
+                    "peer_offer_rejected",
+                    None,
+                    Some(reason),
+                    Some(format!("peer={peer_id}")),
                 );
                 return false;
             }
@@ -1628,9 +1668,32 @@ impl Daemon {
                 return;
             }
             if !self
-                .wait_for_peer_offer_identity(&offer.from_node_id, &mut reservation.cancellation)
+                .wait_for_peer_offer_identity(
+                    &offer.from_node_id,
+                    offer.sender_public_key.as_deref(),
+                    &mut reservation.cancellation,
+                )
                 .await
             {
+                let peers_snapshot = self.control.peers().await;
+                let peer_entry = peers_snapshot.get(&peer_id);
+                let terminal = match peer_entry {
+                    None => true,
+                    Some(peer)
+                        if offer
+                            .sender_public_key
+                            .as_deref()
+                            .is_some_and(|k| !k.trim().is_empty() && k.trim() != peer.public_key.trim()) =>
+                    {
+                        true
+                    }
+                    _ => false,
+                };
+                let outcome = if terminal {
+                    control::SignalApplyOutcome::TerminalRejected
+                } else {
+                    control::SignalApplyOutcome::Retry
+                };
                 // A newer offer may have replaced the timed-out value while
                 // the peer was still unknown.  Consume it under the same
                 // owner; otherwise release the owner so a later signal can
@@ -1640,10 +1703,10 @@ impl Daemon {
                     .lock()
                     .finish_responder_work(&peer_id, reservation.owner)
                 else {
-                    offer.complete_delivery(control::SignalApplyOutcome::Retry);
+                    offer.complete_delivery(outcome);
                     return;
                 };
-                offer.complete_delivery(control::SignalApplyOutcome::Retry);
+                offer.complete_delivery(outcome);
                 offer = next;
                 continue;
             }
@@ -1794,7 +1857,11 @@ impl Daemon {
                 return;
             }
             if !self
-                .wait_for_peer_offer_identity(&peer_id, &mut reservation.cancellation)
+                .wait_for_peer_offer_identity(
+                    &peer_id,
+                    offer.sender_public_key.as_deref(),
+                    &mut reservation.cancellation,
+                )
                 .await
             {
                 let Some(next) = self
@@ -3263,15 +3330,37 @@ impl Daemon {
                             )),
                         );
                         let peer_known = self.peers.peer_exists_sync(&from_node_id);
-                        if !peer_known {
-                            // REST signal delivery can beat the independent roster poll.
-                            // Both bounded owners wait for identity publication; waking
-                            // the poll keeps that interval short without blocking this actor.
-                            self.control.refresh_peers_now();
-                        } else if !self.signal_sender_identity_matches_peer(
+                        let peer_online = self
+                            .peers
+                            .peer_session_generation_sync(&from_node_id)
+                            .is_some();
+                        let identity_matches = self.signal_sender_identity_matches_peer(
                             &from_node_id,
                             sender_public_key.as_deref(),
-                        ) {
+                        );
+                        if peer_known && peer_online && identity_matches {
+                            // Fast path: peer is known, online, and sender identity matches.
+                        } else if !peer_known || !peer_online {
+                            // REST signal delivery can beat the independent roster poll,
+                            // or the peer is known from a previous poll but recorded as offline.
+                            // Both bounded owners wait for identity/online publication; waking
+                            // the poll keeps that interval short without blocking this actor.
+                            self.control.refresh_peers_now();
+                            let reason = if !peer_known {
+                                "peer_unknown"
+                            } else {
+                                "peer_lifecycle_pending"
+                            };
+                            self.timeline.emit(
+                                "remote_signal_deferred",
+                                None,
+                                Some(reason),
+                                Some(format!(
+                                    "peer={from_node_id} candidate_generation={candidate_generation}"
+                                )),
+                            );
+                        } else {
+                            // Peer is known and online, but sender public key does not match.
                             self.peers.record_direct_event_non_queuing(
                                 &from_node_id,
                                 "remote_signal_stale_identity",
@@ -3285,7 +3374,7 @@ impl Daemon {
                             self.timeline.emit(
                                 "remote_signal_rejected",
                                 None,
-                                Some("stale_sender_identity"),
+                                Some("sender_key_mismatch"),
                                 Some(format!(
                                     "peer={from_node_id} candidate_generation={candidate_generation}"
                                 )),
@@ -3428,13 +3517,13 @@ impl Daemon {
                                 None,
                                 None,
                                 Some(format!(
-                                    "peer={} owner={} network_generation={} candidate_generation={} session_fp={} deferred_unknown={}",
+                                    "peer={} owner={} network_generation={} candidate_generation={} session_fp={} deferred={}",
                                     from_node_id,
                                     reservation.owner,
                                     network_generation,
                                     candidate_generation,
                                     handshake_token_fingerprint(session_id.as_deref()),
-                                    !peer_known
+                                    !peer_known || !peer_online
                                 )),
                             );
                             responder_work.push(Box::pin(async move {
@@ -3481,7 +3570,9 @@ impl Daemon {
                         // its sender: wake the peer poll so the pending initiator
                         // transaction can be consumed without waiting out the
                         // regular cadence.
-                        if !self.peers.peer_exists_sync(&from_node_id) {
+                        if !self.peers.peer_exists_sync(&from_node_id)
+                            || self.peers.peer_session_generation_sync(&from_node_id).is_none()
+                        {
                             self.control.refresh_peers_now();
                         }
                         self.peers.record_direct_event_non_queuing(
@@ -3695,7 +3786,9 @@ impl Daemon {
                         // A peer-reflexive observation may arrive before the
                         // peer-list poll registers the sender; wake the poll so a
                         // cold-start handshake is not delayed by the cadence.
-                        if !self.peers.peer_exists_sync(&from_node_id) {
+                        if !self.peers.peer_exists_sync(&from_node_id)
+                            || self.peers.peer_session_generation_sync(&from_node_id).is_none()
+                        {
                             self.control.refresh_peers_now();
                         }
                         let work = PendingPeerReflexive {

--- a/client/daemon/src/lib/daemon/core.rs
+++ b/client/daemon/src/lib/daemon/core.rs
@@ -152,7 +152,8 @@ impl Daemon {
         // unwritable state directory, or the counter exhausted): fresh-mapping
         // prediction is disabled rather than silently re-seeded from the wall
         // clock, which could regress below the high-water receivers recorded.
-        let boot_epoch_ms = crate::incarnation::next_boot_incarnation(&config).unwrap_or(0);
+        let boot_epoch_ms = crate::incarnation::take_prepared_or_next_boot_incarnation(&config)
+            .unwrap_or(0);
         // An incarnation that outgrew the 41-bit candidate-generation
         // encoding field also disables fresh prediction (the label must never
         // wrap): ordinary signaling continues with the legacy generation 0.

--- a/client/daemon/src/lib/daemon/handshake.rs
+++ b/client/daemon/src/lib/daemon/handshake.rs
@@ -536,6 +536,144 @@ fn should_mark_connecting_after_session_install(
         )
 }
 
+/// Await an initiator offer only while its reserved pending transaction is
+/// still live.  The control runtime owns the actual HTTP request, but dropping
+/// this receiver wait on cancellation releases the bounded control-event work
+/// slot immediately instead of leaving it occupied until that request times
+/// out.
+async fn await_initiator_offer_or_cancellation<F>(
+    offer: F,
+    cancellation: &mut tokio::sync::watch::Receiver<bool>,
+) -> Option<Result<()>>
+where
+    F: std::future::Future<Output = Result<()>>,
+{
+    // A closed sender is fail-closed too: without the reservation owner we
+    // must not report an old offer as current.
+    if *cancellation.borrow() || cancellation.has_changed().is_err() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        changed = cancellation.changed() => {
+            let _ = changed;
+            None
+        }
+        result = offer => {
+            // If both branches become ready together, prefer cancellation;
+            // this final check also covers a sender being dropped immediately
+            // after the request completed.
+            if *cancellation.borrow() || cancellation.has_changed().is_err() {
+                None
+            } else {
+                Some(result)
+            }
+        }
+    }
+}
+
+/// Spawn bounded idempotent retransmission loop for a pending initiator handshake.
+/// It resends the exact same offer (same initiation_bytes, session_id, probe key, candidates)
+/// at bounded intervals (250ms, 500ms, 750ms, 1500ms -> cumulative 250ms, 750ms, 1.5s, 3s)
+/// until an answer is received, the session is established, or the pending owner is cancelled.
+#[allow(clippy::too_many_arguments)]
+fn spawn_bounded_handshake_retransmission(
+    control: ControlClient,
+    peer_id: String,
+    pending_id: u64,
+    candidates: Vec<String>,
+    candidate_sources: HashMap<String, String>,
+    initiation_bytes: Vec<u8>,
+    punch_at_ms: Option<u64>,
+    session_id: String,
+    probe_ephemeral_public_key: String,
+    pending: Arc<PendingHandshakeStore>,
+    transport: WireGuardTransport,
+    peers: Arc<PeerManager>,
+    timeline: Arc<ConnectionTimeline>,
+    mut cancellation: tokio::sync::watch::Receiver<bool>,
+    initial_network_generation: u64,
+    peer_session_generation: PeerSessionGeneration,
+    is_rekey: bool,
+) {
+    tokio::spawn(async move {
+        const RETRANSMIT_DELAYS_MS: [u64; 4] = [250, 500, 750, 1500];
+        for (retransmit_idx, delay_ms) in RETRANSMIT_DELAYS_MS.iter().enumerate() {
+            let delay = Duration::from_millis(*delay_ms);
+            tokio::select! {
+                changed = cancellation.changed() => {
+                    if changed.is_err() || *cancellation.borrow() {
+                        return;
+                    }
+                }
+                _ = tokio::time::sleep(delay) => {}
+            }
+            if *cancellation.borrow() {
+                return;
+            }
+            let is_current = {
+                let state = pending.lock();
+                state.is_current(&peer_id, pending_id)
+                    && state.peer_session_generation(&peer_id) == Some(peer_session_generation)
+            };
+            if !is_current {
+                return;
+            }
+            if peers.current_network_generation_sync() != initial_network_generation {
+                return;
+            }
+            if !peers.peer_session_is_current_sync(&peer_id, peer_session_generation) {
+                return;
+            }
+            if !is_rekey && transport.has_session(&peer_id).await {
+                return;
+            }
+
+            let attempt_idx = retransmit_idx + 1;
+            let Some(retransmit_result) = await_initiator_offer_or_cancellation(
+                control.send_peer_offer_with_sources_punch_and_session(
+                    &peer_id,
+                    &candidates,
+                    &candidate_sources,
+                    &initiation_bytes,
+                    punch_at_ms,
+                    Some(session_id.clone()),
+                    Some(probe_ephemeral_public_key.clone()),
+                ),
+                &mut cancellation,
+            )
+            .await
+            else {
+                return;
+            };
+
+            timeline.emit(
+                "initiator_offer_retransmitted",
+                None,
+                retransmit_result.as_ref().err().map(|_| "control_plane_error"),
+                Some(format!(
+                    "peer={} pending_id={} attempt={} session_fp={} delivered={} is_rekey={}",
+                    peer_id,
+                    pending_id,
+                    attempt_idx,
+                    handshake_token_fingerprint(Some(&session_id)),
+                    retransmit_result.is_ok(),
+                    is_rekey
+                )),
+            );
+            if retransmit_result.is_ok() {
+                debug!(
+                    peer = %peer_id,
+                    attempt = attempt_idx,
+                    is_rekey,
+                    "retransmitted WireGuard handshake initiation"
+                );
+            }
+        }
+    });
+}
+
 include!("handshake/init.rs");
 include!("handshake/initiate.rs");
 include!("handshake/candidates.rs");

--- a/client/daemon/src/lib/daemon/handshake/answer.rs
+++ b/client/daemon/src/lib/daemon/handshake/answer.rs
@@ -89,10 +89,17 @@ impl Daemon {
         if !self
             .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
         {
+            let reason = if !self.peers.peer_exists_sync(from_node_id) {
+                "membership_revoked"
+            } else if self.peers.peer_session_generation_sync(from_node_id).is_none() {
+                "peer_lifecycle_pending"
+            } else {
+                "sender_key_mismatch"
+            };
             self.timeline.emit(
                 "peer_answer_rejected",
                 None,
-                Some("stale_sender_identity"),
+                Some(reason),
                 Some(format!("peer={from_node_id}")),
             );
             return Ok(false);

--- a/client/daemon/src/lib/daemon/handshake/candidates.rs
+++ b/client/daemon/src/lib/daemon/handshake/candidates.rs
@@ -270,8 +270,9 @@ impl Daemon {
                 .await
                 .as_ref()
                 .map(|profile| {
-                    profile.control_label_with_generation(
+                    profile.control_label_with_generation_and_observation(
                         self.peers.current_local_profile_generation_sync(),
+                        self.peers.current_local_profile_observation_sync(),
                     )
                 })
                 .unwrap_or_else(|| "unknown".to_string());

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -1,39 +1,3 @@
-/// Await an initiator offer only while its reserved pending transaction is
-/// still live.  The control runtime owns the actual HTTP request, but dropping
-/// this receiver wait on cancellation releases the bounded control-event work
-/// slot immediately instead of leaving it occupied until that request times
-/// out.
-async fn await_initiator_offer_or_cancellation<F>(
-    offer: F,
-    cancellation: &mut tokio::sync::watch::Receiver<bool>,
-) -> Option<Result<()>>
-where
-    F: std::future::Future<Output = Result<()>>,
-{
-    // A closed sender is fail-closed too: without the reservation owner we
-    // must not report an old offer as current.
-    if *cancellation.borrow() || cancellation.has_changed().is_err() {
-        return None;
-    }
-
-    tokio::select! {
-        biased;
-        changed = cancellation.changed() => {
-            let _ = changed;
-            None
-        }
-        result = offer => {
-            // If both branches become ready together, prefer cancellation;
-            // this final check also covers a sender being dropped immediately
-            // after the request completed.
-            if *cancellation.borrow() || cancellation.has_changed().is_err() {
-                None
-            } else {
-                Some(result)
-            }
-        }
-    }
-}
 
 enum EventInitiatorReservationOutcome {
     Reserved(HandshakeStartReservation),
@@ -811,7 +775,7 @@ impl Daemon {
                 &initiation_bytes,
                 Some(punch_at_ms),
                 Some(session_id.clone()),
-                Some(probe_ephemeral_public_key),
+                Some(probe_ephemeral_public_key.clone()),
             ),
             &mut reservation.cancellation,
         )
@@ -874,6 +838,30 @@ impl Daemon {
             );
         }
 
+        // Spawn bounded idempotent retransmission loop for the pending initiator handshake.
+        // It resends the exact same offer (same initiation_bytes, session_id, probe key, candidates)
+        // at bounded intervals (250ms, 500ms, 750ms, 1500ms -> cumulative 250ms, 750ms, 1.5s, 3s)
+        // until an answer is received, the session is established, or the pending owner is cancelled.
+        spawn_bounded_handshake_retransmission(
+            self.control.clone(),
+            peer_id.clone(),
+            pending_id,
+            candidates.clone(),
+            candidate_sources.clone(),
+            initiation_bytes.clone(),
+            Some(punch_at_ms),
+            session_id.clone(),
+            probe_ephemeral_public_key.clone(),
+            self.pending_handshakes.clone(),
+            self.transport.clone(),
+            self.peers.clone(),
+            self.timeline.clone(),
+            reservation.cancellation.clone(),
+            handshake_generation,
+            reservation.peer_session_generation,
+            false,
+        );
+
         // Spawn timeout watcher that cleans up only the exact pending owner.
         let pending = self.pending_handshakes.clone();
         let timeout_peer = peer_id;
@@ -882,6 +870,7 @@ impl Daemon {
         let timeout_session_id = session_id;
         let generation = handshake_generation;
         let timeout_peer_session_generation = reservation.peer_session_generation;
+        let path_setup_kick_tx = self.path_setup_kick_tx.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(HANDSHAKE_TIMEOUT_SECS)).await;
             // The pending transaction is the timeout's first authority.  A
@@ -907,6 +896,7 @@ impl Daemon {
             if !removed {
                 return;
             }
+            path_setup_kick_tx.send_modify(|r| *r = r.wrapping_add(1));
 
             if peers.peer_session_is_current_sync(&timeout_peer, timeout_peer_session_generation)
                 && !transport.has_session(&timeout_peer).await

--- a/client/daemon/src/lib/daemon/handshake/offer.rs
+++ b/client/daemon/src/lib/daemon/handshake/offer.rs
@@ -260,10 +260,17 @@ impl Daemon {
         if !self
             .signal_sender_identity_matches_peer(from_node_id, sender_public_key)
         {
+            let reason = if !self.peers.peer_exists_sync(from_node_id) {
+                "membership_revoked"
+            } else if self.peers.peer_session_generation_sync(from_node_id).is_none() {
+                "peer_lifecycle_pending"
+            } else {
+                "sender_key_mismatch"
+            };
             self.timeline.emit(
                 "peer_offer_rejected",
                 None,
-                Some("stale_sender_identity"),
+                Some(reason),
                 Some(format!("peer={from_node_id}")),
             );
             return Ok(());

--- a/client/daemon/src/lib/daemon/handshake_maintenance.rs
+++ b/client/daemon/src/lib/daemon/handshake_maintenance.rs
@@ -20,6 +20,7 @@ struct HandshakeMaintenanceContext {
     /// must not be the first chance to recreate a missing encrypted session.
     kick_rx: tokio::sync::watch::Receiver<u64>,
     handshake_retry_kick_tx: tokio::sync::watch::Sender<u64>,
+    timeline: Arc<ConnectionTimeline>,
 }
 
 enum MaintenanceInitiatorReservationOutcome {
@@ -106,6 +107,7 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
         node_private_key,
         mut kick_rx,
         handshake_retry_kick_tx,
+        timeline,
     } = ctx;
 
     let mut tick = tokio::time::interval(Duration::from_secs(10));
@@ -496,6 +498,27 @@ async fn run_handshake_maintenance(ctx: HandshakeMaintenanceContext) {
                 );
             }
 
+            // Spawn bounded retransmission for handshake maintenance (rebuild or rekey).
+            spawn_bounded_handshake_retransmission(
+                control.clone(),
+                conn.node_id.clone(),
+                pending_id,
+                candidates.clone(),
+                candidate_sources.clone(),
+                initiation_bytes.clone(),
+                punch_at_ms,
+                session_id.clone(),
+                probe_ephemeral_public_key.clone(),
+                pending.clone(),
+                transport.clone(),
+                peers.clone(),
+                timeline.clone(),
+                reservation.cancellation.clone(),
+                handshake_generation,
+                reservation.peer_session_generation,
+                is_rekey,
+            );
+
             // Timeout cleanup runs for both successful and delivery-ambiguous
             // control requests. The short rekey timeout permits retries well
             // before the old WireGuard session reaches hard reject.
@@ -611,7 +634,7 @@ async fn refresh_candidate_cache_for_maintenance_signal(
         }
     };
 
-    peers.update_nat_profile(report.nat_profile.clone()).await;
+    let nat_publication = peers.update_nat_profile(report.nat_profile.clone()).await;
     *nat_profile.write().await = Some(report.nat_profile.clone());
 
     let (mut candidates, mut candidate_sources) = candidate_endpoints_from_report(&report);
@@ -697,7 +720,10 @@ async fn refresh_candidate_cache_for_maintenance_signal(
         drop(refresh_guard);
         let nat_type = report
             .nat_profile
-            .control_label_with_generation(peers.current_local_profile_generation_sync());
+            .control_label_with_generation_and_observation(
+                nat_publication.generation,
+                nat_publication.observation,
+            );
         if let Err(err) = control.update_endpoint(&endpoint, &nat_type).await {
             warn!("Failed to publish pre-signal UDP endpoint '{endpoint}': {err}");
         }

--- a/client/daemon/src/lib/daemon/run.rs
+++ b/client/daemon/src/lib/daemon/run.rs
@@ -576,6 +576,7 @@ impl Daemon {
                     node_private_key: self.config.node.private_key.clone(),
                     kick_rx: handshake_kick_rx,
                     handshake_retry_kick_tx: self.handshake_retry_kick_tx.clone(),
+                    timeline: self.timeline.clone(),
                 }),
             )
             .await;

--- a/client/daemon/src/lib/daemon/udp_direct.rs
+++ b/client/daemon/src/lib/daemon/udp_direct.rs
@@ -488,10 +488,13 @@ async fn run_udp_direct_instance(
                             report.nat_profile.confidence,
                             proxy_env.label(),
                 );
-                peers.update_nat_profile(report.nat_profile.clone()).await;
+                let nat_publication = peers.update_nat_profile(report.nat_profile.clone()).await;
                 advertised_nat_type = report
                     .nat_profile
-                    .control_label_with_generation(peers.current_local_profile_generation_sync());
+                    .control_label_with_generation_and_observation(
+                        nat_publication.generation,
+                        nat_publication.observation,
+                    );
                 let pool_eligible = socket_pool_enabled
                     && report.nat_profile.mapping_behavior
                         == MappingBehavior::AddressOrPortDependent
@@ -600,13 +603,17 @@ async fn run_udp_direct_instance(
             let candidate_refresh_lock = candidate_refresh_lock.clone();
             let runtime = gateway_mapping_runtime.clone();
             let diagnostics = gateway_mapping_diagnostics.clone();
-            let mapping_publication = udp_transport_publication.clone();
             let mapping_owner = lease.owner();
+            let mapping_publication = udp_transport_publication.clone();
+            let mapping_candidate_endpoints = candidate_endpoints.clone();
+            let mapping_candidate_sources = candidate_sources.clone();
             tokio::spawn(async move {
                 let mut discovered = Vec::new();
                 let mut discovered_sources = HashMap::new();
                 maybe_add_port_mapping_udp_candidate(
                     local_addr,
+                    &mapping_candidate_endpoints,
+                    &mapping_candidate_sources,
                     &mut discovered,
                     &mut discovered_sources,
                     runtime,

--- a/client/daemon/src/lib/tests/part05.rs
+++ b/client/daemon/src/lib/tests/part05.rs
@@ -1295,6 +1295,465 @@ async fn stale_sender_identity_fresh_signal_never_enters_new_high_water() {
 }
 
 #[tokio::test]
+async fn offline_peer_first_offer_deferred_and_not_rejected_as_stale_identity() {
+    let config = Config::generate_default("http://127.0.0.1:1", "net1").unwrap();
+    let daemon = Daemon::new(config);
+    // Peer is initially added as offline (online: false)
+    daemon
+        .peers
+        .add_peer(&control::PeerInfo {
+            node_id: "node-offline".to_string(),
+            device_name: String::new(),
+            app_version: String::new(),
+            public_key: "offline-peer-key".to_string(),
+            endpoint: "203.0.113.20:51820".to_string(),
+            nat_type: "Unknown".to_string(),
+            virtual_ip: "10.20.0.5".to_string(),
+            online: false,
+            last_seen: 0,
+            relay_rtt_ms: None,
+        })
+        .await;
+
+    let control = daemon.control.clone();
+    let peers = daemon.peers.clone();
+    let timeline = daemon.timeline.clone();
+    let (net_tx, _net_rx) = mpsc::channel(64);
+    let mut relay_started = false;
+    let mut daemon_task = daemon;
+    let handle = tokio::spawn(async move {
+        daemon_task
+            .run_control_event_loop(&mut relay_started, net_tx)
+            .await;
+    });
+
+    // Send an offer from this known-offline peer with matching key
+    control
+        .event_sender()
+        .send(ControlEvent::PeerOffer {
+            from_node_id: "node-offline".to_string(),
+            candidates: vec!["203.0.113.20:51820".to_string()],
+            session_id: None,
+            probe_ephemeral_public_key: None,
+            candidate_sources: HashMap::new(),
+            candidate_generation: 1,
+            candidates_expires_at_ms: None,
+            handshake_init: Vec::new(),
+            punch_at_ms: None,
+            punch_at_server_ms: None,
+            sender_public_key: Some("offline-peer-key".to_string()),
+        })
+        .unwrap();
+
+    // Verify it is deferred with peer_lifecycle_pending rather than rejected as stale_sender_identity
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let snap = timeline.snapshot();
+            if snap.events.iter().any(|e| {
+                e.event == "remote_signal_deferred"
+                    && e.reason_code.as_deref() == Some("peer_lifecycle_pending")
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("offer from offline peer must be deferred with peer_lifecycle_pending");
+
+    // Ensure it was NOT rejected as stale_sender_identity
+    let conn = peers.get_connection("node-offline").await.unwrap();
+    assert!(
+        !conn
+            .direct_events
+            .iter()
+            .any(|e| e.stage == "remote_signal_stale_identity"),
+        "offer from offline peer must NOT be marked as remote_signal_stale_identity"
+    );
+
+    let snap = timeline.snapshot();
+    assert!(
+        !snap.events.iter().any(|e| {
+            e.event == "remote_signal_rejected"
+                && e.reason_code.as_deref() == Some("stale_sender_identity")
+        }),
+        "offer from offline peer must NOT be rejected with stale_sender_identity"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn initiator_handshake_bounded_retransmission_fires_and_stops_on_answer() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "retransmit-network").unwrap();
+    config.control.auth_token = "retransmit-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must succeed");
+    daemon.relay_available_tx.send_replace(true);
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let peer_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "node-retransmit".to_string(),
+        device_name: String::new(),
+        app_version: String::new(),
+        public_key: hex::encode(peer_identity.public_key()),
+        endpoint: "203.0.113.30:51820".to_string(),
+        nat_type: "Unknown".to_string(),
+        virtual_ip: "10.20.0.6".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    let timeline = daemon.timeline.clone();
+    let mut reservation = daemon
+        .reserve_event_initiator_handshake(&peer_info.node_id)
+        .expect("initiator reservation must be admitted");
+
+    let punch_at = daemon
+        .run_reserved_initiator_handshake(&peer_info, &mut reservation)
+        .await
+        .expect("initial handshake send should proceed");
+    assert!(punch_at.is_some(), "designated initiator must send initial offer");
+
+    // Retransmission task is spawned with first interval 250ms.
+    // Wait for the retransmission event to be emitted on the timeline.
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let snap = timeline.snapshot();
+            if snap
+                .events
+                .iter()
+                .any(|e| e.event == "initiator_offer_retransmitted")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("bounded retransmission must fire within interval");
+
+    // An answer is returned from the peer's responder and delivered to daemon.
+    let bodies = control_capture.signal_bodies();
+    let offers = bodies
+        .iter()
+        .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|body| body.get("type").and_then(serde_json::Value::as_str) == Some("peer_offer"))
+        .collect::<Vec<_>>();
+    assert!(!offers.is_empty(), "must have captured at least one offer");
+    let offer = &offers[0];
+    let initiation_hex = offer
+        .get("handshake")
+        .and_then(serde_json::Value::as_str)
+        .expect("Offer must have handshake initiation");
+    let session_id = offer
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("Offer must have session id")
+        .to_string();
+    let initiation_bytes = hex::decode(initiation_hex).unwrap();
+    let initiation = MessageInitiation::from_bytes(&initiation_bytes).unwrap();
+    let mut remote_responder = HandshakeResponder::new(peer_identity, None);
+    let (response, _) = remote_responder
+        .consume_initiation_and_respond(&initiation)
+        .unwrap();
+    let remote_probe_public = hex::encode(DhKeyPair::generate().public_key());
+
+    // Deliver actual Answer and confirm session is established
+    let accepted = daemon
+        .handle_peer_answer(
+            &peer_info.node_id,
+            &response.to_bytes(),
+            Some(session_id),
+            Some(remote_probe_public),
+        )
+        .await
+        .unwrap();
+    assert!(accepted, "real Answer must be accepted");
+    assert!(
+        daemon.transport.has_session(&peer_info.node_id).await,
+        "WireGuard session must be installed"
+    );
+
+    // Wait a moment and check that retransmission count stops increasing
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    let count_after_answer = timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|e| e.event == "initiator_offer_retransmitted")
+        .count();
+
+    tokio::time::sleep(Duration::from_millis(800)).await;
+    let count_later = timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|e| e.event == "initiator_offer_retransmitted")
+        .count();
+
+    assert_eq!(
+        count_after_answer, count_later,
+        "retransmission must stop after actual answer establishes session"
+    );
+}
+
+#[tokio::test]
+async fn maintenance_rebuild_handshake_bounded_retransmission_fires_and_stops_on_answer() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "maintenance-rebuild-net").unwrap();
+    config.control.auth_token = "maintenance-rebuild-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must succeed");
+    daemon.relay_available_tx.send_replace(true);
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let peer_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "node-rebuild".to_string(),
+        device_name: String::new(),
+        app_version: String::new(),
+        public_key: hex::encode(peer_identity.public_key()),
+        endpoint: "203.0.113.31:51820".to_string(),
+        nat_type: "Unknown".to_string(),
+        virtual_ip: "10.20.0.7".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.control.set_peer_for_test(peer_info.clone()).await;
+    let timeline = daemon.timeline.clone();
+
+    // Spawn maintenance task directly with kick channel
+    let (kick_tx, kick_rx) = tokio::sync::watch::channel(1u64);
+    let ctx = HandshakeMaintenanceContext {
+        peers: daemon.peers.clone(),
+        transport: daemon.transport.clone(),
+        pending: daemon.pending_handshakes.clone(),
+        handshake_arbiter: daemon.handshake_arbiter.clone(),
+        control: daemon.control.clone(),
+        local_candidates: daemon.local_candidates.clone(),
+        local_candidate_sources: daemon.local_candidate_sources.clone(),
+        local_network_identity: daemon.local_network_identity.clone(),
+        candidate_snapshot: daemon.candidate_snapshot.clone(),
+        candidate_refresh_lock: daemon.candidate_refresh_lock.clone(),
+        nat_profile: daemon.nat_profile.clone(),
+        udp_transport: daemon.udp_transport.clone(),
+        runtime_stun_servers: daemon.runtime_stun_servers.clone(),
+        runtime_stun_timeout: daemon.runtime_stun_timeout.clone(),
+        udp_advertise: None,
+        node_private_key: daemon.config.node.private_key.clone(),
+        kick_rx,
+        handshake_retry_kick_tx: daemon.handshake_retry_kick_tx.clone(),
+        timeline: daemon.timeline.clone(),
+    };
+    let maintenance_task = tokio::spawn(run_handshake_maintenance(ctx));
+
+    // Wake maintenance to initiate rebuild
+    kick_tx.send_replace(2);
+
+    // Verify bounded retransmission fires for maintenance initiator
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let snap = timeline.snapshot();
+            if snap
+                .events
+                .iter()
+                .any(|e| e.event == "initiator_offer_retransmitted")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("maintenance rebuild must spawn bounded retransmission");
+
+    // Deliver actual Answer
+    let bodies = control_capture.signal_bodies();
+    let offers = bodies
+        .iter()
+        .filter_map(|body| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|body| body.get("type").and_then(serde_json::Value::as_str) == Some("peer_offer"))
+        .collect::<Vec<_>>();
+    assert!(!offers.is_empty(), "must capture maintenance offer");
+    let offer = &offers[0];
+    let initiation_hex = offer
+        .get("handshake")
+        .and_then(serde_json::Value::as_str)
+        .expect("Offer must have handshake initiation");
+    let session_id = offer
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("Offer must have session id")
+        .to_string();
+    let initiation_bytes = hex::decode(initiation_hex).unwrap();
+    let initiation = MessageInitiation::from_bytes(&initiation_bytes).unwrap();
+    let mut remote_responder = HandshakeResponder::new(peer_identity, None);
+    let (response, _) = remote_responder
+        .consume_initiation_and_respond(&initiation)
+        .unwrap();
+    let remote_probe_public = hex::encode(DhKeyPair::generate().public_key());
+
+    let accepted = daemon
+        .handle_peer_answer(
+            &peer_info.node_id,
+            &response.to_bytes(),
+            Some(session_id),
+            Some(remote_probe_public),
+        )
+        .await
+        .unwrap();
+    assert!(accepted, "real answer must be accepted for rebuild");
+    assert!(daemon.transport.has_session(&peer_info.node_id).await);
+
+    // Verify retransmission stops once answer establishes the session
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    let count_after_answer = timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|e| e.event == "initiator_offer_retransmitted")
+        .count();
+    tokio::time::sleep(Duration::from_millis(800)).await;
+    let count_later = timeline
+        .snapshot()
+        .events
+        .iter()
+        .filter(|e| e.event == "initiator_offer_retransmitted")
+        .count();
+    assert_eq!(count_after_answer, count_later, "retransmission must stop once rebuild session is established");
+
+    maintenance_task.abort();
+}
+
+#[tokio::test]
+async fn maintenance_rekey_handshake_bounded_retransmission_survives_existing_session() {
+    let mut control_capture = start_handshake_control_capture().await;
+    let mut config =
+        Config::generate_default(&control_capture.base_url, "maintenance-rekey-net").unwrap();
+    config.control.auth_token = "maintenance-rekey-token".to_string();
+    config.node.node_id = "node-local".to_string();
+    let daemon = Arc::new(Daemon::new(config));
+    timeout(Duration::from_secs(2), control_capture.wait_registered())
+        .await
+        .expect("daemon registration must succeed");
+    daemon.relay_available_tx.send_replace(true);
+
+    let local_public = daemon.local_identity().unwrap().public_key();
+    let peer_identity = loop {
+        let identity = NodeIdentity::generate();
+        if local_public < identity.public_key() {
+            break identity;
+        }
+    };
+    let peer_info = control::PeerInfo {
+        node_id: "node-rekey".to_string(),
+        device_name: String::new(),
+        app_version: String::new(),
+        public_key: hex::encode(peer_identity.public_key()),
+        endpoint: "203.0.113.32:51820".to_string(),
+        nat_type: "Unknown".to_string(),
+        virtual_ip: "10.20.0.8".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    daemon.peers.add_peer(&peer_info).await;
+    daemon.control.set_peer_for_test(peer_info.clone()).await;
+
+    // Install an initial active session configured to require rekey immediately
+    let mut init_initiator =
+        HandshakeInitiator::new(daemon.local_identity().unwrap(), peer_identity.public_key(), None);
+    let init_initiation = init_initiator.create_initiation().unwrap();
+    let mut init_responder = HandshakeResponder::new(peer_identity.clone(), None);
+    let (init_response, _) = init_responder
+        .consume_initiation_and_respond(&init_initiation)
+        .unwrap();
+    let old_keys = init_initiator.consume_response(&init_response).unwrap();
+    let old_session = TransportSession::new(old_keys)
+        .with_thresholds(0, Duration::ZERO, 1000, Duration::from_secs(60));
+    daemon
+        .transport
+        .add_session(&peer_info.node_id, old_session)
+        .await;
+
+    assert!(daemon.transport.has_session(&peer_info.node_id).await);
+    assert!(daemon.transport.session_needs_rekey(&peer_info.node_id).await);
+
+    let timeline = daemon.timeline.clone();
+
+    // Spawn maintenance task
+    let (kick_tx, kick_rx) = tokio::sync::watch::channel(1u64);
+    let ctx = HandshakeMaintenanceContext {
+        peers: daemon.peers.clone(),
+        transport: daemon.transport.clone(),
+        pending: daemon.pending_handshakes.clone(),
+        handshake_arbiter: daemon.handshake_arbiter.clone(),
+        control: daemon.control.clone(),
+        local_candidates: daemon.local_candidates.clone(),
+        local_candidate_sources: daemon.local_candidate_sources.clone(),
+        local_network_identity: daemon.local_network_identity.clone(),
+        candidate_snapshot: daemon.candidate_snapshot.clone(),
+        candidate_refresh_lock: daemon.candidate_refresh_lock.clone(),
+        nat_profile: daemon.nat_profile.clone(),
+        udp_transport: daemon.udp_transport.clone(),
+        runtime_stun_servers: daemon.runtime_stun_servers.clone(),
+        runtime_stun_timeout: daemon.runtime_stun_timeout.clone(),
+        udp_advertise: None,
+        node_private_key: daemon.config.node.private_key.clone(),
+        kick_rx,
+        handshake_retry_kick_tx: daemon.handshake_retry_kick_tx.clone(),
+        timeline: daemon.timeline.clone(),
+    };
+    let maintenance_task = tokio::spawn(run_handshake_maintenance(ctx));
+
+    // Wake maintenance to initiate rekey
+    kick_tx.send_replace(2);
+
+    // Verify bounded retransmission fires despite has_session being true!
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let snap = timeline.snapshot();
+            if snap
+                .events
+                .iter()
+                .any(|e| e.event == "initiator_offer_retransmitted" && e.detail.as_deref().unwrap_or("").contains("is_rekey=true"))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("maintenance rekey must retransmit even when active session exists");
+
+    maintenance_task.abort();
+}
+
+#[tokio::test]
 async fn direct_validation_registry_single_flight_merges_newest_endpoint() {
     let peers = Arc::new(PeerManager::new(
         Config::generate_default("https://ctrl.test", "net1").unwrap(),

--- a/client/daemon/src/peer.rs
+++ b/client/daemon/src/peer.rs
@@ -14,8 +14,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use p2pnet_crypto::{hmac, NodeIdentity};
 use p2pnet_nat::{
-    parse_nat_hint, plan_traversal, LocalNetwork, MappingBehavior, NatCapabilities, NatProfile,
-    ProbeMacKey, RemoteNatProfile, TraversalContext, TraversalPlan,
+    parse_nat_hint, plan_traversal, FilteringBehavior, LocalNetwork, MappingBehavior,
+    NatCapabilities, NatProfile, ProbeMacKey, RemoteNatProfile, TraversalContext, TraversalPlan,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;

--- a/client/daemon/src/peer/connection/core.rs
+++ b/client/daemon/src/peer/connection/core.rs
@@ -317,14 +317,88 @@ impl PeerConnection {
     ) -> bool {
         let hint = parse_nat_hint(nat_type);
         let incoming_generation = hint.profile_generation;
+        let incoming_lifecycle = hint.registration_lifecycle;
+        let incoming_observation = hint.observation_sequence;
         let current_generation = self
             .remote_nat_profile
             .as_ref()
             .and_then(|profile| profile.generation);
-        let accepts = match (current_generation, incoming_generation) {
-            (Some(current), Some(incoming)) => incoming >= current,
+        let current_lifecycle = self
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.registration_lifecycle);
+        let current_observation = self
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.observation_sequence);
+        let stable_endpoint = stable_endpoint.filter(|endpoint| is_public_probe_endpoint(*endpoint));
+        let new_capabilities = NatCapabilities::from_fingerprint_hint(&hint, stable_endpoint);
+        // A server-issued registration lifecycle is the outermost ordering
+        // fence. A daemon restart may legitimately restart local `g` and `o`
+        // at low values, but an in-flight PATCH from the old registration must
+        // never replace the new profile. Once we have seen a lifecycle, a
+        // label that omits it cannot downgrade that protection.
+        let lifecycle_advanced = match (current_lifecycle, incoming_lifecycle) {
+            (Some(current), Some(incoming)) if incoming < current => {
+                debug!(
+                    peer = %self.node_id,
+                    current_lifecycle,
+                    incoming_lifecycle,
+                    "ignored stale remote NAT registration lifecycle"
+                );
+                return false;
+            }
+            (Some(_), None) => {
+                debug!(
+                    peer = %self.node_id,
+                    current_lifecycle,
+                    "ignored remote NAT label without the current registration lifecycle"
+                );
+                return false;
+            }
+            (Some(current), Some(incoming)) => incoming > current,
+            (None, _) => false,
+        };
+
+        let accepts = if lifecycle_advanced {
+            true
+        } else {
+            match (current_generation, incoming_generation) {
+            (Some(current), Some(incoming)) => {
+                if incoming < current {
+                    false
+                } else if incoming == current {
+                    if let Some(existing) = self.remote_nat_profile.as_ref() {
+                        let cur_m = existing.capabilities.mapping_behavior;
+                        let inc_m = new_capabilities.mapping_behavior;
+                        if cur_m != MappingBehavior::Unknown
+                            && inc_m != MappingBehavior::Unknown
+                            && cur_m != inc_m
+                        {
+                            return false;
+                        }
+                        let cur_f = existing.capabilities.filtering_behavior;
+                        let inc_f = new_capabilities.filtering_behavior;
+                        if cur_f != FilteringBehavior::Unknown
+                            && inc_f != FilteringBehavior::Unknown
+                            && cur_f != inc_f
+                        {
+                            return false;
+                        }
+                        let cur_a = &existing.capabilities.allocation_model;
+                        let inc_a = &new_capabilities.allocation_model;
+                        if cur_a.is_some() && inc_a.is_some() && cur_a != inc_a {
+                            return false;
+                        }
+                    }
+                    true
+                } else {
+                    true
+                }
+            }
             (Some(_), None) => false,
             (None, _) => true,
+            }
         };
         if !accepts {
             debug!(
@@ -335,17 +409,68 @@ impl PeerConnection {
             );
             return false;
         }
-        let stable_endpoint = stable_endpoint.filter(|endpoint| is_public_probe_endpoint(*endpoint));
+
+        // `o` is emitted only after a real successful STUN observation. It
+        // therefore renews the remote evidence age at a stable capability,
+        // while a heartbeat that replays the same cached label preserves the
+        // old age. The same-generation ordering is deliberate: a new `g` (or
+        // a new registration lifecycle) already represents a new capability
+        // snapshot and starts a fresh observation epoch.
+        let observation_advanced = !lifecycle_advanced
+            && current_generation == incoming_generation
+            && match (current_observation, incoming_observation) {
+                (Some(current), Some(incoming)) if incoming < current => {
+                    debug!(
+                        peer = %self.node_id,
+                        current_observation,
+                        incoming_observation,
+                        "ignored stale remote NAT observation"
+                    );
+                    return false;
+                }
+                (Some(_), None) => {
+                    debug!(
+                        peer = %self.node_id,
+                        current_observation,
+                        "ignored remote NAT label without the current observation fence"
+                    );
+                    return false;
+                }
+                (Some(current), Some(incoming)) => incoming > current,
+                (None, Some(_)) => true,
+                (None, None) => false,
+            };
+        let received_at_ms = if let Some(existing) = self.remote_nat_profile.as_ref() {
+            if !lifecycle_advanced
+                && !observation_advanced
+                && existing.generation == incoming_generation
+                && existing.capabilities.mapping_behavior == new_capabilities.mapping_behavior
+                && existing.capabilities.filtering_behavior == new_capabilities.filtering_behavior
+                && existing.capabilities.allocation_model == new_capabilities.allocation_model
+            {
+                // Identical capability at same generation (e.g. heartbeat republishing cached NAT):
+                // Retain existing observation timestamp to avoid infinite pseudo-freshness.
+                existing.received_at_ms
+            } else {
+                nat_profile_now_ms()
+            }
+        } else {
+            nat_profile_now_ms()
+        };
         self.remote_nat_profile = Some(RemoteNatProfile {
-            capabilities: NatCapabilities::from_fingerprint_hint(&hint, stable_endpoint),
+            capabilities: new_capabilities,
             generation: incoming_generation,
-            received_at_ms: nat_profile_now_ms(),
+            registration_lifecycle: incoming_lifecycle,
+            observation_sequence: incoming_observation,
+            received_at_ms,
         });
         self.remote_nat_profile_candidate_epoch = Some(self.remote_candidate_epoch);
         debug!(
             event = "remote_nat_profile_updated",
             peer = %self.node_id,
+            remote_registration_lifecycle = ?incoming_lifecycle,
             remote_profile_generation = ?incoming_generation,
+            remote_observation_sequence = ?incoming_observation,
             mapping_behavior = ?hint.mapping,
             filtering_behavior = ?hint.filtering,
             prediction_confidence = ?hint.confidence,

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -59,6 +59,8 @@ impl PeerManager {
             dplpmtud_runtime: Arc::new(RwLock::new(None)),
             local_nat_profile: Arc::new(RwLock::new(None)),
             local_profile_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            local_profile_observation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            local_profile_current_observation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             local_interface_networks: Arc::new(RwLock::new(Vec::new())),
             traversal_history: Arc::new(RwLock::new(traversal_history)),
             traversal_history_path,
@@ -425,11 +427,48 @@ impl PeerManager {
     }
 
     /// Update the latest local NAT profile used by adaptive probe scheduling.
-    pub async fn update_nat_profile(&self, profile: NatProfile) {
-        let (profile_generation, profile_changed) = {
+    ///
+    /// A call to this method is the authenticated boundary for a completed
+    /// live STUN gather. It returns the exact version to put on the resulting
+    /// control publication: capability changes advance `g`, while any gather
+    /// with a server-reflexive response advances `o`. Ordinary endpoint
+    /// heartbeats never call this method and therefore replay, rather than
+    /// manufacture, the last observation sequence.
+    pub async fn update_nat_profile(&self, profile: NatProfile) -> NatProfilePublication {
+        let live_observation = profile
+            .observations
+            .iter()
+            .any(|observation| observation.mapped_address.is_some());
+        let (profile_generation, capabilities_changed, observation) = {
             let mut current = self.local_nat_profile.write().await;
-            if current.as_ref() == Some(&profile) {
-                (self.current_local_profile_generation_sync(), false)
+            let substantive_same = current.as_ref().is_some_and(|curr| {
+                curr.local_addr == profile.local_addr
+                    && curr.udp_blocked == profile.udp_blocked
+                    && curr.public_endpoint == profile.public_endpoint
+                    && curr.public_ip_stable == profile.public_ip_stable
+                    && curr.public_port_stable == profile.public_port_stable
+                    && curr.port_preserved == profile.port_preserved
+                    && curr.port_delta == profile.port_delta
+                    && curr.likely_symmetric == profile.likely_symmetric
+                    && curr.mapping_behavior == profile.mapping_behavior
+                    && curr.filtering_behavior == profile.filtering_behavior
+                    && curr.hairpin_behavior == profile.hairpin_behavior
+                    && curr.mapping_lifetime == profile.mapping_lifetime
+                    && curr.prediction_candidate == profile.prediction_candidate
+                    && curr.predicted_endpoints == profile.predicted_endpoints
+                    && curr.birthday_candidate == profile.birthday_candidate
+                    && curr.confidence == profile.confidence
+            });
+
+            if substantive_same {
+                // Transient observation fluctuations (e.g. STUN RTT jitter) update the
+                // cached profile age without advancing generation or clearing direct sessions.
+                *current = Some(profile.clone());
+                (
+                    self.current_local_profile_generation_sync(),
+                    false,
+                    self.next_local_profile_observation(live_observation),
+                )
             } else {
                 *current = Some(profile.clone());
                 let previous = self
@@ -440,7 +479,11 @@ impl PeerManager {
                         |generation| Some(generation.saturating_add(1)),
                     )
                     .unwrap_or(u64::MAX);
-                (previous.saturating_add(1), true)
+                (
+                    previous.saturating_add(1),
+                    true,
+                    self.next_local_profile_observation(live_observation),
+                )
             }
         };
         let network_generation = self.current_network_generation_sync();
@@ -450,6 +493,8 @@ impl PeerManager {
             event = "nat_profile_updated",
             network_generation,
             local_profile_generation = profile_generation,
+            local_observation_sequence = ?observation,
+            capabilities_changed,
             mapping_behavior = ?capabilities.mapping_behavior,
             filtering_behavior = ?capabilities.filtering_behavior,
             allocation_model = ?capabilities.allocation_model,
@@ -457,14 +502,54 @@ impl PeerManager {
             prediction_window = capabilities.prediction_window,
             "updated local NAT capability evidence"
         );
-        if profile_changed {
+        if capabilities_changed {
             self.clear_hard_hard_sessions(None).await;
+        }
+        NatProfilePublication {
+            generation: profile_generation,
+            observation,
+            observation_advanced: observation.is_some(),
         }
     }
 
     pub(crate) fn current_local_profile_generation_sync(&self) -> u64 {
         self.local_profile_generation
             .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Latest successful live-observation sequence for labels assembled from
+    /// the already-committed local NAT snapshot. New gather paths should use
+    /// the exact [`NatProfilePublication`] returned by [`Self::update_nat_profile`]
+    /// instead, so an older gather cannot borrow a newer profile version.
+    pub(crate) fn current_local_profile_observation_sync(&self) -> Option<u64> {
+        let observation = self
+            .local_profile_current_observation
+            .load(std::sync::atomic::Ordering::Acquire);
+        (observation != 0).then_some(observation)
+    }
+
+    /// Advance the daemon-local STUN observation counter only for a live
+    /// server-reflexive result, then bind (or clear) that sequence on the
+    /// profile currently protected by `local_nat_profile`'s writer lock.
+    fn next_local_profile_observation(&self, live_observation: bool) -> Option<u64> {
+        let observation = if live_observation {
+            let previous = self
+                .local_profile_observation
+                .fetch_update(
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                    |observation| Some(observation.saturating_add(1)),
+                )
+                .unwrap_or(u64::MAX);
+            Some(previous.saturating_add(1))
+        } else {
+            None
+        };
+        self.local_profile_current_observation.store(
+            observation.unwrap_or_default(),
+            std::sync::atomic::Ordering::Release,
+        );
+        observation
     }
 
     /// Publish the currently enumerated physical interface prefixes used by

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -227,6 +227,17 @@ impl PeerManager {
             .then_some(public_key)
     }
 
+    /// Returns the peer's recorded public key from the identity ledger if known,
+    /// regardless of whether the peer is currently online or offline.
+    #[allow(dead_code)]
+    pub(crate) fn peer_identity_recorded_public_key_sync(&self, node_id: &str) -> Option<String> {
+        self.remote_identity_ledger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(node_id)
+            .map(|identity| identity.public_key.clone())
+    }
+
     pub(crate) fn signal_sender_identity_matches_peer_sync(
         &self,
         node_id: &str,
@@ -743,16 +754,68 @@ impl PeerManager {
             .remote_nat_profile
             .as_ref()
             .and_then(|profile| profile.generation);
+        let previous_remote_profile_lifecycle = conn
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.registration_lifecycle);
+        let previous_remote_profile_observation = conn
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.observation_sequence);
         let remote_profile_accepted =
             conn.update_remote_nat_profile(&info.nat_type, signaled_endpoint);
         let remote_profile_generation = conn
             .remote_nat_profile
             .as_ref()
             .and_then(|profile| profile.generation);
-        if remote_profile_accepted
-            && previous_remote_profile_generation != remote_profile_generation
+        let remote_profile_lifecycle = conn
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.registration_lifecycle);
+        let remote_profile_observation = conn
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.observation_sequence);
+        let mut recovery_reopen_reason_after_lock = None;
+        let lifecycle_changed = previous_remote_profile_lifecycle != remote_profile_lifecycle;
+        let generation_changed = previous_remote_profile_generation != remote_profile_generation;
+        let observation_advanced = !lifecycle_changed
+            && !generation_changed
+            && match (
+                previous_remote_profile_observation,
+                remote_profile_observation,
+            ) {
+                (Some(previous), Some(current)) => current > previous,
+                (None, Some(_)) => true,
+                _ => false,
+            };
+        if info.online
+            && remote_profile_accepted
+            && (lifecycle_changed || generation_changed || observation_advanced)
         {
-            clear_hard_hard_after_lock = true;
+            // Capability or registration replacement invalidates an active
+            // fresh-mapping rendezvous. A same-capability `o=` advance is
+            // intentionally lighter: it renews evidence and grants the
+            // bounded recovery epoch another attempt without tearing down a
+            // healthy Direct path or rekeying an encrypted session.
+            if lifecycle_changed || generation_changed {
+                clear_hard_hard_after_lock = true;
+            }
+            if previous_remote_profile_generation.is_some()
+                || remote_profile_generation.is_some()
+                || previous_remote_profile_lifecycle.is_some()
+                || remote_profile_lifecycle.is_some()
+                || previous_remote_profile_observation.is_some()
+                || remote_profile_observation.is_some()
+            {
+                recovery_reopen_reason_after_lock = Some(if lifecycle_changed {
+                    "remote_nat_registration_lifecycle_advanced"
+                } else if generation_changed {
+                    "remote_nat_profile_generation_advanced"
+                } else {
+                    "remote_nat_profile_observation_advanced"
+                });
+            }
         }
         if let Some(addr) = signaled_endpoint {
             conn.ensure_candidate_pair(addr, generation);
@@ -845,6 +908,9 @@ impl PeerManager {
         }
         if let Some(reason) = unquarantine_after_lock {
             self.unquarantine_peer(&info.node_id, reason).await;
+        }
+        if let Some(reason) = recovery_reopen_reason_after_lock {
+            self.recovery_reopen_on_evidence(&info.node_id, reason).await;
         }
         PeerUpdate {
             is_new,

--- a/client/daemon/src/peer/manager/recovery_epoch.rs
+++ b/client/daemon/src/peer/manager/recovery_epoch.rs
@@ -529,6 +529,12 @@ impl PeerManager {
             return RecoveryAdmission::BudgetExhausted { epoch: entry.epoch };
         }
         if entry.budget_exhausted {
+            // When an epoch has exhausted its probe credits (0 remaining), unfreezing
+            // without new evidence would only trigger immediate zero-send re-exhaustion loops.
+            // Retain dormant sleep until new evidence or max age rotation.
+            if entry.epoch_probe_credit_remaining == 0 {
+                return RecoveryAdmission::BudgetExhausted { epoch: entry.epoch };
+            }
             // The controlled backoff elapsed: unfreeze and record that the
             // re-open was backoff-driven (observable, budgeted, not churn).
             entry.budget_exhausted = false;
@@ -542,6 +548,9 @@ impl PeerManager {
                 peer_id,
                 entry.epoch,
             );
+        }
+        if entry.epoch_probe_credit_remaining == 0 {
+            return RecoveryAdmission::BudgetExhausted { epoch: entry.epoch };
         }
         RecoveryAdmission::Accepted { epoch: entry.epoch }
     }

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -8,6 +8,24 @@ type NetworkGenerationHandshakeCancelHook =
 type NetworkGenerationHandshakeCancelHookSlot =
     Arc<std::sync::Mutex<Option<NetworkGenerationHandshakeCancelHook>>>;
 
+/// The immutable version assigned to one local NAT gather result.
+///
+/// `generation` changes only when traversal-relevant capabilities change.
+/// `observation` changes only after this invocation contains a successful
+/// live STUN observation. Keeping the two axes separate avoids both stale
+/// profile expiry and RTT-jitter-driven session teardown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NatProfilePublication {
+    /// Traversal-capability generation (`g=`).
+    pub generation: u64,
+    /// Real live-observation sequence (`o=`), absent when this gather did not
+    /// obtain a server-reflexive result.
+    pub observation: Option<u64>,
+    /// Whether this gather supplied a new `o=` value rather than replaying a
+    /// cached control-plane label.
+    pub observation_advanced: bool,
+}
+
 /// The local, non-wire identity fence for one Hard↔Hard rendezvous.
 ///
 /// The session id alone is not sufficient: a late response from an older
@@ -491,6 +509,17 @@ pub struct PeerManager {
     /// separate domain from the local network generation: a profile refresh
     /// can invalidate a Hard↔Hard session without implying a link handover.
     local_profile_generation: Arc<std::sync::atomic::AtomicU64>,
+    /// Monotonic sequence of successful *live* STUN observations for the
+    /// current daemon registration. Unlike `local_profile_generation`, this
+    /// advances when a stable NAT profile is re-observed and is carried as
+    /// `o=` in the control label so peers can renew freshness without treating
+    /// heartbeat replays as new network evidence.
+    local_profile_observation: Arc<std::sync::atomic::AtomicU64>,
+    /// Observation sequence bound to the currently committed local profile.
+    /// Zero means the current profile came from a gather with no successful
+    /// STUN response, so publications must omit `o=` rather than reuse an old
+    /// successful observation from a different profile snapshot.
+    local_profile_current_observation: Arc<std::sync::atomic::AtomicU64>,
     /// Directly-connected local interface prefixes used by the Host fast lane.
     local_interface_networks: Arc<RwLock<Vec<LocalNetwork>>>,
     /// Anonymous local traversal outcome history.

--- a/client/daemon/src/peer/tests/part01a.rs
+++ b/client/daemon/src/peer/tests/part01a.rs
@@ -553,3 +553,79 @@ async fn stale_nominated_trial_expires_and_falls_back_to_relay() {
     );
     assert!(!pair.probe_due);
 }
+
+#[tokio::test]
+async fn nat_profile_update_ignores_observation_jitter_and_advances_on_capability_change() {
+    let config = test_config();
+    let manager = PeerManager::new(config);
+
+    let mut profile = birthday_nat_profile();
+    profile.observations = vec![p2pnet_nat::StunObservation {
+        server: "stun1.example.com".to_string(),
+        mapped_address: Some("203.0.113.10:40007".to_string()),
+        rtt_ms: Some(25),
+        error: None,
+    }];
+
+    // 1. Initial profile update sets generation 1
+    manager.update_nat_profile(profile.clone()).await;
+    let gen1 = manager.current_local_profile_generation_sync();
+    assert_eq!(gen1, 1, "first profile update sets generation 1");
+
+    // 2. STUN RTT jitter / transient observation update must NOT advance generation
+    let mut rtt_jitter_profile = profile.clone();
+    rtt_jitter_profile.observations[0].rtt_ms = Some(85);
+    manager.update_nat_profile(rtt_jitter_profile).await;
+    let gen2 = manager.current_local_profile_generation_sync();
+    assert_eq!(
+        gen2, gen1,
+        "observation RTT jitter must not advance local_profile_generation"
+    );
+
+    // 3. Substantive capability change MUST advance generation
+    let mut capability_changed_profile = profile.clone();
+    capability_changed_profile.mapping_behavior = p2pnet_nat::MappingBehavior::EndpointIndependent;
+    manager.update_nat_profile(capability_changed_profile).await;
+    let gen3 = manager.current_local_profile_generation_sync();
+    assert_eq!(
+        gen3, 2,
+        "substantive capability change must advance local_profile_generation"
+    );
+}
+
+#[tokio::test]
+async fn nat_profile_publication_tracks_real_observations_separately_from_capabilities() {
+    let manager = PeerManager::new(test_config());
+    let mut profile = birthday_nat_profile();
+    profile.observations = vec![p2pnet_nat::StunObservation {
+        server: "stun1.example.com".to_string(),
+        mapped_address: Some("203.0.113.10:40007".to_string()),
+        rtt_ms: Some(25),
+        error: None,
+    }];
+
+    let first = manager.update_nat_profile(profile.clone()).await;
+    assert_eq!(first.generation, 1);
+    assert_eq!(first.observation, Some(1));
+    assert!(first.observation_advanced);
+
+    // A second live STUN result with the same traversal capability advances
+    // only `o`, so peers can renew freshness without tearing down sessions.
+    let mut same_capability = profile.clone();
+    same_capability.observations[0].rtt_ms = Some(90);
+    let second = manager.update_nat_profile(same_capability).await;
+    assert_eq!(second.generation, first.generation);
+    assert_eq!(second.observation, Some(2));
+    assert_eq!(manager.current_local_profile_observation_sync(), Some(2));
+
+    // A gather without a server-reflexive response never reuses o=2. This is
+    // the state a control heartbeat must carry until another live success.
+    let mut no_live_observation = profile.clone();
+    no_live_observation.observations[0].mapped_address = None;
+    no_live_observation.observations[0].error = Some("timeout".to_string());
+    let no_observation = manager.update_nat_profile(no_live_observation).await;
+    assert_eq!(no_observation.generation, first.generation);
+    assert_eq!(no_observation.observation, None);
+    assert!(!no_observation.observation_advanced);
+    assert_eq!(manager.current_local_profile_observation_sync(), None);
+}

--- a/client/daemon/src/peer/tests/part17.rs
+++ b/client/daemon/src/peer/tests/part17.rs
@@ -39,6 +39,61 @@ fn legacy_remote_nat_label_cannot_downgrade_versioned_profile() {
 }
 
 #[test]
+fn same_generation_real_observation_renews_freshness_but_cached_or_stale_metadata_does_not() {
+    let mut connection = PeerConnection::new("peer-observation-freshness", "10.20.0.31");
+    let base = "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown;g=7;l=11";
+    let endpoint = Some("203.0.113.31:41000".parse().unwrap());
+
+    assert!(connection.update_remote_nat_profile(&format!("{base};o=1"), endpoint));
+    connection.remote_nat_profile.as_mut().unwrap().received_at_ms =
+        nat_profile_now_ms().saturating_sub(61_000);
+    assert!(
+        !connection.remote_nat_profile_is_fresh(),
+        "the test must begin with an expired observation"
+    );
+
+    // A heartbeat replays the exact cached label. It is accepted as metadata
+    // but deliberately retains the old timestamp.
+    assert!(connection.update_remote_nat_profile(&format!("{base};o=1"), endpoint));
+    assert!(
+        !connection.remote_nat_profile_is_fresh(),
+        "repeated cached observation must not manufacture freshness"
+    );
+
+    // Neither an older observation nor a missing observation fence may erase
+    // the accepted o=1 profile.
+    assert!(!connection.update_remote_nat_profile(&format!("{base};o=0"), endpoint));
+    assert!(!connection.update_remote_nat_profile(base, endpoint));
+    assert_eq!(
+        connection
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.observation_sequence),
+        Some(1)
+    );
+
+    assert!(connection.update_remote_nat_profile(&format!("{base};o=2"), endpoint));
+    assert!(
+        connection.remote_nat_profile_is_fresh(),
+        "a newer real observation at the same capability generation must renew freshness"
+    );
+
+    // An older registration cannot override a newer profile, even if it
+    // carries an apparently newer local observation counter.
+    let stale_lifecycle = base.replacen("l=11", "l=10", 1);
+    assert!(
+        !connection.update_remote_nat_profile(&format!("{stale_lifecycle};o=99"), endpoint)
+    );
+    assert_eq!(
+        connection
+            .remote_nat_profile
+            .as_ref()
+            .and_then(|profile| profile.registration_lifecycle),
+        Some(11)
+    );
+}
+
+#[test]
 fn remote_profile_is_invalidated_by_candidate_epoch_and_rebound_only_by_hh1_context() {
     let mut connection = PeerConnection::new("peer-profile-context", "10.20.0.4");
     let profile =
@@ -56,4 +111,118 @@ fn remote_profile_is_invalidated_by_candidate_epoch_and_rebound_only_by_hh1_cont
     assert!(!connection.bind_remote_nat_profile_to_candidate_epoch(8));
     assert!(connection.bind_remote_nat_profile_to_candidate_epoch(7));
     assert!(connection.remote_nat_profile_matches_candidate_epoch());
+}
+
+#[tokio::test]
+async fn remote_nat_profile_generation_advance_reopens_recovery_budget_and_zero_send_does_not_burn_network_failures() {
+    let manager = PeerManager::new(test_config());
+    let mut info = PeerInfo {
+        node_id: "peer-recovery".to_string(),
+        device_name: "test-device".to_string(),
+        app_version: "1.0.0".to_string(),
+        public_key: "pk-recovery-1".to_string(),
+        endpoint: "203.0.113.50:50000".to_string(),
+        nat_type: "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown;g=1".to_string(),
+        virtual_ip: "10.20.0.50".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    manager.add_peer(&info).await;
+    manager.recovery_epoch_admit("peer-recovery").await;
+
+    // Exhaust remaining probe credit, plan builds and sessions
+    while manager.try_consume_recovery_probe_credit("peer-recovery").await {}
+    for _ in 0..RECOVERY_EPOCH_PLAN_BUILDS {
+        assert!(manager.try_consume_recovery_plan_build("peer-recovery").await);
+    }
+    for _ in 0..RECOVERY_EPOCH_SESSIONS {
+        assert!(manager.try_consume_recovery_session("peer-recovery").await);
+    }
+
+    // Zero-send session occurs: all candidates rejected by budget.
+    manager
+        .record_zero_send_recovery_session("peer-recovery", 10, 10, 10, "all_probes_rejected_by_budget")
+        .await;
+
+    // 1. Recovery budget is frozen.
+    assert!(manager.recovery_budget_frozen("peer-recovery").await);
+
+    // 2. Failure count and consecutive_failures are NOT incremented!
+    let conn = manager.get_connection("peer-recovery").await.unwrap();
+    assert_eq!(conn.direct_health.failure_count, 0, "sent=0 must not increment network failure count");
+    assert_eq!(conn.direct_health.consecutive_failures, 0, "sent=0 must not increment consecutive failures");
+
+    // 3. Stale or duplicate remote profile update does NOT reopen the recovery budget.
+    info.nat_type = "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown;g=1".to_string();
+    manager.add_peer(&info).await;
+    assert!(manager.recovery_budget_frozen("peer-recovery").await, "duplicate profile generation must not reopen budget");
+
+    // 4. Authoritative generation advance (g=2) reopens the recovery budget with small retry credit!
+    info.nat_type = "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown;g=2".to_string();
+    manager.add_peer(&info).await;
+    assert!(!manager.recovery_budget_frozen("peer-recovery").await, "generation advance must reopen recovery budget");
+
+    let report = manager
+        .recovery_epoch_work_budget_report("peer-recovery")
+        .await
+        .expect("epoch must exist");
+    assert_eq!(report.probe_credit_remaining, RECOVERY_EVIDENCE_RETRY_CREDIT);
+    assert_eq!(report.plan_builds_remaining, RECOVERY_EVIDENCE_REGRANT_PLAN_BUILDS);
+    assert_eq!(report.sessions_remaining, RECOVERY_EVIDENCE_REGRANT_SESSIONS);
+    assert_eq!(report.zero_send_streak, 0);
+    assert_eq!(report.stage, RecoveryStage::Initial);
+}
+
+#[tokio::test]
+async fn newer_same_generation_nat_observation_reopens_only_the_bounded_recovery_epoch() {
+    let manager = PeerManager::new(test_config());
+    let mut info = PeerInfo {
+        node_id: "peer-observation-recovery".to_string(),
+        device_name: "test-device".to_string(),
+        app_version: "1.0.0".to_string(),
+        public_key: "pk-observation-recovery".to_string(),
+        endpoint: "203.0.113.51:50000".to_string(),
+        nat_type: "p2v2:m=address_or_port_dependent;a=linear;d=4;c=90;f=address_dependent;h=unknown;g=1;o=1;l=3".to_string(),
+        virtual_ip: "10.20.0.51".to_string(),
+        online: true,
+        last_seen: 0,
+        relay_rtt_ms: None,
+    };
+    manager.add_peer(&info).await;
+    manager.recovery_epoch_admit(&info.node_id).await;
+    while manager.try_consume_recovery_probe_credit(&info.node_id).await {}
+    for _ in 0..RECOVERY_EPOCH_PLAN_BUILDS {
+        assert!(manager.try_consume_recovery_plan_build(&info.node_id).await);
+    }
+    for _ in 0..RECOVERY_EPOCH_SESSIONS {
+        assert!(manager.try_consume_recovery_session(&info.node_id).await);
+    }
+    manager
+        .record_zero_send_recovery_session(
+            &info.node_id,
+            10,
+            10,
+            10,
+            "all_probes_rejected_by_budget",
+        )
+        .await;
+    assert!(manager.recovery_budget_frozen(&info.node_id).await);
+
+    // A replayed heartbeat o=1 cannot unfreeze work.
+    manager.add_peer(&info).await;
+    assert!(manager.recovery_budget_frozen(&info.node_id).await);
+
+    // o=2 is a new successful remote STUN observation at unchanged g=1. It
+    // grants only the existing evidence-bound recovery allowance; it does not
+    // rotate a peer session or create an unlimited retry loop.
+    info.nat_type = info.nat_type.replacen("o=1", "o=2", 1);
+    manager.add_peer(&info).await;
+    let report = manager
+        .recovery_epoch_work_budget_report(&info.node_id)
+        .await
+        .expect("epoch must exist");
+    assert_eq!(report.probe_credit_remaining, RECOVERY_EVIDENCE_RETRY_CREDIT);
+    assert_eq!(report.plan_builds_remaining, RECOVERY_EVIDENCE_REGRANT_PLAN_BUILDS);
+    assert_eq!(report.sessions_remaining, RECOVERY_EVIDENCE_REGRANT_SESSIONS);
 }

--- a/client/nat/src/ice.rs
+++ b/client/nat/src/ice.rs
@@ -331,6 +331,76 @@ impl NatProfile {
         format!("{};g={generation}", self.control_label())
     }
 
+    /// Add an independently monotonic, *real measurement* sequence to the
+    /// control-plane NAT hint.
+    ///
+    /// `g` describes a change in the usable NAT capability. It deliberately
+    /// does not change for a stable mapping whose STUN RTT merely varies. A
+    /// receiver still needs to learn that a new STUN transaction actually
+    /// succeeded, however: otherwise it must either let good evidence expire
+    /// after one minute or let cached heartbeat metadata keep it fresh forever.
+    /// `o` is that proof-of-new-observation fence. Callers must only provide
+    /// it after a live gather has produced a successful server-reflexive
+    /// observation; cached heartbeat publication reuses the prior label.
+    ///
+    /// The device `nat_type` field is capped at 128 bytes. The normal label is
+    /// much shorter, but maximal `g` and `o` values combined with the longest
+    /// diagnostics fields can exceed the cap. In that exceptional case drop
+    /// optional hairpin then confidence diagnostics while retaining every
+    /// traversal-affecting field (`m`, `a`, `d`, `f`) and both ordering fences.
+    /// Never truncate a field: malformed labels must stay malformed rather
+    /// than silently changing traversal behavior.
+    pub fn control_label_with_generation_and_observation(
+        &self,
+        generation: u64,
+        observation: Option<u64>,
+    ) -> String {
+        self.control_label_with_evidence(generation, observation, None)
+    }
+
+    /// Build the fully fenced NAT label used by the control plane.
+    ///
+    /// `l` is a server-issued registration lifecycle. It resets `g`/`o`
+    /// ordering after a daemon re-registers, while preventing endpoint PATCHes
+    /// from an earlier process incarnation from overwriting the new one.
+    pub fn control_label_with_evidence(
+        &self,
+        generation: u64,
+        observation: Option<u64>,
+        lifecycle: Option<u64>,
+    ) -> String {
+        if observation.is_none() && lifecycle.is_none() {
+            return self.control_label_with_generation(generation);
+        }
+
+        const CONTROL_LABEL_MAX_BYTES: usize = 128;
+        let mut suffix = format!(";g={generation}");
+        if let Some(observation) = observation {
+            suffix.push_str(&format!(";o={observation}"));
+        }
+        if let Some(lifecycle) = lifecycle {
+            suffix.push_str(&format!(";l={lifecycle}"));
+        }
+        let mut label = self.control_label();
+        if label.len() + suffix.len() > CONTROL_LABEL_MAX_BYTES {
+            label = remove_control_label_field(&label, "h");
+        }
+        if label.len() + suffix.len() > CONTROL_LABEL_MAX_BYTES {
+            label = remove_control_label_field(&label, "c");
+        }
+        if label.len() + suffix.len() > CONTROL_LABEL_MAX_BYTES {
+            // `f` is an additive refinement. Mapping/allocation/delta remain
+            // sufficient for the conservative legacy-compatible planner.
+            label = remove_control_label_field(&label, "f");
+        }
+
+        debug_assert!(
+            label.len() + suffix.len() <= CONTROL_LABEL_MAX_BYTES,
+            "NAT control label must fit the server cap"
+        );
+        format!("{label}{suffix}")
+    }
+
     fn unknown(local_addr: SocketAddr) -> Self {
         Self {
             local_addr: local_addr.to_string(),
@@ -354,6 +424,25 @@ impl NatProfile {
     }
 }
 
+/// Remove exactly one complete `;key=value` field from a compact control
+/// label. This is deliberately field-aware instead of byte truncation so the
+/// parser either receives a valid conservative label or rejects it entirely.
+fn remove_control_label_field(label: &str, key: &str) -> String {
+    let needle = format!(";{key}=");
+    let Some(start) = label.find(&needle) else {
+        return label.to_string();
+    };
+    let value_start = start + needle.len();
+    let end = label[value_start..]
+        .find(';')
+        .map(|offset| value_start + offset)
+        .unwrap_or(label.len());
+    let mut compact = String::with_capacity(label.len().saturating_sub(end - start));
+    compact.push_str(&label[..start]);
+    compact.push_str(&label[end..]);
+    compact
+}
+
 /// Parsed value of the `a=` (allocation) token in a [`control_label`].
 ///
 /// `allocation` is DERIVED in `NatProfile::control_label` (it is not stored as
@@ -371,7 +460,7 @@ pub enum NatAllocation {
 }
 
 /// Structured view of a peer `nat_type` control label
-/// (`p2:`/`p2v2:m=..;a=..;d=..;c=..;f=..;h=..[;g=..]`).
+/// (`p2:`/`p2v2:m=..;a=..;d=..;c=..;f=..;h=..[;g=..][;o=..][;l=..]`).
 ///
 /// Receiver-side counterpart to [`NatProfile::control_label`]: the daemon
 /// advertises the label through the relay and the peer parses it back into
@@ -395,6 +484,16 @@ pub struct NatFingerprintHint {
     pub hairpin: HairpinBehavior,
     /// Parsed `g=` profile/evidence generation, if advertised.
     pub profile_generation: Option<u64>,
+    /// Parsed `o=` real STUN observation sequence, if advertised.
+    ///
+    /// This is independent of `g=`: a stable NAT capability may receive many
+    /// live observations without invalidating an established Direct session.
+    pub observation_sequence: Option<u64>,
+    /// Parsed `l=` server-issued registration lifecycle, if advertised.
+    ///
+    /// A newer lifecycle permits a producer to restart its local `g`/`o`
+    /// counters; an older lifecycle must never overwrite a newer one.
+    pub registration_lifecycle: Option<u64>,
     /// `true` only when a well-formed `p2:`/`p2v2:` label was recognized.
     pub parsed: bool,
     /// The trimmed, lower-cased input, retained for the legacy fallback.
@@ -481,7 +580,7 @@ pub fn parse_nat_hint(input: &str) -> NatFingerprintHint {
         return unparsed_hint(&raw);
     };
     // A well-formed label is one or more `key=value` fields joined by `;`,
-    // each with a recognized key (m/a/d/c/f/h/g) AND a recognized value
+    // each with a recognized key (m/a/d/c/f/h/g/o/l) AND a recognized value
     // (d/c numeric where applicable).  Being strict here is the conservative
     // direction: any malformed segment (no `=`), unrecognized key, or bad
     // value yields `parsed == false` and the caller falls back to the legacy
@@ -498,6 +597,8 @@ pub fn parse_nat_hint(input: &str) -> NatFingerprintHint {
     let mut filtering = FilteringBehavior::Unknown;
     let mut hairpin = HairpinBehavior::Unknown;
     let mut profile_generation: Option<u64> = None;
+    let mut observation_sequence: Option<u64> = None;
+    let mut registration_lifecycle: Option<u64> = None;
     let mut fields = 0u8;
     for field in payload.split(';') {
         if field.is_empty() {
@@ -564,6 +665,20 @@ pub fn parse_nat_hint(input: &str) -> NatFingerprintHint {
                 };
                 fields += 1;
             }
+            "o" => {
+                observation_sequence = match value.parse::<u64>() {
+                    Ok(observation) => Some(observation),
+                    Err(_) => return unparsed_hint(&raw),
+                };
+                fields += 1;
+            }
+            "l" => {
+                registration_lifecycle = match value.parse::<u64>() {
+                    Ok(lifecycle) => Some(lifecycle),
+                    Err(_) => return unparsed_hint(&raw),
+                };
+                fields += 1;
+            }
             _ => return unparsed_hint(&raw), // unrecognized key → corrupted
         }
     }
@@ -578,6 +693,8 @@ pub fn parse_nat_hint(input: &str) -> NatFingerprintHint {
         filtering,
         hairpin,
         profile_generation,
+        observation_sequence,
+        registration_lifecycle,
         parsed: true,
         raw,
     }
@@ -594,6 +711,8 @@ fn unparsed_hint(raw: &str) -> NatFingerprintHint {
         filtering: FilteringBehavior::Unknown,
         hairpin: HairpinBehavior::Unknown,
         profile_generation: None,
+        observation_sequence: None,
+        registration_lifecycle: None,
         parsed: false,
         raw: raw.to_string(),
     }

--- a/client/nat/src/ice/tests/fingerprint.rs
+++ b/client/nat/src/ice/tests/fingerprint.rs
@@ -257,6 +257,33 @@ fn test_profile_generation_is_additive_and_bounded() {
     assert_eq!(hint.profile_generation, Some(u64::MAX));
 }
 
+#[test]
+fn test_observation_and_registration_lifecycle_round_trip_without_exceeding_cap() {
+    let profile = fingerprint_profile(
+        MappingBehavior::AddressOrPortDependent,
+        FilteringBehavior::AddressOrPortDependent,
+        HairpinBehavior::NotApplicable,
+        false,
+        true,
+        Some(i32::MAX),
+        Some(true),
+        100,
+    );
+
+    let label = profile.control_label_with_evidence(u64::MAX, Some(u64::MAX), Some(u64::MAX));
+    assert!(label.len() <= 128, "label exceeds server cap: {label}");
+    let hint = parse_nat_hint(&label);
+    assert!(hint.parsed, "bounded label must remain parseable: {label}");
+    assert_eq!(hint.profile_generation, Some(u64::MAX));
+    assert_eq!(hint.observation_sequence, Some(u64::MAX));
+    assert_eq!(hint.registration_lifecycle, Some(u64::MAX));
+    // The cap fallback is permitted to omit diagnostics, but must retain the
+    // traversal-bearing mapping/allocation/delta information.
+    assert_eq!(hint.mapping, MappingBehavior::AddressOrPortDependent);
+    assert_eq!(hint.allocation, NatAllocation::Linear);
+    assert_eq!(hint.port_delta, Some(i32::MAX));
+}
+
 /// Mirror of `control_label`'s allocation derivation, used only to assert the
 /// round-tripped `a=` equals the source profile's derived allocation.
 fn expected_allocation(p: &NatProfile) -> NatAllocation {

--- a/client/nat/src/traversal.rs
+++ b/client/nat/src/traversal.rs
@@ -302,6 +302,19 @@ impl NatProfileEvidence {
 pub struct RemoteNatProfile {
     pub capabilities: NatCapabilities,
     pub generation: Option<u64>,
+    /// Server-issued lifecycle for the remote registration. A newer lifecycle
+    /// deliberately resets the producer's local generation/observation
+    /// counters; a delayed older lifecycle is rejected before it can do so.
+    #[serde(default)]
+    pub registration_lifecycle: Option<u64>,
+    /// Monotonic sequence of the remote's latest real NAT observation.
+    ///
+    /// A repeated control heartbeat carries the same value and must not renew
+    /// `received_at_ms`; a strictly newer value has crossed a fresh STUN
+    /// measurement and may renew it without forcing a capability generation
+    /// change.
+    #[serde(default)]
+    pub observation_sequence: Option<u64>,
     pub received_at_ms: u64,
 }
 

--- a/contracts/fixtures/status.json
+++ b/contracts/fixtures/status.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "version": "0.1.152",
+  "version": "0.1.153",
   "process_id": 44413,
   "node_id": "node-a",
   "virtual_ip": "10.20.0.7",

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -22,6 +22,11 @@ type Server struct {
 	relayTicketSigner        *auth.RelayTicketSigner
 	relayRevocationFeedToken string
 	signalNotifier           *signalNotifier
+	// registrationSessionLocks serializes a device's registration with its
+	// device-token control actions.  The database performs the final conditional
+	// update for lease-changing operations; this lock covers complex signal and
+	// WebSocket actions that span multiple queries in this server process.
+	registrationSessionLocks registrationSessionLocker
 }
 
 // NewServer creates a new API server.
@@ -63,6 +68,7 @@ func NewServer(authService *auth.Service, hub *signaling.Hub, db *database.DB) *
 		relayTicketSigner:        signer,
 		relayRevocationFeedToken: strings.TrimSpace(os.Getenv("RELAY_REVOCATION_FEED_TOKEN")),
 		signalNotifier:           newSignalNotifier(),
+		registrationSessionLocks: newRegistrationSessionLocks(),
 	}
 }
 

--- a/server/api/device_handlers.go
+++ b/server/api/device_handlers.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/yhan-sun/p2wlan/server/auth"
+	"github.com/yhan-sun/p2wlan/server/database"
 )
 
 // ---- Device endpoints ----
@@ -24,6 +26,10 @@ func (s *Server) RegisterDevice(w http.ResponseWriter, r *http.Request) {
 		Ed25519PublicKey    string `json:"ed25519_public_key"`
 		ChallengeID         string `json:"challenge_id"`
 		ChallengeSignature  string `json:"challenge_signature"`
+		// RegistrationIncarnation is the daemon's durable monotonic boot
+		// counter. It fences a late registration from an older process that
+		// still holds the same device credential.
+		RegistrationIncarnation *int64 `json:"registration_incarnation"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error":"invalid request"}`, http.StatusBadRequest)
@@ -66,6 +72,10 @@ func (s *Server) RegisterDevice(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(req.AppVersion) > 64 {
 		http.Error(w, `{"error":"app_version too long"}`, http.StatusBadRequest)
+		return
+	}
+	if req.RegistrationIncarnation != nil && *req.RegistrationIncarnation < 0 {
+		http.Error(w, `{"error":"registration_incarnation must not be negative"}`, http.StatusBadRequest)
 		return
 	}
 
@@ -133,10 +143,55 @@ func (s *Server) RegisterDevice(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	device, err := s.db.CreateDeviceWithOptions(userID, networkID, req.PublicKey, req.DeviceName, req.Platform, ed25519PubKey, req.VirtualIP, req.AppVersion)
+	// Serialize a re-registration with control requests from the existing
+	// daemon.  The request that already held the per-device lock is allowed to
+	// finish before its replacement clears transport state; every request that
+	// begins afterwards observes the new registration sequence.  New public
+	// keys have no prior daemon session to fence.
+	var previousRegistrationSequence int64
+	if existingDevice, err := s.db.GetDeviceByPublicKey(networkID, req.PublicKey); err == nil {
+		unlock := s.lockDeviceRegistrationSession(existingDevice.ID)
+		defer unlock()
+		// Refresh under the lock in case an earlier registration completed while
+		// this request was waiting for it.
+		if currentDevice, currentErr := s.db.GetDevice(existingDevice.ID); currentErr == nil {
+			previousRegistrationSequence = currentDevice.RegistrationSeq
+		}
+	}
+
+	device, err := s.db.RegisterDeviceWithOptions(
+		userID,
+		networkID,
+		req.PublicKey,
+		req.DeviceName,
+		req.Platform,
+		ed25519PubKey,
+		req.VirtualIP,
+		req.AppVersion,
+		database.DeviceRegistrationAttempt{
+			Incarnation:        req.RegistrationIncarnation,
+			EnforceIncarnation: true,
+		},
+	)
 	if err != nil {
+		var conflict *database.RegistrationConflictError
+		if errors.As(err, &conflict) {
+			writeJSON(w, http.StatusConflict, map[string]interface{}{
+				"error":                    conflict.Error(),
+				"error_code":               conflict.Code,
+				"registration_seq":         conflict.CurrentSequence,
+				"registration_incarnation": conflict.CurrentIncarnation,
+			})
+			return
+		}
 		writeDeviceMutationError(w, err, "device registration failed")
 		return
+	}
+	if previousRegistrationSequence != 0 && device.RegistrationSeq != previousRegistrationSequence && s.hub != nil {
+		// A freshly registered daemon owns the wake-up channel.  This also
+		// closes an older already-upgraded socket; future upgrades require the
+		// new header sequence through RequireCurrentDeviceRegistrationSession.
+		s.hub.Disconnect(device.ID)
 	}
 
 	var cidr string
@@ -146,11 +201,13 @@ func (s *Server) RegisterDevice(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"success":       true,
-		"node_id":       device.ID,
-		"virtual_ip":    device.VirtualIP,
-		"cidr":          cidr,
-		"relay_servers": s.relayServers,
+		"success":                  true,
+		"node_id":                  device.ID,
+		"virtual_ip":               device.VirtualIP,
+		"cidr":                     cidr,
+		"registration_seq":         device.RegistrationSeq,
+		"registration_incarnation": device.RegistrationIncarnation,
+		"relay_servers":            s.relayServers,
 	}
 
 	// Include relay catalog for new clients that support it
@@ -302,11 +359,18 @@ func (s *Server) UpdateDeviceEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	var updateErr error
 	if refreshLease {
-		updateErr = s.db.UpdateDeviceEndpoint(pathDeviceID, req.Endpoint, req.NATType, req.RelayRTTMS)
+		if registrationSequence, ok := currentRequestRegistrationSequence(r); ok {
+			updateErr = s.db.UpdateDeviceEndpointForRegistrationSession(pathDeviceID, registrationSequence, req.Endpoint, req.NATType, req.RelayRTTMS)
+		} else {
+			updateErr = s.db.UpdateDeviceEndpoint(pathDeviceID, req.Endpoint, req.NATType, req.RelayRTTMS)
+		}
 	} else {
 		updateErr = s.db.UpdateDeviceEndpointMetadata(pathDeviceID, req.Endpoint, req.NATType, req.RelayRTTMS)
 	}
 	if updateErr != nil {
+		if writeRegistrationSessionConflict(w, updateErr) {
+			return
+		}
 		http.Error(w, `{"error":"endpoint update failed"}`, http.StatusInternalServerError)
 		return
 	}
@@ -325,8 +389,10 @@ func (s *Server) ReleaseDevicePresence(w http.ResponseWriter, r *http.Request) {
 	}
 
 	authorized := false
+	deviceAuthenticated := false
 	if deviceClaims, err := auth.GetDeviceClaims(r.Context()); err == nil {
 		authorized = pathDeviceID == deviceClaims.DeviceID
+		deviceAuthenticated = authorized
 	} else if userClaims, err := auth.GetClaims(r.Context()); err == nil {
 		belongs, err := s.db.DeviceBelongsToUser(pathDeviceID, userClaims.UserID)
 		authorized = err == nil && belongs
@@ -336,7 +402,20 @@ func (s *Server) ReleaseDevicePresence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.db.ReleaseDevicePresence(pathDeviceID); err != nil {
+	var releaseErr error
+	if deviceAuthenticated {
+		if registrationSequence, ok := currentRequestRegistrationSequence(r); ok {
+			releaseErr = s.db.ReleaseDevicePresenceForRegistrationSession(pathDeviceID, registrationSequence)
+		} else {
+			releaseErr = s.db.ReleaseDevicePresence(pathDeviceID)
+		}
+	} else {
+		releaseErr = s.db.ReleaseDevicePresence(pathDeviceID)
+	}
+	if releaseErr != nil {
+		if writeRegistrationSessionConflict(w, releaseErr) {
+			return
+		}
 		http.Error(w, `{"error":"presence release failed"}`, http.StatusInternalServerError)
 		return
 	}

--- a/server/api/device_update_test.go
+++ b/server/api/device_update_test.go
@@ -125,6 +125,236 @@ func TestRegisterDeviceStoresRequestedIPAndVersion(t *testing.T) {
 	}
 }
 
+func TestDeviceCredentialReregistrationKeepsDeviceOnlyAuthenticationAfterResponseLoss(t *testing.T) {
+	t.Setenv("RELAY_CATALOG_JSON", `[{"region":"test","audience":"relay-test","endpoint":"tls://relay.example.com:18081"}]`)
+	t.Setenv("RELAY_TICKET_SIGNER_JSON", `{"active":{"kid":"test-key","private_key":"0101010101010101010101010101010101010101010101010101010101010101"}}`)
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("device-reregister@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "device-reregister-key", "before", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	_, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+
+	// The handlers are wrapped in the real credential middleware. The token is
+	// deliberately not a user JWT, so any success below proves there was no
+	// user-token fallback after the registration response was dropped.
+	service := auth.NewService("credential-reregister-test", db)
+	server := NewServer(service, nil, db)
+	register := auth.RequireAnyAuth(service, db)(server.RegisterDevice)
+
+	registrationReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"device-reregister-key","device_name":"after","platform":"macos","network_id":"default","registration_incarnation":100}`),
+	)
+	registrationReq.Header.Set("Authorization", "Bearer "+credential)
+	registrationRecorder := httptest.NewRecorder()
+	register(registrationRecorder, registrationReq)
+	if registrationRecorder.Code != http.StatusOK {
+		t.Fatalf("device-authenticated re-registration: HTTP %d %s", registrationRecorder.Code, registrationRecorder.Body.String())
+	}
+
+	var registrationResponse struct {
+		Success                 bool   `json:"success"`
+		RegistrationSeq         int64  `json:"registration_seq"`
+		RegistrationIncarnation int64  `json:"registration_incarnation"`
+		DeviceCredential        string `json:"device_credential"`
+	}
+	if err := json.Unmarshal(registrationRecorder.Body.Bytes(), &registrationResponse); err != nil {
+		t.Fatalf("decode registration response: %v", err)
+	}
+	if !registrationResponse.Success || registrationResponse.RegistrationSeq != 2 || registrationResponse.RegistrationIncarnation != 100 {
+		t.Fatalf("unexpected registration response: %+v", registrationResponse)
+	}
+	if registrationResponse.DeviceCredential != "" {
+		t.Fatalf("credential-preserving re-registration must not unexpectedly rotate into the response: %+v", registrationResponse)
+	}
+
+	// The first response is intentionally ignored. A same-incarnation retry
+	// must be idempotent: the server must not clear state or consume another
+	// registration sequence while the daemon is recovering from a lost reply.
+	replayReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"device-reregister-key","device_name":"after","platform":"macos","network_id":"default","registration_incarnation":100}`),
+	)
+	replayReq.Header.Set("Authorization", "Bearer "+credential)
+	replayRecorder := httptest.NewRecorder()
+	register(replayRecorder, replayReq)
+	if replayRecorder.Code != http.StatusOK {
+		t.Fatalf("same-incarnation registration replay: HTTP %d %s", replayRecorder.Code, replayRecorder.Body.String())
+	}
+	var replayResponse struct {
+		RegistrationSeq int64 `json:"registration_seq"`
+	}
+	if err := json.Unmarshal(replayRecorder.Body.Bytes(), &replayResponse); err != nil {
+		t.Fatalf("decode replay response: %v", err)
+	}
+	if replayResponse.RegistrationSeq != registrationResponse.RegistrationSeq {
+		t.Fatalf("same-incarnation replay advanced registration sequence: got %d want %d", replayResponse.RegistrationSeq, registrationResponse.RegistrationSeq)
+	}
+
+	// Ignore the response after its server-side completion, as if it was lost.
+	// The persisted credential must still authenticate the daemon's next
+	// endpoint heartbeat without a user JWT.
+	endpoint := auth.RequireDeviceAuth(db)(server.UpdateDeviceEndpoint)
+	endpointReq := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/devices/"+device.ID+"/endpoint",
+		strings.NewReader(`{"endpoint":"198.51.100.88:51820","nat_type":"p2v2:m=endpoint_independent;g=1;l=2"}`),
+	)
+	endpointReq.SetPathValue("id", device.ID)
+	endpointReq.Header.Set("Authorization", "Bearer "+credential)
+	endpointRecorder := httptest.NewRecorder()
+	endpoint(endpointRecorder, endpointReq)
+	if endpointRecorder.Code != http.StatusOK {
+		t.Fatalf("device credential did not authenticate endpoint heartbeat after re-registration: HTTP %d %s", endpointRecorder.Code, endpointRecorder.Body.String())
+	}
+
+	updated, err := db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	if updated.Endpoint != "198.51.100.88:51820" || updated.NATType != "p2v2:m=endpoint_independent;g=1;l=2" || !updated.Online {
+		t.Fatalf("device-only heartbeat did not publish the new incarnation: %+v", updated)
+	}
+
+	// A delayed duplicate may arrive after the daemon already published its
+	// endpoint. It must retain those facts as well as the registration sequence.
+	postHeartbeatReplayReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"device-reregister-key","device_name":"after","platform":"macos","network_id":"default","registration_incarnation":100}`),
+	)
+	postHeartbeatReplayReq.Header.Set("Authorization", "Bearer "+credential)
+	postHeartbeatReplayRecorder := httptest.NewRecorder()
+	register(postHeartbeatReplayRecorder, postHeartbeatReplayReq)
+	if postHeartbeatReplayRecorder.Code != http.StatusOK {
+		t.Fatalf("post-heartbeat same-incarnation replay: HTTP %d %s", postHeartbeatReplayRecorder.Code, postHeartbeatReplayRecorder.Body.String())
+	}
+	updated, err = db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice after post-heartbeat replay: %v", err)
+	}
+	if updated.RegistrationSeq != 2 || updated.Endpoint != "198.51.100.88:51820" || updated.NATType != "p2v2:m=endpoint_independent;g=1;l=2" {
+		t.Fatalf("same-incarnation replay cleared live endpoint facts: %+v", updated)
+	}
+
+	listNodes := auth.RequireAnyAuth(service, db)(server.ListNodes)
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/nodes", nil)
+	listReq.Header.Set("Authorization", "Bearer "+credential)
+	listRecorder := httptest.NewRecorder()
+	listNodes(listRecorder, listReq)
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("device credential did not authenticate roster fetch: HTTP %d %s", listRecorder.Code, listRecorder.Body.String())
+	}
+
+	relayTicket := auth.RequireDeviceAuth(db)(server.CreateRelayTicket)
+	ticketReq := httptest.NewRequest(http.MethodPost, "/api/v1/relay/tickets", strings.NewReader(`{"audience":"relay-test"}`))
+	ticketReq.Header.Set("Authorization", "Bearer "+credential)
+	ticketRecorder := httptest.NewRecorder()
+	relayTicket(ticketRecorder, ticketReq)
+	if ticketRecorder.Code != http.StatusOK {
+		t.Fatalf("device credential did not authenticate relay ticket fetch: HTTP %d %s", ticketRecorder.Code, ticketRecorder.Body.String())
+	}
+
+	newerReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"device-reregister-key","device_name":"newer","platform":"macos","network_id":"default","registration_incarnation":101}`),
+	)
+	newerReq.Header.Set("Authorization", "Bearer "+credential)
+	newerRecorder := httptest.NewRecorder()
+	register(newerRecorder, newerReq)
+	if newerRecorder.Code != http.StatusOK {
+		t.Fatalf("newer incarnation registration: HTTP %d %s", newerRecorder.Code, newerRecorder.Body.String())
+	}
+
+	staleReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"device-reregister-key","device_name":"late-old","platform":"macos","network_id":"default","registration_incarnation":100}`),
+	)
+	staleReq.Header.Set("Authorization", "Bearer "+credential)
+	staleRecorder := httptest.NewRecorder()
+	register(staleRecorder, staleReq)
+	if staleRecorder.Code != http.StatusConflict {
+		t.Fatalf("late older incarnation must be fenced: HTTP %d %s", staleRecorder.Code, staleRecorder.Body.String())
+	}
+	updated, err = db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice after stale registration: %v", err)
+	}
+	if updated.DeviceName != "newer" || updated.RegistrationIncarnation != 101 || updated.RegistrationSeq != 3 {
+		t.Fatalf("stale registration overwrote newer daemon state: %+v", updated)
+	}
+}
+
+func TestRevokedDeviceCredentialCannotReregisterOrUpdateEndpoint(t *testing.T) {
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("revoked-reregister@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "revoked-reregister-key", "device", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	cred, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+	if err := db.RevokeDeviceCredential(cred.ID); err != nil {
+		t.Fatalf("RevokeDeviceCredential: %v", err)
+	}
+
+	service := auth.NewService("revoked-reregister-test", db)
+	server := NewServer(service, nil, db)
+	register := auth.RequireAnyAuth(service, db)(server.RegisterDevice)
+	registrationReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/devices",
+		strings.NewReader(`{"public_key":"revoked-reregister-key","device_name":"stale","platform":"macos","network_id":"default"}`),
+	)
+	registrationReq.Header.Set("Authorization", "Bearer "+credential)
+	registrationRecorder := httptest.NewRecorder()
+	register(registrationRecorder, registrationReq)
+	if registrationRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked credential re-registration: HTTP %d %s", registrationRecorder.Code, registrationRecorder.Body.String())
+	}
+
+	endpoint := auth.RequireDeviceAuth(db)(server.UpdateDeviceEndpoint)
+	endpointReq := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/devices/"+device.ID+"/endpoint",
+		strings.NewReader(`{"endpoint":"198.51.100.89:51820","nat_type":"unknown"}`),
+	)
+	endpointReq.SetPathValue("id", device.ID)
+	endpointReq.Header.Set("Authorization", "Bearer "+credential)
+	endpointRecorder := httptest.NewRecorder()
+	endpoint(endpointRecorder, endpointReq)
+	if endpointRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked credential endpoint update: HTTP %d %s", endpointRecorder.Code, endpointRecorder.Body.String())
+	}
+}
+
 func TestUpdateDeviceChangesVirtualIP(t *testing.T) {
 	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
 	if err != nil {

--- a/server/api/registration_session.go
+++ b/server/api/registration_session.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/yhan-sun/p2wlan/server/auth"
+	"github.com/yhan-sun/p2wlan/server/database"
+	"github.com/yhan-sun/p2wlan/server/signaling"
+)
+
+type registrationSessionContextKey struct{}
+
+type registrationSessionLocker interface {
+	Lock(deviceID string) func()
+}
+
+type deviceRegistrationSessionLocks struct {
+	locks sync.Map // map[string]*sync.Mutex
+}
+
+func newRegistrationSessionLocks() *deviceRegistrationSessionLocks {
+	return &deviceRegistrationSessionLocks{}
+}
+
+func (locks *deviceRegistrationSessionLocks) Lock(deviceID string) func() {
+	value, _ := locks.locks.LoadOrStore(deviceID, &sync.Mutex{})
+	lock := value.(*sync.Mutex)
+	lock.Lock()
+	return lock.Unlock
+}
+
+// RequireCurrentDeviceRegistrationSession validates the sequence proof and
+// serializes the validated device-token REST action with device
+// re-registration.  The mutex is deliberately per device: a long signal poll
+// for one daemon must not delay an unrelated daemon's registration.
+// Endpoint and presence writes additionally re-check the sequence in their
+// database write transaction. The signaling hub and this lock are process
+// local, so a future multi-process control-plane deployment must add shared
+// session fencing and connection eviction before it is supported.
+func (s *Server) RequireCurrentDeviceRegistrationSession(next http.HandlerFunc) http.HandlerFunc {
+	return s.requireCurrentDeviceRegistrationSession(next)
+}
+
+func (s *Server) requireCurrentDeviceRegistrationSession(next http.HandlerFunc) http.HandlerFunc {
+	validated := auth.RequireCurrentDeviceRegistrationSession(s.db)(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := auth.GetDeviceClaims(r.Context()); err == nil {
+			if sequence, ok := registrationSequenceFromHeader(r); ok {
+				r = r.WithContext(context.WithValue(r.Context(), registrationSessionContextKey{}, sequence))
+			}
+		}
+		next(w, r)
+	})
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		claims, err := auth.GetDeviceClaims(r.Context())
+		if err != nil {
+			validated(w, r)
+			return
+		}
+		unlock := s.lockDeviceRegistrationSession(claims.DeviceID)
+		defer unlock()
+		validated(w, r)
+	}
+}
+
+// WebSocketRegistrationSessionGuard keeps a device's registration lock from
+// the authoritative sequence re-check through signaling.Hub.register.  The
+// signaling package releases it immediately after registration, before the
+// socket begins its long-lived read/write pumps.
+func (s *Server) WebSocketRegistrationSessionGuard() signaling.UpgradeGuard {
+	return func(w http.ResponseWriter, r *http.Request) (func(), bool) {
+		claims, err := auth.GetDeviceClaims(r.Context())
+		if err != nil {
+			http.Error(w, `{"error":"device authentication required"}`, http.StatusUnauthorized)
+			return nil, false
+		}
+		unlock := s.lockDeviceRegistrationSession(claims.DeviceID)
+		accepted := false
+		auth.RequireCurrentDeviceRegistrationSession(s.db)(func(http.ResponseWriter, *http.Request) {
+			accepted = true
+		})(w, r)
+		if !accepted {
+			unlock()
+			return nil, false
+		}
+		return unlock, true
+	}
+}
+
+func (s *Server) lockDeviceRegistrationSession(deviceID string) func() {
+	if deviceID == "" {
+		return func() {}
+	}
+	return s.registrationSessionLocks.Lock(deviceID)
+}
+
+func registrationSequenceFromHeader(r *http.Request) (int64, bool) {
+	values := r.Header.Values(auth.RegistrationSequenceHeader)
+	if len(values) != 1 {
+		return 0, false
+	}
+	sequence, err := strconv.ParseInt(values[0], 10, 64)
+	if err != nil || sequence <= 0 {
+		return 0, false
+	}
+	return sequence, true
+}
+
+func currentRequestRegistrationSequence(r *http.Request) (int64, bool) {
+	sequence, ok := r.Context().Value(registrationSessionContextKey{}).(int64)
+	return sequence, ok && sequence > 0
+}
+
+func writeRegistrationSessionConflict(w http.ResponseWriter, err error) bool {
+	var conflict *database.RegistrationSessionConflictError
+	if !errors.As(err, &conflict) {
+		return false
+	}
+	writeJSON(w, http.StatusConflict, map[string]interface{}{
+		"error":            "device registration session is no longer current",
+		"error_code":       auth.RegistrationLifecycleConflictCode,
+		"registration_seq": conflict.CurrentSequence,
+	})
+	return true
+}

--- a/server/api/registration_session_fence_test.go
+++ b/server/api/registration_session_fence_test.go
@@ -1,0 +1,456 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/yhan-sun/p2wlan/server/auth"
+	"github.com/yhan-sun/p2wlan/server/database"
+	"github.com/yhan-sun/p2wlan/server/signaling"
+)
+
+type registrationSessionFixture struct {
+	db         *database.DB
+	server     *Server
+	service    *auth.Service
+	device     *database.Device
+	peer       *database.Device
+	credential string
+}
+
+type observedRegistrationSessionLocker struct {
+	serial        sync.Mutex
+	mu            sync.Mutex
+	calls         int
+	firstAcquired chan struct{}
+	secondAttempt chan struct{}
+}
+
+func (l *observedRegistrationSessionLocker) Lock(_ string) func() {
+	l.mu.Lock()
+	l.calls++
+	call := l.calls
+	if call == 1 {
+		close(l.firstAcquired)
+	}
+	if call == 2 {
+		close(l.secondAttempt)
+	}
+	l.mu.Unlock()
+	l.serial.Lock()
+	return l.serial.Unlock
+}
+
+func newRegistrationSessionFixture(t *testing.T) *registrationSessionFixture {
+	t.Helper()
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	user, err := db.CreateUser("registration-fence@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "registration-fence-device", "daemon", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	peer, err := db.CreateDevice(user.ID, "default", "registration-fence-peer", "peer", "linux", "")
+	if err != nil {
+		t.Fatalf("CreateDevice peer: %v", err)
+	}
+	_, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+	incarnation := int64(9001)
+	device, err = db.RegisterDeviceWithOptions(
+		user.ID, device.NetworkID, device.PublicKey, "daemon", "macos", "", "", "",
+		database.DeviceRegistrationAttempt{Incarnation: &incarnation, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("RegisterDeviceWithOptions: %v", err)
+	}
+	if device.RegistrationIncarnation != incarnation || device.RegistrationSeq < 2 {
+		t.Fatalf("expected incarnation-aware device, got %+v", device)
+	}
+	return &registrationSessionFixture{
+		db:         db,
+		server:     NewServer(auth.NewService("registration-fence", db), nil, db),
+		service:    auth.NewService("registration-fence", db),
+		device:     device,
+		peer:       peer,
+		credential: credential,
+	}
+}
+
+func (f *registrationSessionFixture) anySession(handler http.HandlerFunc) http.HandlerFunc {
+	return auth.RequireAnyAuth(f.service, f.db)(f.server.RequireCurrentDeviceRegistrationSession(handler))
+}
+
+func (f *registrationSessionFixture) deviceSession(handler http.HandlerFunc) http.HandlerFunc {
+	return auth.RequireDeviceAuth(f.db)(f.server.RequireCurrentDeviceRegistrationSession(handler))
+}
+
+func (f *registrationSessionFixture) deviceWebSocketSession(hub *signaling.Hub) http.HandlerFunc {
+	return auth.RequireDeviceAuth(f.db)(signaling.ServeWS(hub, f.server.WebSocketRegistrationSessionGuard()))
+}
+
+func (f *registrationSessionFixture) request(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+f.credential)
+	return req
+}
+
+func assertRegistrationLifecycleConflict(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("expected HTTP 409, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		ErrorCode string `json:"error_code"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode conflict response: %v (%s)", err, recorder.Body.String())
+	}
+	if response.ErrorCode != auth.RegistrationLifecycleConflictCode {
+		t.Fatalf("error_code = %q, want %q", response.ErrorCode, auth.RegistrationLifecycleConflictCode)
+	}
+}
+
+func TestDeviceRegistrationSessionFenceStopsRESTControlActions(t *testing.T) {
+	f := newRegistrationSessionFixture(t)
+	// These values make any accidental action observable even if the test runs
+	// within a single wall-clock second.
+	if _, err := f.db.Exec(`UPDATE devices SET endpoint = ?, nat_type = ?, relay_rtt_ms = ?, last_seen = ?, online = 1 WHERE id = ?`,
+		"198.51.100.10:51820", "p2v2:m=endpoint_independent;g=4;l="+strconv.FormatInt(f.device.RegistrationSeq, 10), 17, 123, f.device.ID); err != nil {
+		t.Fatalf("prepare device state: %v", err)
+	}
+	if _, err := f.db.CreateSignal(f.peer.ID, f.device.ID, "peer_offer", []string{"203.0.113.10:51820"}, nil, ""); err != nil {
+		t.Fatalf("queue signal: %v", err)
+	}
+
+	type endpointCase struct {
+		name    string
+		handler http.HandlerFunc
+		method  string
+		path    string
+		body    string
+		pathID  string
+	}
+	cases := []endpointCase{
+		{
+			name:    "list nodes",
+			handler: f.anySession(f.server.ListNodes),
+			method:  http.MethodGet,
+			path:    "/api/v1/nodes",
+		},
+		{
+			name:    "endpoint heartbeat",
+			handler: f.anySession(f.server.UpdateDeviceEndpoint),
+			method:  http.MethodPatch,
+			path:    "/api/v1/devices/" + f.device.ID + "/endpoint",
+			pathID:  f.device.ID,
+			body:    `{"endpoint":"198.51.100.99:51820","nat_type":"p2v2:m=endpoint_independent;g=5;l=2"}`,
+		},
+		{
+			name:    "offline presence",
+			handler: f.anySession(f.server.ReleaseDevicePresence),
+			method:  http.MethodPost,
+			path:    "/api/v1/devices/" + f.device.ID + "/offline",
+			pathID:  f.device.ID,
+		},
+		{
+			name:    "create signal",
+			handler: f.anySession(f.server.CreateSignal),
+			method:  http.MethodPost,
+			path:    "/api/v1/signals",
+			body:    `{"to_node_id":"` + f.peer.ID + `","type":"peer_reflexive","candidates":["203.0.113.20:51820"]}`,
+		},
+		{
+			name:    "list signals",
+			handler: f.anySession(f.server.ListSignals),
+			method:  http.MethodGet,
+			path:    "/api/v1/signals",
+		},
+		{
+			name:    "ack signals",
+			handler: f.anySession(f.server.AckSignals),
+			method:  http.MethodPost,
+			path:    "/api/v1/signals/ack",
+			body:    `{"signals":[]}`,
+		},
+		{
+			name:    "relay ticket",
+			handler: f.deviceSession(f.server.CreateRelayTicket),
+			method:  http.MethodPost,
+			path:    "/api/v1/relay/tickets",
+			body:    `{"audience":"not-reached"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := f.request(tc.method, tc.path, tc.body)
+			if tc.pathID != "" {
+				req.SetPathValue("id", tc.pathID)
+			}
+			recorder := httptest.NewRecorder()
+			tc.handler(recorder, req)
+			assertRegistrationLifecycleConflict(t, recorder)
+		})
+	}
+
+	stored, err := f.db.GetDevice(f.device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	if stored.Endpoint != "198.51.100.10:51820" || stored.NATType != "p2v2:m=endpoint_independent;g=4;l="+strconv.FormatInt(f.device.RegistrationSeq, 10) || stored.LastSeen != 123 || !stored.Online {
+		t.Fatalf("stale session changed endpoint or lease: %+v", stored)
+	}
+	if stored.RelayRTTMS == nil || *stored.RelayRTTMS != 17 {
+		t.Fatalf("stale session changed relay RTT: %+v", stored)
+	}
+	var queued int
+	if err := f.db.QueryRow(`SELECT COUNT(*) FROM signals WHERE to_node_id = ?`, f.device.ID).Scan(&queued); err != nil {
+		t.Fatalf("count queued signals: %v", err)
+	}
+	if queued != 1 {
+		t.Fatalf("stale session created, consumed, or acknowledged signals: count=%d", queued)
+	}
+
+	// The exact current header retains the device-token-only path.
+	validReq := f.request(http.MethodGet, "/api/v1/nodes", "")
+	validReq.Header.Set(auth.RegistrationSequenceHeader, strconv.FormatInt(f.device.RegistrationSeq, 10))
+	validRecorder := httptest.NewRecorder()
+	f.anySession(f.server.ListNodes)(validRecorder, validReq)
+	if validRecorder.Code != http.StatusOK {
+		t.Fatalf("current session rejected: HTTP %d %s", validRecorder.Code, validRecorder.Body.String())
+	}
+}
+
+func TestDeviceRegistrationSessionFenceRejectsStaleWebSocketBeforeUpgrade(t *testing.T) {
+	f := newRegistrationSessionFixture(t)
+	hub := signaling.NewHub()
+	t.Cleanup(hub.Close)
+	f.server.hub = hub
+	server := httptest.NewServer(f.deviceWebSocketSession(hub))
+	t.Cleanup(server.Close)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: time.Second,
+		Subprotocols:     []string{signaling.ProtocolName},
+	}
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	staleHeaders := http.Header{"Authorization": []string{"Bearer " + f.credential}}
+	connection, response, err := dialer.Dial(endpoint, staleHeaders)
+	if connection != nil {
+		_ = connection.Close()
+		t.Fatal("stale registration session unexpectedly upgraded WebSocket")
+	}
+	if err == nil || response == nil {
+		t.Fatalf("expected failed WebSocket upgrade, err=%v response=%v", err, response)
+	}
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("stale WebSocket status = %d, want 409", response.StatusCode)
+	}
+
+	currentHeaders := http.Header{
+		"Authorization":                 []string{"Bearer " + f.credential},
+		auth.RegistrationSequenceHeader: []string{strconv.FormatInt(f.device.RegistrationSeq, 10)},
+	}
+	connection, response, err = dialer.Dial(endpoint, currentHeaders)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("current WebSocket upgrade: %v (HTTP %d)", err, response.StatusCode)
+		}
+		t.Fatalf("current WebSocket upgrade: %v", err)
+	}
+	defer connection.Close()
+	if _, _, err := connection.ReadMessage(); err != nil {
+		t.Fatalf("read current-session ready message: %v", err)
+	}
+
+	// A newer registration must evict a socket that was valid for the prior
+	// sequence.  Otherwise an already-upgraded old daemon could keep receiving
+	// wakeups even though its next REST control request would be fenced.
+	register := auth.RequireAnyAuth(f.service, f.db)(f.server.RegisterDevice)
+	registrationReq := f.request(
+		http.MethodPost,
+		"/api/v1/devices",
+		`{"public_key":"`+f.device.PublicKey+`","device_name":"new daemon","platform":"macos","network_id":"default","registration_incarnation":9002}`,
+	)
+	registrationRecorder := httptest.NewRecorder()
+	register(registrationRecorder, registrationReq)
+	if registrationRecorder.Code != http.StatusOK {
+		t.Fatalf("new registration: HTTP %d %s", registrationRecorder.Code, registrationRecorder.Body.String())
+	}
+	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := connection.ReadMessage(); err == nil {
+		t.Fatal("old WebSocket remained usable after newer registration")
+	}
+}
+
+func TestWebSocketRegistrationGuardSerializesUpgradeAndNewRegistration(t *testing.T) {
+	f := newRegistrationSessionFixture(t)
+	hub := signaling.NewHub()
+	t.Cleanup(hub.Close)
+	f.server.hub = hub
+	locker := &observedRegistrationSessionLocker{
+		firstAcquired: make(chan struct{}),
+		secondAttempt: make(chan struct{}),
+	}
+	f.server.registrationSessionLocks = locker
+
+	allowUpgrade := make(chan struct{})
+	guardEntered := make(chan struct{})
+	releaseRegistered := make(chan bool, 1)
+	baseGuard := f.server.WebSocketRegistrationSessionGuard()
+	guard := func(w http.ResponseWriter, r *http.Request) (func(), bool) {
+		release, ok := baseGuard(w, r)
+		if !ok {
+			return nil, false
+		}
+		close(guardEntered)
+		<-allowUpgrade
+		return func() {
+			// signaling.ServeWS invokes this only after Hub.register.  A live
+			// enqueue proves the registration happened before the session lock
+			// became available to the concurrent newer registration below.
+			releaseRegistered <- hub.Notify(f.device.ID)
+			release()
+		}, true
+	}
+	server := httptest.NewServer(auth.RequireDeviceAuth(f.db)(signaling.ServeWS(hub, guard)))
+	t.Cleanup(server.Close)
+
+	dialResult := make(chan struct {
+		connection *websocket.Conn
+		response   *http.Response
+		err        error
+	}, 1)
+	go func() {
+		dialer := websocket.Dialer{HandshakeTimeout: 2 * time.Second, Subprotocols: []string{signaling.ProtocolName}}
+		connection, response, err := dialer.Dial(
+			"ws"+strings.TrimPrefix(server.URL, "http"),
+			http.Header{
+				"Authorization":                 []string{"Bearer " + f.credential},
+				auth.RegistrationSequenceHeader: []string{strconv.FormatInt(f.device.RegistrationSeq, 10)},
+			},
+		)
+		dialResult <- struct {
+			connection *websocket.Conn
+			response   *http.Response
+			err        error
+		}{connection, response, err}
+	}()
+
+	select {
+	case <-guardEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WebSocket guard did not acquire the registration lock")
+	}
+	select {
+	case <-locker.firstAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first registration-session lock acquisition was not observed")
+	}
+
+	registrationDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		register := auth.RequireAnyAuth(f.service, f.db)(f.server.RegisterDevice)
+		req := f.request(
+			http.MethodPost,
+			"/api/v1/devices",
+			`{"public_key":"`+f.device.PublicKey+`","device_name":"new daemon","platform":"macos","network_id":"default","registration_incarnation":9002}`,
+		)
+		recorder := httptest.NewRecorder()
+		register(recorder, req)
+		registrationDone <- recorder
+	}()
+	select {
+	case <-locker.secondAttempt:
+		// The second call has reached the exact same lock, but cannot acquire
+		// it until signaling registers the first socket and releases the guard.
+	case <-time.After(2 * time.Second):
+		t.Fatal("new registration did not contend for the WebSocket session lock")
+	}
+	select {
+	case recorder := <-registrationDone:
+		t.Fatalf("new registration completed before guarded Hub.register: HTTP %d %s", recorder.Code, recorder.Body.String())
+	default:
+	}
+
+	close(allowUpgrade)
+	select {
+	case registered := <-releaseRegistered:
+		if !registered {
+			t.Fatal("session lock was released before WebSocket entered the Hub")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WebSocket did not reach Hub.register")
+	}
+	select {
+	case recorder := <-registrationDone:
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("new registration after WebSocket registration: HTTP %d %s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("new registration remained blocked after Hub.register")
+	}
+	select {
+	case result := <-dialResult:
+		if result.connection != nil {
+			_ = result.connection.Close()
+		}
+		if result.err != nil && result.response == nil {
+			t.Fatalf("guarded WebSocket failed before registration: %v", result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("guarded WebSocket dial did not finish")
+	}
+}
+
+func TestLegacyDeviceCredentialControlRequestRemainsHeaderFree(t *testing.T) {
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	user, err := db.CreateUser("registration-fence-legacy@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "registration-fence-legacy", "legacy", "linux", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	_, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+	server := NewServer(nil, nil, db)
+	handler := auth.RequireDeviceAuth(db)(server.RequireCurrentDeviceRegistrationSession(server.ListNodes))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/nodes", nil)
+	req.Header.Set("Authorization", "Bearer "+credential)
+	recorder := httptest.NewRecorder()
+	handler(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("legacy header-free request: HTTP %d %s", recorder.Code, recorder.Body.String())
+	}
+
+	var incarnation sql.NullInt64
+	if err := db.QueryRow(`SELECT registration_incarnation FROM devices WHERE id = ?`, device.ID).Scan(&incarnation); err != nil || !incarnation.Valid || incarnation.Int64 != 0 {
+		t.Fatalf("legacy fixture was not legacy: incarnation=%+v err=%v", incarnation, err)
+	}
+}

--- a/server/api/support_handlers.go
+++ b/server/api/support_handlers.go
@@ -19,10 +19,15 @@ import (
 )
 
 const (
-	supportLogSchemaVersion      = 1
+	supportLogSchemaVersion1     = 1
+	supportLogSchemaVersion2     = 2
 	maxSupportLogCompressedBytes = 8 << 20
 	maxSupportLogExpandedBytes   = 32 << 20
-	maxSupportLogFiles           = 3
+	maxSupportLogFilesV1         = 3
+	maxSupportLogRoomInstances   = 8
+	maxSupportLogInstancesV2     = 1 + maxSupportLogRoomInstances
+	maxSupportLogFilesV2         = 2 + (maxSupportLogRoomInstances * 2)
+	maxSupportLogOmittedRooms    = maxSupportLogRoomInstances * 2
 	defaultSupportLogRetention   = 14 * 24 * time.Hour
 )
 
@@ -33,7 +38,31 @@ type supportLogBundle struct {
 	Platform      string                 `json:"platform"`
 	ClientBuild   map[string]string      `json:"client_build,omitempty"`
 	DaemonBuild   map[string]string      `json:"daemon_build,omitempty"`
-	Files         []supportLogBundleFile `json:"files"`
+	Files         []supportLogBundleFile `json:"files,omitempty"`
+	Manifest      *supportLogManifest    `json:"manifest,omitempty"`
+	Instances     []supportLogInstance   `json:"instances,omitempty"`
+}
+
+type supportLogManifest struct {
+	TotalInstances        int      `json:"total_instances"`
+	NetworkIDs            []string `json:"network_ids,omitempty"`
+	HasRoomLogs           bool     `json:"has_room_logs"`
+	RetainedRoomInstances int      `json:"retained_room_instances,omitempty"`
+	OmittedRoomInstances  int      `json:"omitted_room_instances,omitempty"`
+	OmittedReason         string   `json:"omitted_reason,omitempty"`
+}
+
+type supportLogInstance struct {
+	InstanceType  string            `json:"instance_type"` // "main" or "room"
+	NetworkID     string            `json:"network_id,omitempty"`
+	ProfileID     string            `json:"profile_id,omitempty"`
+	BootID        string            `json:"boot_id,omitempty"`
+	Build         map[string]string `json:"build,omitempty"`
+	StartedAt     string            `json:"started_at,omitempty"`
+	EndedAt       string            `json:"ended_at,omitempty"`
+	Truncated     bool              `json:"truncated"`
+	StatusSummary string            `json:"status_summary,omitempty"`
+	Log           string            `json:"log,omitempty"`
 }
 
 type supportLogBundleFile struct {
@@ -93,7 +122,8 @@ func (s *Server) UploadSupportLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid support log JSON"}`, http.StatusBadRequest)
 		return
 	}
-	if err := validateSupportLogBundle(bundle); err != nil {
+	instanceCount, err := validateSupportLogBundle(bundle)
+	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
 		return
 	}
@@ -121,6 +151,7 @@ func (s *Server) UploadSupportLogs(w http.ResponseWriter, r *http.Request) {
 		"success":     true,
 		"upload_id":   uploadID,
 		"received_at": receivedAt.Format(time.RFC3339Nano),
+		"instances":   instanceCount,
 	})
 }
 
@@ -131,36 +162,168 @@ func supportLogDirFromEnv() string {
 	return filepath.Join("data", "log-uploads")
 }
 
-func validateSupportLogBundle(bundle supportLogBundle) error {
-	if bundle.SchemaVersion != supportLogSchemaVersion {
-		return fmt.Errorf("unsupported support log schema version")
+func isAllowedSupportLogFileName(name string, schemaVersion int) bool {
+	if name == "p2wlan-daemon.log" || name == "p2wlan-client.log" {
+		return true
+	}
+	if schemaVersion < supportLogSchemaVersion2 {
+		return false
+	}
+	if name == "p2wlan-room.log" || name == "status-summary.json" {
+		return true
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) == 3 && parts[0] == "rooms" {
+		if isValidHex64(parts[1]) {
+			fileName := parts[2]
+			return fileName == "p2wlan-daemon.log" || fileName == "p2wlan-room.log" || fileName == "status-summary.json"
+		}
+	}
+	return false
+}
+
+func isValidHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for i := 0; i < 64; i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateSupportLogBundle(bundle supportLogBundle) (int, error) {
+	if bundle.SchemaVersion != supportLogSchemaVersion1 && bundle.SchemaVersion != supportLogSchemaVersion2 {
+		return 0, fmt.Errorf("unsupported support log schema version")
 	}
 	if len(bundle.DeviceName) > 128 || len(bundle.Platform) > 64 {
-		return fmt.Errorf("support log metadata is too long")
+		return 0, fmt.Errorf("support log metadata is too long")
 	}
-	if len(bundle.Files) == 0 {
-		return fmt.Errorf("support log bundle is empty")
+	maxFiles := maxSupportLogFilesV1
+	if bundle.SchemaVersion >= supportLogSchemaVersion2 {
+		maxFiles = maxSupportLogFilesV2
 	}
-	if len(bundle.Files) > maxSupportLogFiles {
-		return fmt.Errorf("support log bundle contains too many files")
+	if len(bundle.Files) == 0 && len(bundle.Instances) == 0 {
+		return 0, fmt.Errorf("support log bundle is empty")
+	}
+	if len(bundle.Files) > maxFiles {
+		return 0, fmt.Errorf("support log bundle contains too many files")
+	}
+	maxInstances := maxSupportLogFilesV1
+	if bundle.SchemaVersion >= supportLogSchemaVersion2 {
+		maxInstances = maxSupportLogInstancesV2
+	}
+	if len(bundle.Instances) > maxInstances {
+		return 0, fmt.Errorf("support log bundle contains too many instances")
 	}
 	seen := make(map[string]struct{}, len(bundle.Files))
+	roomProfiles := make(map[string]struct{})
+	roomLogFiles := make(map[string]struct{})
+	hasLegacyRoomFiles := false
 	for _, file := range bundle.Files {
-		if file.Name != "p2wlan-daemon.log" && file.Name != "p2wlan-client.log" {
-			return fmt.Errorf("unsupported support log file: %s", file.Name)
+		if !isAllowedSupportLogFileName(file.Name, bundle.SchemaVersion) {
+			return 0, fmt.Errorf("unsupported support log file: %s", file.Name)
 		}
 		if _, ok := seen[file.Name]; ok {
-			return fmt.Errorf("duplicate support log file: %s", file.Name)
+			return 0, fmt.Errorf("duplicate support log file: %s", file.Name)
 		}
 		seen[file.Name] = struct{}{}
 		if len(file.Content) == 0 {
-			return fmt.Errorf("support log file is empty: %s", file.Name)
+			return 0, fmt.Errorf("support log file is empty: %s", file.Name)
 		}
 		if len(file.Content) > maxSupportLogExpandedBytes {
-			return fmt.Errorf("support log file is too large: %s", file.Name)
+			return 0, fmt.Errorf("support log file is too large: %s", file.Name)
+		}
+		if profileID, fileName, ok := supportLogRoomFileName(file.Name); ok {
+			roomProfiles[profileID] = struct{}{}
+			if fileName != "status-summary.json" {
+				if _, exists := roomLogFiles[profileID]; exists {
+					return 0, fmt.Errorf("multiple room log files for profile_id: %s", profileID)
+				}
+				roomLogFiles[profileID] = struct{}{}
+			}
+		} else if file.Name == "p2wlan-room.log" || file.Name == "status-summary.json" {
+			hasLegacyRoomFiles = true
 		}
 	}
-	return nil
+	if len(roomProfiles) > maxSupportLogRoomInstances {
+		return 0, fmt.Errorf("support log bundle contains too many room instances")
+	}
+	if hasLegacyRoomFiles && len(roomProfiles) >= maxSupportLogRoomInstances {
+		return 0, fmt.Errorf("support log bundle contains too many room instances")
+	}
+
+	instanceCount := 1 + len(roomProfiles)
+	if hasLegacyRoomFiles {
+		instanceCount++
+	}
+	if len(bundle.Files) == 0 {
+		instanceCount = len(bundle.Instances)
+	}
+	instanceProfiles := make(map[string]struct{})
+	for _, inst := range bundle.Instances {
+		if inst.InstanceType != "main" && inst.InstanceType != "room" {
+			return 0, fmt.Errorf("invalid instance_type: %s", inst.InstanceType)
+		}
+		if inst.ProfileID != "" && !isValidHex64(inst.ProfileID) {
+			return 0, fmt.Errorf("invalid profile_id: %s", inst.ProfileID)
+		}
+		if inst.InstanceType == "room" && inst.ProfileID != "" {
+			if _, ok := instanceProfiles[inst.ProfileID]; ok {
+				return 0, fmt.Errorf("duplicate room instance profile_id: %s", inst.ProfileID)
+			}
+			instanceProfiles[inst.ProfileID] = struct{}{}
+		}
+		if len(inst.Log) > maxSupportLogExpandedBytes {
+			return 0, fmt.Errorf("instance log is too large")
+		}
+		if len(inst.StatusSummary) > maxSupportLogExpandedBytes {
+			return 0, fmt.Errorf("instance status summary is too large")
+		}
+	}
+	if len(bundle.Files) > 0 && len(bundle.Instances) > 0 && len(bundle.Instances) != instanceCount {
+		return 0, fmt.Errorf("support log instances do not match file instance count")
+	}
+	if bundle.Manifest != nil {
+		if bundle.Manifest.TotalInstances <= 0 || bundle.Manifest.TotalInstances > maxInstances {
+			return 0, fmt.Errorf("invalid manifest total_instances")
+		}
+		if bundle.Manifest.TotalInstances != instanceCount {
+			return 0, fmt.Errorf("manifest total_instances (%d) does not match instance count (%d)", bundle.Manifest.TotalInstances, instanceCount)
+		}
+		retainedRoomInstances := len(roomProfiles)
+		if hasLegacyRoomFiles {
+			retainedRoomInstances++
+		}
+		if bundle.Manifest.RetainedRoomInstances != 0 && bundle.Manifest.RetainedRoomInstances != retainedRoomInstances {
+			return 0, fmt.Errorf("manifest retained_room_instances does not match file room count")
+		}
+		if bundle.Manifest.OmittedRoomInstances < 0 || bundle.Manifest.OmittedRoomInstances > maxSupportLogOmittedRooms {
+			return 0, fmt.Errorf("invalid manifest omitted_room_instances")
+		}
+		if bundle.Manifest.OmittedRoomInstances == 0 && bundle.Manifest.OmittedReason != "" {
+			return 0, fmt.Errorf("manifest omitted_reason requires omitted_room_instances")
+		}
+		if bundle.Manifest.OmittedRoomInstances > 0 && bundle.Manifest.OmittedReason != "room_instance_budget" {
+			return 0, fmt.Errorf("invalid manifest omitted_reason")
+		}
+		hasRoomLogs := retainedRoomInstances > 0
+		if bundle.Manifest.HasRoomLogs != hasRoomLogs {
+			return 0, fmt.Errorf("manifest has_room_logs does not match instance count")
+		}
+	}
+	return instanceCount, nil
+}
+
+func supportLogRoomFileName(name string) (string, string, bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) != 3 || parts[0] != "rooms" || !isValidHex64(parts[1]) {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
 }
 
 func newSupportLogUploadID() (string, error) {

--- a/server/api/support_handlers_test.go
+++ b/server/api/support_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,7 @@ func TestUploadSupportLogsStoresCompressedPrivateBundle(t *testing.T) {
 	server := NewServer(nil, nil, nil)
 
 	bundle := supportLogBundle{
-		SchemaVersion: supportLogSchemaVersion,
+		SchemaVersion: supportLogSchemaVersion1,
 		UploadedAt:    "2026-08-23T08:00:00Z",
 		DeviceName:    "Mini",
 		Platform:      "macos",
@@ -54,8 +55,9 @@ func TestUploadSupportLogsStoresCompressedPrivateBundle(t *testing.T) {
 		t.Fatalf("UploadSupportLogs: HTTP %d %s", recorder.Code, recorder.Body.String())
 	}
 	var response struct {
-		Success  bool   `json:"success"`
-		UploadID string `json:"upload_id"`
+		Success   bool   `json:"success"`
+		UploadID  string `json:"upload_id"`
+		Instances int    `json:"instances"`
 	}
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -103,6 +105,133 @@ func TestUploadSupportLogsStoresCompressedPrivateBundle(t *testing.T) {
 	}
 }
 
+func TestUploadSupportLogsV2WithRoomInstances(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("LOG_UPLOAD_DIR", directory)
+	server := NewServer(nil, nil, nil)
+
+	roomHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	bundle := supportLogBundle{
+		SchemaVersion: supportLogSchemaVersion2,
+		UploadedAt:    "2026-09-09T08:00:00Z",
+		DeviceName:    "MacBook",
+		Platform:      "macos",
+		Manifest: &supportLogManifest{
+			TotalInstances: 2,
+			NetworkIDs:     []string{"net-main", "room-123"},
+			HasRoomLogs:    true,
+		},
+		Instances: []supportLogInstance{
+			{
+				InstanceType:  "main",
+				NetworkID:     "net-main",
+				BootID:        "boot-1",
+				Log:           "main daemon log\n",
+				StatusSummary: `{"virtual_ip":"10.20.0.1"}`,
+			},
+			{
+				InstanceType:  "room",
+				NetworkID:     "room-123",
+				ProfileID:     roomHex,
+				BootID:        "boot-2",
+				Log:           "room daemon log\n",
+				StatusSummary: `{"virtual_ip":"10.20.1.2"}`,
+			},
+		},
+		Files: []supportLogBundleFile{
+			{
+				Name:    "p2wlan-daemon.log",
+				Content: "main log file\n",
+			},
+			{
+				Name:    "rooms/" + roomHex + "/p2wlan-room.log",
+				Content: "room log file\n",
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var body bytes.Buffer
+	writer := gzip.NewWriter(&body)
+	if _, err := writer.Write(encoded); err != nil {
+		t.Fatalf("gzip.Write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip.Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", &body)
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "user-v2",
+	}))
+	recorder := httptest.NewRecorder()
+	server.UploadSupportLogs(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("UploadSupportLogs v2: HTTP %d %s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Success   bool   `json:"success"`
+		UploadID  string `json:"upload_id"`
+		Instances int    `json:"instances"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Success || response.Instances != 2 {
+		t.Fatalf("unexpected v2 response: %+v", response)
+	}
+}
+
+func TestUploadSupportLogsRejectsInvalidFileNameOrTraversal(t *testing.T) {
+	server := NewServer(nil, nil, nil)
+	tests := []struct {
+		name          string
+		schemaVersion int
+		fileName      string
+	}{
+		{"traversal in v1", supportLogSchemaVersion1, "../../etc/passwd"},
+		{"room file in v1", supportLogSchemaVersion1, "p2wlan-room.log"},
+		{"traversal in v2", supportLogSchemaVersion2, "rooms/../../p2wlan-room.log"},
+		{"invalid profile_id in v2", supportLogSchemaVersion2, "rooms/short/p2wlan-room.log"},
+		{"arbitrary file in v2", supportLogSchemaVersion2, "arbitrary.log"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := supportLogBundle{
+				SchemaVersion: tc.schemaVersion,
+				UploadedAt:    "2026-09-09T08:00:00Z",
+				DeviceName:    "Device",
+				Platform:      "macos",
+				Files: []supportLogBundleFile{{
+					Name:    tc.fileName,
+					Content: "content\n",
+				}},
+			}
+			encoded, _ := json.Marshal(bundle)
+			var body bytes.Buffer
+			writer := gzip.NewWriter(&body)
+			_, _ = writer.Write(encoded)
+			_ = writer.Close()
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", &body)
+			req.Header.Set("Content-Encoding", "gzip")
+			req = req.WithContext(context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+				UserID: "user-1",
+			}))
+			recorder := httptest.NewRecorder()
+			server.UploadSupportLogs(recorder, req)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("expected Bad Request for %s, got HTTP %d", tc.name, recorder.Code)
+			}
+		})
+	}
+}
+
 func TestUploadSupportLogsRejectsDeviceCredentials(t *testing.T) {
 	server := NewServer(nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", bytes.NewReader(nil))
@@ -115,4 +244,262 @@ func TestUploadSupportLogsRejectsDeviceCredentials(t *testing.T) {
 	if recorder.Code != http.StatusUnauthorized {
 		t.Fatalf("device credential accepted: HTTP %d", recorder.Code)
 	}
+}
+
+func TestUploadSupportLogsV2CountsEachRoomOnce(t *testing.T) {
+	t.Setenv("LOG_UPLOAD_DIR", t.TempDir())
+	server := NewServer(nil, nil, nil)
+	roomHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	bundle := supportLogBundle{
+		SchemaVersion: 2, DeviceName: "review", Platform: "macos",
+		Manifest: &supportLogManifest{TotalInstances: 2, HasRoomLogs: true},
+		Files: []supportLogBundleFile{
+			{Name: "p2wlan-daemon.log", Content: "main"},
+			{Name: "rooms/" + roomHex + "/p2wlan-daemon.log", Content: "room"},
+			{Name: "rooms/" + roomHex + "/status-summary.json", Content: "{}"},
+		},
+	}
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	zw := gzip.NewWriter(&body)
+	if _, err := zw.Write(encoded); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", &body)
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{UserID: "review"}))
+	rec := httptest.NewRecorder()
+	server.UploadSupportLogs(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HTTP %d: %s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Instances int `json:"instances"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Instances != 2 {
+		t.Fatalf("one main daemon and one room must be 2 instances, got %d", response.Instances)
+	}
+}
+
+func TestUploadSupportLogsRejectsManifestTotalInstancesMismatch(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("LOG_UPLOAD_DIR", directory)
+	server := NewServer(nil, nil, nil)
+	roomHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	bundle := supportLogBundle{
+		SchemaVersion: 2, DeviceName: "review", Platform: "macos",
+		Manifest: &supportLogManifest{TotalInstances: 5, HasRoomLogs: true},
+		Files: []supportLogBundleFile{
+			{Name: "p2wlan-daemon.log", Content: "main"},
+			{Name: "rooms/" + roomHex + "/p2wlan-daemon.log", Content: "room"},
+		},
+	}
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body bytes.Buffer
+	zw := gzip.NewWriter(&body)
+	if _, err := zw.Write(encoded); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", &body)
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{UserID: "review"}))
+	rec := httptest.NewRecorder()
+	server.UploadSupportLogs(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected HTTP 400 for manifest mismatch, got HTTP %d: %s", rec.Code, rec.Body.String())
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected bundle was persisted: %+v", entries)
+	}
+}
+
+func TestUploadSupportLogsV2AcceptsFiveAndEightRoomBundles(t *testing.T) {
+	for _, roomCount := range []int{5, 8} {
+		t.Run(fmt.Sprintf("%d rooms", roomCount), func(t *testing.T) {
+			directory := t.TempDir()
+			t.Setenv("LOG_UPLOAD_DIR", directory)
+			server := NewServer(nil, nil, nil)
+			bundle := supportLogBundleForRooms(roomCount)
+			recorder := postSupportLogBundle(t, server, bundle)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("%d room bundle (%d files): HTTP %d %s", roomCount, len(bundle.Files), recorder.Code, recorder.Body.String())
+			}
+			var response struct {
+				Success   bool `json:"success"`
+				Instances int  `json:"instances"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if !response.Success || response.Instances != roomCount+1 {
+				t.Fatalf("unexpected response: %+v", response)
+			}
+		})
+	}
+}
+
+func TestUploadSupportLogsV2RejectsMoreThanDefaultRoomBudget(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("LOG_UPLOAD_DIR", directory)
+	server := NewServer(nil, nil, nil)
+	recorder := postSupportLogBundle(t, server, supportLogBundleForRooms(9))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 9 room bundle to be rejected, got HTTP %d: %s", recorder.Code, recorder.Body.String())
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected bundle was persisted: %+v", entries)
+	}
+}
+
+func TestUploadSupportLogsV2RejectsMultipleLogsForOneRoom(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("LOG_UPLOAD_DIR", directory)
+	server := NewServer(nil, nil, nil)
+	profileID := fmt.Sprintf("%064x", 1)
+	bundle := supportLogBundle{
+		SchemaVersion: supportLogSchemaVersion2,
+		DeviceName:    "support-test",
+		Platform:      "macos",
+		Manifest: &supportLogManifest{
+			TotalInstances: 2,
+			HasRoomLogs:    true,
+		},
+		Files: []supportLogBundleFile{
+			{Name: "p2wlan-daemon.log", Content: "main daemon log\n"},
+			{Name: "rooms/" + profileID + "/p2wlan-daemon.log", Content: "new room log\n"},
+			{Name: "rooms/" + profileID + "/p2wlan-room.log", Content: "legacy room log\n"},
+		},
+	}
+	recorder := postSupportLogBundle(t, server, bundle)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected duplicate room logs to be rejected, got HTTP %d: %s", recorder.Code, recorder.Body.String())
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected bundle was persisted: %+v", entries)
+	}
+}
+
+func TestUploadSupportLogsV2RecordsOmittedRoomInstances(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("LOG_UPLOAD_DIR", directory)
+	server := NewServer(nil, nil, nil)
+	bundle := supportLogBundleForRooms(maxSupportLogRoomInstances)
+	bundle.Manifest.OmittedRoomInstances = 1
+	bundle.Manifest.OmittedReason = "room_instance_budget"
+	recorder := postSupportLogBundle(t, server, bundle)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("omitted-room bundle: HTTP %d %s", recorder.Code, recorder.Body.String())
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one stored bundle, got %+v", entries)
+	}
+	storedFile, err := os.Open(filepath.Join(directory, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("Open upload: %v", err)
+	}
+	decompressed, err := gzip.NewReader(storedFile)
+	if err != nil {
+		t.Fatalf("stored gzip: %v", err)
+	}
+	storedBytes, err := io.ReadAll(decompressed)
+	if err != nil {
+		t.Fatalf("Read stored bundle: %v", err)
+	}
+	_ = decompressed.Close()
+	_ = storedFile.Close()
+	var stored storedSupportLogBundle
+	if err := json.Unmarshal(storedBytes, &stored); err != nil {
+		t.Fatalf("decode stored bundle: %v", err)
+	}
+	if stored.Bundle.Manifest == nil ||
+		stored.Bundle.Manifest.OmittedRoomInstances != 1 ||
+		stored.Bundle.Manifest.OmittedReason != "room_instance_budget" {
+		t.Fatalf("omitted-room metadata was not preserved: %+v", stored.Bundle.Manifest)
+	}
+}
+
+func supportLogBundleForRooms(roomCount int) supportLogBundle {
+	files := []supportLogBundleFile{
+		{Name: "p2wlan-daemon.log", Content: "main daemon log\n"},
+		{Name: "p2wlan-client.log", Content: "client log\n"},
+	}
+	for room := 1; room <= roomCount; room++ {
+		profileID := fmt.Sprintf("%064x", room)
+		files = append(files,
+			supportLogBundleFile{
+				Name:    "rooms/" + profileID + "/p2wlan-daemon.log",
+				Content: "room daemon log\n",
+			},
+			supportLogBundleFile{
+				Name:    "rooms/" + profileID + "/status-summary.json",
+				Content: `{"phase":"unavailable"}`,
+			},
+		)
+	}
+	return supportLogBundle{
+		SchemaVersion: supportLogSchemaVersion2,
+		DeviceName:    "support-test",
+		Platform:      "macos",
+		Manifest: &supportLogManifest{
+			TotalInstances:        roomCount + 1,
+			HasRoomLogs:           true,
+			RetainedRoomInstances: roomCount,
+		},
+		Files: files,
+	}
+}
+
+func postSupportLogBundle(t *testing.T, server *Server, bundle supportLogBundle) *httptest.ResponseRecorder {
+	t.Helper()
+	encoded, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var body bytes.Buffer
+	writer := gzip.NewWriter(&body)
+	if _, err := writer.Write(encoded); err != nil {
+		t.Fatalf("gzip.Write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip.Close: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/support/logs", &body)
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(context.WithValue(req.Context(), auth.UserClaimsKey, &auth.Claims{
+		UserID: "support-test",
+	}))
+	recorder := httptest.NewRecorder()
+	server.UploadSupportLogs(recorder, req)
+	return recorder
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -118,6 +120,15 @@ func (k contextKey) String() string { return "auth." + string(k) }
 const (
 	UserClaimsKey   contextKey = "user_claims"
 	DeviceClaimsKey contextKey = "device_claims"
+
+	// RegistrationSequenceHeader is the current daemon registration session
+	// proof.  It is deliberately a request header rather than NAT metadata so
+	// every device-token control-plane operation can be fenced, including
+	// operations that do not publish an endpoint.
+	RegistrationSequenceHeader = "X-P2WLAN-Registration-Seq"
+	// RegistrationLifecycleConflictCode is returned when a device credential is
+	// valid but belongs to an older daemon registration session.
+	RegistrationLifecycleConflictCode = "registration_lifecycle_conflict"
 )
 
 // RequireAuth is middleware that requires a valid JWT token.
@@ -269,4 +280,80 @@ func RequireDeviceAuth(db interface {
 			next(w, r.WithContext(ctx))
 		}
 	}
+}
+
+// RequireCurrentDeviceRegistrationSession fences device-token requests to the
+// currently registered daemon process.  A device credential remains valid
+// across daemon restarts so a dropped registration response cannot strand the
+// daemon, but that alone must not let the old process keep renewing its lease,
+// consume durable signals, or replace the new process's WebSocket.
+//
+// Rows with registration_incarnation = 0 predate the fencing protocol and
+// intentionally retain their header-free compatibility path.  For every
+// incarnation-aware row, the caller must supply exactly one canonical decimal
+// X-P2WLAN-Registration-Seq header whose value is the current server sequence.
+// User-JWT requests pass through unchanged.
+func RequireCurrentDeviceRegistrationSession(db interface {
+	GetDevice(deviceID string) (*database.Device, error)
+}) func(http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			claims, err := GetDeviceClaims(r.Context())
+			if err != nil {
+				// This is a user-JWT request authenticated by RequireAnyAuth, or a
+				// handler wired without device auth.  The session proof applies only
+				// to the durable device credential flow.
+				next(w, r)
+				return
+			}
+
+			device, err := db.GetDevice(claims.DeviceID)
+			if err != nil {
+				writeRegistrationLifecycleConflict(w, nil)
+				return
+			}
+			if device.RegistrationIncarnation <= 0 {
+				next(w, r)
+				return
+			}
+
+			if !hasCurrentRegistrationSequence(r, device.RegistrationSeq) {
+				writeRegistrationLifecycleConflict(w, device)
+				return
+			}
+			next(w, r)
+		}
+	}
+}
+
+func hasCurrentRegistrationSequence(r *http.Request, expected int64) bool {
+	values := r.Header.Values(RegistrationSequenceHeader)
+	if len(values) != 1 {
+		return false
+	}
+	raw := values[0]
+	// Reject whitespace, leading plus signs, leading zeroes, and non-decimal
+	// forms.  This makes the proof deterministic through proxies and prevents
+	// ambiguous duplicate-value handling.
+	if raw == "" || strings.TrimSpace(raw) != raw {
+		return false
+	}
+	sequence, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || sequence <= 0 || strconv.FormatInt(sequence, 10) != raw {
+		return false
+	}
+	return sequence == expected
+}
+
+func writeRegistrationLifecycleConflict(w http.ResponseWriter, device *database.Device) {
+	response := map[string]interface{}{
+		"error":      "device registration session is no longer current",
+		"error_code": RegistrationLifecycleConflictCode,
+	}
+	if device != nil {
+		response["registration_seq"] = device.RegistrationSeq
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	_ = json.NewEncoder(w).Encode(response)
 }

--- a/server/auth/registration_session_test.go
+++ b/server/auth/registration_session_test.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yhan-sun/p2wlan/server/database"
+)
+
+func TestCurrentDeviceRegistrationSessionRequiresExactSequenceOnlyAfterUpgrade(t *testing.T) {
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	user, err := db.CreateUser("registration-session@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "registration-session-key", "before", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	_, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+
+	incarnation := int64(7001)
+	registered, err := db.RegisterDeviceWithOptions(
+		user.ID, device.NetworkID, device.PublicKey, "after", "macos", "", "", "",
+		database.DeviceRegistrationAttempt{Incarnation: &incarnation, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("RegisterDeviceWithOptions: %v", err)
+	}
+	if registered.RegistrationIncarnation != incarnation || registered.RegistrationSeq <= device.RegistrationSeq {
+		t.Fatalf("registration did not advance lifecycle: before=%+v after=%+v", device, registered)
+	}
+
+	called := 0
+	handler := RequireDeviceAuth(db)(RequireCurrentDeviceRegistrationSession(db)(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	request := func(headerValues ...string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/control", nil)
+		req.Header.Set("Authorization", "Bearer "+credential)
+		for _, value := range headerValues {
+			req.Header.Add(RegistrationSequenceHeader, value)
+		}
+		recorder := httptest.NewRecorder()
+		handler(recorder, req)
+		return recorder
+	}
+
+	for name, values := range map[string][]string{
+		"missing":         nil,
+		"wrong":           {"1"},
+		"whitespace":      {" " + fmtInt64ForSessionTest(registered.RegistrationSeq)},
+		"noncanonical":    {"0" + fmtInt64ForSessionTest(registered.RegistrationSeq)},
+		"duplicate":       {fmtInt64ForSessionTest(registered.RegistrationSeq), fmtInt64ForSessionTest(registered.RegistrationSeq)},
+		"malformed":       {"two"},
+		"zero":            {"0"},
+		"negative":        {"-1"},
+		"larger sequence": {fmtInt64ForSessionTest(registered.RegistrationSeq + 1)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := request(values...)
+			if recorder.Code != http.StatusConflict {
+				t.Fatalf("HTTP %d: %s", recorder.Code, recorder.Body.String())
+			}
+			if !strings.Contains(recorder.Body.String(), RegistrationLifecycleConflictCode) {
+				t.Fatalf("missing lifecycle conflict code: %s", recorder.Body.String())
+			}
+		})
+	}
+	if called != 0 {
+		t.Fatalf("stale registration session reached protected handler %d times", called)
+	}
+
+	valid := request(fmtInt64ForSessionTest(registered.RegistrationSeq))
+	if valid.Code != http.StatusNoContent || called != 1 {
+		t.Fatalf("current sequence was not accepted: HTTP %d called=%d body=%s", valid.Code, called, valid.Body.String())
+	}
+
+	// Device rows created before registration-incarnation support remain
+	// header-free during the rolling upgrade.
+	legacy, err := db.CreateDevice(user.ID, "default", "registration-session-legacy", "legacy", "linux", "")
+	if err != nil {
+		t.Fatalf("CreateDevice legacy: %v", err)
+	}
+	_, legacyCredential, err := db.CreateDeviceCredential(legacy.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential legacy: %v", err)
+	}
+	legacyCalled := false
+	legacyHandler := RequireDeviceAuth(db)(RequireCurrentDeviceRegistrationSession(db)(func(w http.ResponseWriter, _ *http.Request) {
+		legacyCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	legacyReq := httptest.NewRequest(http.MethodGet, "/control", nil)
+	legacyReq.Header.Set("Authorization", "Bearer "+legacyCredential)
+	legacyRecorder := httptest.NewRecorder()
+	legacyHandler(legacyRecorder, legacyReq)
+	if legacyRecorder.Code != http.StatusNoContent || !legacyCalled {
+		t.Fatalf("legacy device should remain compatible: HTTP %d %s", legacyRecorder.Code, legacyRecorder.Body.String())
+	}
+}
+
+func fmtInt64ForSessionTest(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/server/database/database_test.go
+++ b/server/database/database_test.go
@@ -505,6 +505,245 @@ func TestDeviceReregistrationClearsPreviousRuntimeEndpointFacts(t *testing.T) {
 	}
 }
 
+func TestDeviceReregistrationRetainsExistingCredentialsAndAdvancesSequence(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "p2wlan.db"))
+	if err != nil {
+		t.Fatalf("New database: %v", err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("reregister-credential@p2wlan.local", "pwd")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "reregister-credential-key", "before", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	credential, token, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+
+	reregistered, err := db.CreateDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "after", "macos", "", "", "0.1.152",
+	)
+	if err != nil {
+		t.Fatalf("CreateDeviceWithOptions re-registration: %v", err)
+	}
+	if reregistered.RegistrationSeq != device.RegistrationSeq+1 {
+		t.Fatalf("registration sequence = %d, want %d", reregistered.RegistrationSeq, device.RegistrationSeq+1)
+	}
+	if _, _, err := db.ValidateDeviceCredential(token); err != nil {
+		t.Fatalf("re-registration must retain the credential that can authorize the restarted daemon: %v", err)
+	}
+
+	var revoked int
+	if err := db.QueryRow(`SELECT revoked FROM device_credentials WHERE id = ?`, credential.ID).Scan(&revoked); err != nil {
+		t.Fatalf("read credential state: %v", err)
+	}
+	if revoked != 0 {
+		t.Fatal("re-registration must not revoke an otherwise valid credential")
+	}
+}
+
+func TestSequenceAwareRegistrationFencesOlderIncarnationAndReplaysSameBoot(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "p2wlan.db"))
+	if err != nil {
+		t.Fatalf("New database: %v", err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("registration-fence@p2wlan.local", "pwd")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "registration-fence-key", "initial", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	oldBoot := int64(100)
+	first, err := db.RegisterDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "boot-100", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &oldBoot, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("register first boot: %v", err)
+	}
+	if first.RegistrationSeq != 2 || first.RegistrationIncarnation != oldBoot {
+		t.Fatalf("unexpected first registration: %+v", first)
+	}
+	if err := db.UpdateDeviceEndpoint(first.ID, "198.51.100.10:51820", "p2v2:m=endpoint_independent;g=1;l=2", nil); err != nil {
+		t.Fatalf("publish endpoint: %v", err)
+	}
+
+	// A replay from the same boot models a completed request whose HTTP
+	// response was lost. It must return the same registration instead of
+	// clearing endpoint state or consuming another sequence.
+	replayed, err := db.RegisterDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "boot-100-retry", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &oldBoot, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("idempotent replay: %v", err)
+	}
+	if replayed.RegistrationSeq != first.RegistrationSeq || replayed.Endpoint != "198.51.100.10:51820" {
+		t.Fatalf("same-boot replay changed registration state: %+v", replayed)
+	}
+
+	newBoot := int64(101)
+	newer, err := db.RegisterDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "boot-101", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &newBoot, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("register newer boot: %v", err)
+	}
+	if newer.RegistrationSeq != 3 || newer.RegistrationIncarnation != newBoot || newer.Endpoint != "" || newer.NATType != "unknown" {
+		t.Fatalf("newer boot did not create a clean incarnation: %+v", newer)
+	}
+
+	// An incarnation-aware device accepts endpoint metadata only from the
+	// exact registration sequence returned by the server. Missing, stale, and
+	// guessed-future labels must retain the new boot's clean transport state;
+	// heartbeat calls still complete so a stale daemon cannot turn this into an
+	// error-amplification loop.
+	if err := db.ReleaseDevicePresence(device.ID); err != nil {
+		t.Fatalf("ReleaseDevicePresence: %v", err)
+	}
+	for _, staleNAT := range []string{
+		"p2v2:m=endpoint_independent;g=1",
+		"p2v2:m=endpoint_independent;g=1;l=2",
+		"p2v2:m=endpoint_independent;g=1;l=999",
+		"p2v2:m=endpoint_independent;g=1;l=not-a-number",
+	} {
+		if err := db.UpdateDeviceEndpoint(device.ID, "198.51.100.11:51820", staleNAT, nil); err != nil {
+			t.Fatalf("stale lifecycle heartbeat %q: %v", staleNAT, err)
+		}
+		stored, err := db.GetDevice(device.ID)
+		if err != nil {
+			t.Fatalf("GetDevice after stale lifecycle heartbeat: %v", err)
+		}
+		if stored.Endpoint != "" || stored.NATType != "unknown" || !stored.Online {
+			t.Fatalf("stale lifecycle metadata overwrote new boot for %q: %+v", staleNAT, stored)
+		}
+	}
+	if err := db.UpdateDeviceEndpoint(device.ID, "198.51.100.12:51820", "p2v2:m=endpoint_independent;g=1;l=3", nil); err != nil {
+		t.Fatalf("current lifecycle endpoint update: %v", err)
+	}
+	storedAfterEndpoint, err := db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice after current lifecycle endpoint: %v", err)
+	}
+	if storedAfterEndpoint.Endpoint != "198.51.100.12:51820" || storedAfterEndpoint.NATType != "p2v2:m=endpoint_independent;g=1;l=3" {
+		t.Fatalf("current lifecycle endpoint was not accepted: %+v", storedAfterEndpoint)
+	}
+
+	_, err = db.RegisterDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "legacy-late-request", "macos", "", "", "",
+		DeviceRegistrationAttempt{EnforceIncarnation: true},
+	)
+	var upgradeConflict *RegistrationConflictError
+	if !errors.As(err, &upgradeConflict) || upgradeConflict.Code != "registration_protocol_upgrade_required" {
+		t.Fatalf("unfenced legacy request must be rejected after lifecycle upgrade, got err=%v conflict=%+v", err, upgradeConflict)
+	}
+
+	_, err = db.RegisterDeviceWithOptions(
+		user.ID, "default", device.PublicKey, "late-boot-100", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &oldBoot, EnforceIncarnation: true},
+	)
+	var conflict *RegistrationConflictError
+	if !errors.As(err, &conflict) || conflict.Code != "registration_conflict" || conflict.CurrentSequence != newer.RegistrationSeq {
+		t.Fatalf("older boot must be fenced, got err=%v conflict=%+v", err, conflict)
+	}
+	stored, err := db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	if stored.RegistrationIncarnation != newBoot || stored.DeviceName != "boot-101" || stored.RegistrationSeq != newer.RegistrationSeq {
+		t.Fatalf("late old registration overwrote the newer boot: %+v", stored)
+	}
+}
+
+func TestUpdateDeviceEndpointMonotonicGeneration(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "p2wlan.db"))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("monotonic-test@p2wlan.local", "pwd")
+	if err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	dev, err := db.CreateDeviceWithOptions(
+		user.ID, "default", "monotonic-pubkey", "mono-device", "macos", "", "", "0.1.152",
+	)
+	if err != nil {
+		t.Fatalf("CreateDeviceWithOptions failed: %v", err)
+	}
+
+	// 1. Initial publication at generation 2
+	rtt2 := int64(20)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.1:51820", "p2v2:m=endpoint_independent;g=2", &rtt2); err != nil {
+		t.Fatalf("generation 2 update failed: %v", err)
+	}
+	stored, err := db.GetDevice(dev.ID)
+	if err != nil || stored.Endpoint != "198.51.100.1:51820" || stored.NATType != "p2v2:m=endpoint_independent;g=2" {
+		t.Fatalf("unexpected stored device after gen 2: %+v", stored)
+	}
+
+	// 2. Stale update at generation 1 should NOT overwrite endpoint or nat_type, but refreshes relay RTT
+	rtt1 := int64(15)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.1:51821", "p2v2:m=address_or_port_dependent;g=1", &rtt1); err != nil {
+		t.Fatalf("generation 1 update failed: %v", err)
+	}
+	stored, err = db.GetDevice(dev.ID)
+	if err != nil {
+		t.Fatalf("GetDevice failed: %v", err)
+	}
+	if stored.Endpoint != "198.51.100.1:51820" {
+		t.Fatalf("stale generation 1 overwrote endpoint: got %s, want 198.51.100.1:51820", stored.Endpoint)
+	}
+	if stored.NATType != "p2v2:m=endpoint_independent;g=2" {
+		t.Fatalf("stale generation 1 overwrote nat_type: got %s, want gen 2", stored.NATType)
+	}
+	if stored.RelayRTTMS == nil || *stored.RelayRTTMS != 15 {
+		t.Fatalf("stale update should still refresh relay RTT: got %+v", stored.RelayRTTMS)
+	}
+
+	// 3. Newer update at generation 3 should overwrite
+	rtt3 := int64(25)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.2:51820", "p2v2:m=endpoint_independent;g=3", &rtt3); err != nil {
+		t.Fatalf("generation 3 update failed: %v", err)
+	}
+	stored, err = db.GetDevice(dev.ID)
+	if err != nil || stored.Endpoint != "198.51.100.2:51820" || stored.NATType != "p2v2:m=endpoint_independent;g=3" {
+		t.Fatalf("generation 3 should update device: %+v", stored)
+	}
+
+	// 4. Re-registration starts a new process lifecycle: resets nat_type to unknown
+	redev, err := db.CreateDeviceWithOptions(
+		user.ID, "default", "monotonic-pubkey", "mono-device-restart", "macos", "", "", "0.1.152",
+	)
+	if err != nil {
+		t.Fatalf("re-registration failed: %v", err)
+	}
+	if redev.NATType != "unknown" {
+		t.Fatalf("re-registration should reset nat_type: got %s", redev.NATType)
+	}
+	// A fresh generation 1 in the new lifecycle is accepted
+	rttFresh := int64(10)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.3:51820", "p2v2:m=endpoint_independent;g=1", &rttFresh); err != nil {
+		t.Fatalf("fresh lifecycle gen 1 update failed: %v", err)
+	}
+	stored, err = db.GetDevice(dev.ID)
+	if err != nil || stored.Endpoint != "198.51.100.3:51820" || stored.NATType != "p2v2:m=endpoint_independent;g=1" {
+		t.Fatalf("fresh lifecycle should accept gen 1: %+v", stored)
+	}
+}
+
 func TestUpdateDeviceVirtualIPValidatesNetworkPool(t *testing.T) {
 	db, err := New(filepath.Join(t.TempDir(), "p2wlan.db"))
 	if err != nil {
@@ -1117,5 +1356,179 @@ func TestSignalSeqMigrationSeedsFromBackfilledRows(t *testing.T) {
 	}
 	if next.SignalSeq != maxAssigned+1 {
 		t.Fatalf("the next create must continue the backfilled sequence (max=%d), got %d", maxAssigned, next.SignalSeq)
+	}
+}
+
+func TestReviewNATStaleMetadataCannotOverwrite(t *testing.T) {
+	for _, api := range []string{"heartbeat", "metadata"} {
+		for _, stale := range []struct{ name, label string }{
+			{"unversioned", "unknown"},
+			{"same_generation_conflicting_capability", "p2v2:m=address_or_port_dependent;g=3"},
+		} {
+			t.Run(api+"/"+stale.name, func(t *testing.T) {
+				db, device := createTestDevice(t, "review@p2wlan.local", "review-device")
+				defer db.Close()
+				freshLabel := "p2v2:m=endpoint_independent;g=3"
+				freshEndpoint := "198.51.100.1:51820"
+				if err := db.UpdateDeviceEndpoint(device.ID, freshEndpoint, freshLabel, nil); err != nil {
+					t.Fatal(err)
+				}
+				var err error
+				if api == "heartbeat" {
+					err = db.UpdateDeviceEndpoint(device.ID, "", stale.label, nil)
+				} else {
+					err = db.UpdateDeviceEndpointMetadata(device.ID, "", stale.label, nil)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				stored, err := db.GetDevice(device.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if stored.Endpoint != freshEndpoint || stored.NATType != freshLabel {
+					t.Fatalf("stale publication replaced fresh snapshot: endpoint=%q nat_type=%q; want endpoint=%q nat_type=%q", stored.Endpoint, stored.NATType, freshEndpoint, freshLabel)
+				}
+			})
+		}
+	}
+}
+
+func TestReviewNATConcurrentOutOfOrder(t *testing.T) {
+	db, device := createTestDevice(t, "concurrent-nat@p2wlan.local", "concurrent-nat-dev")
+	defer db.Close()
+
+	freshEndpoint := "198.51.100.10:51820"
+	freshNAT := "p2v2:m=endpoint_independent;g=5"
+	if err := db.UpdateDeviceEndpoint(device.ID, freshEndpoint, freshNAT, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	// Concurrently send out-of-order stale updates and unversioned heartbeats
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if idx%3 == 0 {
+				_ = db.UpdateDeviceEndpoint(device.ID, "", "unknown", nil)
+			} else if idx%3 == 1 {
+				_ = db.UpdateDeviceEndpoint(device.ID, "10.0.0.1:1234", "p2v2:m=address_or_port_dependent;g=2", nil)
+			} else {
+				_ = db.UpdateDeviceEndpointMetadata(device.ID, "", "p2v2:m=address_or_port_dependent;g=5", nil)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	stored, err := db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Endpoint != freshEndpoint || stored.NATType != freshNAT {
+		t.Fatalf("concurrent stale updates corrupted state: endpoint=%q nat_type=%q; want %q %q",
+			stored.Endpoint, stored.NATType, freshEndpoint, freshNAT)
+	}
+}
+
+func TestReviewNATRebootDelayedStaleRequest(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "p2wlan.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	user, err := db.CreateUser("reboot-nat@p2wlan.local", "pwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dev, err := db.CreateDeviceWithOptions(
+		user.ID, "default", "reboot-pubkey", "reboot-dev", "macos", "", "", "0.1.152",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Daemon lifecycle 1 publishes g=3 with lifecycle=1
+	rtt3 := int64(25)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.1:51820", "p2v2:m=endpoint_independent;g=3;l=1", &rtt3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Daemon restarts and re-registers (now registration_seq is 2)
+	redev, err := db.CreateDeviceWithOptions(
+		user.ID, "default", "reboot-pubkey", "reboot-dev", "macos", "", "", "0.1.152",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if redev.NATType != "unknown" || redev.Endpoint != "" {
+		t.Fatalf("re-registration must clear runtime transport: nat_type=%q endpoint=%q", redev.NATType, redev.Endpoint)
+	}
+
+	// A delayed request from lifecycle 1 (g=3;l=1) arrives AFTER restart
+	rttStale := int64(20)
+	if err := db.UpdateDeviceEndpoint(dev.ID, "198.51.100.1:51820", "p2v2:m=endpoint_independent;g=3;l=1", &rttStale); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := db.GetDevice(dev.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Delayed request from lifecycle 1 must NOT overwrite the new lifecycle's empty/unknown state
+	if stored.Endpoint != "" || stored.NATType != "unknown" {
+		t.Fatalf("delayed request from old lifecycle overwrote restarted device: endpoint=%q nat_type=%q",
+			stored.Endpoint, stored.NATType)
+	}
+
+	// New process publishes fresh generation 1 in lifecycle 2 (l=2)
+	rttFresh := int64(15)
+	freshEndpoint := "198.51.100.2:51820"
+	freshNAT := "p2v2:m=endpoint_independent;g=1;l=2"
+	if err := db.UpdateDeviceEndpoint(dev.ID, freshEndpoint, freshNAT, &rttFresh); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = db.GetDevice(dev.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Endpoint != freshEndpoint || stored.NATType != freshNAT {
+		t.Fatalf("fresh lifecycle update was not accepted: endpoint=%q nat_type=%q",
+			stored.Endpoint, stored.NATType)
+	}
+}
+
+func TestReviewNATSameGenObservationFreshness(t *testing.T) {
+	db, device := createTestDevice(t, "obs-nat@p2wlan.local", "obs-dev")
+	defer db.Close()
+
+	endpoint := "198.51.100.5:51820"
+	// Generation 3 with observation sequence 1
+	if err := db.UpdateDeviceEndpoint(device.ID, endpoint, "p2v2:m=endpoint_independent;g=3;o=1", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh observation sequence 2 with same capability and generation: allowed
+	if err := db.UpdateDeviceEndpoint(device.ID, endpoint, "p2v2:m=endpoint_independent;g=3;o=2", nil); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.NATType != "p2v2:m=endpoint_independent;g=3;o=2" {
+		t.Fatalf("fresh observation was not accepted: got %q", stored.NATType)
+	}
+
+	// Stale observation sequence 1: rejected from overwriting
+	if err := db.UpdateDeviceEndpoint(device.ID, endpoint, "p2v2:m=endpoint_independent;g=3;o=1", nil); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = db.GetDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.NATType != "p2v2:m=endpoint_independent;g=3;o=2" {
+		t.Fatalf("stale observation overwrote newer observation: got %q", stored.NATType)
 	}
 }

--- a/server/database/devices.go
+++ b/server/database/devices.go
@@ -4,19 +4,169 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
+
+var natGenRegex = regexp.MustCompile(`\bg=(\d+)\b`)
+
+func parseNATGeneration(natType string) (int64, bool) {
+	matches := natGenRegex.FindStringSubmatch(natType)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	gen, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return gen, true
+}
+
+type parsedNAT struct {
+	raw          string
+	hasGen       bool
+	generation   int64
+	mapping      string
+	filtering    string
+	allocation   string
+	hasRev       bool
+	revision     int64
+	hasObs       bool
+	observation  int64
+	hasLifecycle bool
+	lifecycle    string
+}
+
+func parseNAT(natType string) parsedNAT {
+	p := parsedNAT{raw: strings.TrimSpace(natType)}
+	if p.raw == "" || strings.EqualFold(p.raw, "unknown") {
+		return p
+	}
+	payload := p.raw
+	if strings.HasPrefix(payload, "p2v2:") {
+		payload = strings.TrimPrefix(payload, "p2v2:")
+	} else if strings.HasPrefix(payload, "p2:") {
+		payload = strings.TrimPrefix(payload, "p2:")
+	}
+	tokens := strings.Split(payload, ";")
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		parts := strings.SplitN(token, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		k := strings.TrimSpace(parts[0])
+		v := strings.TrimSpace(parts[1])
+		switch k {
+		case "g":
+			if g, err := strconv.ParseInt(v, 10, 64); err == nil {
+				p.hasGen = true
+				p.generation = g
+			}
+		case "m":
+			p.mapping = strings.ToLower(v)
+		case "f":
+			p.filtering = strings.ToLower(v)
+		case "a":
+			p.allocation = strings.ToLower(v)
+		case "r":
+			if r, err := strconv.ParseInt(v, 10, 64); err == nil {
+				p.hasRev = true
+				p.revision = r
+			}
+		case "o":
+			if o, err := strconv.ParseInt(v, 10, 64); err == nil {
+				p.hasObs = true
+				p.observation = o
+			}
+		case "l":
+			p.hasLifecycle = true
+			p.lifecycle = v
+		}
+	}
+	return p
+}
+
+func shouldOverwriteNAT(currentEndpoint, currentNAT string, currentRegSeq int64, requireLifecycle bool, incomingEndpoint, incomingNAT string) bool {
+	curr := parseNAT(currentNAT)
+	inc := parseNAT(incomingNAT)
+
+	// An incarnation-aware registration has a server-issued sequence. Every
+	// endpoint update for it must echo that exact lifecycle. Merely rejecting a
+	// lower `l=` is insufficient: an old/legacy request can omit `l=`, and a
+	// malformed or guessed higher value must not clobber the newer process's
+	// endpoint facts. Legacy rows retain the historical optional-label behavior
+	// for a rolling upgrade.
+	if requireLifecycle {
+		if !inc.hasLifecycle {
+			return false
+		}
+		reqSeq, err := strconv.ParseInt(inc.lifecycle, 10, 64)
+		if err != nil || reqSeq != currentRegSeq {
+			return false
+		}
+	} else if inc.hasLifecycle {
+		// Preserve old-client compatibility while still refusing a clearly stale
+		// lifecycle label on a legacy device.
+		if reqSeq, err := strconv.ParseInt(inc.lifecycle, 10, 64); err == nil && reqSeq < currentRegSeq {
+			return false
+		}
+	}
+
+	if curr.hasGen {
+		// Versioned metadata cannot be replaced by unversioned/unknown
+		if !inc.hasGen {
+			return false
+		}
+		// Lower generation is stale
+		if inc.generation < curr.generation {
+			return false
+		}
+		// Same generation checks
+		if inc.generation == curr.generation {
+			// Capability conflicts: mapping, filtering, allocation
+			if curr.mapping != "" && inc.mapping != "" && curr.mapping != inc.mapping {
+				return false
+			}
+			if curr.filtering != "" && inc.filtering != "" && curr.filtering != inc.filtering {
+				return false
+			}
+			if curr.allocation != "" && inc.allocation != "" && curr.allocation != inc.allocation {
+				return false
+			}
+			// Empty incoming endpoint cannot wipe out a valid non-empty current endpoint
+			if strings.TrimSpace(incomingEndpoint) == "" && strings.TrimSpace(currentEndpoint) != "" {
+				return false
+			}
+			// Stale capability revision
+			if inc.hasRev && curr.hasRev && inc.revision < curr.revision {
+				return false
+			}
+			// Stale observation sequence
+			if inc.hasObs && curr.hasObs && inc.observation < curr.observation {
+				return false
+			}
+			return true
+		}
+		// Higher generation: allowed
+		return true
+	}
+
+	// Current NAT is unversioned/unknown: incoming is accepted
+	return true
+}
 
 // GetDevice retrieves a device by ID.
 func (db *DB) GetDevice(deviceID string) (*Device, error) {
 	var d Device
 	var online int
 	var relayRTTMS sql.NullInt64
-	err := db.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(ed25519_public_key, '')
+	err := db.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(ed25519_public_key, ''), COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0)
 		FROM devices WHERE id = ?`, deviceID).
 		Scan(&d.ID, &d.UserID, &d.NetworkID, &d.PublicKey, &d.DeviceName, &d.Platform,
-			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt, &d.Ed25519PublicKey)
+			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt, &d.Ed25519PublicKey, &d.RegistrationSeq, &d.RegistrationIncarnation)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +193,70 @@ type Device struct {
 	AppVersion       string `json:"app_version"`
 	Online           bool   `json:"online"`
 	Ed25519PublicKey string `json:"ed25519_public_key,omitempty"`
-	CreatedAt        int64  `json:"created_at"`
+	// RegistrationSeq identifies the current daemon/transport incarnation. It
+	// is intentionally independent from device credentials: a restart must not
+	// invalidate the bearer token that authorized that restart.
+	RegistrationSeq int64 `json:"registration_seq,omitempty"`
+	// RegistrationIncarnation is the daemon's persisted, monotonic boot
+	// incarnation. It is kept private because it is a control-plane fencing
+	// value rather than peer-visible metadata.
+	RegistrationIncarnation int64 `json:"-"`
+	CreatedAt               int64 `json:"created_at"`
+}
+
+// DeviceRegistrationAttempt provides the monotonic boot-incarnation proof
+// sent by current daemon builds. The daemon reserves this value in durable
+// local state before it contacts the control plane, so a duplicate request
+// from the same boot is idempotent while a late request from an older boot is
+// fenced without revoking its long-lived device credential.
+//
+// EnforceIncarnation is set only on untrusted HTTP registration requests. The
+// older CreateDeviceWithOptions API remains available to trusted internal
+// callers and migration tests without changing its historical signature.
+type DeviceRegistrationAttempt struct {
+	Incarnation        *int64
+	EnforceIncarnation bool
+}
+
+// RegistrationConflictError is returned when an in-flight registration no
+// longer matches the server's current transport incarnation. Clients must not
+// retry it with a newer incarnation because that could let an old daemon replace
+// a newer daemon's endpoint state.
+type RegistrationConflictError struct {
+	CurrentSequence    int64
+	CurrentIncarnation int64
+	Code               string
+}
+
+func (e *RegistrationConflictError) Error() string {
+	if e.Code == "registration_protocol_upgrade_required" {
+		return "registration requires a sequence-aware client"
+	}
+	return "registration sequence conflict"
+}
+
+// RegistrationSessionConflictError means an authenticated device credential
+// presented a registration sequence that is no longer current.  It is
+// separate from RegistrationConflictError: the latter fences a registration
+// request by its durable boot incarnation, while this error fences a normal
+// control action from an already superseded daemon process.
+type RegistrationSessionConflictError struct {
+	CurrentSequence    int64
+	CurrentIncarnation int64
+}
+
+func (e *RegistrationSessionConflictError) Error() string {
+	return "registration lifecycle conflict"
+}
+
+func validateDeviceRegistrationAttempt(attempt DeviceRegistrationAttempt) error {
+	if !attempt.EnforceIncarnation {
+		return nil
+	}
+	if attempt.Incarnation != nil && *attempt.Incarnation < 0 {
+		return fmt.Errorf("registration_incarnation must not be negative")
+	}
+	return nil
 }
 
 func nullInt64Ptr(value sql.NullInt64) *int64 {
@@ -61,6 +274,21 @@ func (db *DB) CreateDevice(userID, networkID, publicKey, deviceName, platform, e
 
 // CreateDeviceWithOptions inserts or updates a device with optional runtime metadata.
 func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, platform, ed25519PublicKey, requestedVirtualIP, appVersion string) (*Device, error) {
+	return db.registerDeviceWithOptions(userID, networkID, publicKey, deviceName, platform, ed25519PublicKey, requestedVirtualIP, appVersion, DeviceRegistrationAttempt{})
+}
+
+// RegisterDeviceWithOptions performs a sequence-aware daemon registration.
+// HTTP callers must set EnforceIncarnation; this prevents a late request from a
+// previous daemon process from clearing the endpoint facts published by a
+// newer process that holds the same long-lived device credential.
+func (db *DB) RegisterDeviceWithOptions(userID, networkID, publicKey, deviceName, platform, ed25519PublicKey, requestedVirtualIP, appVersion string, attempt DeviceRegistrationAttempt) (*Device, error) {
+	return db.registerDeviceWithOptions(userID, networkID, publicKey, deviceName, platform, ed25519PublicKey, requestedVirtualIP, appVersion, attempt)
+}
+
+func (db *DB) registerDeviceWithOptions(userID, networkID, publicKey, deviceName, platform, ed25519PublicKey, requestedVirtualIP, appVersion string, attempt DeviceRegistrationAttempt) (*Device, error) {
+	if err := validateDeviceRegistrationAttempt(attempt); err != nil {
+		return nil, err
+	}
 	tx, err := db.beginRoomWrite()
 	if err != nil {
 		return nil, err
@@ -81,16 +309,55 @@ func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, 
 	var existing Device
 	var online int
 	var existingRelayRTTMS sql.NullInt64
-	err = tx.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at
+	err = tx.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0)
 		FROM devices WHERE public_key = ? LIMIT 1`, publicKey).
 		Scan(&existing.ID, &existing.UserID, &existing.NetworkID, &existing.PublicKey, &existing.DeviceName, &existing.Platform,
-			&existing.VirtualIP, &existing.NATType, &existing.Endpoint, &existingRelayRTTMS, &existing.LastSeen, &existing.AppVersion, &online, &existing.CreatedAt)
+			&existing.VirtualIP, &existing.NATType, &existing.Endpoint, &existingRelayRTTMS, &existing.LastSeen, &existing.AppVersion, &online, &existing.CreatedAt, &existing.RegistrationSeq, &existing.RegistrationIncarnation)
 	if err == nil {
 		if existing.UserID != userID {
 			return nil, fmt.Errorf("public key is already registered by another user")
 		}
 		if existing.NetworkID != networkID {
 			return nil, fmt.Errorf("public key is already registered in another network")
+		}
+		if attempt.EnforceIncarnation {
+			if attempt.Incarnation == nil || *attempt.Incarnation == 0 {
+				// A legacy client may perform one migration registration while
+				// this field is still empty. Once an incarnation-aware daemon has
+				// registered, allowing a request with no fencing proof would let an
+				// old in-flight request overwrite that newer incarnation.
+				if existing.RegistrationIncarnation != 0 {
+					return nil, &RegistrationConflictError{
+						CurrentSequence:    existing.RegistrationSeq,
+						CurrentIncarnation: existing.RegistrationIncarnation,
+						Code:               "registration_protocol_upgrade_required",
+					}
+				}
+			} else {
+				incoming := *attempt.Incarnation
+				if incoming == existing.RegistrationIncarnation {
+					// Idempotent retry after a lost response. Preserve endpoint/NAT
+					// facts that this same boot may already have published, but refresh
+					// its online lease.
+					now := time.Now().Unix()
+					if _, err := tx.Exec(`UPDATE devices SET last_seen = ?, online = 1 WHERE id = ?`, now, existing.ID); err != nil {
+						return nil, err
+					}
+					if err := tx.Commit(); err != nil {
+						return nil, err
+					}
+					existing.LastSeen = now
+					existing.Online = true
+					return &existing, nil
+				}
+				if incoming < existing.RegistrationIncarnation {
+					return nil, &RegistrationConflictError{
+						CurrentSequence:    existing.RegistrationSeq,
+						CurrentIncarnation: existing.RegistrationIncarnation,
+						Code:               "registration_conflict",
+					}
+				}
+			}
 		}
 
 		virtualIP := existing.VirtualIP
@@ -106,11 +373,24 @@ func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, 
 		// RTT describe the previous process's runtime transport. Clear all three
 		// atomically before publishing online=1; the first authenticated endpoint
 		// PATCH will publish facts for the new incarnation.
-		_, err = tx.Exec(`UPDATE devices SET device_name = ?, platform = ?, virtual_ip = ?, app_version = CASE WHEN ? != '' THEN ? ELSE app_version END, endpoint = '', nat_type = 'unknown', relay_rtt_ms = NULL, last_seen = ?, online = 1, ed25519_public_key = CASE WHEN ? != '' THEN ? ELSE ed25519_public_key END WHERE id = ?`,
-			deviceName, platform, virtualIP, appVersion, appVersion, now, ed25519PublicKey, ed25519PublicKey, existing.ID)
+		registrationIncarnation := existing.RegistrationIncarnation
+		if attempt.EnforceIncarnation && attempt.Incarnation != nil && *attempt.Incarnation > 0 {
+			registrationIncarnation = *attempt.Incarnation
+		}
+		_, err = tx.Exec(`UPDATE devices SET device_name = ?, platform = ?, virtual_ip = ?, app_version = CASE WHEN ? != '' THEN ? ELSE app_version END, endpoint = '', nat_type = 'unknown', relay_rtt_ms = NULL, last_seen = ?, online = 1, ed25519_public_key = CASE WHEN ? != '' THEN ? ELSE ed25519_public_key END, registration_seq = COALESCE(registration_seq, 1) + 1, registration_incarnation = ? WHERE id = ?`,
+			deviceName, platform, virtualIP, appVersion, appVersion, now, ed25519PublicKey, ed25519PublicKey, registrationIncarnation, existing.ID)
 		if err != nil {
 			return nil, err
 		}
+		// Registration changes the daemon's transport incarnation. It does not
+		// change the device identity that authenticated this request. In
+		// particular, revoking credentials here would allow a device-token-only
+		// daemon to receive HTTP 200 and then lose the sole token needed for its
+		// next heartbeat if the response is dropped. Credential invalidation is
+		// deliberately limited to explicit credential revocation, device deletion,
+		// and room-access revocation. The registration sequence is returned to
+		// the daemon so endpoint metadata can distinguish transport incarnations
+		// without treating a restart as a credential-revocation event.
 		if err := tx.Commit(); err != nil {
 			return nil, err
 		}
@@ -126,6 +406,8 @@ func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, 
 		}
 		existing.LastSeen = now
 		existing.Online = true
+		existing.RegistrationSeq++
+		existing.RegistrationIncarnation = registrationIncarnation
 		return &existing, nil
 	} else if err != sql.ErrNoRows {
 		return nil, err
@@ -143,9 +425,13 @@ func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, 
 		return nil, err
 	}
 
-	_, err = tx.Exec(`INSERT INTO devices (id, user_id, network_id, public_key, device_name, platform, virtual_ip, app_version, last_seen, online, created_at, ed25519_public_key)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
-		id, userID, networkID, publicKey, deviceName, platform, virtualIP, appVersion, now, now, ed25519PublicKey)
+	registrationIncarnation := int64(0)
+	if attempt.EnforceIncarnation && attempt.Incarnation != nil && *attempt.Incarnation > 0 {
+		registrationIncarnation = *attempt.Incarnation
+	}
+	_, err = tx.Exec(`INSERT INTO devices (id, user_id, network_id, public_key, device_name, platform, virtual_ip, app_version, last_seen, online, created_at, ed25519_public_key, registration_seq, registration_incarnation)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 1, ?)`,
+		id, userID, networkID, publicKey, deviceName, platform, virtualIP, appVersion, now, now, ed25519PublicKey, registrationIncarnation)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +444,7 @@ func (db *DB) CreateDeviceWithOptions(userID, networkID, publicKey, deviceName, 
 		ID: id, UserID: userID, NetworkID: networkID,
 		PublicKey: publicKey, DeviceName: deviceName, Platform: platform,
 		VirtualIP: virtualIP, AppVersion: appVersion, LastSeen: now, Online: true,
-		Ed25519PublicKey: ed25519PublicKey, CreatedAt: now,
+		Ed25519PublicKey: ed25519PublicKey, RegistrationSeq: 1, RegistrationIncarnation: registrationIncarnation, CreatedAt: now,
 	}, nil
 }
 
@@ -167,10 +453,10 @@ func (db *DB) GetDeviceByPublicKey(networkID, publicKey string) (*Device, error)
 	var d Device
 	var online int
 	var relayRTTMS sql.NullInt64
-	err := db.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(ed25519_public_key, '')
+	err := db.QueryRow(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(ed25519_public_key, ''), COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0)
 		FROM devices WHERE network_id = ? AND public_key = ? LIMIT 1`, networkID, publicKey).
 		Scan(&d.ID, &d.UserID, &d.NetworkID, &d.PublicKey, &d.DeviceName, &d.Platform,
-			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt, &d.Ed25519PublicKey)
+			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt, &d.Ed25519PublicKey, &d.RegistrationSeq, &d.RegistrationIncarnation)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +594,7 @@ func (db *DB) ListDevicesByUserAndNetwork(userID, networkID string) ([]Device, e
 func (db *DB) listDevices(fromClause string, args ...interface{}) ([]Device, error) {
 	now := time.Now().Unix()
 
-	rows, err := db.Query(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at `+fromClause, args...)
+	rows, err := db.Query(`SELECT id, user_id, network_id, public_key, device_name, platform, virtual_ip, nat_type, endpoint, relay_rtt_ms, last_seen, COALESCE(app_version, ''), online, created_at, COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0) `+fromClause, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +606,7 @@ func (db *DB) listDevices(fromClause string, args ...interface{}) ([]Device, err
 		var online int
 		var relayRTTMS sql.NullInt64
 		if err := rows.Scan(&d.ID, &d.UserID, &d.NetworkID, &d.PublicKey, &d.DeviceName, &d.Platform,
-			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt); err != nil {
+			&d.VirtualIP, &d.NATType, &d.Endpoint, &relayRTTMS, &d.LastSeen, &d.AppVersion, &online, &d.CreatedAt, &d.RegistrationSeq, &d.RegistrationIncarnation); err != nil {
 			return nil, err
 		}
 		d.RelayRTTMS = nullInt64Ptr(relayRTTMS)
@@ -342,11 +628,69 @@ func (db *DB) MarkStaleDevicesOffline(ttlSeconds int64) error {
 	return err
 }
 
+func (db *DB) updateDeviceEndpointInternal(deviceID, endpoint, natType string, relayRTTMS *int64, isHeartbeat bool, expectedRegistrationSequence *int64) error {
+	tx, err := db.beginRoomWrite()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	now := time.Now().Unix()
+	var currentEndpoint, currentNAT string
+	var currentRegSeq, registrationIncarnation int64
+	row := tx.QueryRow(`SELECT COALESCE(endpoint, ''), COALESCE(nat_type, ''), COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0) FROM devices WHERE id = ?`, deviceID)
+	if err := row.Scan(&currentEndpoint, &currentNAT, &currentRegSeq, &registrationIncarnation); err != nil {
+		return err
+	}
+	if expectedRegistrationSequence != nil && registrationIncarnation > 0 {
+		incoming := parseNAT(natType)
+		incomingSequence, parseErr := strconv.ParseInt(incoming.lifecycle, 10, 64)
+		if *expectedRegistrationSequence != currentRegSeq || !incoming.hasLifecycle || parseErr != nil || incomingSequence != currentRegSeq {
+			return &RegistrationSessionConflictError{
+				CurrentSequence:    currentRegSeq,
+				CurrentIncarnation: registrationIncarnation,
+			}
+		}
+	}
+
+	canOverwrite := shouldOverwriteNAT(currentEndpoint, currentNAT, currentRegSeq, registrationIncarnation > 0, endpoint, natType)
+
+	if canOverwrite {
+		if isHeartbeat {
+			_, err = tx.Exec(`UPDATE devices SET endpoint = ?, nat_type = ?, relay_rtt_ms = ?, last_seen = ?, online = 1 WHERE id = ?`,
+				endpoint, natType, relayRTTMS, now, deviceID)
+		} else {
+			_, err = tx.Exec(`UPDATE devices SET endpoint = ?, nat_type = ?, relay_rtt_ms = ? WHERE id = ?`,
+				endpoint, natType, relayRTTMS, deviceID)
+		}
+	} else {
+		// Stale / conflicting / unversioned: refresh online presence and relay RTT if heartbeat, but do not overwrite endpoint or nat_type.
+		if isHeartbeat {
+			_, err = tx.Exec(`UPDATE devices SET relay_rtt_ms = ?, last_seen = ?, online = 1 WHERE id = ?`,
+				relayRTTMS, now, deviceID)
+		} else {
+			_, err = tx.Exec(`UPDATE devices SET relay_rtt_ms = ? WHERE id = ?`,
+				relayRTTMS, deviceID)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // UpdateDeviceEndpoint updates a device's endpoint and NAT type.
 func (db *DB) UpdateDeviceEndpoint(deviceID, endpoint, natType string, relayRTTMS *int64) error {
-	_, err := db.Exec(`UPDATE devices SET endpoint = ?, nat_type = ?, relay_rtt_ms = ?, last_seen = ?, online = 1 WHERE id = ?`,
-		endpoint, natType, relayRTTMS, time.Now().Unix(), deviceID)
-	return err
+	return db.updateDeviceEndpointInternal(deviceID, endpoint, natType, relayRTTMS, true, nil)
+}
+
+// UpdateDeviceEndpointForRegistrationSession updates a device-authenticated
+// heartbeat only if it still belongs to the supplied server-issued
+// registration sequence.  The check and the lease/RRT mutation share one
+// write transaction, so a late daemon cannot renew its lease after a newer
+// registration completes between HTTP middleware validation and this update.
+func (db *DB) UpdateDeviceEndpointForRegistrationSession(deviceID string, registrationSequence int64, endpoint, natType string, relayRTTMS *int64) error {
+	return db.updateDeviceEndpointInternal(deviceID, endpoint, natType, relayRTTMS, true, &registrationSequence)
 }
 
 // ReleaseDevicePresence marks a device offline without deleting its
@@ -357,14 +701,40 @@ func (db *DB) ReleaseDevicePresence(deviceID string) error {
 	return err
 }
 
+// ReleaseDevicePresenceForRegistrationSession marks a device offline only if
+// the request belongs to its current daemon registration sequence.  This
+// prevents an older process exiting after its replacement has become online
+// from taking the replacement offline.
+func (db *DB) ReleaseDevicePresenceForRegistrationSession(deviceID string, registrationSequence int64) error {
+	tx, err := db.beginRoomWrite()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var currentRegSeq, registrationIncarnation int64
+	if err := tx.QueryRow(`SELECT COALESCE(registration_seq, 1), COALESCE(registration_incarnation, 0) FROM devices WHERE id = ?`, deviceID).
+		Scan(&currentRegSeq, &registrationIncarnation); err != nil {
+		return err
+	}
+	if registrationIncarnation > 0 && registrationSequence != currentRegSeq {
+		return &RegistrationSessionConflictError{
+			CurrentSequence:    currentRegSeq,
+			CurrentIncarnation: registrationIncarnation,
+		}
+	}
+	if _, err := tx.Exec(`UPDATE devices SET online = 0 WHERE id = ?`, deviceID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // UpdateDeviceEndpointMetadata updates advertised metadata without asserting a
 // live daemon lease. It is used for user-JWT management requests once a device
 // has an active device credential; only device-authenticated heartbeats may
 // refresh last_seen/online in that state.
 func (db *DB) UpdateDeviceEndpointMetadata(deviceID, endpoint, natType string, relayRTTMS *int64) error {
-	_, err := db.Exec(`UPDATE devices SET endpoint = ?, nat_type = ?, relay_rtt_ms = ? WHERE id = ?`,
-		endpoint, natType, relayRTTMS, deviceID)
-	return err
+	return db.updateDeviceEndpointInternal(deviceID, endpoint, natType, relayRTTMS, false, nil)
 }
 
 // UpdateDeviceName changes the user-visible name of a registered device.

--- a/server/database/migrations.go
+++ b/server/database/migrations.go
@@ -175,6 +175,8 @@ func migrate(db *sql.DB) error {
 		{"users", "username", "TEXT NOT NULL DEFAULT ''"},
 		{"devices", "app_version", "TEXT NOT NULL DEFAULT ''"},
 		{"devices", "relay_rtt_ms", "INTEGER"},
+		{"devices", "registration_seq", "INTEGER NOT NULL DEFAULT 1"},
+		{"devices", "registration_incarnation", "INTEGER NOT NULL DEFAULT 0"},
 		{"signals", "protocol_version", "INTEGER NOT NULL DEFAULT 1"},
 		{"signals", "candidate_sources", "TEXT NOT NULL DEFAULT '{}'"},
 		{"signals", "candidate_generation", "INTEGER NOT NULL DEFAULT 0"},

--- a/server/database/registration_session_fence_test.go
+++ b/server/database/registration_session_fence_test.go
@@ -1,0 +1,101 @@
+package database
+
+import (
+	"errors"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestRegistrationSessionConditionalEndpointAndOfflineRejectStaleSequence(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	user, err := db.CreateUser("registration-session-conditional@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "registration-session-conditional-key", "daemon", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	firstIncarnation := int64(301)
+	first, err := db.RegisterDeviceWithOptions(
+		user.ID, device.NetworkID, device.PublicKey, "first", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &firstIncarnation, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("register first incarnation: %v", err)
+	}
+	secondIncarnation := int64(302)
+	second, err := db.RegisterDeviceWithOptions(
+		user.ID, device.NetworkID, device.PublicKey, "second", "macos", "", "", "",
+		DeviceRegistrationAttempt{Incarnation: &secondIncarnation, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("register second incarnation: %v", err)
+	}
+	if second.RegistrationSeq <= first.RegistrationSeq {
+		t.Fatalf("registration sequence did not advance: first=%d second=%d", first.RegistrationSeq, second.RegistrationSeq)
+	}
+
+	currentRTT := int64(31)
+	currentEndpoint := "198.51.100.31:51820"
+	currentNAT := "p2v2:m=endpoint_independent;g=1;l=" + strconv.FormatInt(second.RegistrationSeq, 10)
+	if err := db.UpdateDeviceEndpointForRegistrationSession(second.ID, second.RegistrationSeq, currentEndpoint, currentNAT, &currentRTT); err != nil {
+		t.Fatalf("publish current endpoint: %v", err)
+	}
+	before, err := db.GetDevice(second.ID)
+	if err != nil {
+		t.Fatalf("GetDevice before stale actions: %v", err)
+	}
+
+	staleRTT := int64(99)
+	err = db.UpdateDeviceEndpointForRegistrationSession(
+		second.ID,
+		first.RegistrationSeq,
+		"198.51.100.99:51820",
+		"p2v2:m=address_or_port_dependent;g=9;l="+strconv.FormatInt(first.RegistrationSeq, 10),
+		&staleRTT,
+	)
+	assertRegistrationSessionConflict(t, err, second.RegistrationSeq)
+
+	err = db.ReleaseDevicePresenceForRegistrationSession(second.ID, first.RegistrationSeq)
+	assertRegistrationSessionConflict(t, err, second.RegistrationSeq)
+
+	after, err := db.GetDevice(second.ID)
+	if err != nil {
+		t.Fatalf("GetDevice after stale actions: %v", err)
+	}
+	if after.Endpoint != before.Endpoint || after.NATType != before.NATType || after.LastSeen != before.LastSeen || after.Online != before.Online {
+		t.Fatalf("stale session changed endpoint or lease: before=%+v after=%+v", before, after)
+	}
+	if after.RelayRTTMS == nil || before.RelayRTTMS == nil || *after.RelayRTTMS != *before.RelayRTTMS {
+		t.Fatalf("stale session changed relay RTT: before=%+v after=%+v", before.RelayRTTMS, after.RelayRTTMS)
+	}
+
+	if err := db.ReleaseDevicePresenceForRegistrationSession(second.ID, second.RegistrationSeq); err != nil {
+		t.Fatalf("current session release: %v", err)
+	}
+	current, err := db.GetDevice(second.ID)
+	if err != nil {
+		t.Fatalf("GetDevice after current release: %v", err)
+	}
+	if current.Online {
+		t.Fatal("current session did not release presence")
+	}
+}
+
+func assertRegistrationSessionConflict(t *testing.T, err error, wantSequence int64) {
+	t.Helper()
+	var conflict *RegistrationSessionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected registration session conflict, got %v", err)
+	}
+	if conflict.CurrentSequence != wantSequence {
+		t.Fatalf("conflict sequence = %d, want %d", conflict.CurrentSequence, wantSequence)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -88,37 +88,7 @@ func main() {
 	mux.HandleFunc("GET /api/v1/profile", authService.RequireAuth(apiServer.Profile))
 	mux.HandleFunc("PATCH /api/v1/profile", authService.RequireAuth(apiServer.Profile))
 
-	// Dual-auth routes (accept user JWT or device credential)
-	anyAuth := auth.RequireAnyAuth(authService, db)
-	mux.HandleFunc("POST /api/v1/devices", anyAuth(apiServer.RegisterDevice))
-	mux.HandleFunc("GET /api/v1/nodes", anyAuth(apiServer.ListNodes))
-	mux.HandleFunc("POST /api/v1/signals", anyAuth(apiServer.CreateSignal))
-	mux.HandleFunc("GET /api/v1/signals", anyAuth(apiServer.ListSignals))
-	mux.HandleFunc("POST /api/v1/signals/ack", anyAuth(apiServer.AckSignals))
-	mux.HandleFunc("POST /api/v1/tunnels", anyAuth(apiServer.CreateTunnel))
-	mux.HandleFunc("GET /api/v1/tunnels", anyAuth(apiServer.ListTunnels))
-	mux.HandleFunc("DELETE /api/v1/tunnels/{id}", anyAuth(apiServer.DeleteTunnel))
-	mux.HandleFunc("PATCH /api/v1/devices/{id}", anyAuth(apiServer.UpdateDevice))
-	mux.HandleFunc("DELETE /api/v1/devices/{id}", anyAuth(apiServer.DeleteDevice))
-	mux.HandleFunc("POST /api/v1/devices/{id}/offline", anyAuth(apiServer.ReleaseDevicePresence))
-
-	// Device-only routes (device credential required)
-	deviceAuth := auth.RequireDeviceAuth(db)
-	mux.HandleFunc("DELETE /api/v1/devices/credential", deviceAuth(apiServer.RevokeCurrentDeviceCredential))
-
-	// Relay ticket endpoint (device-credential-only, rate limited)
-	mux.HandleFunc("POST /api/v1/relay/tickets", deviceAuth(rateLimit(apiServer.CreateRelayTicket, 5, time.Minute)))
-	mux.HandleFunc("GET /api/v1/relay/revocations", apiServer.RelayRevocations)
-
-	// Backward-compat: endpoint update accepts user JWT (anyAuth)
-	mux.HandleFunc("PATCH /api/v1/devices/{id}/endpoint", anyAuth(apiServer.UpdateDeviceEndpoint))
-
-	// Device-authenticated WebSocket wake-up channel. Signal payloads remain
-	// durable in the database and are consumed through GET /api/v1/signals.
-	signalWS := deviceAuth(signaling.ServeWS(hub))
-	mux.HandleFunc("GET /api/v1/signals/ws", signalWS)
-	// Secure compatibility alias for pre-v1 endpoint discovery.
-	mux.HandleFunc("GET /ws", signalWS)
+	registerDeviceControlRoutes(mux, authService, db, apiServer, hub)
 
 	// HTTP server
 	addr := fmt.Sprintf(":%s", port)
@@ -161,6 +131,54 @@ func main() {
 	log.Println("Server stopped")
 }
 
+// registerDeviceControlRoutes installs every daemon/device-token control
+// route in one place.  Keeping the sequence fence here makes the production
+// mux and the route-level regression tests share the same wiring.
+func registerDeviceControlRoutes(mux *http.ServeMux, authService *auth.Service, db *database.DB, apiServer *api.Server, hub *signaling.Hub) {
+	// Dual-auth routes (accept user JWT or device credential).  Once a device
+	// has registered with an incarnation, its long-lived credential also needs
+	// the current registration sequence on every control action.  Otherwise an
+	// older daemon that still holds that credential could renew its lease or
+	// consume signals after a newer daemon has taken over.
+	anyAuth := auth.RequireAnyAuth(authService, db)
+	deviceSession := apiServer.RequireCurrentDeviceRegistrationSession
+	anySessionAuth := func(next http.HandlerFunc) http.HandlerFunc {
+		return anyAuth(deviceSession(next))
+	}
+	mux.HandleFunc("POST /api/v1/devices", anyAuth(apiServer.RegisterDevice))
+	mux.HandleFunc("GET /api/v1/nodes", anySessionAuth(apiServer.ListNodes))
+	mux.HandleFunc("POST /api/v1/signals", anySessionAuth(apiServer.CreateSignal))
+	mux.HandleFunc("GET /api/v1/signals", anySessionAuth(apiServer.ListSignals))
+	mux.HandleFunc("POST /api/v1/signals/ack", anySessionAuth(apiServer.AckSignals))
+	mux.HandleFunc("POST /api/v1/tunnels", anySessionAuth(apiServer.CreateTunnel))
+	mux.HandleFunc("GET /api/v1/tunnels", anySessionAuth(apiServer.ListTunnels))
+	mux.HandleFunc("DELETE /api/v1/tunnels/{id}", anySessionAuth(apiServer.DeleteTunnel))
+	mux.HandleFunc("PATCH /api/v1/devices/{id}", anySessionAuth(apiServer.UpdateDevice))
+	mux.HandleFunc("DELETE /api/v1/devices/{id}", anySessionAuth(apiServer.DeleteDevice))
+	mux.HandleFunc("POST /api/v1/devices/{id}/offline", anySessionAuth(apiServer.ReleaseDevicePresence))
+
+	// Device-only routes (device credential required).
+	deviceAuth := auth.RequireDeviceAuth(db)
+	deviceSessionAuth := func(next http.HandlerFunc) http.HandlerFunc {
+		return deviceAuth(deviceSession(next))
+	}
+	mux.HandleFunc("DELETE /api/v1/devices/credential", deviceSessionAuth(apiServer.RevokeCurrentDeviceCredential))
+
+	// Relay ticket endpoint (device-credential-only, rate limited).
+	mux.HandleFunc("POST /api/v1/relay/tickets", deviceSessionAuth(rateLimit(apiServer.CreateRelayTicket, 5, time.Minute)))
+	mux.HandleFunc("GET /api/v1/relay/revocations", apiServer.RelayRevocations)
+
+	// Backward-compat: endpoint update accepts user JWT (anyAuth).
+	mux.HandleFunc("PATCH /api/v1/devices/{id}/endpoint", anySessionAuth(apiServer.UpdateDeviceEndpoint))
+
+	// Device-authenticated WebSocket wake-up channel. Signal payloads remain
+	// durable in the database and are consumed through GET /api/v1/signals.
+	signalWS := deviceAuth(signaling.ServeWS(hub, apiServer.WebSocketRegistrationSessionGuard()))
+	mux.HandleFunc("GET /api/v1/signals/ws", signalWS)
+	// Secure compatibility alias for pre-v1 endpoint discovery.
+	mux.HandleFunc("GET /ws", signalWS)
+}
+
 // withCORS allows explicitly configured browser origins to call the control
 // API. The browser console was deleted and Flutter Web is out of scope, so
 // there is no default browser origin: only origins listed in
@@ -174,7 +192,7 @@ func withCORS(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, "+auth.RegistrationSequenceHeader)
 			w.Header().Set("Access-Control-Max-Age", "600")
 		}
 		if r.Method == http.MethodOptions {

--- a/server/main_session_fence_test.go
+++ b/server/main_session_fence_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/yhan-sun/p2wlan/server/api"
+	"github.com/yhan-sun/p2wlan/server/auth"
+	"github.com/yhan-sun/p2wlan/server/database"
+	"github.com/yhan-sun/p2wlan/server/signaling"
+)
+
+func TestProductionDeviceControlRoutesFenceRegistrationSession(t *testing.T) {
+	db, err := database.New(filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	user, err := db.CreateUser("main-session-fence@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	device, err := db.CreateDevice(user.ID, "default", "main-session-fence-device", "daemon", "macos", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	peer, err := db.CreateDevice(user.ID, "default", "main-session-fence-peer", "peer", "linux", "")
+	if err != nil {
+		t.Fatalf("CreateDevice peer: %v", err)
+	}
+	_, credential, err := db.CreateDeviceCredential(device.ID, 3600)
+	if err != nil {
+		t.Fatalf("CreateDeviceCredential: %v", err)
+	}
+	incarnation := int64(4101)
+	device, err = db.RegisterDeviceWithOptions(
+		user.ID, device.NetworkID, device.PublicKey, "daemon", "macos", "", "", "",
+		database.DeviceRegistrationAttempt{Incarnation: &incarnation, EnforceIncarnation: true},
+	)
+	if err != nil {
+		t.Fatalf("RegisterDeviceWithOptions: %v", err)
+	}
+
+	service := auth.NewService("main-session-fence", db)
+	hub := signaling.NewHub()
+	t.Cleanup(hub.Close)
+	apiServer := api.NewServer(service, hub, db)
+	mux := http.NewServeMux()
+	registerDeviceControlRoutes(mux, service, db, apiServer, hub)
+	httpServer := httptest.NewServer(mux)
+	t.Cleanup(httpServer.Close)
+
+	request := func(method, path, body string, registrationSeq string) *http.Response {
+		req, err := http.NewRequest(method, httpServer.URL+path, strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+credential)
+		if registrationSeq != "" {
+			req.Header.Set(auth.RegistrationSequenceHeader, registrationSeq)
+		}
+		response, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("HTTP %s %s: %v", method, path, err)
+		}
+		return response
+	}
+	assertConflict := func(response *http.Response) {
+		t.Helper()
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusConflict {
+			t.Fatalf("expected 409, got %d", response.StatusCode)
+		}
+		var body struct {
+			ErrorCode string `json:"error_code"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+			t.Fatalf("decode conflict body: %v", err)
+		}
+		if body.ErrorCode != auth.RegistrationLifecycleConflictCode {
+			t.Fatalf("error_code = %q", body.ErrorCode)
+		}
+	}
+
+	assertConflict(request(http.MethodGet, "/api/v1/nodes", "", ""))
+	assertConflict(request(http.MethodPatch, "/api/v1/devices/"+device.ID+"/endpoint", `{"endpoint":"198.51.100.44:51820","nat_type":"p2v2:m=endpoint_independent;g=1;l=2"}`, ""))
+	assertConflict(request(http.MethodPost, "/api/v1/devices/"+device.ID+"/offline", "", ""))
+	assertConflict(request(http.MethodPost, "/api/v1/signals", `{"to_node_id":"`+peer.ID+`","type":"peer_reflexive","candidates":["203.0.113.44:51820"]}`, ""))
+	assertConflict(request(http.MethodGet, "/api/v1/signals", "", ""))
+	assertConflict(request(http.MethodPost, "/api/v1/signals/ack", `{"signals":[]}`, ""))
+	assertConflict(request(http.MethodPost, "/api/v1/relay/tickets", `{"audience":"not-reached"}`, ""))
+
+	currentSeq := strconv.FormatInt(device.RegistrationSeq, 10)
+	valid := request(http.MethodGet, "/api/v1/nodes", "", currentSeq)
+	defer valid.Body.Close()
+	if valid.StatusCode != http.StatusOK {
+		t.Fatalf("current production route request: HTTP %d", valid.StatusCode)
+	}
+
+	dialer := websocket.Dialer{HandshakeTimeout: time.Second, Subprotocols: []string{signaling.ProtocolName}}
+	wsURL := "ws" + strings.TrimPrefix(httpServer.URL, "http") + "/api/v1/signals/ws"
+	connection, response, err := dialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer " + credential}})
+	if connection != nil {
+		_ = connection.Close()
+		t.Fatal("missing production WebSocket sequence unexpectedly upgraded")
+	}
+	if err == nil || response == nil || response.StatusCode != http.StatusConflict {
+		status := 0
+		if response != nil {
+			status = response.StatusCode
+		}
+		t.Fatalf("missing production WebSocket sequence: err=%v status=%d", err, status)
+	}
+}

--- a/server/signaling/signaling.go
+++ b/server/signaling/signaling.go
@@ -23,14 +23,15 @@ import (
 )
 
 const (
-	ProtocolName          = "p2wlan.signaling.v1"
-	ProtocolVersion       = 1
-	DefaultMaxConnections = 10_000
-	sendQueueCapacity     = 64
-	readLimitBytes        = 4 << 10
-	writeWait             = 5 * time.Second
-	pongWait              = 45 * time.Second
-	pingPeriod            = 20 * time.Second
+	ProtocolName            = "p2wlan.signaling.v1"
+	ProtocolVersion         = 1
+	DefaultMaxConnections   = 10_000
+	sendQueueCapacity       = 64
+	readLimitBytes          = 4 << 10
+	writeWait               = 5 * time.Second
+	upgradeHandshakeTimeout = 5 * time.Second
+	pongWait                = 45 * time.Second
+	pingPeriod              = 20 * time.Second
 )
 
 var (
@@ -51,6 +52,14 @@ type closeRequest struct {
 	code int
 	text string
 }
+
+// UpgradeGuard runs before a WebSocket upgrade and may retain a short-lived
+// critical-section release function until the authenticated connection has
+// been registered in the hub.  It is used by the control plane to make a
+// registration-session validation atomic with the upgrade/register window.
+// A guard writes its own HTTP error response and returns ok=false when it
+// rejects the request.
+type UpgradeGuard func(http.ResponseWriter, *http.Request) (release func(), ok bool)
 
 // Client is one authenticated device connection. Identity comes exclusively
 // from device credential claims; clients never self-declare node or network.
@@ -221,7 +230,9 @@ func (c *Client) requestClose(code int, text string) {
 }
 
 // ServeWS upgrades a request already authenticated by RequireDeviceAuth.
-func ServeWS(hub *Hub) http.HandlerFunc {
+// An optional guard can fence an identity check with hub registration.  The
+// variadic form preserves the direct callers used by older tests and embeds.
+func ServeWS(hub *Hub, guards ...UpgradeGuard) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		claims, err := auth.GetDeviceClaims(r.Context())
 		if err != nil {
@@ -236,12 +247,26 @@ func ServeWS(hub *Hub) http.HandlerFunc {
 			http.Error(w, `{"error":"required websocket subprotocol is missing"}`, http.StatusUpgradeRequired)
 			return
 		}
+		var releaseGuard func()
+		if len(guards) > 0 && guards[0] != nil {
+			var ok bool
+			releaseGuard, ok = guards[0](w, r)
+			if !ok {
+				return
+			}
+			defer func() {
+				if releaseGuard != nil {
+					releaseGuard()
+				}
+			}()
+		}
 
 		upgrader := websocket.Upgrader{
-			ReadBufferSize:  1024,
-			WriteBufferSize: 1024,
-			Subprotocols:    []string{ProtocolName},
-			CheckOrigin:     checkOrigin,
+			HandshakeTimeout: upgradeHandshakeTimeout,
+			ReadBufferSize:   1024,
+			WriteBufferSize:  1024,
+			Subprotocols:     []string{ProtocolName},
+			CheckOrigin:      checkOrigin,
 		}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -260,6 +285,13 @@ func ServeWS(hub *Hub) http.HandlerFunc {
 			expiresAt:  time.Unix(claims.ExpiresAt, 0),
 		}
 		previous, err := hub.register(client)
+		// Registration session fencing only needs to cover validation through
+		// hub registration.  Keeping it during readPump would deadlock the next
+		// daemon registration behind a long-lived socket.
+		if releaseGuard != nil {
+			releaseGuard()
+			releaseGuard = nil
+		}
 		if err != nil {
 			_ = conn.WriteControl(
 				websocket.CloseMessage,
@@ -390,6 +422,11 @@ func (h *Hub) Disconnect(nodeID string) {
 	client := h.clients[nodeID]
 	h.mu.RUnlock()
 	if client != nil {
+		// Stop accepting wake-ups before asking the writer to close the
+		// connection.  A registration handoff must not leave a short window in
+		// which Notify can enqueue a signal for the superseded daemon while its
+		// close request is waiting behind the writer's send queue.
+		client.stop()
 		client.requestClose(websocket.ClosePolicyViolation, "device authorization changed")
 	}
 }

--- a/server/signaling/signaling_test.go
+++ b/server/signaling/signaling_test.go
@@ -263,6 +263,37 @@ func TestHubBackpressureIsBounded(t *testing.T) {
 	}
 }
 
+func TestHubDisconnectStopsFutureWakeupsBeforeSocketClosure(t *testing.T) {
+	hub := NewHubWithLimit(1)
+	client := &Client{
+		nodeID:   "node-a",
+		done:     make(chan struct{}),
+		send:     make(chan []byte, 1),
+		closeReq: make(chan closeRequest, 1),
+	}
+	if _, err := hub.register(client); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	hub.Disconnect(client.nodeID)
+	select {
+	case <-client.done:
+	default:
+		t.Fatal("disconnect did not stop the superseded client")
+	}
+	if hub.Notify(client.nodeID) {
+		t.Fatal("disconnected client accepted a later wakeup")
+	}
+	select {
+	case request := <-client.closeReq:
+		if request.code != websocket.ClosePolicyViolation {
+			t.Fatalf("unexpected close code %d", request.code)
+		}
+	default:
+		t.Fatal("disconnected client was not scheduled for close")
+	}
+}
+
 func TestHubCloseWaitsForConnectionTasksAndRejectsRegistration(t *testing.T) {
 	fixture := newWebSocketFixture(t)
 	conn := fixture.dial(t, "")


### PR DESCRIPTION
## Summary

Fixes the friend-room handshake and session handoff paths that caused encrypted-session stalls, fallback to ordinary punching, and slow direct connectivity.

- Add bounded first-offer identity refresh and idempotent handshake retransmission.
- Preserve monotonic NAT/endpoint observations and gateway-aware UDP mapping.
- Fence stale daemon registration sessions across REST and WebSocket control paths.
- Add Android incarnation reuse, v2 support log bundles, and finer room connection states.
- Bump release metadata to v0.1.153.

## Validation

- Go: `go test -count=1 ./...`
- Rust daemon: 1305 tests passed
- Flutter: 650 passed, 9 skipped
- Formatting and diff checks passed