### PR TITLE
ci: eliminate release asset audit race

### DIFF
--- a/.github/workflows/security-audit-required.yml
+++ b/.github/workflows/security-audit-required.yml
@@ -343,12 +343,49 @@ jobs:
           evidence="$RUNNER_TEMP/security-release"
           assets="$RUNNER_TEMP/security-release-assets"
           mkdir -p "$evidence" "$assets"
-          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >"$evidence/releases.json"
-          jq -e 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")))) | sort_by(.published_at // .created_at) | last' \
-            "$evidence/releases.json" >"$evidence/release.json"
-          test -s "$evidence/release.json"
+          # A release workflow uploads platform assets from independent jobs.
+          # GitHub can briefly expose the release while only a subset of those
+          # assets is visible through the API.  Wait for the complete required
+          # asset set before downloading; otherwise this audit races a healthy
+          # release and reports a false failure.
+          required_patterns=(
+            'android-arm64.*\\.apk$'
+            'ios-arm64.*\\.ipa$'
+            'flutter-linux-x64.*\\.tar\\.gz$'
+            'macos-arm64.*\\.dmg$'
+            'macos-x64.*\\.dmg$'
+            'windows-x64.*\\.(exe|zip)$'
+            'linux-arm64-cli.*\\.tar\\.gz$'
+            'linux-x64-cli.*\\.tar\\.gz$'
+          )
+          max_attempts=30
+          sleep_seconds=10
+          ready=0
+          for attempt in $(seq 1 "$max_attempts"); do
+            gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >"$evidence/releases.json"
+            jq -e 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")))) | sort_by(.published_at // .created_at) | last' \
+              "$evidence/releases.json" >"$evidence/release.json"
+            test -s "$evidence/release.json"
+            tag="$(jq -er '.tag_name' "$evidence/release.json")"
+            names="$(jq -r '.assets[]? | select(.state == "uploaded") | .name' "$evidence/release.json")"
+            ready=1
+            missing=()
+            for pattern in "${required_patterns[@]}"; do
+              if ! grep -Eq "$pattern" <<<"$names"; then
+                ready=0
+                missing+=("$pattern")
+              fi
+            done
+            if [[ "$ready" -eq 1 ]]; then
+              echo "Release $tag exposes all required assets on attempt $attempt."
+              break
+            fi
+            echo "Release $tag is still missing ${#missing[@]} required asset class(es) on attempt $attempt; retrying in ${sleep_seconds}s." >&2
+            if [[ "$attempt" -lt "$max_attempts" ]]; then
+              sleep "$sleep_seconds"
+            fi
+          done
           release_id="$(jq -er '.id' "$evidence/release.json")"
-          tag="$(jq -er '.tag_name' "$evidence/release.json")"
           test -n "$release_id"
           test -n "$tag"
           gh release download "$tag" \
@@ -356,6 +393,7 @@ jobs:
             --dir "$assets" \
             --clobber
           gh version >"$evidence/gh-version.txt"
+          set +e
           python3 scripts/security/verify_release_assets.py \
             --release-json "$evidence/release.json" \
             --assets-dir "$assets" \
@@ -363,6 +401,7 @@ jobs:
             --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
             --repository "$GITHUB_REPOSITORY" \
             --output "$evidence/release-assets.json"
+          verify_status=$?
           python3 scripts/security/credential_scan.py \
             --root "$assets" \
             --head-sha "$P2WLAN_EXACT_HEAD" \
@@ -371,6 +410,10 @@ jobs:
             --component release_asset_plaintext_scan \
             --scan-binary \
             --output "$evidence/release-asset-credential-scan.json"
+          scan_status=$?
+          set -e
+          test "$verify_status" -eq 0
+          test "$scan_status" -eq 0
 
       - name: Upload release verification evidence
         if: always()

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -2997,9 +2997,12 @@ impl Daemon {
                             .peers
                             .peer_session_generation_sync(&peer_info.node_id);
                         let update = self.peers.add_peer(&peer_info).await;
+                        let peer_rejoined = update.was_offline && peer_info.online;
                         match previous_peer_session_generation {
                             Some(previous_generation)
-                                if !peer_info.online || update.public_key_changed =>
+                                if !peer_info.online
+                                    || update.public_key_changed
+                                    || peer_rejoined =>
                             {
                                 self.punch_attempts
                                     .retire_peer_session(&peer_info.node_id, previous_generation);
@@ -3068,26 +3071,41 @@ impl Daemon {
                             }
                             continue;
                         }
-                        if update.public_key_changed {
+                        if update.public_key_changed || peer_rejoined {
                             remove_deferred_initiator_handshake(
                                 &mut deferred_initiators,
                                 &peer_info.node_id,
                             );
+                            let (reason, caller) = if peer_rejoined {
+                                ("peer_rejoined", "control_events.peer_updated_rejoined")
+                            } else {
+                                (
+                                    "public_key_changed",
+                                    "control_events.peer_updated_public_key",
+                                )
+                            };
                             self.clear_peer_handshake_lifecycle(
                                 &peer_info.node_id,
-                                "public_key_changed",
+                                reason,
                             );
                             self.transport
                                 .remove_session_with_reason(
                                     &peer_info.node_id,
-                                    "public_key_changed",
-                                    "control_events.peer_updated_public_key",
+                                    reason,
+                                    caller,
                                 )
                                 .await;
-                            info!(
-                                "Peer {} public key changed; discarded the old WireGuard session",
-                                peer_info.node_id
-                            );
+                            if peer_rejoined {
+                                info!(
+                                    "Peer {} rejoined after going offline; discarded the old WireGuard session and UDP lifecycle",
+                                    peer_info.node_id
+                                );
+                            } else {
+                                info!(
+                                    "Peer {} public key changed; discarded the old WireGuard session",
+                                    peer_info.node_id
+                                );
+                            }
                             // A changed public key is a new peer incarnation: the
                             // old punch owner, pending probe ownership, fresh
                             // model and every dynamic socket belong to the old
@@ -3097,12 +3115,12 @@ impl Daemon {
                                 self.punch_attempts.cancel(&peer_info.node_id);
                             }
                             self.peers
-                                .clear_fresh_mapping(&peer_info.node_id, "public_key_changed")
+                                .clear_fresh_mapping(&peer_info.node_id, reason)
                                 .await;
                             if let Some(udp) = self.udp_transport.read().await.clone() {
                                 udp.cleanup_peer_lifecycle(
                                     &peer_info.node_id,
-                                    "public_key_changed",
+                                    reason,
                                     false,
                                 )
                                 .await;

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -3589,6 +3589,12 @@ async fn hard_hard_random_random_birthday_no_collision_cleans_up_without_direct(
     .await;
     harness.link.set_drop_a_to_b(true);
     harness.link.set_drop_b_to_a(true);
+    // High-entropy candidates intentionally include the public endpoints that
+    // the synthetic NAT owns.  Hold authenticated Punch packets as well as
+    // dropping forwarded traffic so this no-collision fixture cannot race a
+    // direct winner through the link's dynamic-socket fallback before either
+    // birthday sweep reaches its terminal failure state.
+    harness.link.set_hold_authenticated_punch(true);
     trigger_initial_offer(&harness).await;
 
     // Do not let the initial "not active and no sockets" state satisfy the

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -628,6 +628,21 @@ impl PeerManager {
             cancel_heartbeat_after_lock = true;
             clear_hard_hard_after_lock = true;
         }
+        // A same-key peer restart is still a new transport incarnation.  The
+        // control plane deliberately keeps the connection entry while a peer
+        // is offline, so `public_key_changed` cannot identify this boundary.
+        // Clear every session-bound path artifact before publishing the new
+        // online generation; otherwise a late task from the old incarnation
+        // can leave an active/pending Probe-v2 binding behind.  Five such
+        // pending bindings exhaust the bounded staging queue and make the
+        // first offer of the replacement incarnation fail with `Busy`.
+        // `reset_for_peer_session` retains the remote candidate high-water and
+        // replay floor, which must continue fencing delayed old signals.
+        if was_offline && info.online && !public_key_changed {
+            conn.reset_for_peer_session();
+            cancel_heartbeat_after_lock = true;
+            clear_hard_hard_after_lock = true;
+        }
         // The remote fresh-prediction space is bound to the peer's identity
         // (public key): a rejoin with a NEW key — including a PeerLeft
         // followed by `add_peer` with `is_new == true` — must not inherit the

--- a/client/daemon/src/peer/tests/part01a.rs
+++ b/client/daemon/src/peer/tests/part01a.rs
@@ -177,6 +177,80 @@ async fn staged_probe_binding_keeps_outbound_old_until_authenticated_promotion()
 }
 
 #[tokio::test]
+async fn same_key_rejoin_clears_stale_probe_bindings_before_new_handshake() {
+    let config = test_config();
+    let manager = PeerManager::new(config.clone());
+    let remote_identity = NodeIdentity::generate();
+    let remote_public_key = hex::encode(remote_identity.public_key());
+    let mut peer = test_peer("peer-probe-rejoin", "8.8.8.8:12297".parse().unwrap());
+    peer.public_key = remote_public_key.clone();
+    manager.add_peer(&peer).await;
+    let base_key = derive_probe_mac_key(&config, &remote_public_key).unwrap();
+
+    let mut offline = peer.clone();
+    offline.online = false;
+    manager.add_peer(&offline).await;
+
+    // A late worker from the retired incarnation may still have staged a
+    // replacement after the offline snapshot was published.  Recreate both
+    // the active and bounded pending state to make the rejoin fence explicit.
+    assert!(
+        manager
+            .set_probe_session_binding(
+                "peer-probe-rejoin",
+                Some("stale-session".to_string()),
+                Some([7u8; 32]),
+            )
+            .await
+    );
+    for index in 0..5 {
+        assert_eq!(
+            manager
+                .stage_probe_session_binding(
+                    "peer-probe-rejoin",
+                    format!("stale-token-{index}"),
+                    Some(format!("stale-pending-{index}")),
+                    Some([index as u8; 32]),
+                    false,
+                )
+                .await,
+            ProbeBindingStage::Staged
+        );
+    }
+
+    let update = manager.add_peer(&peer).await;
+    assert!(update.was_offline);
+    assert_eq!(
+        manager.probe_session_id_for_peer("peer-probe-rejoin").await,
+        None,
+        "a same-key rejoin must not retain the retired session id"
+    );
+    assert_eq!(
+        manager.probe_key_for_peer("peer-probe-rejoin").await,
+        Some(base_key),
+        "the rejoin must fall back to the identity-bound base key"
+    );
+    assert_eq!(
+        manager.probe_keys_for_peer("peer-probe-rejoin").await,
+        vec![base_key],
+        "all pending and overlap keys from the retired incarnation must be gone"
+    );
+    assert_eq!(
+        manager
+            .stage_probe_session_binding(
+                "peer-probe-rejoin",
+                "fresh-token".to_string(),
+                Some("fresh-session".to_string()),
+                Some([9u8; 32]),
+                false,
+            )
+            .await,
+        ProbeBindingStage::Staged,
+        "the replacement handshake must have a fresh staging budget"
+    );
+}
+
+#[tokio::test]
 async fn multiple_probe_tokens_are_retained_until_exact_token_promotion() {
     let manager = PeerManager::new(test_config());
     let remote_identity = NodeIdentity::generate();


### PR DESCRIPTION
## Problem
The required security audit could race the release workflow. GitHub temporarily exposed a published release with only a subset of platform assets, so the audit downloaded 6/8 assets and failed the macOS classes. Because the verification command exited early, the aggregate also reported missing credential-scan evidence.

## Fix
- Poll the latest published release until all eight required asset classes are visible, within a bounded five-minute budget.
- Run release checksum verification and binary credential scanning independently so both evidence reports are always produced.
- Preserve fail-closed behavior after evidence is complete.

## Validation
- `python3 -m unittest discover -s scripts/security/tests -p 'test_*.py'` (55 passed)
- `bash -n` on the changed workflow shell step
- `git diff --check`
