### PR TITLE
fix: keep relay startup live under contention

### DIFF
--- a/.github/workflows/security-audit-required.yml
+++ b/.github/workflows/security-audit-required.yml
@@ -343,12 +343,49 @@ jobs:
           evidence="$RUNNER_TEMP/security-release"
           assets="$RUNNER_TEMP/security-release-assets"
           mkdir -p "$evidence" "$assets"
-          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >"$evidence/releases.json"
-          jq -e 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")))) | sort_by(.published_at // .created_at) | last' \
-            "$evidence/releases.json" >"$evidence/release.json"
-          test -s "$evidence/release.json"
+          # A release workflow uploads platform assets from independent jobs.
+          # GitHub can briefly expose the release while only a subset of those
+          # assets is visible through the API.  Wait for the complete required
+          # asset set before downloading; otherwise this audit races a healthy
+          # release and reports a false failure.
+          required_patterns=(
+            'android-arm64.*\\.apk$'
+            'ios-arm64.*\\.ipa$'
+            'flutter-linux-x64.*\\.tar\\.gz$'
+            'macos-arm64.*\\.dmg$'
+            'macos-x64.*\\.dmg$'
+            'windows-x64.*\\.(exe|zip)$'
+            'linux-arm64-cli.*\\.tar\\.gz$'
+            'linux-x64-cli.*\\.tar\\.gz$'
+          )
+          max_attempts=30
+          sleep_seconds=10
+          ready=0
+          for attempt in $(seq 1 "$max_attempts"); do
+            gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >"$evidence/releases.json"
+            jq -e 'map(select(.draft == false and .prerelease == false and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")))) | sort_by(.published_at // .created_at) | last' \
+              "$evidence/releases.json" >"$evidence/release.json"
+            test -s "$evidence/release.json"
+            tag="$(jq -er '.tag_name' "$evidence/release.json")"
+            names="$(jq -r '.assets[]? | select(.state == "uploaded") | .name' "$evidence/release.json")"
+            ready=1
+            missing=()
+            for pattern in "${required_patterns[@]}"; do
+              if ! grep -Eq "$pattern" <<<"$names"; then
+                ready=0
+                missing+=("$pattern")
+              fi
+            done
+            if [[ "$ready" -eq 1 ]]; then
+              echo "Release $tag exposes all required assets on attempt $attempt."
+              break
+            fi
+            echo "Release $tag is still missing ${#missing[@]} required asset class(es) on attempt $attempt; retrying in ${sleep_seconds}s." >&2
+            if [[ "$attempt" -lt "$max_attempts" ]]; then
+              sleep "$sleep_seconds"
+            fi
+          done
           release_id="$(jq -er '.id' "$evidence/release.json")"
-          tag="$(jq -er '.tag_name' "$evidence/release.json")"
           test -n "$release_id"
           test -n "$tag"
           gh release download "$tag" \
@@ -356,6 +393,7 @@ jobs:
             --dir "$assets" \
             --clobber
           gh version >"$evidence/gh-version.txt"
+          set +e
           python3 scripts/security/verify_release_assets.py \
             --release-json "$evidence/release.json" \
             --assets-dir "$assets" \
@@ -363,6 +401,7 @@ jobs:
             --workflow-sha "$P2WLAN_WORKFLOW_SHA" \
             --repository "$GITHUB_REPOSITORY" \
             --output "$evidence/release-assets.json"
+          verify_status=$?
           python3 scripts/security/credential_scan.py \
             --root "$assets" \
             --head-sha "$P2WLAN_EXACT_HEAD" \
@@ -371,6 +410,10 @@ jobs:
             --component release_asset_plaintext_scan \
             --scan-binary \
             --output "$evidence/release-asset-credential-scan.json"
+          scan_status=$?
+          set -e
+          test "$verify_status" -eq 0
+          test "$scan_status" -eq 0
 
       - name: Upload release verification evidence
         if: always()

--- a/client/daemon/src/control/client.rs
+++ b/client/daemon/src/control/client.rs
@@ -80,6 +80,7 @@ impl ControlClient {
         let (candidate_offer_tx, candidate_offer_rx) =
             mpsc::channel(CANDIDATE_OFFER_QUEUE_CAPACITY);
         let (critical_auth_tx, critical_auth_rx) = watch::channel(None);
+        let event_loop_ready = Arc::new(AtomicBool::new(false));
 
         let state = Arc::new(RwLock::new(ClientState {
             room_authorization: Arc::new(crate::rooms::RoomAuthorization::new(&config.network.network_id)),
@@ -101,6 +102,7 @@ impl ControlClient {
         let critical_lifecycle_tx = cmd_tx.clone();
         let client = Self {
             shutdown_lifecycle,
+            event_loop_ready: event_loop_ready.clone(),
             event_tx: event_tx.clone(),
             cmd_tx: cmd_tx.clone(),
             critical_offer_tx,
@@ -179,6 +181,7 @@ impl ControlClient {
                     critical_auth_tx,
                     health,
                     advertised_snapshot,
+                    event_loop_ready,
                 )
                 .await;
             };
@@ -248,6 +251,7 @@ impl ControlClient {
         }));
         Self {
             shutdown_lifecycle: None,
+            event_loop_ready: Arc::new(AtomicBool::new(false)),
             event_tx,
             cmd_tx,
             critical_offer_tx,
@@ -264,6 +268,15 @@ impl ControlClient {
             #[cfg(test)]
             test_signal_generation: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Allow the ordinary control runtime to start leasing signal rows only
+    /// after the daemon has installed its main event consumer.  This closes
+    /// the startup race where a first offer was leased before the state
+    /// machine could apply it, causing ordered redelivery to wait for the
+    /// server lease timeout.
+    pub(crate) fn mark_event_loop_ready(&self) {
+        self.event_loop_ready.store(true, Ordering::Release);
     }
 
     /// Install a test-only in-process signaling forwarder. The adapter is

--- a/client/daemon/src/control/http.rs
+++ b/client/daemon/src/control/http.rs
@@ -41,6 +41,11 @@ pub(super) const PRESENCE_RELEASE_TIMEOUT: Duration = Duration::from_secs(1);
 /// of its short receive-only key lifetime. Delivery remains ambiguous on
 /// timeout, so the daemon retains staged state for authenticated confirmation.
 const SIGNAL_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+/// A leased signal must not hold its sender's ordered ACK lane forever when
+/// the daemon state machine is wedged.  Keep this below the server lease so a
+/// timed-out row can be redelivered before its lease expires and later rows
+/// cannot be blocked behind a permanently pending receipt.
+const SIGNAL_APPLICATION_TIMEOUT: Duration = Duration::from_secs(8);
 
 fn signal_poll_timeout(wait_ms: u64) -> Duration {
     CONTROL_REQUEST_TIMEOUT.saturating_add(Duration::from_millis(wait_ms))

--- a/client/daemon/src/control/http/signal.rs
+++ b/client/daemon/src/control/http/signal.rs
@@ -565,6 +565,23 @@ struct LeasedSignalDelivery {
     prepared: PreparedSignalDelivery,
 }
 
+async fn wait_for_signal_application(
+    waiter: SignalDeliveryWaiter,
+    signal_id: &str,
+    from_node_id: &str,
+    signal_seq: Option<u64>,
+) -> SignalApplyOutcome {
+    match tokio::time::timeout(SIGNAL_APPLICATION_TIMEOUT, waiter.wait()).await {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            warn!(
+                "Control signal {signal_id} from {from_node_id} at sequence {signal_seq:?} did not reach the daemon state machine within {SIGNAL_APPLICATION_TIMEOUT:?}; leaving its lease for ordered redelivery"
+            );
+            SignalApplyOutcome::Retry
+        }
+    }
+}
+
 /// Apply one leased server batch in response order without blocking the
 /// heartbeat/roster polling loop.  ACKs are deliberately emitted one row at a
 /// time: if an ACK is ambiguous, later rows stay unacknowledged and the
@@ -615,7 +632,13 @@ fn spawn_signal_application_lane(
                                 delivery.signal_id, delivery.from_node_id, delivery.signal_seq
                             );
                             application_waiter = Some(waiter.clone());
-                            waiter.wait().await
+                            wait_for_signal_application(
+                                waiter,
+                                &delivery.signal_id,
+                                &delivery.from_node_id,
+                                delivery.signal_seq,
+                            )
+                            .await
                         }
                         TrackedSignalApplication::Start { receipt, waiter } => {
                             application_waiter = Some(waiter.clone());
@@ -639,7 +662,13 @@ fn spawn_signal_application_lane(
                                 );
                                 break;
                             }
-                            waiter.wait().await
+                            wait_for_signal_application(
+                                waiter,
+                                &delivery.signal_id,
+                                &delivery.from_node_id,
+                                delivery.signal_seq,
+                            )
+                            .await
                         }
                     }
                 }

--- a/client/daemon/src/control/runtime/loop.rs
+++ b/client/daemon/src/control/runtime/loop.rs
@@ -11,6 +11,7 @@ async fn run_control_loop(
     critical_auth_tx: watch::Sender<Option<CriticalControlAuth>>,
     health: Option<Arc<crate::tasks::HealthState>>,
     advertised_snapshot: Arc<std::sync::Mutex<AdvertisedEndpointSnapshot>>,
+    event_loop_ready: Arc<AtomicBool>,
 ) {
     let base_url = normalize_http_base_url(&config.control.server_url);
 
@@ -301,6 +302,11 @@ async fn run_control_loop(
             }
             let _ = event_tx.send(ControlEvent::ControlHealthy);
         }
+        // Do not lease the first signal until the daemon's main consumer is
+        // ready.  A leased signal delivered during startup cannot be applied;
+        // the server's ordered lease would then fence every later signal for
+        // its full TTL, making a healthy relay handshake appear to stall.
+        wait_for_event_loop_ready(&event_loop_ready).await;
         let initial_signal_poll = async {
             let current_http = http.current()?;
             poll_signals(
@@ -677,4 +683,14 @@ async fn run_control_loop(
         // brief pause before re-register to avoid hammering a restarting server
         tokio::time::sleep(Duration::from_secs(1)).await;
     } // end outer loop — will hit the `return` inside on Shutdown, or loop around
+}
+
+/// Wait for `Daemon::run` to install its control-event consumer.  Do not read
+/// the command channel here: commands can carry response senders and must
+/// remain queued for the normal polling loop rather than being consumed and
+/// dropped while startup is still in progress.
+async fn wait_for_event_loop_ready(ready: &Arc<AtomicBool>) {
+    while !ready.load(Ordering::Acquire) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }

--- a/client/daemon/src/control/types.rs
+++ b/client/daemon/src/control/types.rs
@@ -560,6 +560,15 @@ struct SignalResponse {
 #[derive(Clone)]
 pub struct ControlClient {
     shutdown_lifecycle: Option<Arc<ControlShutdown>>,
+    /// Set by the daemon after its main control-event consumer is ready.
+    ///
+    /// Registration and peer-roster polling may run during daemon startup,
+    /// but signal polling must wait for this edge.  Otherwise the first
+    /// leased offer/answer can be delivered while `Daemon::run` is still
+    /// waiting for `Registered` or bringing up the dataplane.  The server's
+    /// ordered lease then fences later signals until it expires, adding a
+    /// multi-second delay to an otherwise healthy relay handshake.
+    event_loop_ready: Arc<AtomicBool>,
     /// Channel to send events to the daemon.
     event_tx: mpsc::UnboundedSender<ControlEvent>,
     /// Channel to send commands to the background task.

--- a/client/daemon/src/diagnostics/snapshot.rs
+++ b/client/daemon/src/diagnostics/snapshot.rs
@@ -143,7 +143,14 @@ async fn capture_stable_peer_snapshot(
     direct_retry_after: Duration,
     udp_local_endpoint: Option<std::net::SocketAddr>,
 ) -> StablePeerSnapshot {
-    const MAX_CAPTURE_ATTEMPTS: usize = 8;
+    // A status request commonly races the final peer/path event of a NAT
+    // validation burst.  Yielding alone is not enough here: Tokio's fair
+    // RwLock can keep a reader contended for several scheduler turns while a
+    // short lifecycle writer drains.  Retry for a small bounded window before
+    // falling back to the validated cache, keeping /status responsive while
+    // making normal transient contention converge to a fresh snapshot.
+    const MAX_CAPTURE_ATTEMPTS: usize = 32;
+    const CAPTURE_RETRY_DELAY: Duration = Duration::from_millis(2);
 
     for attempt in 0..MAX_CAPTURE_ATTEMPTS {
         let revision_before = context.status_events.current_seq();
@@ -155,13 +162,8 @@ async fn capture_stable_peer_snapshot(
                 "initial_read",
                 attempt,
             );
-            return cached_or_best_effort_peer_snapshot(
-                context,
-                relay_connected,
-                direct_retry_after,
-                udp_local_endpoint,
-            )
-            .await;
+            tokio::time::sleep(CAPTURE_RETRY_DELAY).await;
+            continue;
         };
         let mut node_ids: Vec<_> = connections_before
             .into_iter()
@@ -197,7 +199,7 @@ async fn capture_stable_peer_snapshot(
                 "peer_diagnostic_read",
                 attempt,
             );
-            tokio::task::yield_now().await;
+            tokio::time::sleep(CAPTURE_RETRY_DELAY).await;
             continue;
         }
         peers.sort_by(|left, right| left.node_id.cmp(&right.node_id));
@@ -209,13 +211,8 @@ async fn capture_stable_peer_snapshot(
                 "validation_read",
                 attempt,
             );
-            return cached_or_best_effort_peer_snapshot(
-                context,
-                relay_connected,
-                direct_retry_after,
-                udp_local_endpoint,
-            )
-            .await;
+            tokio::time::sleep(CAPTURE_RETRY_DELAY).await;
+            continue;
         };
         let revision_after = context.status_events.current_seq();
         let generation_after = context.peers.current_network_generation_sync();
@@ -223,7 +220,7 @@ async fn capture_stable_peer_snapshot(
             || generation_before != generation_after
             || !peer_snapshot_core_matches(&peers, &live_after)
         {
-            tokio::task::yield_now().await;
+            tokio::time::sleep(CAPTURE_RETRY_DELAY).await;
             continue;
         }
 

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -3489,6 +3489,16 @@ impl Daemon {
                             if let Some(receipt) = delivery_receipt.as_ref() {
                                 receipt.complete(candidate_signal_outcome);
                             }
+                            // This branch continues the receiver loop before the
+                            // common post-event drain.  Revisit the retry ledger
+                            // here so a prepared encrypted offer that became
+                            // ready during candidate admission is not left
+                            // waiting for an unrelated control event.
+                            daemon.drain_initiator_retry_ledger(&mut retry_work);
+                            daemon.drain_deferred_initiator_handshakes(
+                                &mut slow_work,
+                                &mut deferred_initiators,
+                            );
                             continue;
                         }
 

--- a/client/daemon/src/lib/daemon/control_events.rs
+++ b/client/daemon/src/lib/daemon/control_events.rs
@@ -2997,9 +2997,12 @@ impl Daemon {
                             .peers
                             .peer_session_generation_sync(&peer_info.node_id);
                         let update = self.peers.add_peer(&peer_info).await;
+                        let peer_rejoined = update.was_offline && peer_info.online;
                         match previous_peer_session_generation {
                             Some(previous_generation)
-                                if !peer_info.online || update.public_key_changed =>
+                                if !peer_info.online
+                                    || update.public_key_changed
+                                    || peer_rejoined =>
                             {
                                 self.punch_attempts
                                     .retire_peer_session(&peer_info.node_id, previous_generation);
@@ -3068,26 +3071,41 @@ impl Daemon {
                             }
                             continue;
                         }
-                        if update.public_key_changed {
+                        if update.public_key_changed || peer_rejoined {
                             remove_deferred_initiator_handshake(
                                 &mut deferred_initiators,
                                 &peer_info.node_id,
                             );
+                            let (reason, caller) = if peer_rejoined {
+                                ("peer_rejoined", "control_events.peer_updated_rejoined")
+                            } else {
+                                (
+                                    "public_key_changed",
+                                    "control_events.peer_updated_public_key",
+                                )
+                            };
                             self.clear_peer_handshake_lifecycle(
                                 &peer_info.node_id,
-                                "public_key_changed",
+                                reason,
                             );
                             self.transport
                                 .remove_session_with_reason(
                                     &peer_info.node_id,
-                                    "public_key_changed",
-                                    "control_events.peer_updated_public_key",
+                                    reason,
+                                    caller,
                                 )
                                 .await;
-                            info!(
-                                "Peer {} public key changed; discarded the old WireGuard session",
-                                peer_info.node_id
-                            );
+                            if peer_rejoined {
+                                info!(
+                                    "Peer {} rejoined after going offline; discarded the old WireGuard session and UDP lifecycle",
+                                    peer_info.node_id
+                                );
+                            } else {
+                                info!(
+                                    "Peer {} public key changed; discarded the old WireGuard session",
+                                    peer_info.node_id
+                                );
+                            }
                             // A changed public key is a new peer incarnation: the
                             // old punch owner, pending probe ownership, fresh
                             // model and every dynamic socket belong to the old
@@ -3097,12 +3115,12 @@ impl Daemon {
                                 self.punch_attempts.cancel(&peer_info.node_id);
                             }
                             self.peers
-                                .clear_fresh_mapping(&peer_info.node_id, "public_key_changed")
+                                .clear_fresh_mapping(&peer_info.node_id, reason)
                                 .await;
                             if let Some(udp) = self.udp_transport.read().await.clone() {
                                 udp.cleanup_peer_lifecycle(
                                     &peer_info.node_id,
-                                    "public_key_changed",
+                                    reason,
                                     false,
                                 )
                                 .await;

--- a/client/daemon/src/lib/daemon/handshake/initiate.rs
+++ b/client/daemon/src/lib/daemon/handshake/initiate.rs
@@ -119,7 +119,7 @@ impl Daemon {
             phase,
             Instant::now(),
         );
-        let Some((identity, revision)) = scheduled else {
+        let Some((identity, revision, wake_after)) = scheduled else {
             // Capacity, TTL, or an ownership mismatch cannot leave a prepared
             // reservation with no progress edge.  Cancel only the exact owner;
             // a replacement lifecycle remains untouched.
@@ -159,6 +159,18 @@ impl Daemon {
             )),
         );
         self.handshake_retry_kick_tx.send_replace(revision);
+        // The periodic retry tick is a safety net, but a dedicated delayed
+        // wake makes the exact backoff deadline independent of control-event
+        // traffic.  This is especially important when a candidate-only signal
+        // is being applied at the same time and the serial event loop has no
+        // idle control event to wake it.
+        let retry_kick = self.handshake_retry_kick_tx.clone();
+        tokio::spawn(async move {
+            if !wake_after.is_zero() {
+                tokio::time::sleep(wake_after).await;
+            }
+            retry_kick.send_replace(revision);
+        });
         true
     }
 

--- a/client/daemon/src/lib/daemon/run.rs
+++ b/client/daemon/src/lib/daemon/run.rs
@@ -597,6 +597,12 @@ impl Daemon {
             info!("Android daemon startup completed; VPN dataplane is ready");
         }
 
+        // Signal leasing is gated until this point so an offer/answer cannot
+        // be held by the server while startup is still constructing the
+        // daemon's control-event consumer.  Mark the edge immediately before
+        // entering the consumer loop; any queued roster events are then
+        // drained in order and the first signal is applied without lease HOL.
+        self.control.mark_event_loop_ready();
         self.run_control_event_loop(&mut relay_started, network_inbound_tx.clone())
             .await;
 

--- a/client/daemon/src/lib/pending_handshake.rs
+++ b/client/daemon/src/lib/pending_handshake.rs
@@ -638,7 +638,7 @@ impl PendingHandshakeState {
         reservation: &HandshakeStartReservation,
         phase: InitiatorRetryPhase,
         now: Instant,
-    ) -> Option<(HandshakeRetryIdentity, u64)> {
+    ) -> Option<(HandshakeRetryIdentity, u64, Duration)> {
         if self.starting_ids.get(peer_id).copied() != Some(reservation.owner)
             || self.starting_network_generations.get(peer_id)
                 != Some(&reservation.network_generation)
@@ -709,7 +709,7 @@ impl PendingHandshakeState {
             },
         );
         self.retry_revision = self.retry_revision.wrapping_add(1);
-        Some((identity, self.retry_revision))
+        Some((identity, self.retry_revision, backoff))
     }
 
     fn expire_initiator_retries(&mut self, now: Instant) {

--- a/client/daemon/src/lib/tests/part03.rs
+++ b/client/daemon/src/lib/tests/part03.rs
@@ -3660,7 +3660,7 @@ fn exact_handshake_retry_has_strict_ttl_and_all_lifecycle_cancellations_are_term
         .claim_ready_initiator_retry(now + Duration::from_millis(12))
         .expect("the merged retry must become ready deterministically");
     assert_eq!(claimed_identity.attempt, 2);
-    let (rescheduled_identity, _) = ttl_state
+    let (rescheduled_identity, _, _) = ttl_state
         .schedule_initiator_retry(
             "peer-retry-ttl",
             &claimed_reservation,
@@ -7660,9 +7660,9 @@ async fn test_network_outbound_queue_overflow_counts_packets_and_bytes_exactly()
 
     // Keep the overflow count below the independently bounded diagnostic
     // event ledger. The structural counter remains authoritative; this load
-    // still crosses the exact 256-packet queue cap by 44 entries and lets the
+    // still crosses the exact 512-packet queue cap by 44 entries and lets the
     // test compare every retained per-drop event byte-for-byte.
-    let total = 300usize;
+    let total = 556usize;
     let packet_len = Ipv4Packet::build_icmp_echo_request(
         "10.20.0.1".parse().unwrap(),
         "10.20.0.2".parse().unwrap(),
@@ -7692,7 +7692,7 @@ async fn test_network_outbound_queue_overflow_counts_packets_and_bytes_exactly()
     // Wait for the worker to drain the input and the overflow counters to
     // reach their FINAL value (the first overflow drop lands while later
     // packets are still in flight).
-    let expected_dropped = (total - 256) as u64;
+    let expected_dropped = (total - 512) as u64;
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     let (dropped, bytes) = loop {
         let stats = peers.outbound_loss_stats().await;
@@ -7713,7 +7713,7 @@ async fn test_network_outbound_queue_overflow_counts_packets_and_bytes_exactly()
 
     assert_eq!(
         dropped, expected_dropped,
-        "exactly the packets beyond the 256-per-peer bound must be counted"
+        "exactly the packets beyond the 512-per-peer bound must be counted"
     );
     assert_eq!(
         bytes,

--- a/client/daemon/src/lib/tests/part07.rs
+++ b/client/daemon/src/lib/tests/part07.rs
@@ -3589,6 +3589,12 @@ async fn hard_hard_random_random_birthday_no_collision_cleans_up_without_direct(
     .await;
     harness.link.set_drop_a_to_b(true);
     harness.link.set_drop_b_to_a(true);
+    // High-entropy candidates intentionally include the public endpoints that
+    // the synthetic NAT owns.  Hold authenticated Punch packets as well as
+    // dropping forwarded traffic so this no-collision fixture cannot race a
+    // direct winner through the link's dynamic-socket fallback before either
+    // birthday sweep reaches its terminal failure state.
+    harness.link.set_hold_authenticated_punch(true);
     trigger_initial_offer(&harness).await;
 
     // Do not let the initial "not active and no sockets" state satisfy the

--- a/client/daemon/src/network_outbound.rs
+++ b/client/daemon/src/network_outbound.rs
@@ -70,11 +70,14 @@ pub(crate) const OUTBOUND_DELIVERY_DEADLINE: Duration = Duration::from_secs(3);
 pub(crate) const OUTBOUND_MAINTENANCE_INTERVAL: Duration = Duration::from_millis(100);
 /// Per-peer pending queue bounds.  A not-yet-usable peer cannot build
 /// unbounded memory pressure while it waits for a path.
-// A 256-packet overlay burst exactly fills this business queue. Control and
+// A relay validation round can contain one 256-packet request burst and the
+// matching 256-packet echo burst.  The flush task owns part of the FIFO while
+// new TUN packets continue arriving, so the live ingress queue needs room for
+// the complete bidirectional burst without evicting its tail. Control and
 // handshake packets use a separate lane, so they consume none of this bound.
 // The independent 2 MiB cap prevents a peer from filling the limit with
 // maximum-size IP packets.
-const MAX_PENDING_PACKETS_PER_PEER: usize = 256;
+const MAX_PENDING_PACKETS_PER_PEER: usize = 512;
 const MAX_PENDING_BYTES_PER_PEER: usize = 2 * 1024 * 1024;
 /// Maximum packets sent from ONE peer's queue in a single flush pass. Flushes
 /// for different peers run concurrently; this bound still prevents one

--- a/client/daemon/src/peer/manager/core.rs
+++ b/client/daemon/src/peer/manager/core.rs
@@ -31,6 +31,8 @@ impl PeerManager {
         let (dplpmtud_capability_tx, _) =
             tokio::sync::watch::channel(Arc::new(HashMap::new()));
         let (direct_business_budget_change_tx, _) = tokio::sync::watch::channel(0);
+        let (ip_to_node_snapshot, _) =
+            tokio::sync::watch::channel(Arc::new(HashMap::<String, String>::new()));
         let (local_mtu_feedback_tx, _) = tokio::sync::broadcast::channel(256);
         Self {
             connections: Arc::new(RwLock::new(HashMap::new())),
@@ -51,6 +53,7 @@ impl PeerManager {
                 crate::business_mtu::LocalMtuFeedbackRateLimiter::default(),
             )),
             ip_to_node: Arc::new(RwLock::new(HashMap::new())),
+            ip_to_node_snapshot,
             network_generation: Arc::new(RwLock::new(0)),
             network_generation_sync: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             network_generation_handshake_cancel_hook: Arc::new(std::sync::Mutex::new(None)),

--- a/client/daemon/src/peer/manager/diagnostics.rs
+++ b/client/daemon/src/peer/manager/diagnostics.rs
@@ -50,15 +50,25 @@ impl PeerManager {
 
     /// Record bytes sent to a peer.
     pub async fn record_sent(&self, node_id: &str, n: u64) {
-        if let Some(conn) = self.connections.write().await.get_mut(node_id) {
-            conn.record_sent(n);
+        // Traffic counters are advisory diagnostics.  Never enqueue a writer
+        // from the dataplane: Tokio's fair RwLock keeps later try-only relay
+        // confirmation commits contended while this low-value update waits
+        // behind a lifecycle transaction.
+        if let Ok(mut connections) = self.connections.try_write() {
+            if let Some(conn) = connections.get_mut(node_id) {
+                conn.record_sent(n);
+            }
         }
     }
 
     /// Record bytes received from a peer.
     pub async fn record_received(&self, node_id: &str, n: u64) {
-        if let Some(conn) = self.connections.write().await.get_mut(node_id) {
-            conn.record_received(n);
+        // See `record_sent`: a dropped counter sample is preferable to
+        // parking the single dataplane task behind a fair writer queue.
+        if let Ok(mut connections) = self.connections.try_write() {
+            if let Some(conn) = connections.get_mut(node_id) {
+                conn.record_received(n);
+            }
         }
     }
 

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -875,6 +875,11 @@ impl PeerManager {
         }
 
         ip_map.insert(info.virtual_ip.clone(), info.node_id.clone());
+        // Publish the complete routing index after the authoritative map has
+        // been updated. Dataplane lookups consume this immutable snapshot and
+        // therefore never wait behind this control-plane writer.
+        self.ip_to_node_snapshot
+            .send_replace(Arc::new(ip_map.clone()));
         // Publish membership only after the connection is fully initialized.
         // Readers of the no-await mirror may then safely dispatch candidate
         // work without mistaking an in-progress PeerJoined for a ready peer.
@@ -1027,6 +1032,8 @@ impl PeerManager {
         if let Some(virtual_ip) = removed_virtual_ip {
             let mut ip_map = self.ip_to_node.write().await;
             ip_map.remove(&virtual_ip);
+            self.ip_to_node_snapshot
+                .send_replace(Arc::new(ip_map.clone()));
         }
         self.cancel_relay_backoff_heartbeat(node_id);
         self.clear_relay_not_found_grace(node_id).await;
@@ -1046,7 +1053,10 @@ impl PeerManager {
 
     /// Look up the node ID for a virtual IP.
     pub async fn resolve_virtual_ip(&self, virtual_ip: &str) -> Option<String> {
-        self.ip_to_node.read().await.get(virtual_ip).cloned()
+        self.ip_to_node_snapshot
+            .borrow()
+            .get(virtual_ip)
+            .cloned()
     }
 
     /// Update a peer's connection state.

--- a/client/daemon/src/peer/manager/peers.rs
+++ b/client/daemon/src/peer/manager/peers.rs
@@ -628,6 +628,21 @@ impl PeerManager {
             cancel_heartbeat_after_lock = true;
             clear_hard_hard_after_lock = true;
         }
+        // A same-key peer restart is still a new transport incarnation.  The
+        // control plane deliberately keeps the connection entry while a peer
+        // is offline, so `public_key_changed` cannot identify this boundary.
+        // Clear every session-bound path artifact before publishing the new
+        // online generation; otherwise a late task from the old incarnation
+        // can leave an active/pending Probe-v2 binding behind.  Five such
+        // pending bindings exhaust the bounded staging queue and make the
+        // first offer of the replacement incarnation fail with `Busy`.
+        // `reset_for_peer_session` retains the remote candidate high-water and
+        // replay floor, which must continue fencing delayed old signals.
+        if was_offline && info.online && !public_key_changed {
+            conn.reset_for_peer_session();
+            cancel_heartbeat_after_lock = true;
+            clear_hard_hard_after_lock = true;
+        }
         // The remote fresh-prediction space is bound to the peer's identity
         // (public key): a rejoin with a NEW key — including a PeerLeft
         // followed by `add_peer` with `is_new == true` — must not inherit the

--- a/client/daemon/src/peer/manager/state.rs
+++ b/client/daemon/src/peer/manager/state.rs
@@ -466,8 +466,13 @@ pub struct PeerManager {
     local_mtu_feedback_tx: tokio::sync::broadcast::Sender<Vec<u8>>,
     local_mtu_feedback_limiter:
         Arc<std::sync::Mutex<crate::business_mtu::LocalMtuFeedbackRateLimiter>>,
-    /// Virtual IP → node ID mapping for routing.
+    /// Virtual IP → node ID mapping for control-plane updates.
     ip_to_node: Arc<RwLock<HashMap<String, String>>>,
+    /// Lock-free latest-value routing index consumed by the dataplane. The
+    /// authoritative map above is updated under the lifecycle transaction;
+    /// this snapshot lets every TUN packet resolve its destination without
+    /// joining Tokio's fair async-lock queue.
+    ip_to_node_snapshot: tokio::sync::watch::Sender<Arc<HashMap<String, String>>>,
     /// Monotonic local network generation. Incremented when local UDP candidates change.
     network_generation: Arc<RwLock<u64>>,
     /// Lock-free mirror of `network_generation`, updated in the same critical

--- a/client/daemon/src/peer/tests/part01a.rs
+++ b/client/daemon/src/peer/tests/part01a.rs
@@ -177,6 +177,80 @@ async fn staged_probe_binding_keeps_outbound_old_until_authenticated_promotion()
 }
 
 #[tokio::test]
+async fn same_key_rejoin_clears_stale_probe_bindings_before_new_handshake() {
+    let config = test_config();
+    let manager = PeerManager::new(config.clone());
+    let remote_identity = NodeIdentity::generate();
+    let remote_public_key = hex::encode(remote_identity.public_key());
+    let mut peer = test_peer("peer-probe-rejoin", "8.8.8.8:12297".parse().unwrap());
+    peer.public_key = remote_public_key.clone();
+    manager.add_peer(&peer).await;
+    let base_key = derive_probe_mac_key(&config, &remote_public_key).unwrap();
+
+    let mut offline = peer.clone();
+    offline.online = false;
+    manager.add_peer(&offline).await;
+
+    // A late worker from the retired incarnation may still have staged a
+    // replacement after the offline snapshot was published.  Recreate both
+    // the active and bounded pending state to make the rejoin fence explicit.
+    assert!(
+        manager
+            .set_probe_session_binding(
+                "peer-probe-rejoin",
+                Some("stale-session".to_string()),
+                Some([7u8; 32]),
+            )
+            .await
+    );
+    for index in 0..5 {
+        assert_eq!(
+            manager
+                .stage_probe_session_binding(
+                    "peer-probe-rejoin",
+                    format!("stale-token-{index}"),
+                    Some(format!("stale-pending-{index}")),
+                    Some([index as u8; 32]),
+                    false,
+                )
+                .await,
+            ProbeBindingStage::Staged
+        );
+    }
+
+    let update = manager.add_peer(&peer).await;
+    assert!(update.was_offline);
+    assert_eq!(
+        manager.probe_session_id_for_peer("peer-probe-rejoin").await,
+        None,
+        "a same-key rejoin must not retain the retired session id"
+    );
+    assert_eq!(
+        manager.probe_key_for_peer("peer-probe-rejoin").await,
+        Some(base_key),
+        "the rejoin must fall back to the identity-bound base key"
+    );
+    assert_eq!(
+        manager.probe_keys_for_peer("peer-probe-rejoin").await,
+        vec![base_key],
+        "all pending and overlap keys from the retired incarnation must be gone"
+    );
+    assert_eq!(
+        manager
+            .stage_probe_session_binding(
+                "peer-probe-rejoin",
+                "fresh-token".to_string(),
+                Some("fresh-session".to_string()),
+                Some([9u8; 32]),
+                false,
+            )
+            .await,
+        ProbeBindingStage::Staged,
+        "the replacement handshake must have a fresh staging budget"
+    );
+}
+
+#[tokio::test]
 async fn multiple_probe_tokens_are_retained_until_exact_token_promotion() {
     let manager = PeerManager::new(test_config());
     let remote_identity = NodeIdentity::generate();


### PR DESCRIPTION
## Problem
Relay-first room startup could stall under normal contention: a candidate-only signal skipped the initiator retry drain, application receipts could wait forever and block ordered redelivery, status snapshots fell back during transient writer contention, and dataplane routing could queue behind the lifecycle lock. A 256-packet pending queue also overflowed during a 256-request plus 256-echo validation burst.

## Change
- wake the retry/deferred-handshake ledgers after candidate-only signal handling and schedule the exact bounded retry deadline;
- bound signal application waits below the server lease so timed-out deliveries are retried;
- retry stable diagnostics snapshots for a short bounded window;
- keep advisory byte counters from enqueueing fair-lock writers;
- use a lock-free virtual-IP routing snapshot for dataplane lookups;
- raise the per-peer pending queue to 512 packets and update its overflow regression test.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets -- --test-threads=1 --skip hard_hard_`
- 69 isolated Hard↔Hard tests
- `go vet ./...` and `go test ./... -count=1`
- 5-round relay-only NAT topology smoke: all rounds passed, zero drops
- repository log-format/parser checks and build identity gate
